### PR TITLE
fix(tjsp): cjpg_n_pags suporta novo formato de paginação do TJSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- TJSP CJPG: extracao do numero de paginas voltou a funcionar apos mudanca no HTML do tribunal. O texto da paginacao mudou de "Mostrando 1 a 10 de N resultados" para "Resultados 1 a 10 de N", e o regex antigo exigia a palavra "resultado" depois do numero. `cjpg_n_pags` agora usa estrategia robusta de seletor + regex em cascata (mesmo padrao de `cjsg_n_pags`), suportando ambos os formatos.
+
 ### Added
 
 - TJRJ: scraper de jurisprudencia (cjsg) do Tribunal de Justica do Rio de Janeiro, via API JSON. O site exibe reCAPTCHA v2 mas o backend nao valida o token. Filtros: pesquisa livre, data de julgamento

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,15 @@ juscraper e uma biblioteca Python para raspagem de dados de tribunais brasileiro
 - `paginas` e sempre 1-based: range(1, 4) baixa paginas 1, 2 e 3; paginas=3 e equivalente a range(1, 4)
 - Normalizacao centralizada em `src/juscraper/utils/params.py`
 
+## Extracao de numero de paginas/resultados em raspadores HTML
+
+Paginas de tribunais mudam estrutura sem aviso. Ao escrever logica que extrai contagem de resultados ou numero de paginas a partir de HTML:
+
+- Use selecao em cascata (varios seletores tentados em sequencia), nao um unico seletor fragil como `bgcolor` ou class especifica.
+- Use regex em cascata, nao um unico regex que assume o texto exato. Padrao recomendado: tentar `\d+$` (numero no final), depois `(?<=de )[0-9]+` (numero apos "de"), depois capturas com descritores opcionais (`resultado`, `registro`, `pagina`), e como ultimo recurso pegar o maior `\d+` do texto.
+- Referencia canonica no projeto: `cjsg_n_pags` em `src/juscraper/courts/tjsp/cjsg_parse.py` e `cjpg_n_pags` em `src/juscraper/courts/tjsp/cjpg_parse.py`.
+- Quando um regex novo for adicionado, salvar um sample HTML em `tests/<tribunal>/samples/` cobrindo cada formato suportado (antigo e novo) e ter um teste unitario por formato.
+
 ## Regras de workflow no GitHub
 
 - Nunca tentar aprovar o proprio PR (`gh pr review --approve` falha para o autor do PR)

--- a/src/juscraper/courts/tjsp/cjpg_parse.py
+++ b/src/juscraper/courts/tjsp/cjpg_parse.py
@@ -13,25 +13,73 @@ logger = logging.getLogger("juscraper.cjpg_parse")
 
 def cjpg_n_pags(page_source):
     """
-    Extracts the number of pages from the Cjpg search results HTML.
+    Extracts the number of pages from the CJPG search results HTML.
+
+    Uses cascading selector + regex strategy to tolerate TJSP layout changes.
+    Mirrors the approach in ``cjsg_n_pags`` (CJSG uses 20 results/page; CJPG uses 10).
     """
     soup = BeautifulSoup(page_source, "html.parser")
-    page_element = soup.find(attrs={'bgcolor': '#EEEEEE'})
+
+    # --- Selector cascade ---
+    page_element = None
+
+    # 1) <td> containing "Resultados" / "resultados" (current TJSP format,
+    #    e.g. "Resultados 1 a 10 de 39764")
+    for td in soup.find_all("td"):
+        if 'resultado' in td.get_text().lower():
+            page_element = td
+            break
+
+    # 2) Original selector: bgcolor='#EEEEEE' (legacy format)
     if page_element is None:
+        page_element = soup.find(attrs={'bgcolor': '#EEEEEE'})
+
+    # 3) Any <td> that mentions "página" plus "de" or "total"
+    if page_element is None:
+        for td in soup.find_all("td"):
+            txt = td.get_text().lower()
+            if 'página' in txt and ('de' in txt or 'total' in txt):
+                page_element = td
+                break
+
+    # 4) If results table exists but no pagination element, assume 1 page
+    if page_element is None:
+        div_dados = soup.find('div', {'id': 'divDadosResultado'})
+        if div_dados is not None and div_dados.find('tr', class_='fundocinza1'):
+            return 1
         raise ValueError(
-            "Não foi possível encontrar o seletor de número de páginas"
-            "na resposta HTML. Verifique se a busca retornou resultados"
+            "Não foi possível encontrar o seletor de número de páginas "
+            "na resposta HTML. Verifique se a busca retornou resultados "
             "ou se a estrutura da página mudou."
         )
