### PR TITLE
docs(changelog): mover entradas pós-0.2.1 para [Unreleased] e reforçar CLAUDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- eSAJ: `juscraper.utils.params.validate_intervalo_datas` aceita parametro `origem` (default `"O eSAJ"`) para reuso em tribunais nao-eSAJ com mensagem de erro correta. Janela maxima default aumentada de 365 para 366 dias para nao rejeitar cliente-side uma janela de 1 ano calendario que atravesse 29/02 (ex: `01/01/2024` -> `01/01/2025`).
+
+### Fixed
+
+- eSAJ (TJSP cjpg/cjsg, TJAC/TJCE/TJMS/TJAM cjsg): validacao antecipada do intervalo entre `data_*_inicio` e `data_*_fim`. O eSAJ rejeita janelas maiores que 1 ano, mas antes o erro aparecia como "Nao foi possivel encontrar o seletor de numero de paginas" apos a requisicao ser feita. Agora um `ValueError` acionavel e lancado antes de qualquer HTTP, explicando o limite e orientando dividir a consulta em janelas menores (novo helper `juscraper.utils.params.validate_intervalo_datas`). Refs #91.
+
 ## [0.2.1] - 2026-04-13
 
 ### Fixed
 
 - TJSP CJPG: extracao do numero de paginas voltou a funcionar apos mudanca no HTML do tribunal. O texto da paginacao mudou de "Mostrando 1 a 10 de N resultados" para "Resultados 1 a 10 de N", e o regex antigo exigia a palavra "resultado" depois do numero. `cjpg_n_pags` agora usa estrategia robusta de seletor + regex em cascata (mesmo padrao de `cjsg_n_pags`), suportando ambos os formatos.
-- eSAJ (TJSP cjpg/cjsg, TJAC/TJCE/TJMS/TJAM cjsg): validacao antecipada do intervalo entre `data_*_inicio` e `data_*_fim`. O eSAJ rejeita janelas maiores que 1 ano, mas antes o erro aparecia como "Nao foi possivel encontrar o seletor de numero de paginas" apos a requisicao ser feita. Agora um `ValueError` acionavel e lancado antes de qualquer HTTP, explicando o limite e orientando dividir a consulta em janelas menores (novo helper `juscraper.utils.params.validate_intervalo_datas`). Refs #91.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,9 @@ Paginas de tribunais mudam estrutura sem aviso. Ao escrever logica que extrai co
 - Seguimos o padrao [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Toda mudanca relevante deve ser registrada em `CHANGELOG.md` sob `[Unreleased]`
 - Categorias: Added, Changed, Deprecated, Removed, Fixed, Security
+- **Secoes de versoes ja lancadas (`## [0.2.1]`, `## [0.2.0]`, ...) sao imutaveis.** Nunca adicionar, editar ou remover linhas dentro delas — elas descrevem o que foi publicado naquela tag. Toda entrada nova vai em `[Unreleased]`, mesmo que corrija algo introduzido na ultima versao.
+- **Antes de inserir uma entrada, confirme que ela cai *acima* do primeiro heading `## [x.y.z]` do arquivo** (ou seja, dentro de `[Unreleased]`). Se `[Unreleased]` estiver sem subsecoes (`### Added/Changed/Fixed/...`), crie a subsecao necessaria.
+- **Todo commit de `feat:`, `fix:`, `refactor:` ou `deprecated:` com efeito observavel pelo usuario deve incluir a entrada em `[Unreleased]` no mesmo commit** — nao em commit posterior. Mudancas puramente internas (testes, tipagem, rename de simbolo privado, docs) nao precisam.
 
 ## Documentacao
 


### PR DESCRIPTION
## Summary

- O fix do #91 (`b027dbe`, validação antecipada do intervalo de datas no eSAJ) foi inserido por engano dentro da seção `[0.2.1]` do `CHANGELOG.md`, que já havia sido publicada em 2026-04-13. Esta PR move a entrada de volta para `[Unreleased] Fixed`.
- O refactor do #95 (`af62055`, `origem` configurável + janela default de 365→366 dias para tolerar 29/02) não tinha entrada no changelog. Adiciona a linha em `[Unreleased] Changed`.
- `CLAUDE.md` ganha 3 regras explícitas na seção Changelog para evitar o mesmo erro no futuro: (1) seções de versões já lançadas são imutáveis, (2) conferir que a nova entrada cai dentro de `[Unreleased]` acima do primeiro heading `## [x.y.z]`, (3) toda mudança user-visible traz a entrada no mesmo commit.

## Test plan

- [ ] `git diff main -- CHANGELOG.md` mostra que a linha do eSAJ/#91 saiu de `[0.2.1]` e entrou em `[Unreleased] Fixed`, e que a nova linha do refactor do #95 aparece em `[Unreleased] Changed`.
- [ ] `[0.2.1]` continua com apenas o fix do `cjpg_n_pags` em `Fixed` (que foi o que de fato entrou na tag publicada) e a lista de scrapers novos em `Added`.
- [ ] Ler `CLAUDE.md §Changelog` e verificar que os 3 novos bullets deixam claras as regras de imutabilidade, posicionamento e mesmo-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)