### PR TITLE
fix: compatibilidade com Google Colab - resolve conflitos de dependencias

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "unidecode>=1.3.8",
     "webdriver-manager>=4.0.2",
+    "websockets>=10.4,<15.1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,13 @@ dependencies = [
     "playwright>=1.46.0",
     "pyarrow>=14.0.0,<20.0.0",
     "pyjwt>=2.10.1",
-    "pyppeteer>=2.0.0,<3.0.0",
     "python-dotenv>=1.1.0",
     "requests>=2.32.3",
     "selenium>=4.31.0",
     "tqdm>=4.67.1",
     "unidecode>=1.3.8",
     "webdriver-manager>=4.0.2",
-    "websockets>=10.0,<11.0",
+    "websockets>=15.0.1,<15.1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "tqdm>=4.67.1",
     "unidecode>=1.3.8",
     "webdriver-manager>=4.0.2",
-    "websockets>=10.4,<15.1.0",
+    "websockets>=15.0.1,<15.1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,14 @@ dependencies = [
     "playwright>=1.46.0",
     "pyarrow>=14.0.0,<20.0.0",
     "pyjwt>=2.10.1",
+    "pyppeteer>=2.0.0",
     "python-dotenv>=1.1.0",
     "requests>=2.32.3",
     "selenium>=4.31.0",
     "tqdm>=4.67.1",
     "unidecode>=1.3.8",
     "webdriver-manager>=4.0.2",
-    "websockets>=15.0.1,<15.1.0",
+    "websockets>=10.4,<11.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dependencies = [
     "beautifulsoup4>=4.13.4",
     "browser-cookie3>=0.20.1",
     "nest-asyncio>=1.6.0",
-    "pandas>=2.2.3",
+    "pandas>=2.0.0,<2.2.4",
     "playwright>=1.46.0",
-    "pyarrow>=19.0.1",
+    "pyarrow>=14.0.0,<20.0.0",
     "pyjwt>=2.10.1",
     "pyppeteer>=2.0.0",
     "python-dotenv>=1.1.0",
@@ -74,6 +74,7 @@ web = [
     "flask>=3.1.1",
     "joblib>=1.5.0",
 ]
+
 
 [project.urls]
 Homepage = "https://github.com/jtrecenti/juscraper"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,14 @@ dependencies = [
     "playwright>=1.46.0",
     "pyarrow>=14.0.0,<20.0.0",
     "pyjwt>=2.10.1",
-    "pyppeteer>=2.0.0",
+    "pyppeteer>=2.0.0,<3.0.0",
     "python-dotenv>=1.1.0",
     "requests>=2.32.3",
     "selenium>=4.31.0",
     "tqdm>=4.67.1",
     "unidecode>=1.3.8",
     "webdriver-manager>=4.0.2",
-    "websockets>=15.0.1,<15.1.0",
+    "websockets>=10.0,<11.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Resolve Issue #25 - Compatibilidade com Google Colab

Este PR resolve os conflitos de dependencias reportados na issue #25 para instalacao no Google Colab.

Mudancas implementadas:
- pandas: >=2.0.0,<2.2.4 (compativel com versao 2.2.2 do Colab)
- pyarrow: >=14.0.0,<20.0.0 (compativel com versao <20.0.0 do Colab)  
- websockets: >=10.4,<11.0 (compativel com pyppeteer e Colab)

Teste realizado com sucesso no Google Colab:
https://colab.research.google.com/drive/1gQ3ut6jJauALWv-rOJzXbUIRbqa2wPIb

Esta e uma solucao parcial que ameniza significativamente o problema. Os conflitos restantes sao relacionados a bibliotecas nao essenciais para o funcionamento do JusScraper.

Resultado: instalacao bem-sucedida no Colab com funcionalidade principal preservada.