### PR TITLE
release: bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-04-13
+
 ### Fixed
 
 - TJSP CJPG: extracao do numero de paginas voltou a funcionar apos mudanca no HTML do tribunal. O texto da paginacao mudou de "Mostrando 1 a 10 de N resultados" para "Resultados 1 a 10 de N", e o regex antigo exigia a palavra "resultado" depois do numero. `cjpg_n_pags` agora usa estrategia robusta de seletor + regex em cascata (mesmo padrao de `cjsg_n_pags`), suportando ambos os formatos.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "juscraper"
-version = "0.2.0.9000"
+version = "0.2.1"
 description = "Raspador de tribunais e outros sistemas relacionados ao poder judiciário."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bumps version to 0.2.1
- Moves [Unreleased] CHANGELOG entries under [0.2.1] - 2026-04-13

## Highlights of 0.2.1
- New scrapers: TJRJ, TJGO, TJMG (with captcha handling), TJAC, TJAL, TJAM, TJMS (eSAJ)
- TJSE and TJMA documented as unsupported (server-side captcha validation)
- Fix: TJSP CJPG pagination parsing now supports both old and new HTML formats

## Test plan
- [ ] Merge triggers tag/release flow which publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)