### PR TITLE
chore: add CLAUDE.md with project conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- Adicionado `CLAUDE.md` com convencoes do projeto para orientar agentes de IA
+
 ### Changed
 
 - Removidas dependências não utilizadas: `pyppeteer`, `playwright`, `selenium`, `webdriver-manager` (#25)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,14 @@ juscraper e uma biblioteca Python para raspagem de dados de tribunais brasileiro
 - Nunca tentar aprovar o proprio PR (`gh pr review --approve` falha para o autor do PR)
 - Usar `gh pr review --comment` para deixar notas de revisao nos proprios PRs
 - Sempre fazer push para uma branch de feature e abrir PR — nunca fazer push direto na main
+
+## Changelog
+
+- Seguimos o padrao [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+- Toda mudanca relevante deve ser registrada em `CHANGELOG.md` sob `[Unreleased]`
+- Categorias: Added, Changed, Deprecated, Removed, Fixed, Security
+
+## Documentacao
+
+- Documentacao do projeto (em `docs/`) deve ser escrita em ingles
+- Portugues causa problemas de encoding no build do site (Quarto + GitHub Actions)


### PR DESCRIPTION
## Summary

- Adiciona `CLAUDE.md` com convencoes do projeto para orientar o Claude Code
- Documenta arquitetura (estrutura `courts.<tribunal>.client`), regras de desenvolvimento, testes e workflow do GitHub
- Inclui regra explicita para nunca tentar aprovar o proprio PR

## Motivacao

Durante a revisao do PR #54, o Claude Code tentou `gh pr review --approve` no proprio PR, o que falhou. Este arquivo previne que o erro se repita e serve como referencia rapida sobre o projeto.

## Test plan

- [x] Arquivo e somente documentacao — sem impacto no codigo
- [ ] Verificar que o Claude Code carrega o `CLAUDE.md` ao iniciar uma sessao neste repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)