### PR TITLE
fix(tjsp): tipos opcionais e limite de 120 chars no campo pesquisa (#30, #35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- TJSP CJPG/CJSG: validacao de tamanho do campo `pesquisa` antes da requisicao. O backend do eSAJ trunca strings com mais de 120 caracteres silenciosamente; agora `cjpg_download` e `cjsg_download` levantam `ValueError` acionavel quando o limite e excedido. Refs #35.
+
 ### Changed
 
 - eSAJ: `juscraper.utils.params.validate_intervalo_datas` aceita parametro `origem` (default `"O eSAJ"`) para reuso em tribunais nao-eSAJ com mensagem de erro correta. Janela maxima default aumentada de 365 para 366 dias para nao rejeitar cliente-side uma janela de 1 ano calendario que atravesse 29/02 (ex: `01/01/2024` -> `01/01/2025`).
@@ -14,6 +18,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- TJSP CJPG/CJSG: anotacoes de tipo dos parametros opcionais agora explicitam `| None` (antes eram `T = None` e disparavam erros do mypy `no_implicit_optional`). Refs #30.
 - eSAJ (TJSP cjpg/cjsg, TJAC/TJCE/TJMS/TJAM cjsg): validacao antecipada do intervalo entre `data_*_inicio` e `data_*_fim`. O eSAJ rejeita janelas maiores que 1 ano, mas antes o erro aparecia como "Nao foi possivel encontrar o seletor de numero de paginas" apos a requisicao ser feita. Agora um `ValueError` acionavel e lancado antes de qualquer HTTP, explicando o limite e orientando dividir a consulta em janelas menores (novo helper `juscraper.utils.params.validate_intervalo_datas`). Refs #91.
 - `juscraper.utils.cnj.clean_cnj`: agora remove qualquer caractere nao-digito (espacos, tabs, quebras de linha), nao apenas `.` e `-`. Numeros CNJ vindos de CSV/Excel com whitespace deixam de ser silenciosamente descartados pelo DataJud (refs #59).
 - `sanitize_filename`: removido `isinstance` redundante que conflitava com a anotacao de tipo e quebrava o pre-commit do mypy (refs #33).

--- a/src/juscraper/courts/tjsp/cjpg_download.py
+++ b/src/juscraper/courts/tjsp/cjpg_download.py
@@ -12,18 +12,23 @@ from tqdm import tqdm
 from ...utils.cnj import clean_cnj
 
 
+# Limite imposto pelo backend do eSAJ no campo "pesquisaLivre" do CJPG.
+# Strings maiores são truncadas silenciosamente pelo TJSP.
+_TJSP_PESQUISA_MAX_CHARS = 120
+
+
 def cjpg_download(
     pesquisa: str,
     session: requests.Session,
     u_base: str,
     download_path: str,
     sleep_time: float = 0.5,
-    classes: list[str] = None,
-    assuntos: list[str] = None,
-    varas: list[str] = None,
-    id_processo: str = None,
-    data_inicio: str = None,
-    data_fim: str = None,
+    classes: 'list[str] | None' = None,
+    assuntos: 'list[str] | None' = None,
+    varas: 'list[str] | None' = None,
+    id_processo: 'str | None' = None,
+    data_inicio: 'str | None' = None,
+    data_fim: 'str | None' = None,
     paginas: 'int | list | range | None' = None,
     get_n_pags_callback=None
 ):
@@ -31,7 +36,8 @@ def cjpg_download(
     Downloads cases from the TJSP jurisprudence search.
 
     Args:
-        pesquisa (str): The search query for the jurisprudence.
+        pesquisa (str): The search query for the jurisprudence. Maximum 120 characters
+            (TJSP backend limit).
         session (requests.Session): Authenticated session.
         u_base (str): Base URL of the ESAJ.
         download_path (str): Base directory for saving files.
@@ -45,6 +51,12 @@ def cjpg_download(
         paginas (range, optional): Page range (1-based, e.g., range(1, 4) downloads pages 1-3).
         get_n_pags_callback (callable): Callback function to extract number of pages.
     """
+    if pesquisa is not None and len(pesquisa) > _TJSP_PESQUISA_MAX_CHARS:
+        raise ValueError(
+            f"O campo 'pesquisa' do CJPG do TJSP aceita no máximo "
+            f"{_TJSP_PESQUISA_MAX_CHARS} caracteres (recebido: {len(pesquisa)}). "
+            "Reduza a busca ou divida em consultas menores."
+        )
     if assuntos is not None:
         assuntos = ','.join(assuntos)
     if varas is not None:

--- a/src/juscraper/courts/tjsp/cjsg_download.py
+++ b/src/juscraper/courts/tjsp/cjsg_download.py
@@ -13,19 +13,25 @@ from tqdm import tqdm
 logger = logging.getLogger("juscraper.cjsg_download")
 
 
+# Limite imposto pelo backend do eSAJ no campo "buscaInteiroTeor" do CJSG.
+# Strings maiores são truncadas silenciosamente pelo TJSP, levando a
+# resultados inesperados — preferimos abortar na origem.
+_TJSP_PESQUISA_MAX_CHARS = 120
+
+
 def cjsg_download(
     pesquisa: str,
     download_path: str,
     u_base: str,
     sleep_time: float = 0.5,
     verbose: int = 1,
-    ementa: str = None,
-    classe: str = None,
-    assunto: str = None,
-    comarca: str = None,
-    orgao_julgador: str = None,
-    data_inicio: str = None,
-    data_fim: str = None,
+    ementa: 'str | None' = None,
+    classe: 'str | None' = None,
+    assunto: 'str | None' = None,
+    comarca: 'str | None' = None,
+    orgao_julgador: 'str | None' = None,
+    data_inicio: 'str | None' = None,
+    data_fim: 'str | None' = None,
     baixar_sg: bool = True,
     tipo_decisao: str = 'acordao',
     paginas: 'int | list | range | None' = None,
@@ -33,12 +39,12 @@ def cjsg_download(
 ):
     """
     Downloads HTML files from the CJSG search results pages.
-    
+
     Uses requests library only, following the same approach as the R implementation.
     No browser automation is needed.
 
     Args:
-        pesquisa (str): Search term.
+        pesquisa (str): Search term. Maximum 120 characters (TJSP backend limit).
         download_path (str): Base directory for saving files.
         u_base (str): ESAJ base URL.
         sleep_time (float): Time to wait between requests.
@@ -49,6 +55,12 @@ def cjsg_download(
         paginas (range): Page range to download (1-based, e.g., range(1, 4) downloads pages 1-3).
         get_n_pags_callback (callable): Callback function to extract number of pages from HTML.
     """
+    if pesquisa is not None and len(pesquisa) > _TJSP_PESQUISA_MAX_CHARS:
+        raise ValueError(
+            f"O campo 'pesquisa' do CJSG do TJSP aceita no máximo "
+            f"{_TJSP_PESQUISA_MAX_CHARS} caracteres (recebido: {len(pesquisa)}). "
+            "Reduza a busca ou divida em consultas menores."
+        )
     if get_n_pags_callback is None:
         raise ValueError(
             'É necessário fornecer get_n_pags_callback para extrair o número de páginas.'

--- a/tests/tjsp/test_search_limit.py
+++ b/tests/tjsp/test_search_limit.py
@@ -1,0 +1,71 @@
+"""Limite de 120 caracteres do campo de busca no CJPG/CJSG do TJSP (refs #35)."""
+from unittest.mock import MagicMock
+
+import pytest
+
+from juscraper.courts.tjsp.cjpg_download import cjpg_download
+from juscraper.courts.tjsp.cjsg_download import cjsg_download
+
+
+def _is_length_guard_error(exc: BaseException) -> bool:
+    """True se o erro for o ValueError do guard de 120 chars (e não outro ValueError qualquer)."""
+    return (
+        isinstance(exc, ValueError)
+        and "pesquisa" in str(exc)
+        and "120" in str(exc)
+    )
+
+
+class TestCjpgSearchLimit:
+    def test_120_chars_passes_validation(self):
+        # 120 caracteres é exatamente o limite — o guard NÃO deve rejeitar.
+        # A execução prossegue e falha downstream (MagicMock / URL inválida);
+        # qualquer erro downstream é aceitável, desde que não seja o guard.
+        pesquisa = "a" * 120
+        with pytest.raises(Exception) as exc_info:
+            cjpg_download(
+                pesquisa=pesquisa,
+                session=MagicMock(),
+                u_base="https://example.invalid/",
+                download_path="/tmp",
+                get_n_pags_callback=None,
+            )
+        assert not _is_length_guard_error(exc_info.value), (
+            f"guard de 120 chars rejeitou indevidamente 120 caracteres: {exc_info.value}"
+        )
+
+    def test_121_chars_raises(self):
+        pesquisa = "a" * 121
+        with pytest.raises(ValueError, match="120 caracteres"):
+            cjpg_download(
+                pesquisa=pesquisa,
+                session=MagicMock(),
+                u_base="https://example.invalid/",
+                download_path="/tmp",
+                get_n_pags_callback=lambda r: 1,
+            )
+
+
+class TestCjsgSearchLimit:
+    def test_120_chars_passes_validation(self):
+        pesquisa = "a" * 120
+        with pytest.raises(Exception) as exc_info:
+            cjsg_download(
+                pesquisa=pesquisa,
+                download_path="/tmp",
+                u_base="https://example.invalid/",
+                get_n_pags_callback=None,
+            )
+        assert not _is_length_guard_error(exc_info.value), (
+            f"guard de 120 chars rejeitou indevidamente 120 caracteres: {exc_info.value}"
+        )
+
+    def test_121_chars_raises(self):
+        pesquisa = "a" * 121
+        with pytest.raises(ValueError, match="120 caracteres"):
+            cjsg_download(
+                pesquisa=pesquisa,
+                download_path="/tmp",
+                u_base="https://example.invalid/",
+                get_n_pags_callback=lambda r: 1,
+            )


### PR DESCRIPTION
## Summary

Duas correções pequenas no TJSP:

- **#30** — `cjpg_download.py` e `cjsg_download.py`: parâmetros opcionais agora têm anotação `T | None = None` em vez de `T = None`. Resolve os falsos positivos de mypy sobre `no_implicit_optional` e o conflito de tipos derivado.
- **#35** — Mesmos arquivos: o backend do eSAJ trunca o campo de busca em 120 caracteres silenciosamente. Agora ambos levantam `ValueError` antes de qualquer requisição quando o limite é excedido, apontando o tamanho recebido e sugerindo dividir a consulta.

## Test plan

- [x] `uv run pytest tests/tjsp/test_search_limit.py` — 4 passados (limite exato + acima)
- [x] `uv run pytest -m "not integration"` — 87 passados

Closes #30
Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)