### PR TITLE
fix(esaj): validar intervalo de datas antes da requisição (#91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - TJSP CJPG: extracao do numero de paginas voltou a funcionar apos mudanca no HTML do tribunal. O texto da paginacao mudou de "Mostrando 1 a 10 de N resultados" para "Resultados 1 a 10 de N", e o regex antigo exigia a palavra "resultado" depois do numero. `cjpg_n_pags` agora usa estrategia robusta de seletor + regex em cascata (mesmo padrao de `cjsg_n_pags`), suportando ambos os formatos.
+- eSAJ (TJSP cjpg/cjsg, TJAC/TJCE/TJMS/TJAM cjsg): validacao antecipada do intervalo entre `data_*_inicio` e `data_*_fim`. O eSAJ rejeita janelas maiores que 1 ano, mas antes o erro aparecia como "Nao foi possivel encontrar o seletor de numero de paginas" apos a requisicao ser feita. Agora um `ValueError` acionavel e lancado antes de qualquer HTTP, explicando o limite e orientando dividir a consulta em janelas menores (novo helper `juscraper.utils.params.validate_intervalo_datas`). Refs #91.
 
 ### Added
 

--- a/src/juscraper/courts/tjac/client.py
+++ b/src/juscraper/courts/tjac/client.py
@@ -4,7 +4,7 @@ import shutil
 
 import requests
 from juscraper.core.base import BaseScraper
-from juscraper.utils.params import normalize_paginas, normalize_datas
+from juscraper.utils.params import normalize_paginas, normalize_datas, validate_intervalo_datas
 
 from .cjsg_download import cjsg_download as _cjsg_download
 from .cjsg_parse import cjsg_n_pags, cjsg_parse_manager
@@ -146,6 +146,16 @@ class TJACScraper(BaseScraper):
             data_publicacao_inicio=data_publicacao_inicio,
             data_publicacao_fim=data_publicacao_fim,
             **kwargs,
+        )
+        validate_intervalo_datas(
+            datas["data_julgamento_inicio"],
+            datas["data_julgamento_fim"],
+            rotulo="data_julgamento",
+        )
+        validate_intervalo_datas(
+            datas["data_publicacao_inicio"],
+            datas["data_publicacao_fim"],
+            rotulo="data_publicacao",
         )
         download_dir = diretorio or self.download_path
         return _cjsg_download(

--- a/src/juscraper/courts/tjam/client.py
+++ b/src/juscraper/courts/tjam/client.py
@@ -4,7 +4,7 @@ import shutil
 
 import requests
 from juscraper.core.base import BaseScraper
-from juscraper.utils.params import normalize_paginas, normalize_datas
+from juscraper.utils.params import normalize_paginas, normalize_datas, validate_intervalo_datas
 
 from .cjsg_download import cjsg_download as _cjsg_download
 from .cjsg_parse import cjsg_n_pags, cjsg_parse_manager
@@ -146,6 +146,16 @@ class TJAMScraper(BaseScraper):
             data_publicacao_inicio=data_publicacao_inicio,
             data_publicacao_fim=data_publicacao_fim,
             **kwargs,
+        )
+        validate_intervalo_datas(
+            datas["data_julgamento_inicio"],
+            datas["data_julgamento_fim"],
+            rotulo="data_julgamento",
+        )
+        validate_intervalo_datas(
+            datas["data_publicacao_inicio"],
+            datas["data_publicacao_fim"],
+            rotulo="data_publicacao",
         )
         download_dir = diretorio or self.download_path
         return _cjsg_download(

--- a/src/juscraper/courts/tjce/client.py
+++ b/src/juscraper/courts/tjce/client.py
@@ -4,7 +4,7 @@ import shutil
 
 import requests
 from juscraper.core.base import BaseScraper
-from juscraper.utils.params import normalize_paginas, normalize_datas
+from juscraper.utils.params import normalize_paginas, normalize_datas, validate_intervalo_datas
 
 from .cjsg_download import cjsg_download as _cjsg_download
 from .cjsg_parse import cjsg_n_pags, cjsg_parse_manager
@@ -146,6 +146,16 @@ class TJCEScraper(BaseScraper):
             data_publicacao_inicio=data_publicacao_inicio,
             data_publicacao_fim=data_publicacao_fim,
             **kwargs,
+        )
+        validate_intervalo_datas(
+            datas["data_julgamento_inicio"],
+            datas["data_julgamento_fim"],
+            rotulo="data_julgamento",
+        )
+        validate_intervalo_datas(
+            datas["data_publicacao_inicio"],
+            datas["data_publicacao_fim"],
+            rotulo="data_publicacao",
         )
         download_dir = diretorio or self.download_path
         return _cjsg_download(

--- a/src/juscraper/courts/tjms/client.py
+++ b/src/juscraper/courts/tjms/client.py
@@ -4,7 +4,7 @@ import shutil
 
 import requests
 from juscraper.core.base import BaseScraper
-from juscraper.utils.params import normalize_paginas, normalize_datas
+from juscraper.utils.params import normalize_paginas, normalize_datas, validate_intervalo_datas
 
 from .cjsg_download import cjsg_download as _cjsg_download
 from .cjsg_parse import cjsg_n_pags, cjsg_parse_manager
@@ -146,6 +146,16 @@ class TJMSScraper(BaseScraper):
             data_publicacao_inicio=data_publicacao_inicio,
             data_publicacao_fim=data_publicacao_fim,
             **kwargs,
+        )
+        validate_intervalo_datas(
+            datas["data_julgamento_inicio"],
+            datas["data_julgamento_fim"],
+            rotulo="data_julgamento",
+        )
+        validate_intervalo_datas(
+            datas["data_publicacao_inicio"],
+            datas["data_publicacao_fim"],
+            rotulo="data_publicacao",
         )
         download_dir = diretorio or self.download_path
         return _cjsg_download(

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -11,7 +11,7 @@ import urllib3
 import requests
 
 from ...core.base import BaseScraper
-from ...utils.params import normalize_paginas, normalize_datas
+from ...utils.params import normalize_paginas, normalize_datas, validate_intervalo_datas
 
 from .cpopg_download import cpopg_download_html, cpopg_download_api
 from .cpopg_parse import get_cpopg_download_links, cpopg_parse_manager
@@ -258,12 +258,21 @@ class TJSPScraper(BaseScraper):
             baixar_sg (bool): If True, also downloads from Second Stage.
             tipo_decisao (str): 'acordao' or 'monocratica'.
             paginas (int, list, range, or None): Pages (1-based). None downloads all.
+
+        Note:
+            The eSAJ accepts at most 1 year between ``data_julgamento_inicio``
+            and ``data_julgamento_fim``. Split longer ranges on the caller side.
         """
         paginas = normalize_paginas(paginas)
         datas = normalize_datas(
             data_julgamento_inicio=data_julgamento_inicio,
             data_julgamento_fim=data_julgamento_fim,
             **kwargs,
+        )
+        validate_intervalo_datas(
+            datas["data_julgamento_inicio"],
+            datas["data_julgamento_fim"],
+            rotulo="data_julgamento",
         )
         return cjsg_download_mod(
             pesquisa=pesquisa,
@@ -309,6 +318,11 @@ class TJSPScraper(BaseScraper):
             data_julgamento_inicio: Start date. ``data_inicio`` accepted as alias.
             data_julgamento_fim: End date. ``data_fim`` accepted as alias.
             paginas (int, list, range, or None): Pages (1-based). None downloads all.
+
+        Note:
+            The eSAJ accepts at most 1 year between ``data_julgamento_inicio``
+            and ``data_julgamento_fim``. Split longer ranges into yearly
+            windows on the caller side.
         """
         path_result = self.cjpg_download(
             pesquisa=pesquisa,
@@ -349,12 +363,21 @@ class TJSPScraper(BaseScraper):
             data_julgamento_inicio: Start date. ``data_inicio`` accepted as alias.
             data_julgamento_fim: End date. ``data_fim`` accepted as alias.
             paginas (int, list, range, or None): Pages (1-based). None downloads all.
+
+        Note:
+            The eSAJ accepts at most 1 year between ``data_julgamento_inicio``
+            and ``data_julgamento_fim``. Split longer ranges on the caller side.
         """
         paginas = normalize_paginas(paginas)
         datas = normalize_datas(
             data_julgamento_inicio=data_julgamento_inicio,
             data_julgamento_fim=data_julgamento_fim,
             **kwargs,
+        )
+        validate_intervalo_datas(
+            datas["data_julgamento_inicio"],
+            datas["data_julgamento_fim"],
+            rotulo="data_julgamento",
         )
 
         def get_n_pags_callback(r0):

--- a/src/juscraper/utils/params.py
+++ b/src/juscraper/utils/params.py
@@ -163,27 +163,32 @@ def validate_intervalo_datas(
     data_inicio,
     data_fim,
     *,
-    max_dias=365,
+    max_dias=366,
     formato="%d/%m/%Y",
     rotulo="data",
+    origem="O eSAJ",
 ):
     """Validate a date interval before firing an HTTP request.
 
-    The eSAJ jurisprudence endpoints (cjpg/cjsg) reject ranges greater than one
-    year with a server message ("A faixa entre data de início e data de fim
-    deve ser de no máximo 1 ano."). Checking the interval client-side turns a
-    cryptic downstream failure (missing paginator, truncated HTML) into an
-    actionable error raised before the request.
+    Several tribunal search endpoints reject date ranges wider than a
+    platform-specific window. The eSAJ jurisprudence endpoints (cjpg/cjsg),
+    for example, cap the range at one year ("A faixa entre data de início e
+    data de fim deve ser de no máximo 1 ano."). Checking the interval
+    client-side turns a cryptic downstream failure (missing paginator,
+    truncated HTML) into an actionable error raised before the request.
 
     Args:
         data_inicio: Start date as a string (``DD/MM/YYYY`` by default) or
-            ``None``. ``None`` skips validation — eSAJ allows single-bound
-            searches.
+            ``None``. ``None`` skips validation — single-bound searches are
+            left to the server.
         data_fim: End date as a string or ``None``.
-        max_dias: Maximum allowed interval in days (default: 365).
+        max_dias: Maximum allowed interval in days (default: 366 to admit a
+            full calendar year even across a leap day).
         formato: ``strptime`` format of the input strings.
         rotulo: Human-readable label for the parameter pair in error messages
             (e.g. ``"data_julgamento"``).
+        origem: Subject of the over-limit error message (e.g. ``"O eSAJ"``,
+            ``"O TJRS"``). Appears as ``"{origem} aceita no máximo N dias..."``.
 
     Raises:
         ValueError: If either string does not match ``formato``, if
@@ -215,7 +220,7 @@ def validate_intervalo_datas(
     dias = (dt_fim - dt_inicio).days
     if dias > max_dias:
         raise ValueError(
-            f"O eSAJ aceita no máximo {max_dias} dias entre '{rotulo}_inicio' "
+            f"{origem} aceita no máximo {max_dias} dias entre '{rotulo}_inicio' "
             f"e '{rotulo}_fim' (recebido: {dias} dias, de {data_inicio} a "
             f"{data_fim}). Divida a consulta em janelas menores."
         )

--- a/src/juscraper/utils/params.py
+++ b/src/juscraper/utils/params.py
@@ -2,6 +2,7 @@
 Utility functions for normalizing public API parameters across all scrapers.
 """
 import warnings
+from datetime import datetime
 
 
 def normalize_paginas(paginas):
@@ -156,6 +157,68 @@ def normalize_datas(**kwargs):
                 result[canonical] = value
 
     return result
+
+
+def validate_intervalo_datas(
+    data_inicio,
+    data_fim,
+    *,
+    max_dias=365,
+    formato="%d/%m/%Y",
+    rotulo="data",
+):
+    """Validate a date interval before firing an HTTP request.
+
+    The eSAJ jurisprudence endpoints (cjpg/cjsg) reject ranges greater than one
+    year with a server message ("A faixa entre data de início e data de fim
+    deve ser de no máximo 1 ano."). Checking the interval client-side turns a
+    cryptic downstream failure (missing paginator, truncated HTML) into an
+    actionable error raised before the request.
+
+    Args:
+        data_inicio: Start date as a string (``DD/MM/YYYY`` by default) or
+            ``None``. ``None`` skips validation — eSAJ allows single-bound
+            searches.
+        data_fim: End date as a string or ``None``.
+        max_dias: Maximum allowed interval in days (default: 365).
+        formato: ``strptime`` format of the input strings.
+        rotulo: Human-readable label for the parameter pair in error messages
+            (e.g. ``"data_julgamento"``).
+
+    Raises:
+        ValueError: If either string does not match ``formato``, if
+            ``data_inicio > data_fim``, or if the interval exceeds
+            ``max_dias``.
+    """
+    if data_inicio is None or data_fim is None:
+        return
+
+    try:
+        dt_inicio = datetime.strptime(data_inicio, formato)
+    except ValueError as exc:
+        raise ValueError(
+            f"'{rotulo}_inicio' inválida: {data_inicio!r}. Formato esperado: {formato}."
+        ) from exc
+    try:
+        dt_fim = datetime.strptime(data_fim, formato)
+    except ValueError as exc:
+        raise ValueError(
+            f"'{rotulo}_fim' inválida: {data_fim!r}. Formato esperado: {formato}."
+        ) from exc
+
+    if dt_inicio > dt_fim:
+        raise ValueError(
+            f"'{rotulo}_inicio' ({data_inicio}) é posterior a "
+            f"'{rotulo}_fim' ({data_fim})."
+        )
+
+    dias = (dt_fim - dt_inicio).days
+    if dias > max_dias:
+        raise ValueError(
+            f"O eSAJ aceita no máximo {max_dias} dias entre '{rotulo}_inicio' "
+            f"e '{rotulo}_fim' (recebido: {dias} dias, de {data_inicio} a "
+            f"{data_fim}). Divida a consulta em janelas menores."
+        )
 
 
 def warn_unsupported(param_name, tribunal):

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -152,14 +152,19 @@ class TestValidateIntervaloDatas:
         assert validate_intervalo_datas(None, "31/12/2023") is None
 
     def test_one_year_exact_ok(self):
-        # 365-day window passes with default max_dias=365.
+        # 365-day window passes with default max_dias=366.
         assert validate_intervalo_datas("01/01/2023", "01/01/2024") is None
+
+    def test_one_year_across_leap_day_ok(self):
+        # 2024 is a leap year — 01/01/2024 -> 01/01/2025 spans 366 days, still
+        # a calendar year. Must not be rejected client-side.
+        assert validate_intervalo_datas("01/01/2024", "01/01/2025") is None
 
     def test_same_day_ok(self):
         assert validate_intervalo_datas("15/06/2023", "15/06/2023") is None
 
     def test_over_one_year_raises(self):
-        with pytest.raises(ValueError, match="no máximo 365 dias"):
+        with pytest.raises(ValueError, match="no máximo 366 dias"):
             validate_intervalo_datas("01/01/2020", "31/12/2021")
 
     def test_rotulo_in_message(self):
@@ -190,6 +195,16 @@ class TestValidateIntervaloDatas:
         with pytest.raises(ValueError, match="no máximo 31 dias"):
             validate_intervalo_datas(
                 "01/01/2023", "02/02/2023", max_dias=31
+            )
+
+    def test_default_origem_esaj(self):
+        with pytest.raises(ValueError, match="O eSAJ aceita no máximo"):
+            validate_intervalo_datas("01/01/2020", "31/12/2021")
+
+    def test_custom_origem(self):
+        with pytest.raises(ValueError, match="O TJRS aceita no máximo"):
+            validate_intervalo_datas(
+                "01/01/2020", "31/12/2021", origem="O TJRS"
             )
 
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -5,6 +5,7 @@ from juscraper.utils.params import (
     normalize_paginas,
     normalize_pesquisa,
     normalize_datas,
+    validate_intervalo_datas,
     warn_unsupported,
 )
 
@@ -136,6 +137,60 @@ class TestNormalizeDatas:
         )
         assert result["data_publicacao_inicio"] == "01/01/2023"
         assert result["data_publicacao_fim"] == "31/12/2023"
+
+
+# --- validate_intervalo_datas ---
+
+class TestValidateIntervaloDatas:
+
+    def test_both_none_skips(self):
+        # No exception; returns None
+        assert validate_intervalo_datas(None, None) is None
+
+    def test_one_none_skips(self):
+        assert validate_intervalo_datas("01/01/2023", None) is None
+        assert validate_intervalo_datas(None, "31/12/2023") is None
+
+    def test_one_year_exact_ok(self):
+        # 365-day window passes with default max_dias=365.
+        assert validate_intervalo_datas("01/01/2023", "01/01/2024") is None
+
+    def test_same_day_ok(self):
+        assert validate_intervalo_datas("15/06/2023", "15/06/2023") is None
+
+    def test_over_one_year_raises(self):
+        with pytest.raises(ValueError, match="no máximo 365 dias"):
+            validate_intervalo_datas("01/01/2020", "31/12/2021")
+
+    def test_rotulo_in_message(self):
+        with pytest.raises(ValueError, match="data_julgamento_inicio"):
+            validate_intervalo_datas(
+                "01/01/2020",
+                "31/12/2021",
+                rotulo="data_julgamento",
+            )
+
+    def test_inicio_after_fim_raises(self):
+        with pytest.raises(ValueError, match="posterior"):
+            validate_intervalo_datas("31/12/2023", "01/01/2023")
+
+    def test_invalid_format_raises(self):
+        with pytest.raises(ValueError, match="Formato esperado"):
+            validate_intervalo_datas("2020-01-01", "31/12/2020")
+
+    def test_invalid_fim_format_raises(self):
+        with pytest.raises(ValueError, match="data_fim"):
+            validate_intervalo_datas("01/01/2020", "2020-12-31", rotulo="data")
+
+    def test_custom_max_dias(self):
+        # 31 days allowed, 32 not.
+        assert validate_intervalo_datas(
+            "01/01/2023", "01/02/2023", max_dias=31
+        ) is None
+        with pytest.raises(ValueError, match="no máximo 31 dias"):
+            validate_intervalo_datas(
+                "01/01/2023", "02/02/2023", max_dias=31
+            )
 
 
 # --- warn_unsupported ---

--- a/tests/tjac/test_tjac_cjsg.py
+++ b/tests/tjac/test_tjac_cjsg.py
@@ -1,4 +1,6 @@
 """Integration tests for the TJAC CJSG scraper."""
+from unittest.mock import MagicMock
+
 import pandas as pd
 import pytest
 
@@ -56,3 +58,34 @@ class TestCJSGTJAC:
         df_int = self.scraper.cjsg("direito", paginas=2)
         df_range = self.scraper.cjsg("direito", paginas=range(1, 3))
         assert len(df_int) == len(df_range)
+
+
+class TestCJSGTJACDateRangeValidation:
+    """Pre-request date-range validation (#91). Unit-level, no network."""
+
+    def _make_scraper(self):
+        scraper = jus.scraper("tjac")
+        scraper.session = MagicMock()
+        return scraper
+
+    def test_julgamento_over_limit_raises_before_request(self):
+        scraper = self._make_scraper()
+        with pytest.raises(ValueError, match="data_julgamento"):
+            scraper.cjsg_download(
+                pesquisa="direito",
+                data_julgamento_inicio="01/01/2020",
+                data_julgamento_fim="31/12/2021",
+            )
+        scraper.session.get.assert_not_called()
+        scraper.session.post.assert_not_called()
+
+    def test_publicacao_over_limit_raises_before_request(self):
+        scraper = self._make_scraper()
+        with pytest.raises(ValueError, match="data_publicacao"):
+            scraper.cjsg_download(
+                pesquisa="direito",
+                data_publicacao_inicio="01/01/2020",
+                data_publicacao_fim="31/12/2021",
+            )
+        scraper.session.get.assert_not_called()
+        scraper.session.post.assert_not_called()

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -247,5 +247,64 @@ class TestCJPGDownload1Based:
         assert len(urls) == 2
 
 
+class TestCJPGDateRangeValidation:
+    """Pre-request date-range validation for the eSAJ 1-year limit (#91)."""
+
+    def _patched_scraper(self):
+        """Build a TJSPScraper whose session.get would fail the test if called."""
+        scraper = juscraper.scraper('tjsp')
+        # Replace session with a MagicMock that records calls — if validation
+        # fails to short-circuit, .get() would be invoked and we can detect it.
+        scraper.session = MagicMock()
+        return scraper
+
+    def test_range_over_one_year_raises_before_request(self):
+        scraper = self._patched_scraper()
+        with pytest.raises(ValueError, match="no máximo 365 dias"):
+            scraper.cjpg_download(
+                pesquisa="direito",
+                data_julgamento_inicio="01/01/2020",
+                data_julgamento_fim="31/12/2021",
+            )
+        # Crucially, nothing hit the network.
+        scraper.session.get.assert_not_called()
+        scraper.session.post.assert_not_called()
+
+    def test_invalid_format_raises_before_request(self):
+        scraper = self._patched_scraper()
+        with pytest.raises(ValueError, match="Formato esperado"):
+            scraper.cjpg_download(
+                pesquisa="direito",
+                data_julgamento_inicio="2020-01-01",
+                data_julgamento_fim="31/12/2020",
+            )
+        scraper.session.get.assert_not_called()
+
+    def test_inicio_after_fim_raises_before_request(self):
+        scraper = self._patched_scraper()
+        with pytest.raises(ValueError, match="posterior"):
+            scraper.cjpg_download(
+                pesquisa="direito",
+                data_julgamento_inicio="31/12/2023",
+                data_julgamento_fim="01/01/2023",
+            )
+        scraper.session.get.assert_not_called()
+
+    def test_valid_one_year_window_proceeds_to_request(self):
+        """A valid 1-year window should NOT short-circuit; the download
+        proceeds and the mocked session receives the first GET."""
+        scraper = self._patched_scraper()
+        # Make the mock raise after the first .get() so we don't actually
+        # exercise the parsing flow — we only care that validation passed.
+        scraper.session.get.side_effect = RuntimeError("short-circuit after validate")
+        with pytest.raises(RuntimeError, match="short-circuit"):
+            scraper.cjpg_download(
+                pesquisa="direito",
+                data_julgamento_inicio="01/01/2023",
+                data_julgamento_fim="31/12/2023",
+            )
+        assert scraper.session.get.called
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -260,7 +260,7 @@ class TestCJPGDateRangeValidation:
 
     def test_range_over_one_year_raises_before_request(self):
         scraper = self._patched_scraper()
-        with pytest.raises(ValueError, match="no máximo 365 dias"):
+        with pytest.raises(ValueError, match="no máximo 366 dias"):
             scraper.cjpg_download(
                 pesquisa="direito",
                 data_julgamento_inicio="01/01/2020",


### PR DESCRIPTION
## Summary

O eSAJ rejeita janelas de data > 1 ano com a mensagem "A faixa entre data de inicio e data de fim deve ser de no máximo 1 ano" / "O período entre... deve ser de no máximo 1 ano", mas antes desse PR o erro chegava ao usuário como `ValueError` genérico de paginador ausente, depois de já ter feito a requisição.

Este PR adiciona `juscraper.utils.params.validate_intervalo_datas` — um helper que levanta `ValueError` acionável **antes** de qualquer HTTP, explicando o limite e orientando a dividir a consulta. O helper é chamado logo após `normalize_datas` em todos os downloads eSAJ confirmados empiricamente:

- TJSP: `cjpg_download` e `cjsg_download` (par `data_julgamento_*`)
- TJAC, TJCE, TJMS, TJAM: `cjsg_download` (pares `data_julgamento_*` e `data_publicacao_*`)

## Extensibilidade

O helper é reutilizável por tribunais não-eSAJ — todos os parâmetros relevantes são kwargs:

- `max_dias` (default 366 — tolera um ano calendário mesmo cruzando dia bissexto)
- `formato` (default `"%d/%m/%Y"`, compatível com o resto da API)
- `rotulo` (nome do par nos erros, ex.: `"data_julgamento"`)
- `origem` (default `"O eSAJ"`, troca a mensagem para `"O TJRS aceita..."` em outras plataformas)

## Confirmação empírica do limite

Testei janela de 2 anos (`01/01/2023` → `31/12/2024`) em cada endpoint eSAJ:

| Endpoint | Mensagem do servidor |
|---|---|
| TJSP cjpg | "O período entre a data de início e fim da pesquisa deve ser de no máximo 1 ano." |
| TJAC cjsg | "A faixa entre data de inicio e data de fim deve ser de no máximo 1 ano." |
| TJMS cjsg | idem |
| TJAM cjsg | idem |
| TJCE cjsg | SSL/auth wall (inconclusivo) — aplicado por paridade com eSAJ irmão |
| TJSP cjsg | limite eSAJ confirmado pelo owner no comentário da issue |

## Fora de escopo (rejeitado pelo owner no comentário da issue)

- Auto-chunking (`auto_chunk=True`). A orientação é deixar a partição do intervalo a cargo do caller.

## Test plan

- [x] `pytest -m "not integration"` — **83 passed**, nenhum teste existente quebrou
- [x] 12 testes unitários em `tests/test_params.py` cobrindo o helper (formato inválido, ordem invertida, janela > `max_dias`, bissexto, `None` em qualquer lado, `max_dias` customizável, `origem` customizável)
- [x] 4 testes mock em `tests/tjsp/test_cjpg.py` provando que o `ValueError` sobe antes do primeiro `session.get()` no TJSP cjpg
- [x] 2 testes mock em `tests/tjac/test_tjac_cjsg.py` cobrindo tanto `data_julgamento` quanto `data_publicacao` no cjsg
- [ ] Integration (manual): `scraper.cjpg(pesquisa="direito", data_julgamento_inicio="01/01/2020", data_julgamento_fim="31/12/2021")` falha com "no máximo 366 dias" sem fazer request
- [ ] Integration (manual): janela de 1 ano continua funcionando normalmente
- [ ] Integration (manual): janela cruzando bissexto (`01/01/2024` → `01/01/2025` = 366 dias) passa

Refs #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)