### PR TITLE
chore: bump version to 0.2.1.9000 (dev)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "juscraper"
-version = "0.2.1"
+version = "0.2.1.9000"
 description = "Raspador de tribunais e outros sistemas relacionados ao poder judiciário."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- Bumps in-development version to 0.2.1.9000 after the v0.2.1 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)