### PR TITLE
fix: limpeza mecânica (#33, #59, #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - eSAJ: `juscraper.utils.params.validate_intervalo_datas` aceita parametro `origem` (default `"O eSAJ"`) para reuso em tribunais nao-eSAJ com mensagem de erro correta. Janela maxima default aumentada de 365 para 366 dias para nao rejeitar cliente-side uma janela de 1 ano calendario que atravesse 29/02 (ex: `01/01/2024` -> `01/01/2025`).
+- `tests/tjsp/`: removidos hacks de `sys.path.insert` e `from src.juscraper`. Os testes agora dependem do install editavel (`uv pip install -e ".[dev]"`), conforme o `CLAUDE.md` (refs #88).
 
 ### Fixed
 
 - eSAJ (TJSP cjpg/cjsg, TJAC/TJCE/TJMS/TJAM cjsg): validacao antecipada do intervalo entre `data_*_inicio` e `data_*_fim`. O eSAJ rejeita janelas maiores que 1 ano, mas antes o erro aparecia como "Nao foi possivel encontrar o seletor de numero de paginas" apos a requisicao ser feita. Agora um `ValueError` acionavel e lancado antes de qualquer HTTP, explicando o limite e orientando dividir a consulta em janelas menores (novo helper `juscraper.utils.params.validate_intervalo_datas`). Refs #91.
+- `juscraper.utils.cnj.clean_cnj`: agora remove qualquer caractere nao-digito (espacos, tabs, quebras de linha), nao apenas `.` e `-`. Numeros CNJ vindos de CSV/Excel com whitespace deixam de ser silenciosamente descartados pelo DataJud (refs #59).
+- `sanitize_filename`: removido `isinstance` redundante que conflitava com a anotacao de tipo e quebrava o pre-commit do mypy (refs #33).
 
 ## [0.2.1] - 2026-04-13
 

--- a/src/juscraper/utils/__init__.py
+++ b/src/juscraper/utils/__init__.py
@@ -7,6 +7,7 @@ Contém funções auxiliares diversas.
 
 import re
 
+
 def sanitize_filename(filename: str) -> str:
     """
     Remove ou substitui caracteres de uma string que não são adequados para nomes de arquivo.
@@ -14,8 +15,6 @@ def sanitize_filename(filename: str) -> str:
     Substitui sequências de caracteres inválidos por um único underscore.
     Remove underscores no início ou fim do nome.
     """
-    if not isinstance(filename, str):
-        filename = str(filename) # Tenta converter para string se não for
     # Remove caracteres inválidos, substituindo por underscore
     # Permite letras (incluindo acentuadas), números, espaços, hífens, underscores, pontos.
     # Caracteres como / \ : * ? " < > | são problemáticos

--- a/src/juscraper/utils/cnj.py
+++ b/src/juscraper/utils/cnj.py
@@ -1,12 +1,21 @@
 """
 Funções utilitárias para manipulação de números CNJ (Conselho Nacional de Justiça).
 """
+import re
+
+_NON_DIGIT_RE = re.compile(r"\D")
+
 
 def clean_cnj(numero: str) -> str:
-    """Limpa o número do processo, removendo pontos e traços.
-    Exemplo: 0000000-00.0000.0.00.0000 -> 00000000000000000000
+    """Limpa o número do processo, mantendo apenas dígitos.
+
+    Remove pontos, traços, espaços, quebras de linha e qualquer outro
+    caractere não-numérico — útil para entradas vindas de CSV/Excel onde
+    sobra whitespace.
+
+    Exemplo: ``"0000000-00.0000.0.00.0000 "`` -> ``"00000000000000000000"``
     """
-    return numero.replace(".", "").replace("-", "")
+    return _NON_DIGIT_RE.sub("", numero)
 
 def split_cnj(numero: str) -> dict:
     """Divide um número de processo CNJ (limpo ou formatado) em suas partes.
@@ -18,7 +27,7 @@ def split_cnj(numero: str) -> dict:
         raise ValueError(
             f"Número CNJ '{numero}' inválido. Após limpeza, deve ter 20 dígitos, mas tem {len(numero_limpo)}."
         )
-    
+
     return {
         "num": numero_limpo[:7],
         "dv": numero_limpo[7:9],

--- a/tests/test_cnj.py
+++ b/tests/test_cnj.py
@@ -1,0 +1,59 @@
+"""Testes para utilitários de número CNJ."""
+import pytest
+
+from juscraper.utils.cnj import clean_cnj, format_cnj, split_cnj
+
+
+class TestCleanCnj:
+    def test_remove_dots_and_dashes(self):
+        assert clean_cnj("0003325-88.2014.8.01.0001") == "00033258820148010001"
+
+    def test_already_clean(self):
+        assert clean_cnj("00033258820148010001") == "00033258820148010001"
+
+    def test_strips_trailing_space(self):
+        # Issue #59: CSVs exportados de Excel costumam trazer espaço sobrando.
+        assert clean_cnj("00033258820148010001 ") == "00033258820148010001"
+
+    def test_strips_leading_space(self):
+        assert clean_cnj(" 00033258820148010001") == "00033258820148010001"
+
+    def test_removes_newlines_and_tabs(self):
+        assert clean_cnj("00033258820148010001\n") == "00033258820148010001"
+        assert clean_cnj("\t00033258820148010001\t") == "00033258820148010001"
+
+    def test_removes_internal_whitespace(self):
+        assert clean_cnj("0003325 8820148010001") == "00033258820148010001"
+
+    def test_formatted_with_trailing_space(self):
+        assert clean_cnj("0003325-88.2014.8.01.0001\n") == "00033258820148010001"
+
+
+class TestSplitCnj:
+    def test_split_clean_number(self):
+        partes = split_cnj("00033258820148010001")
+        assert partes == {
+            "num": "0003325",
+            "dv": "88",
+            "ano": "2014",
+            "justica": "8",
+            "tribunal": "01",
+            "orgao": "0001",
+        }
+
+    def test_split_handles_whitespace(self):
+        # Antes da correção #59 isso levantava ValueError silenciosamente
+        # quando vindo de DataJud — agora funciona.
+        assert split_cnj("00033258820148010001 ")["tribunal"] == "01"
+
+    def test_split_invalid_length_raises(self):
+        with pytest.raises(ValueError, match="20 dígitos"):
+            split_cnj("123")
+
+
+class TestFormatCnj:
+    def test_format_from_clean(self):
+        assert format_cnj("00033258820148010001") == "0003325-88.2014.8.01.0001"
+
+    def test_format_idempotent(self):
+        assert format_cnj("0003325-88.2014.8.01.0001") == "0003325-88.2014.8.01.0001"

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -2,44 +2,37 @@
 Tests for TJSP CJPG functionality.
 Includes both integration and unit tests.
 """
-import sys
 import os
 import tempfile
-from unittest.mock import MagicMock, patch, call
-import pytest
+from unittest.mock import MagicMock, call, patch
+
 import pandas as pd
+import pytest
 
-# Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+import juscraper
+from juscraper.courts.tjsp.cjpg_download import cjpg_download
+from juscraper.courts.tjsp.cjpg_parse import cjpg_n_pags, cjpg_parse_manager, cjpg_parse_single
 
-try:
-    import juscraper
-except ImportError:
-    from src.juscraper import scraper as juscraper_scraper
-    juscraper = type('Module', (), {'scraper': juscraper_scraper})()
-
-from src.juscraper.courts.tjsp.cjpg_parse import cjpg_n_pags, cjpg_parse_single, cjpg_parse_manager
-from src.juscraper.courts.tjsp.cjpg_download import cjpg_download
-from tests.tjsp.test_utils import load_sample_html
+from .test_utils import load_sample_html
 
 
 @pytest.mark.integration
 class TestCJPGIntegration:
     """Integration tests for CJPG that hit the real website."""
-    
+
     @pytest.fixture(autouse=True)
     def setup(self):
         """Set up test fixtures."""
         self.scraper = juscraper.scraper('tjsp')
         yield
-    
+
     def test_cjpg_basic_search(self):
         """Test basic CJPG search functionality."""
         results = self.scraper.cjpg('golpe do pix', paginas=range(1, 2))
-        
+
         assert isinstance(results, pd.DataFrame)
         assert len(results) >= 0
-    
+
     def test_cjpg_with_filters(self):
         """Test CJPG search with filters."""
         results = self.scraper.cjpg(
@@ -47,16 +40,16 @@ class TestCJPGIntegration:
             classes=['Procedimento Comum Cível'],
             paginas=range(1, 2)
         )
-        
+
         assert isinstance(results, pd.DataFrame)
-    
+
     def test_cjpg_pagination(self):
         """Test CJPG pagination."""
         results = self.scraper.cjpg('direito', paginas=range(1, 3))
-        
+
         assert isinstance(results, pd.DataFrame)
         assert len(results) >= 0
-    
+
     def test_cjpg_date_filters(self):
         """Test CJPG with date filters."""
         results = self.scraper.cjpg(
@@ -66,13 +59,13 @@ class TestCJPGIntegration:
             paginas=range(1, 2),
         )
         assert isinstance(results, pd.DataFrame)
-    
+
     def test_cjpg_result_structure(self):
         """Test that CJPG results have expected structure."""
         results = self.scraper.cjpg('direito', paginas=range(1, 2))
-        
+
         assert isinstance(results, pd.DataFrame)
-        
+
         if len(results) > 0:
             # Check for expected columns
             assert len(results.columns) > 0
@@ -80,7 +73,7 @@ class TestCJPGIntegration:
 
 class TestCJPGUnit:
     """Unit tests for CJPG parsing functions."""
-    
+
     def test_cjpg_n_pags_extraction(self):
         """Test extracting page count from CJPG HTML (legacy format)."""
         html = load_sample_html('cjpg_results.html')
@@ -123,21 +116,21 @@ class TestCJPGUnit:
         html = "<html><body><p>No pagination</p></body></html>"
         with pytest.raises(ValueError, match="Não foi possível encontrar"):
             cjpg_n_pags(html)
-    
+
     def test_cjpg_parse_single(self):
         """Test parsing a single CJPG results page."""
         html = load_sample_html('cjpg_results.html')
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             df = cjpg_parse_single(temp_path)
-            
+
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 2  # Two processes in sample
-            
+
             # Check first process
             assert df.iloc[0]['id_processo'] == '1001796-12.2024.8.26.0699'
             assert df.iloc[0]['cd_processo'] == 'JF0004W7G0000'
@@ -145,34 +138,34 @@ class TestCJPGUnit:
             assert 'decisao' in df.columns
         finally:
             os.unlink(temp_path)
-    
+
     def test_cjpg_parse_manager_directory(self):
         """Test parsing multiple CJPG files from directory."""
         html = load_sample_html('cjpg_results.html')
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             file1 = os.path.join(temp_dir, 'page1.html')
             file2 = os.path.join(temp_dir, 'page2.html')
-            
+
             with open(file1, 'w', encoding='utf-8') as f:
                 f.write(html)
             with open(file2, 'w', encoding='utf-8') as f:
                 f.write(html)
-            
+
             df = cjpg_parse_manager(temp_dir)
-            
+
             assert isinstance(df, pd.DataFrame)
             # 2 processes per file * 2 files = 4 total
             assert len(df) == 4
-    
+
     def test_cjpg_parse_empty_page(self):
         """Test parsing an empty CJPG page."""
         html = '<html><body><div id="divDadosResultado"></div></body></html>'
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             df = cjpg_parse_single(temp_path)
             assert isinstance(df, pd.DataFrame)

--- a/tests/tjsp/test_cjsg_unit.py
+++ b/tests/tjsp/test_cjsg_unit.py
@@ -1,42 +1,40 @@
 """
 Unit tests for TJSP CJSG functionality using mocked HTML responses.
 """
-import sys
 import os
 import tempfile
+
 import pandas as pd
 import pytest
 
-# Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+from juscraper.courts.tjsp.cjsg_parse import _cjsg_parse_single_page, cjsg_n_pags, cjsg_parse_manager
 
-from src.juscraper.courts.tjsp.cjsg_parse import cjsg_n_pags, _cjsg_parse_single_page, cjsg_parse_manager
-from tests.tjsp.test_utils import load_sample_html
+from .test_utils import load_sample_html
 
 
 class TestCJSGNPages:
     """Test the cjsg_n_pags function."""
-    
+
     def test_extract_pages_from_results(self):
         """Test extracting page count from results HTML."""
         html = load_sample_html('cjsg_results.html')
         n_pags = cjsg_n_pags(html)
         # 45 results / 20 per page = 3 pages (rounded up)
         assert n_pags == 3
-    
+
     def test_extract_pages_from_single_result(self):
         """Test extracting page count from single result HTML."""
         html = load_sample_html('cjsg_single_result.html')
         n_pags = cjsg_n_pags(html)
         # 1 result / 20 per page = 1 page
         assert n_pags == 1
-    
+
     def test_extract_pages_missing_selector(self):
         """Test that missing pagination selector raises ValueError."""
         html = "<html><body><p>No pagination here</p></body></html>"
         with pytest.raises(ValueError, match="Não foi possível encontrar o seletor"):
             cjsg_n_pags(html)
-    
+
     def test_extract_pages_invalid_format(self):
         """Test that invalid pagination format raises ValueError."""
         html = '<html><body><td bgcolor="#EEEEEE">Invalid format</td></body></html>'
@@ -46,21 +44,21 @@ class TestCJSGNPages:
 
 class TestCJSGParseSinglePage:
     """Test the _cjsg_parse_single_page function."""
-    
+
     def test_parse_results_page(self):
         """Test parsing a results page with multiple processes."""
         html = load_sample_html('cjsg_results.html')
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             df = _cjsg_parse_single_page(temp_path)
-            
+
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 2  # Two processes in the sample
-            
+
             # Check first process
             assert df.iloc[0]['processo'] == '1000123-45.2023.8.26.0100'
             assert df.iloc[0]['cd_acordao'] == '12345'
@@ -68,49 +66,49 @@ class TestCJSGParseSinglePage:
             assert 'Apelação Cível' in df.iloc[0].get('classe', '')
             assert 'Direito do Consumidor' in df.iloc[0].get('assunto', '')
             assert 'ementa' in df.columns
-            
+
             # Check second process
             assert df.iloc[1]['processo'] == '1000124-46.2023.8.26.0101'
             assert df.iloc[1]['cd_acordao'] == '12346'
         finally:
             os.unlink(temp_path)
-    
+
     def test_parse_single_result(self):
         """Test parsing a page with a single result."""
         html = load_sample_html('cjsg_single_result.html')
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             df = _cjsg_parse_single_page(temp_path)
-            
+
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 1
-            
+
             assert df.iloc[0]['processo'] == '1000999-99.2024.8.26.0100'
             assert df.iloc[0]['cd_acordao'] == '99999'
             assert 'Apelação Cível' in df.iloc[0].get('classe', '')
             assert 'ementa' in df.columns
         finally:
             os.unlink(temp_path)
-    
+
     def test_parse_empty_page(self):
         """Test parsing an empty results page."""
         html = '<html><body><table></table></body></html>'
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             df = _cjsg_parse_single_page(temp_path)
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 0
         finally:
             os.unlink(temp_path)
-    
+
     def test_parse_missing_elements(self):
         """Test parsing page with missing elements."""
         html = '''
@@ -131,11 +129,11 @@ class TestCJSGParseSinglePage:
         </body>
         </html>
         '''
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             df = _cjsg_parse_single_page(temp_path)
             assert isinstance(df, pd.DataFrame)
@@ -147,63 +145,63 @@ class TestCJSGParseSinglePage:
 
 class TestCJSGParseManager:
     """Test the cjsg_parse_manager function."""
-    
+
     def test_parse_directory(self):
         """Test parsing multiple files from a directory."""
         html1 = load_sample_html('cjsg_results.html')
         html2 = load_sample_html('cjsg_single_result.html')
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             file1 = os.path.join(temp_dir, 'page1.html')
             file2 = os.path.join(temp_dir, 'page2.html')
-            
+
             with open(file1, 'w', encoding='utf-8') as f:
                 f.write(html1)
             with open(file2, 'w', encoding='utf-8') as f:
                 f.write(html2)
-            
+
             df = cjsg_parse_manager(temp_dir)
-            
+
             assert isinstance(df, pd.DataFrame)
             # 2 processes from first file + 1 from second = 3 total
             assert len(df) == 3
-    
+
     def test_parse_single_file(self):
         """Test parsing a single file."""
         html = load_sample_html('cjsg_results.html')
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             df = cjsg_parse_manager(temp_path)
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 2
         finally:
             os.unlink(temp_path)
-    
+
     def test_parse_empty_directory(self):
         """Test parsing an empty directory."""
         with tempfile.TemporaryDirectory() as temp_dir:
             df = cjsg_parse_manager(temp_dir)
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 0
-    
+
     def test_parse_with_invalid_file(self):
         """Test parsing directory with invalid file (should skip it)."""
         html = load_sample_html('cjsg_results.html')
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             valid_file = os.path.join(temp_dir, 'valid.html')
             invalid_file = os.path.join(temp_dir, 'invalid.html')
-            
+
             with open(valid_file, 'w', encoding='utf-8') as f:
                 f.write(html)
             # Create an invalid file (binary data)
             with open(invalid_file, 'wb') as f:
                 f.write(b'\x00\x01\x02\x03')
-            
+
             # Should not raise exception, should skip invalid file
             df = cjsg_parse_manager(temp_dir)
             assert isinstance(df, pd.DataFrame)
@@ -213,4 +211,3 @@ class TestCJSGParseManager:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/tjsp/test_cpopg.py
+++ b/tests/tjsp/test_cpopg.py
@@ -2,73 +2,66 @@
 Tests for TJSP CPOPG functionality.
 Includes both integration and unit tests.
 """
-import sys
 import os
 import tempfile
-import pytest
+
 import pandas as pd
+import pytest
 
-# Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
-
-try:
-    import juscraper
-except ImportError:
-    from src.juscraper import scraper as juscraper_scraper
-    juscraper = type('Module', (), {'scraper': juscraper_scraper})()
-
-from src.juscraper.courts.tjsp.cpopg_parse import (
+import juscraper
+from juscraper.courts.tjsp.cpopg_parse import (
     cpopg_parse_manager,
     cpopg_parse_single,
     cpopg_parse_single_html,
-    get_cpopg_download_links
+    get_cpopg_download_links,
 )
-from tests.tjsp.test_utils import load_sample_html, create_mock_response
+
+from .test_utils import create_mock_response, load_sample_html
 
 
 @pytest.mark.integration
 class TestCPOPGIntegration:
     """Integration tests for CPOPG that hit the real website."""
-    
+
     @pytest.fixture(autouse=True)
     def setup(self):
         """Set up test fixtures."""
         self.scraper = juscraper.scraper('tjsp')
         yield
-    
+
     def test_cpopg_single_process(self):
         """Test downloading a single process from CPOPG."""
         # Use a known process ID from the notebook example
         process_id = '1000149-71.2024.8.26.0346'
         results = self.scraper.cpopg(process_id, method='html')
-        
+
         assert isinstance(results, dict)
         assert 'basicos' in results
         assert 'partes' in results
         assert 'movimentacoes' in results
         assert 'peticoes_diversas' in results
-        
+
         # Check basic info
         assert isinstance(results['basicos'], pd.DataFrame)
         if len(results['basicos']) > 0:
             assert 'id_processo' in results['basicos'].columns
-    
+
     def test_cpopg_multiple_processes(self):
         """Test downloading multiple processes from CPOPG."""
         process_ids = ['1000149-71.2024.8.26.0346']
         results = self.scraper.cpopg(process_ids, method='html')
-        
+
         assert isinstance(results, dict)
         assert 'basicos' in results
         assert isinstance(results['basicos'], pd.DataFrame)
-    
+
     def test_cpopg_result_structure(self):
         """Test that CPOPG results have expected structure."""
         process_id = '1000149-71.2024.8.26.0346'
         results = self.scraper.cpopg(process_id, method='html')
-        
+
         assert isinstance(results, dict)
-        
+
         # All keys should be DataFrames
         for key, value in results.items():
             assert isinstance(value, pd.DataFrame), f"{key} should be a DataFrame"
@@ -76,7 +69,7 @@ class TestCPOPGIntegration:
 
 class TestCPOPGUnit:
     """Unit tests for CPOPG parsing functions."""
-    
+
     def test_get_cpopg_download_links_single_process(self):
         """Test extracting download links from single process page."""
         html = '''
@@ -89,11 +82,11 @@ class TestCPOPGUnit:
         '''
         mock_response = create_mock_response(html)
         links = get_cpopg_download_links(mock_response)
-        
+
         assert isinstance(links, list)
         assert len(links) > 0
         assert 'show.do' in links[0]
-    
+
     def test_get_cpopg_download_links_multiple_processes(self):
         """Test extracting download links from multiple processes page."""
         html = '''
@@ -108,10 +101,10 @@ class TestCPOPGUnit:
         '''
         mock_response = create_mock_response(html)
         links = get_cpopg_download_links(mock_response)
-        
+
         assert isinstance(links, list)
         assert len(links) >= 0
-    
+
     def test_cpopg_parse_single_html(self):
         """Test parsing a single CPOPG HTML file."""
         html = '''
@@ -125,7 +118,7 @@ class TestCPOPGUnit:
             <span id="juizProcesso">RENATA ESSER DE SOUZA</span>
             <div id="dataHoraDistribuicaoProcesso">06/02/2024 às 13:47 - Livre</div>
             <div id="valorAcaoProcesso">R$ 81.439,78</div>
-            
+
             <table id="tablePartesPrincipais">
                 <tr>
                     <td><span class="tipoDeParticipacao">Reqte</span></td>
@@ -136,7 +129,7 @@ class TestCPOPGUnit:
                     <td>BANCO BRADESCO S.A.<br>Advogado:<br>Fabio Cabral Silva</td>
                 </tr>
             </table>
-            
+
             <tbody id="tabelaTodasMovimentacoes">
                 <tr class="containerMovimentacao">
                     <td>05/02/2025</td>
@@ -149,7 +142,7 @@ class TestCPOPGUnit:
                     <td>Contrarrazões Juntada</td>
                 </tr>
             </tbody>
-            
+
             <h2 class="subtitle tituloDoBloco">Petições diversas</h2>
             <table>
                 <tr>
@@ -164,37 +157,37 @@ class TestCPOPGUnit:
         </body>
         </html>
         '''
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             result = cpopg_parse_single_html(temp_path)
-            
+
             assert isinstance(result, dict)
             assert 'basicos' in result
             assert 'partes' in result
             assert 'movimentacoes' in result
             assert 'peticoes_diversas' in result
-            
+
             # Check basic info
             assert result['basicos'].iloc[0]['id_processo'] == '1000149-71.2024.8.26.0346'
             assert 'Procedimento Comum Cível' in result['basicos'].iloc[0]['classe']
-            
+
             # Check partes
             assert len(result['partes']) == 2
             assert result['partes'].iloc[0]['tipo'] == 'Reqte'
-            
+
             # Check movimentacoes
             assert len(result['movimentacoes']) == 2
             assert '05/02/2025' in result['movimentacoes'].iloc[0]['data']
-            
+
             # Check peticoes
             assert len(result['peticoes_diversas']) == 2
         finally:
             os.unlink(temp_path)
-    
+
     def test_cpopg_parse_manager_directory(self):
         """Test parsing multiple CPOPG files from directory."""
         html = '''
@@ -205,33 +198,33 @@ class TestCPOPGUnit:
         </body>
         </html>
         '''
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             file1 = os.path.join(temp_dir, 'process1.html')
             file2 = os.path.join(temp_dir, 'process2.html')
-            
+
             with open(file1, 'w', encoding='utf-8') as f:
                 f.write(html)
             with open(file2, 'w', encoding='utf-8') as f:
                 f.write(html.replace('1000149', '1000150'))
-            
+
             result = cpopg_parse_manager(temp_dir)
-            
+
             assert isinstance(result, dict)
             assert 'basicos' in result
             assert len(result['basicos']) == 2
-    
+
     def test_cpopg_parse_empty_file(self):
         """Test parsing an empty CPOPG HTML file."""
         html = '<html><body></body></html>'
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             result = cpopg_parse_single_html(temp_path)
-            
+
             assert isinstance(result, dict)
             assert 'basicos' in result
             assert len(result['basicos']) == 1
@@ -482,4 +475,3 @@ class TestCPOPGUnit:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-

--- a/tests/tjsp/test_cposg.py
+++ b/tests/tjsp/test_cposg.py
@@ -2,61 +2,50 @@
 Tests for TJSP CPOSG functionality.
 Includes both integration and unit tests.
 """
-import sys
 import os
 import tempfile
-import pytest
+
 import pandas as pd
+import pytest
 
-# Add project root to path
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
-
-try:
-    import juscraper
-except ImportError:
-    from src.juscraper import scraper as juscraper_scraper
-    juscraper = type('Module', (), {'scraper': juscraper_scraper})()
-
-from src.juscraper.courts.tjsp.cposg_parse import (
-    cposg_parse_manager,
-    cposg_parse_single_html
-)
+import juscraper
+from juscraper.courts.tjsp.cposg_parse import cposg_parse_manager, cposg_parse_single_html
 
 
 @pytest.mark.integration
 class TestCPOSGIntegration:
     """Integration tests for CPOSG that hit the real website."""
-    
+
     @pytest.fixture(autouse=True)
     def setup(self):
         """Set up test fixtures."""
         self.scraper = juscraper.scraper('tjsp')
         yield
-    
+
     def test_cposg_single_process(self):
         """Test downloading a single process from CPOSG."""
         # Use a known process ID from the notebook example
         process_id = '00221752420038260344'
         results = self.scraper.cposg(process_id, method='html')
-        
+
         assert isinstance(results, pd.DataFrame)
         assert len(results) >= 0
-    
+
     def test_cposg_multiple_processes(self):
         """Test downloading multiple processes from CPOSG."""
         process_ids = ['00221752420038260344', '10001497120248260346']
         results = self.scraper.cposg(process_ids, method='html')
-        
+
         assert isinstance(results, pd.DataFrame)
         assert len(results) >= 0
-    
+
     def test_cposg_result_structure(self):
         """Test that CPOSG results have expected structure."""
         process_id = '00221752420038260344'
         results = self.scraper.cposg(process_id, method='html')
-        
+
         assert isinstance(results, pd.DataFrame)
-        
+
         if len(results) > 0:
             # Check for expected columns
             assert len(results.columns) > 0
@@ -69,7 +58,7 @@ class TestCPOSGIntegration:
 
 class TestCPOSGUnit:
     """Unit tests for CPOSG parsing functions."""
-    
+
     def test_cposg_parse_single_html(self):
         """Test parsing a single CPOSG HTML file."""
         html = '''
@@ -78,7 +67,7 @@ class TestCPOSGUnit:
             <a href="processo.codigo=1000149-71.2024.8.26.0346">1000149-71.2024.8.26.0346</a>
             <span class="unj-larger">1000149-71.2024.8.26.0346</span>
             <span class="unj-tag">Encerrado</span>
-            
+
             <div>
                 <span class="unj-label">Classe</span>
                 <div>Apelação Cível</div>
@@ -99,7 +88,7 @@ class TestCPOSGUnit:
                 <span class="unj-label">Relator</span>
                 <div>PAULO SERGIO MANGERONA</div>
             </div>
-            
+
             <tbody id="tabelaTodasMovimentacoes">
                 <tr class="movimentacaoProcesso">
                     <td>25/06/2025</td>
@@ -119,17 +108,17 @@ class TestCPOSGUnit:
         </body>
         </html>
         '''
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             result = cposg_parse_single_html(temp_path)
-            
+
             assert isinstance(result, list)
             assert len(result) == 1
-            
+
             row = result[0]
             assert row['id_original'] == '1000149-71.2024.8.26.0346'
             assert row['processo'] == '1000149-71.2024.8.26.0346'
@@ -140,7 +129,7 @@ class TestCPOSGUnit:
             assert len(row['movimentacoes']) == 2
         finally:
             os.unlink(temp_path)
-    
+
     def test_cposg_parse_manager_directory(self):
         """Test parsing multiple CPOSG files from directory."""
         html = '''
@@ -158,29 +147,29 @@ class TestCPOSGUnit:
         </body>
         </html>
         '''
-        
+
         with tempfile.TemporaryDirectory() as temp_dir:
             file1 = os.path.join(temp_dir, 'process1.html')
             file2 = os.path.join(temp_dir, 'process2.html')
-            
+
             with open(file1, 'w', encoding='utf-8') as f:
                 f.write(html)
             with open(file2, 'w', encoding='utf-8') as f:
                 f.write(html.replace('1000149', '1000150'))
-            
+
             result = cposg_parse_manager(temp_dir)
-            
+
             assert isinstance(result, pd.DataFrame)
             assert len(result) == 2
-    
+
     def test_cposg_parse_empty_file(self):
         """Test parsing an empty CPOSG HTML file."""
         html = '<html><body></body></html>'
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             result = cposg_parse_single_html(temp_path)
             # Should return empty list if no movement table
@@ -188,7 +177,7 @@ class TestCPOSGUnit:
             assert len(result) == 0
         finally:
             os.unlink(temp_path)
-    
+
     def test_cposg_parse_no_movement_table(self):
         """Test parsing CPOSG HTML without movement table."""
         html = '''
@@ -198,11 +187,11 @@ class TestCPOSGUnit:
         </body>
         </html>
         '''
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             result = cposg_parse_single_html(temp_path)
             # Should return empty list if no movement table
@@ -210,7 +199,7 @@ class TestCPOSGUnit:
             assert len(result) == 0
         finally:
             os.unlink(temp_path)
-    
+
     def test_cposg_parse_with_parts_and_decisions(self):
         """Test parsing CPOSG HTML with parts and decisions."""
         html = '''
@@ -218,14 +207,14 @@ class TestCPOSGUnit:
         <body>
             <span class="unj-larger">1000149-71.2024.8.26.0346</span>
             <span class="unj-tag">Encerrado</span>
-            
+
             <div id="tablePartesPrincipais">
                 <tr>
                     <td><span class="tipoDeParticipacao">Apelante</span></td>
                     <td>João Silva</td>
                 </tr>
             </div>
-            
+
             <div id="tabelaDecisoes">
                 <tr>
                     <td>24/05/2025</td>
@@ -233,7 +222,7 @@ class TestCPOSGUnit:
                     <td>Acórdão</td>
                 </tr>
             </div>
-            
+
             <tbody id="tabelaTodasMovimentacoes">
                 <tr class="movimentacaoProcesso">
                     <td>25/06/2025</td>
@@ -244,17 +233,17 @@ class TestCPOSGUnit:
         </body>
         </html>
         '''
-        
+
         with tempfile.NamedTemporaryFile(mode='w', suffix='.html', delete=False, encoding='utf-8') as f:
             f.write(html)
             temp_path = f.name
-        
+
         try:
             result = cposg_parse_single_html(temp_path)
-            
+
             assert isinstance(result, list)
             assert len(result) == 1
-            
+
             row = result[0]
             assert 'partes' in row
             assert 'decisoes' in row
@@ -266,4 +255,3 @@ class TestCPOSGUnit:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
-


### PR DESCRIPTION
## Summary

PR de pequenas correções mecânicas, agrupando 3 issues sem risco funcional.

- **#33** — `utils/__init__.py`: remove o `isinstance(filename, str)` redundante que conflitava com a anotação `filename: str` e fazia o mypy reclamar de "unreachable code" no pre-commit.
- **#59** — `utils/cnj.py::clean_cnj`: passa a usar regex `\D` para descartar qualquer caractere não-dígito (espaços, tabs, quebras de linha). Antes, números CNJ vindos de CSV/Excel com whitespace eram silenciosamente descartados pelo DataJud.
- **#88** — `tests/tjsp/`: removidos `sys.path.insert` e `from src.juscraper` dos 4 arquivos com o hack. Agora o código depende do install editável (`uv pip install -e ".[dev]"`) e usa imports relativos (`from .test_utils import ...`), conforme CLAUDE.md.

Inclui `tests/test_cnj.py` cobrindo a correção de `clean_cnj` (espaço, `\n`, `\t`, formato com whitespace).

## Test plan

- [x] `uv run pytest -m "not integration"` — 95 passados, 151 deselecionados
- [x] `uv run mypy src/juscraper/utils/__init__.py` — sem erros
- [x] `git grep -n "sys.path.insert\|from src\.juscraper" tests/` — sem matches

Closes #33
Closes #59
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)