+
     texto = page_element.get_text().strip()
-    match = re.search(r'de\s+(\d+)\s+resultado', texto)
+
+    # --- Regex cascade ---
+    # 1) Number at end of text (covers "Resultados 1 a 10 de 39764")
+    match = re.search(r'(\d+)\s*$', texto)
     if match is None:
-        raise ValueError(
-            "Não foi possível extrair o número de resultados "
-            f"da string: {texto}"
-        )
-    results = int(match.group(1))
-    pags = results // 10 + 1
+        # 2) Number after "de "
+        m2 = re.search(r'(?<=de )([0-9]+)', texto)
+        match = m2
+    if match is None:
+        # 3) Number followed by descriptor
+        m3 = re.search(r'([0-9]+)(?=\s*(?:resultado|registro|página))', texto, re.I)
+        match = m3
+    if match is None:
+        # 4) Last resort: pick the largest number found in the text
+        nums = re.findall(r'\d+', texto)
+        if nums:
+            results = max(int(n) for n in nums)
+        else:
+            raise ValueError(
+                "Não foi possível extrair o número de resultados "
+                f"da string: {texto}"
+            )
+    else:
+        results = int(match.group(1))
+
+    pags = (results + 9) // 10  # math.ceil(results / 10)
     return pags
 
 def cjpg_parse_single(path):

--- a/tests/tjsp/samples/cjpg_results_novo_formato.html
+++ b/tests/tjsp/samples/cjpg_results_novo_formato.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CJPG - Consulta de Julgados de Primeiro Grau</title>
+</head>
+<body>
+    <table>
+        <tr>
+            <td bgcolor="#EEEEEE">
+                Resultados 1 a 10 de 39764
+            </td>
+        </tr>
+    </table>
+    <div id="divDadosResultado">
+        <tr class="fundocinza1">
+            <td>
+                <table>
+                    <tr>
+                        <td>
+                            <a name="JF0004W7G0000" style="vertical-align: top">
+                                <span class="fonteNegrito">1001796-12.2024.8.26.0699</span>
+                            </a>
+                        </td>
+                    </tr>
+                    <tr class="fonte">
+                        <td><strong>Classe:</strong> Procedimento do Juizado Especial Cível</td>
+                    </tr>
+                    <tr class="fonte">
+                        <td><strong>Magistrado:</strong> Renata Fanin Pupo Dos Santos</td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </div>
+</body>
+</html>

--- a/tests/tjsp/samples/cjpg_results_novo_formato.html
+++ b/tests/tjsp/samples/cjpg_results_novo_formato.html
@@ -6,7 +6,7 @@
 <body>
     <table>
         <tr>
-            <td bgcolor="#EEEEEE">
+            <td class="resultadoBuscaPaginacao">
                 Resultados 1 a 10 de 39764
             </td>
         </tr>

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -82,12 +82,25 @@ class TestCJPGUnit:
     """Unit tests for CJPG parsing functions."""
     
     def test_cjpg_n_pags_extraction(self):
-        """Test extracting page count from CJPG HTML."""
+        """Test extracting page count from CJPG HTML (legacy format)."""
         html = load_sample_html('cjpg_results.html')
         n_pags = cjpg_n_pags(html)
-        # 25 results / 10 per page = 3 pages (rounded up)
+        # "Mostrando 1 a 10 de 25 resultados" → 25/10 = 3 pages (ceil)
         assert n_pags == 3
-    
+
+    def test_cjpg_n_pags_novo_formato(self):
+        """Test extracting page count from current TJSP CJPG HTML.
+
+        Regression for the bug where TJSP changed the pagination text from
+        "Mostrando 1 a 10 de N resultados" to "Resultados 1 a 10 de N",
+        breaking the original regex (which required "resultado" after the
+        number).
+        """
+        html = load_sample_html('cjpg_results_novo_formato.html')
+        n_pags = cjpg_n_pags(html)
+        # "Resultados 1 a 10 de 39764" → ceil(39764/10) = 3977
+        assert n_pags == 3977
+
     def test_cjpg_n_pags_missing_selector(self):
         """Test that missing pagination selector raises ValueError."""
         html = "<html><body><p>No pagination</p></body></html>"

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -101,6 +101,23 @@ class TestCJPGUnit:
         # "Resultados 1 a 10 de 39764" → ceil(39764/10) = 3977
         assert n_pags == 3977
 
+    @pytest.mark.parametrize("n_results,expected_pags", [
+        (1, 1),       # 1 result -> 1 page
+        (10, 1),      # exact multiple: 1 page (was incorrectly 2 in old code)
+        (11, 2),      # 2 pages
+        (20, 2),      # exact multiple
+        (25, 3),      # legacy fixture value
+        (39764, 3977),  # current TJSP real value
+    ])
+    def test_cjpg_n_pags_ceiling(self, n_results, expected_pags):
+        """Ceiling division: results / 10 rounded up. Covers exact multiples."""
+        html = (
+            '<html><body><table><tr><td>'
+            f'Resultados 1 a 10 de {n_results}'
+            '</td></tr></table></body></html>'
+        )
+        assert cjpg_n_pags(html) == expected_pags
+
     def test_cjpg_n_pags_missing_selector(self):
         """Test that missing pagination selector raises ValueError."""
         html = "<html><body><p>No pagination</p></body></html>"


### PR DESCRIPTION
## Summary

- Corrige `cjpg_n_pags` no TJSP, que parou de funcionar porque o tribunal mudou o texto da paginação de **\"Mostrando 1 a 10 de N resultados\"** para **\"Resultados 1 a 10 de N\"**. O regex antigo (`de\s+(\d+)\s+resultado`) exigia a palavra \"resultado\" depois do número e nunca casava com o formato novo, derrubando todo o `cjpg()`.
- Aplica em `cjpg_n_pags` a mesma estratégia em cascata (seletor + regex) já adotada em `cjsg_n_pags`. Suporta ambos os formatos (antigo e novo).
- Adiciona seção em `CLAUDE.md` recomendando esse padrão para futuros raspadores HTML, evitando regressões similares.

## Causa raiz

Confirmada via GET em `https://esaj.tjsp.jus.br/cjpg/pesquisar.do`: o texto retornado pelo TJSP hoje é literalmente \"Resultados 1 a 10 de 39764\". O regex `r'de\s+(\d+)\s+resultado'` falhava porque não há a palavra \"resultado\" após o número.

## Mudanças

- `src/juscraper/courts/tjsp/cjpg_parse.py` — `cjpg_n_pags` reescrita com cascata de 4 seletores e 4 regexes.
- `tests/tjsp/samples/cjpg_results_novo_formato.html` — novo fixture com o formato atual do TJSP.
- `tests/tjsp/test_cjpg.py` — novo teste `test_cjpg_n_pags_novo_formato` (regressão direta) + teste antigo continua passando (formato legado).
- `CLAUDE.md` — nova seção \"Extracao de numero de paginas/resultados em raspadores HTML\".
- `CHANGELOG.md` — entrada `Fixed` sob `[Unreleased]`.

## Follow-up sugerido (fora deste PR)

A investigação encontrou regex frágil sem fallback robusto também em outros scrapers (sem evidência de quebra ativa hoje):

- `src/juscraper/courts/tjgo/download.py:16`
- `src/juscraper/courts/tjto/download.py:31`
- `src/juscraper/courts/tjsc/download.py:69`
- `src/juscraper/courts/tjpe/download.py:53`
- `src/juscraper/courts/tjpr/download.py:56-66` (tem fallback parcial)

Recomendação: abrir issue de tracking para padronizar via o padrão agora documentado em `CLAUDE.md`, conforme cada tribunal mudar (ou em PRs pequenos por tribunal).

## Test plan

- [x] `pytest tests/tjsp/test_cjpg.py -m \"not integration\" -v` → 11 passed (inclui novo teste de regressão e teste do formato legado).
- [x] `pytest tests/tjsp/test_cjpg.py::TestCJPGIntegration::test_cjpg_basic_search -v` → passou contra o TJSP real (era o que estava quebrado).
- [ ] Smoke manual: `juscraper.scraper('tjsp').cjpg('golpe do pix', paginas=range(1, 2))` retorna DataFrame não vazio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)