### PR TITLE
test: Phase 1A.1 — contratos eSAJ para TJAC/TJAL/TJAM/TJCE/TJMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Contratos de teste offline para TJAC, TJAL, TJAM, TJCE e TJMS (`cjsg`). Cada tribunal ganhou `tests/<sigla>/test_cjsg_contract.py` cobrindo 3 cenarios (typical com paginacao, pagina unica, sem resultados), alimentados por samples HTML versionados em `tests/<sigla>/samples/cjsg/` e capturados via scripts em `tests/fixtures/capture/<sigla>.py`. Inclui teste de regressao para o adapter TLS `SECLEVEL=1` do TJCE. Primeira fatia da Fase 1 da politica de testes (refs #19, #104).
 - TJSP CJPG/CJSG: validacao de tamanho do campo `pesquisa` antes da requisicao. O backend do eSAJ trunca strings com mais de 120 caracteres silenciosamente; agora `cjpg_download` e `cjsg_download` levantam `QueryTooLongError` (subclasse de `ValueError`) quando o limite e excedido. Refs #35.
 
 ### Changed

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""juscraper test suite (root package)."""

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Test fixtures and sample-capture scripts (not imported by pytest itself)."""

--- a/tests/fixtures/capture/README.md
+++ b/tests/fixtures/capture/README.md
@@ -1,0 +1,62 @@
+# Scripts de captura de samples
+
+Scripts manuais que rodam contra os tribunais reais e salvam HTMLs crus em
+`tests/<tribunal>/samples/<endpoint>/`. Os samples alimentam os testes de
+contrato offline (`test_*_contract.py`) via `responses` + `load_sample_bytes`.
+
+Estes scripts **não são rodados pelo pytest**. São ferramentas de manutenção.
+
+## Quando rodar
+
+- Ao adicionar um scraper novo (gera a primeira leva de samples).
+- Quando um teste de contrato falha porque o tribunal mudou o layout HTML.
+- Periodicamente, em revisão de rotina, para garantir que os samples ainda
+  refletem a realidade.
+
+## Como rodar
+
+Da raiz do repositório, com o ambiente dev instalado:
+
+```bash
+python -m tests.fixtures.capture.tjac
+python -m tests.fixtures.capture.tjal
+python -m tests.fixtures.capture.tjam
+python -m tests.fixtures.capture.tjce
+python -m tests.fixtures.capture.tjms
+```
+
+Cada script:
+
+1. Faz 3 consultas contra o eSAJ do tribunal (typical com paginação, um
+   resultado, zero resultados).
+2. Grava os HTMLs em `tests/<tribunal>/samples/cjsg/`.
+3. Imprime no stdout quais arquivos escreveu.
+
+## Dependências
+
+- Somente `requests` (já nas deps do projeto).
+- Nada de captcha, browser ou auth — os eSAJ do TJAC/TJAL/TJAM/TJCE/TJMS
+  aceitam submissões anônimas.
+
+## Convenção de nomes
+
+Para cjsg, os arquivos gerados são:
+
+| Arquivo | Conteúdo |
+|---|---|
+| `cjsg/post_initial.html` | resposta crua do POST `resultadoCompleta.do` (descartada pelo parser; serve só para o teste mockar o par POST+GET) |
+| `cjsg/results_normal_page_01.html` | GET `trocaDePagina.do?pagina=1` para uma busca com múltiplas páginas |
+| `cjsg/results_normal_page_02.html` | idem página 2 |
+| `cjsg/single_page.html` | GET `?pagina=1` para busca cujos resultados cabem em 1 página (`n_pags == 1`) |
+| `cjsg/no_results.html` | GET `?pagina=1` para busca sem resultados |
+
+Ao mudar a convenção, atualizar este README e os contratos em conjunto.
+
+## Re-captura após falha de teste
+
+1. Reproduza a falha e identifique qual sample quebrou (via `pytest -x -s`).
+2. Rode o script do tribunal afetado.
+3. Revise o `git diff` dos samples para confirmar que a mudança é um upgrade
+   de layout legítimo, não ruído.
+4. Ajuste o parser ou o teste conforme necessário e commite sample + fix
+   juntos.

--- a/tests/fixtures/capture/__init__.py
+++ b/tests/fixtures/capture/__init__.py
@@ -1,0 +1,1 @@
+"""Manual scripts that hit live tribunals and dump samples for offline tests."""

--- a/tests/fixtures/capture/_util.py
+++ b/tests/fixtures/capture/_util.py
@@ -1,0 +1,191 @@
+"""Shared helpers for eSAJ sample-capture scripts.
+
+These scripts run against the live eSAJ platform and dump raw HTML to
+``tests/<tribunal>/samples/cjsg/`` for use by offline contract tests. They
+are NOT run during ``pytest`` — they are maintenance tools, invoked manually
+whenever a tribunal changes its HTML layout.
+
+Usage (from repo root)::
+
+    python -m tests.fixtures.capture.tjac
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+ESAJ_HEADERS = {
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Accept-Encoding": "gzip, deflate, br",
+    "Connection": "keep-alive",
+    "Upgrade-Insecure-Requests": "1",
+    "User-Agent": "juscraper/0.1 (https://github.com/jtrecenti/juscraper)",
+}
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def samples_dir_for(tribunal: str) -> Path:
+    """Return ``tests/<tribunal>/samples/cjsg/`` (created if needed)."""
+    dest = REPO_ROOT / "tests" / tribunal / "samples" / "cjsg"
+    dest.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def make_esaj_body(
+    pesquisa: str,
+    *,
+    tipo_decisao: str = "acordao",
+    origem: str = "T",
+) -> dict:
+    """Build the form body expected by ``cjsg/resultadoCompleta.do``.
+
+    Mirrors the body built by ``src/juscraper/courts/<tribunal>/cjsg_download.py``
+    so captured HTMLs reflect real scraper submissions.
+    """
+    tipo_param = "A" if tipo_decisao == "acordao" else "D"
+    return {
+        "conversationId": "",
+        "dados.buscaInteiroTeor": pesquisa,
+        "dados.pesquisarComSinonimos": "S",
+        "dados.buscaEmenta": "",
+        "dados.nuProcOrigem": "",
+        "dados.nuRegistro": "",
+        "agenteSelectedEntitiesList": "",
+        "contadoragente": "0",
+        "contadorMaioragente": "0",
+        "codigoCr": "",
+        "codigoTr": "",
+        "nmAgente": "",
+        "juizProlatorSelectedEntitiesList": "",
+        "contadorjuizProlator": "0",
+        "contadorMaiorjuizProlator": "0",
+        "codigoJuizCr": "",
+        "codigoJuizTr": "",
+        "nmJuiz": "",
+        "classesTreeSelection.values": "",
+        "classesTreeSelection.text": "",
+        "assuntosTreeSelection.values": "",
+        "assuntosTreeSelection.text": "",
+        "comarcaSelectedEntitiesList": "",
+        "contadorcomarca": "1",
+        "contadorMaiorcomarca": "1",
+        "cdComarca": "",
+        "nmComarca": "",
+        "secoesTreeSelection.values": "",
+        "secoesTreeSelection.text": "",
+        "dados.dtJulgamentoInicio": "",
+        "dados.dtJulgamentoFim": "",
+        "dados.dtRegistroInicio": "",
+        "dados.dtRegistroFim": "",
+        "dados.dtPublicacaoInicio": "",
+        "dados.dtPublicacaoFim": "",
+        "dados.origensSelecionadas": origem,
+        "tipoDecisaoSelecionados": tipo_param,
+        "dados.ordenacao": "dtPublicacao",
+    }
+
+
+def build_session(adapters: dict | None = None) -> requests.Session:
+    """Build a ``requests.Session`` with eSAJ headers preset.
+
+    ``adapters`` lets TJCE attach its ``SECLEVEL=1`` adapter without this
+    helper importing scraper-internal modules.
+    """
+    session = requests.Session()
+    session.headers.update(ESAJ_HEADERS)
+    if adapters:
+        for prefix, adapter in adapters.items():
+            session.mount(prefix, adapter)
+    return session
+
+
+def fetch_cjsg_pages(
+    session: requests.Session,
+    base_url: str,
+    pesquisa: str,
+    paginas: Iterable[int] = (1,),
+    *,
+    tipo_decisao: str = "acordao",
+    timeout: int = 60,
+) -> tuple[requests.Response, list[requests.Response]]:
+    """Submit a cjsg query and fetch the requested pages.
+
+    Mirrors the eSAJ scrapers' two-step flow (POST form, then GETs). Caller
+    decides which responses to save — this helper is agnostic.
+    """
+    tipo_param = "A" if tipo_decisao == "acordao" else "D"
+    post_url = f"{base_url}cjsg/resultadoCompleta.do"
+    body = make_esaj_body(pesquisa, tipo_decisao=tipo_decisao)
+
+    post_resp = session.post(post_url, data=body, timeout=timeout, allow_redirects=True)
+    post_resp.raise_for_status()
+
+    get_responses: list[requests.Response] = []
+    get_url = f"{base_url}cjsg/trocaDePagina.do"
+    for pag in paginas:
+        r = session.get(
+            get_url,
+            params={"tipoDeDecisao": tipo_param, "pagina": str(pag)},
+            headers={"Accept": "text/html; charset=latin1;", "Referer": post_url},
+            timeout=timeout,
+        )
+        r.encoding = "latin1"
+        r.raise_for_status()
+        get_responses.append(r)
+
+    return post_resp, get_responses
+
+
+def dump(path: Path, data: bytes) -> None:
+    """Write raw bytes to ``path``, creating parents."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def capture_cjsg_samples(
+    tribunal: str,
+    base_url: str,
+    *,
+    adapters: dict | None = None,
+    typical_query: str = "dano moral",
+    single_page_query: str = "usucapiao extraordinario predio rural familia",
+    no_results_query: str = "juscraper_probe_zero_hits_xyzqwe",
+    typical_pages: tuple[int, ...] = (1, 2),
+) -> None:
+    """Run three canonical cjsg queries and dump raw HTML.
+
+    Writes to ``tests/<tribunal>/samples/cjsg/``:
+
+    - ``post_initial.html`` — POST response (reused across scenarios)
+    - ``results_normal_page_NN.html`` — typical multi-page
+    - ``single_page.html`` — query whose hits fit in one page (n_pags == 1)
+    - ``no_results.html`` — zero-hit page
+
+    Defaults are hand-picked to yield ≤20 hits across the five eSAJ courts
+    in scope (TJAC/TJAL/TJAM/TJCE/TJMS). Override per-script if a layout
+    refresh breaks the default.
+    """
+    dest = samples_dir_for(tribunal)
+    session = build_session(adapters=adapters)
+
+    post_resp, get_resps = fetch_cjsg_pages(
+        session, base_url, typical_query, paginas=typical_pages
+    )
+    dump(dest / "post_initial.html", post_resp.content)
+    for pag, resp in zip(typical_pages, get_resps):
+        dump(dest / f"results_normal_page_{pag:02d}.html", resp.content)  # noqa: E231
+    print(f"[{tribunal}] typical ({typical_query!r}) → {len(get_resps)} page(s)")
+
+    _, single_resps = fetch_cjsg_pages(session, base_url, single_page_query, paginas=(1,))
+    dump(dest / "single_page.html", single_resps[0].content)
+    print(f"[{tribunal}] single_page ({single_page_query!r}) → saved")
+
+    _, none_resps = fetch_cjsg_pages(session, base_url, no_results_query, paginas=(1,))
+    dump(dest / "no_results.html", none_resps[0].content)
+    print(f"[{tribunal}] no_results ({no_results_query!r}) → saved")
+
+    print(f"[{tribunal}] ALL samples written to {dest}")

--- a/tests/fixtures/capture/tjac.py
+++ b/tests/fixtures/capture/tjac.py
@@ -1,0 +1,19 @@
+"""Capture cjsg samples for TJAC.
+
+Run from repo root::
+
+    python -m tests.fixtures.capture.tjac
+"""
+from ._util import capture_cjsg_samples
+
+
+def main() -> None:
+    """Capture cjsg samples for TJAC."""
+    capture_cjsg_samples(
+        tribunal="tjac",
+        base_url="https://esaj.tjac.jus.br/",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/capture/tjal.py
+++ b/tests/fixtures/capture/tjal.py
@@ -1,0 +1,19 @@
+"""Capture cjsg samples for TJAL.
+
+Run from repo root::
+
+    python -m tests.fixtures.capture.tjal
+"""
+from ._util import capture_cjsg_samples
+
+
+def main() -> None:
+    """Capture cjsg samples for TJAL."""
+    capture_cjsg_samples(
+        tribunal="tjal",
+        base_url="https://www2.tjal.jus.br/",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/capture/tjam.py
+++ b/tests/fixtures/capture/tjam.py
@@ -1,0 +1,19 @@
+"""Capture cjsg samples for TJAM.
+
+Run from repo root::
+
+    python -m tests.fixtures.capture.tjam
+"""
+from ._util import capture_cjsg_samples
+
+
+def main() -> None:
+    """Capture cjsg samples for TJAM."""
+    capture_cjsg_samples(
+        tribunal="tjam",
+        base_url="https://consultasaj.tjam.jus.br/",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/capture/tjce.py
+++ b/tests/fixtures/capture/tjce.py
@@ -1,0 +1,26 @@
+"""Capture cjsg samples for TJCE.
+
+TJCE requires TLS ``SECLEVEL=1`` (see
+``src/juscraper/courts/tjce/cjsg_download.py::_TJCETLSAdapter``). This script
+mounts the same adapter so captures succeed end-to-end.
+
+Run from repo root::
+
+    python -m tests.fixtures.capture.tjce
+"""
+from juscraper.courts.tjce.cjsg_download import _TJCETLSAdapter
+
+from ._util import capture_cjsg_samples
+
+
+def main() -> None:
+    """Capture cjsg samples for TJCE (uses the SECLEVEL=1 TLS adapter)."""
+    capture_cjsg_samples(
+        tribunal="tjce",
+        base_url="https://esaj.tjce.jus.br/",
+        adapters={"https://": _TJCETLSAdapter()},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/capture/tjms.py
+++ b/tests/fixtures/capture/tjms.py
@@ -1,0 +1,19 @@
+"""Capture cjsg samples for TJMS.
+
+Run from repo root::
+
+    python -m tests.fixtures.capture.tjms
+"""
+from ._util import capture_cjsg_samples
+
+
+def main() -> None:
+    """Capture cjsg samples for TJMS."""
+    capture_cjsg_samples(
+        tribunal="tjms",
+        base_url="https://esaj.tjms.jus.br/",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tjac/samples/cjsg/no_results.html
+++ b/tests/tjac/samples/cjsg/no_results.html
@@ -1,0 +1,18 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(0)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="0" />
+
+
+
+			<div align="center" class="ementaClass" style="padding: 80px;">
+				<strong>
+					Não foi encontrado nenhum resultado correspondente à busca realizada.
+				</strong>
+			</div>

--- a/tests/tjac/samples/cjsg/post_initial.html
+++ b/tests/tjac/samples/cjsg/post_initial.html
@@ -1,0 +1,8668 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Nodo 2 -->
+
+<html>
+	<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+
+
+
+
+
+
+
+
+
+
+
+	<script language="javascript" type="text/JavaScript" src="https://esaj.tjac.jus.br/sajcas/verificarLogin.js?script=1776718186272"></script>
+
+	<script language="javascript">
+		if(window.sajcas && window.sajcas.usuarioLogadoNoCasServer) {
+			var urlRetornoSistema = 'https://esaj.tjac.jus.br/cjsg/consultaCompleta.do';
+			if(urlRetornoSistema === '') {
+				urlRetornoSistema = window.location.href;
+			}
+
+			if(urlRetornoSistema.lastIndexOf('?') != -1) {
+				urlRetornoSistema += '&';
+			} else {
+				urlRetornoSistema += '?';
+			}
+			urlRetornoSistema+= 'gateway=true';
+			window.location.href = urlRetornoSistema;
+		}
+	</script>
+
+
+
+
+
+
+
+
+
+
+	<title>Consulta de Jurisprudência do Segundo Grau</title>
+	<script>
+		window.saj = window.saj || {};
+		window.saj.env = window.saj.env || {};
+		window.saj.env.root = '/cjsg';
+		window.saj.env.css = '/cjsg/css';
+		window.saj.env.js = '/cjsg/js';
+		window.saj.env.imagens = '/cjsg/imagens';
+		window.saj.env.cliente = 'AC';
+	</script>
+ 	<script src="/cjsg/js/jquery/jquery.min.js?n=b5d78a2c-2a08-468c-99ae-3769404dce38"></script>
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/saj/saj-web-2.2.41-4.js?n=6951c1f3-a82b-4673-9bb6-d52002a59308"></script>
+
+
+ 	<script>var localeJS = "pt_BR"; </script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMsg.js"></script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMap_pt.js"></script>
+	<script src="/cjsg/js/jquery/jquery.browser.min.js?n=74a8f43c-7969-44ab-8fbf-ca28740913d2"></script>
+ 	<script src="/cjsg/js/spw/spwConcatenado.js?n=27c52ebe-9241-4c43-a21b-3ddbc0b7d1df"></script>
+ 	<link href="/cjsg/css/spw/spwConcatenado.css" rel="stylesheet" type="text/css" />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+<meta http-equiv="pragma" content="no-cache"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<meta http-equiv="expires" content="0"/>
+
+<link href="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/css/esajComum.css" rel="stylesheet" type="text/css" />
+<link href="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/css/esajLayout.css" rel="stylesheet" type="text/css" />
+<link href="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/clientes/AC/css/esajLayoutAC.css" rel="stylesheet" type="text/css" />
+
+<style type="text/css">
+<!--
+/* botao default means o mais claro, que seria o "botï¿½o principal" */
+.spwBotaoDefault, .spwBotaoDefault-o {
+	background-image: url(https://esaj.tjac.jus.br/esaj-layout/tema/padrao/clientes/AC/imagens/layout/fundoBotaoDefault.gif);
+}
+/* o botao secundario, menos provavel de ser clicado, mais escuro */
+.spwBotao, .spwBotao-o {
+	background-image: url(https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/fundoBotao.gif);
+}
+-->
+</style>
+
+
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/js/menu.js?n=2553626853"></script>
+
+<link rel="shortcut icon" href="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/clientes/AC/imagens/favicon.ico" type="image/x-icon" />
+
+
+
+
+<script>
+    var dict = {
+        'certificado.tituloCertificadoDigital': 'Certificado digital',
+        'certificado.msgCarregandoCertificado': 'Carregando certificados...',
+        'certificado.msgNenhumCertificadoEncontrado': 'Nenhum certificado encontrado',
+        'certificado.msgErroCarregarCertificado': 'Erro ao carregar certificados',
+        'certificado.msgCertificadoExpirado': '[Expirado]',
+        'certificado.msgCertificadoNaoValido': '[Ainda não válido]',
+        'certificado.msgCertificadoNaoIcpBrasil': '[Não ICP-Brasil]',
+        'certificado.tituloProblemasAoAssinar': 'Falha de comunicação com o dispositivo de assinatura digital',
+
+        'label.contato': 'Contato',
+        'label.identificarSe': 'Identificar-se ',
+
+        'mensagem.aguarde': 'Por favor, aguarde.',
+        'mensagem.paginaNaoCarregada': 'Não foi possível carregar a página.',
+        'mensagem.marcarLido': 'Marcar como lido',
+        'mensagem.registrosSelecionados': 'Registros selecionados',
+        'mensagem.registroJaSelecionado': 'Este registro já está selecionado',
+
+        'mensagem.data.invalida': 'A data digitada é inválida.',
+        'mensagem.data.anoInvalido': 'O ano informado deve ser maior que',
+        'mensagem.data.mesInvalido': 'O mês não pode ser maior que 12.',
+        'mensagem.data.mes': 'O mês',
+        'mensagem.data.mesMaior29dias': 'não pode ter mais que 29 dias.',
+        'mensagem.data.mesMaior28dias': 'não pode ter mais que 28 dias.',
+        'mensagem.data.mesMaior31dias': 'não pode ter mais que 31 dias.',
+        'mensagem.data.mesMaior30dias': 'não pode ter mais que 30 dias.',
+
+        'mensagem.email.invalido': 'O formato do endereço de e-mail não é válido. Verifique se ele tem o formato "usuario@dominio".',
+        'mensagem.email.caracteresInvalidos': 'O endereço de e-mail possui caracteres inválidos',
+        'mensagem.email.usuarioInvalido': 'O formato do usuário informado no endereço de e-mail não é válido.',
+        'mensagem.email.ipInvalido': 'O endereço IP informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioInvalido': 'O formato do domínio informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioIncompleto': 'O domínio informado no endereço de e-mail deve possuir pelo menos duas partes. Por exemplo: "usuario@empresa.com.br".',
+
+        'mensagem.texto.tamanhoInvalido': 'O tamanho do texto digitado é maior do que o tamanho permitido. Tamanho permitido:',
+        'mensagem.texto.caracter': 'O caracter',
+        'mensagem.texto.caracterPosicaoInvalida': 'não está permitido na posição',
+
+        'mensagem.numero.numeroInvalido': 'O valor digitado não é um número válido.',
+        'mensagem.numero.numeroNaoPodeCasasDecimais': 'O número não pode conter casas decimais',
+        'mensagem.numero.numeroCasaDecimaisInvalidas': 'O número de casas decimais é inválido. O número pode conter apenas',
+        'mensagem.numero.casaDecimais': 'casas decimais',
+        'mensagem.numero.numeroInteiroInvalido': 'O número de dígitos inteiros é inválido. O número pode conter apenas',
+        'mensagem.numero.digitosInteiros': 'dígitos inteiros',
+        'mensagem.numero.numeroTamanhoInvalido': 'O número digitado não pode ser maior que',
+        'mensagem.numero.numeroZeroInvalido': 'O número digitado deve ser diferente de zero.'
+    }
+</script>
+
+
+
+
+
+
+
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/cjsg-2.2.5-0.js?n=260410155"></script>
+ 	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/AC/cjsg.css" />
+	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/AC/link.css" />
+
+
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/spw/spwTab.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-popup-modal.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-tree.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/cjsg.css" />
+
+
+		<script type="text/JavaScript" src="/cjsg/js/jquery/jquery.blockUI.min.js?n=c5ffc7ba-4326-4414-b73c-417e0a6d4191"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tooltip.js?n=df275a5c-c641-4c60-a60c-034d4d36a519"></script>
+		<script type="text/JavaScript" src="/cjsg/js/spw/spwTab.js?n=2803951349"></script>
+		<script type="text/javascript" src="/cjsg/js/saj/saj-popup-modal-1.0.0-1.js?n=ad7b132a-be56-48a3-a7dc-68ed4400000d"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-popup.js?n=2538966893"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tree-2.5.1-1.js?n=13698285-becd-4e70-9ec7-27800642f308"></script>
+
+		<!-- remover valor da versao na proxima versao do sistema -->
+		<script type="text/JavaScript" src="/cjsg/js/filtrosLaterais.js?n=2874483102?c=123"></script>
+		<script type="text/JavaScript" src="/cjsg/jsp/completa/consultaCompleta.js?n=769933514"></script>
+	</head>
+
+	<body style="margin: 0px;">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoCliente" summary=" " role="presentation">
+	<tr>
+		<td><a href="http://www.tjac.jus.br"><img src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/clientes/AC/imagens/layout/cabecalhoLogo.jpg" width="462" height="65" alt="Poder Judici&ccedil;rio do Estado do Acre - TRIBUNAL DE JUSTI&Ccedil;A" /></a></td>
+		<td align="right" valign="top"><img src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/clientes/AC/imagens/layout/cabecalhoImagem.jpg" alt=" " width="407" height="64" /></td>
+	</tr>
+</table>
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/js/libras.js?n=369456521"></script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- cabecalho e-Saj -->
+<table width="100%" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoServico" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaCabecalhoServicoLogo">
+
+
+
+
+<a href="https://esaj.tjac.jus.br/esaj-layout/redirecionarNovoEsaj.do"><img src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServico.gif" title="Voltar para página inicial do e-SAJ" alt="Voltar para página inicial do e-SAJ" width="255" height="53" border="0" /></a><img src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServicoInf.gif" alt=" " width="255" height="28" border="0" />
+</td>
+		<td class="esajCelulaCabecalhoServicoMenu">
+		    <table width="100%" border="0" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+				<tr>
+					<td align="right">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Devido ao alinhamento inline das imagens, elas nÃ£o podem ter nenhum tipo de espaÃ§amento entre elas, portanto Ã© necessÃ¡rio finalizar a linha iniciando um comentÃ¡rio e fechar o comentÃ¡rio imediatamente antes da abertura da nova tag-->
+<img height="24" width="47" alt=" " src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/inicioMenuSup.jpg"/><a href="https://esaj.tjac.jus.br/caixapostal/"><!--
+
+    --><img height="24" width="83" border="0" alt="Caixa Postal" src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/caixaPostal.gif"/></a><!--
+    --><img height="24" width="4" alt=" " src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a href="https://esaj.tjac.jus.br/esaj/cadastro.do"><!--
+
+--><img src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/cadastro.gif" alt="Cadastro" width="81" height="24" border="0" /></a><!--
+
+
+    --><img height="24" width="4" alt=" " src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a target="blank" href="https://esaj.tjac.jus.br/WebHelp/"><!--
+    --><img height="24" width="61" border="0" alt="Ajuda do e-Saj" src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/ajuda.gif"/></a><!--
+
+
+-->
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaIdentificacaoServico" >
+
+
+
+
+<style>
+
+    td.esajCelulaIdentificacao, td.esajCelulaIdentificacaoServico {
+        position: relative;
+    }
+
+    button.escolhaBeta {
+        border: 0;
+        background: #0078D7;
+        color: #fff;
+        margin-right: 5px;
+        font-family: verdana;
+        font-size: 12px;
+        height: 27px;
+        line-height: 14px;
+        border-radius: 0;
+        text-shadow: 1px 1px 1px #797979;
+        position: absolute;
+        top: 30px;
+        right: 3px;
+        padding: 7px 12px;
+        cursor: pointer;
+    }
+
+    button.escolhaBeta:hover {
+        background-color: #0b5c9c;
+    }
+</style>
+
+<span id="identificacao"></span>
+
+<button style="display: none" class="escolhaBeta"></button>
+
+
+
+
+
+
+        <script language="javascript" type="text/JavaScript" src="https://esaj.tjac.jus.br/sajcas/conteudoIdentificacao?script=1776677809508"></script>
+
+
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaCabecalhoServicoCaminho" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<a href="" class="esajCaminhoLink"></a>
+
+ &gt;
+
+
+<a href="https://esaj.tjac.jus.br/esaj?servico=740000" class="esajCaminhoLink">Bem-vindo</a>
+
+ &gt;
+
+
+<a href="https://esaj.tjac.jus.br/esaj?servico=190090" class="esajCaminhoLink">Consultas</a>
+
+ &gt;
+
+
+<a href="https://esaj.tjac.jus.br/esaj?servico=780000" class="esajCaminhoLink">Jurisprudência</a>
+
+ &gt;
+
+
+
+Consulta Completa
+</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+<!-- CONTEUDO -->
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaTitulo" role="presentation">
+	<tr>
+		<td class="esajCelulaMenuSuspenso">
+		<a href="#" onclick="return showMenuSuspenso()"><img src="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSuspenso.gif" alt="Menu de servi&ccedil;os" width="243" height="21" style="display:block" /></a>
+		<div id="layerMenu" style="display:none">
+
+
+<!-- MENU -->
+<ul id="esajMenuArea">
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Consultas</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cpopg/open.do">Processos de 1º Grau</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Pauta de Julgamento</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/pauta-julgamento/consulta">Consulta das Pautas de Julgamento de Segundo Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/pauta-julgamento/sustentacao">Solicitação de Preferência de Julgamento</a></li>
+</ul>
+  </li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cposg5/open.do">Consulta de Processos de 2º Grau</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Ordem de Processos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoMagistradoSgCr.do">null</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoMagistradoSgCr.do">null</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoPg.do">Julgamento de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeAtoPg.do">Publicação e Cumprimento de Atos de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoSgTj.do">Julgamento de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeAtoSgTj.do">Publicação de Cumprimento de Atos de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoSgCr.do">Julgamento do Colégio Recursal e Turma de Uniformização</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cop/abrirConsultaDeOrdemDeAtoSgCr.do">Publicação e Cumprimento de Atos do Colégio Recursal e Turma de Uniformização</a></li>
+</ul>
+  </li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cpa/">Pauta de Audiência</a></li>
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Jurisprudência</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cjsg/consultaSimples.do">Simples</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/cjsg/consultaCompleta.do">Completa</a></li>
+</ul>
+  </li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/pauta-julgamento-virtual">Pauta de Julgamento Virtual do Segundo Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Recolhimento de Custas</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=1&flTipoCusta=0&cdServicoCalculoCusta=690003">Taxa Judiciária (COM previsão de acordo)</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=6&flTipoCusta=1&cdServicoCalculoCusta=690007">Custas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=14&flTipoCusta=0&cdServicoCalculoCusta=690009">Taxa Judiciária (SEM previsão de acordo)</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=9&flTipoCusta=5&cdServicoCalculoCusta=690002">Custas de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=15&flTipoCusta=0&cdServicoCalculoCusta=690012">Cartas Precatórias e Assemelhados</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/abrirConsultaCustas.do">Consulta de Custas</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=12&flTipoCusta=0&cdServicoCalculoCusta=690008">Ações e Procedimenos Penais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=5&flTipoCusta=5&cdServicoCalculoCusta=690006">Atos Avulsos</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=3&flTipoCusta=1&cdServicoCalculoCusta=690005">Custas Intermediárias</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petpg/abrirNovaPeticaoInicial.do?instancia=PG">Peticionamento Inicial de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petpg/abrirNovaPeticaoIntermediaria.do?instancia=PG">Peticionamento Intermediário de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petpg/abrirConsultaPeticoes.do">Consulta de Petições de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petcr/abrirNovaPeticaoIntermediaria.do?instancia=CR">Peticionamento Intermediário nas Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petcr/abrirConsultaPeticoes.do">Consulta de Petições nas Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petsg/abrirNovaPeticaoInicial.do?instancia=SG">Peticionamento Inicial de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petsg/abrirNovaPeticaoIntermediaria.do?instancia=SG">Peticionamento Intermediário de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/petsg/abrirConsultaPeticoes.do">Consulta de Petições de 2º Grau</a></li>
+</ul>
+  </li>
+  <li class="esajMenuFechado"><a href="https://esaj.tjac.jus.br/push/">Push - Acompanhar Processo Judicial</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Intimação e Citação Eletrônica</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/intimacoesweb/abrirConsultaAtosNaoRecebidos.do">Recebimento</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/intimacoesweb/abrirConsultaAtosRecebidos.do">Consulta das Recebidas</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Certidões</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/sco/abrirCadastro.do">Pedido de Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/sco/abrirDownload.do">Baixar Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/sco/abrirConferencia.do">Conferência de Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/scosg/abrirCadastro.do">Pedido de Certidão de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/scosg/abrirDownload.do">Baixar Certidão de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/scosg/abrirConferencia.do">Conferência de Certidão de 2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Conferência de Documentos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/pastadigital/pg/abrirConferenciaDocumento.do">Documento Digital de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjac.jus.br/pastadigital/sg/abrirConferenciaDocumento.do">Documento Digital de 2º Grau</a></li>
+</ul>
+  </li>
+  <li class="esajMenuFechado"><a href="https://esaj.tjac.jus.br/esajperfil/abrirAdministracaoDeUsuario.do">Administração de Convênio</a></li>
+</ul>
+
+		</div>
+		</td>
+		<td class="esajCelulaTituloServico"><h1 class="esajTituloPagina">Consulta Completa</h1></td>
+	</tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaConteudoServico" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <span class="esajTituloOrientacoes">Orientações</span>
+
+
+
+
+            <ul class="esajUlOrientacoes" id="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<li>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Para detalhes sobre cada campo de busca, selecione o campo específico.
+
+
+
+	</li>
+
+
+
+
+            </ul>
+
+
+
+
+    <br>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<form name="consultaCompletaForm" method="post" action="/cjsg/resultadoCompleta.do;jsessionid=C2FF44D7F09DDD96EC5DE8D0D95016E7.cjsg2" autocomplete="off" enctype="" onsubmit="return applySubmit(this, eval('function spwSubmit(t, e){decodificaInputMulSelOnSubmit();if (!IS_enableSubmit) return false; return BENV_isCamposValidos(t); } spwSubmit(this, event);'));" id="" target="">
+	<input type="hidden" name="conversationId" value="">
+
+
+
+
+
+<div style="display: none;">
+
+	<div id="inteiroTeor">
+		<b>"Pesquisa Livre"</b> <br />Busca acórdãos que contenham as <br /> palavras/expressões desejadas no seu inteiro teor.
+	</div>
+
+	<div id="ementa">
+		<b>"Ementa"</b><br>Busca acórdaos que contenham as palavras/express&otilde;es<br />desejadas na ementa do acórdão.
+	</div>
+
+	<div id="classesTooltip">
+		<b>"Classe"</b><br />Busca decisões que sejam de uma determinada classe processual.<br> Exemplo: Ação Penal.
+	</div>
+
+	<div id="assuntosTooltip">
+		<b>"Assuntos"</b><br />Busca acórdãos que sejam de um determinado assunto.
+	</div>
+
+	<div id="secoesTooltip">
+		<b>"Orgão julgadores"</b><br /> Busca acórdãos que sejam de uma determinado orgão julgador.
+	</div>
+
+	<div id="dtJulgamentoInicioTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtJulgamentoFimTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoInicioTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoFimTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroInicioTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroFimTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="orgaoJulgador">
+		<b>"Órgão Julgador"</b><br />Busca acórdãos que sejam de um determinado órgão julgador.<br />Exemplo: 10ª Câmara de Direito Público.
+	</div>
+
+	<div id="comarcaTooltip">
+		<b>"Comarca"</b><br>Busca acórdãos que sejam de uma determinada comarca de origem.<br> Exemplo: São Paulo.
+	</div>
+
+	<div id="agenteTooltip">
+		<b>"Relator"</b><br>Busca acórdãos que sejam de um determinado relator.
+	</div>
+
+	<div id="juizProlatorTooltip">
+		<b>"Juiz prolator"</b><br>Busca acórdãos para o juiz prolator selecionado.<br />
+	</div>
+
+	<div id="nuRegistro">
+		<b>&quot;N&uacute;mero do Registro&quot;</b><br>Busca acórdãos que tenham sido registrados<br />com o número informado.
+	</div>
+
+	<div id="nuProcOrigem">
+		<b>"Número do recurso"</b><br/>Busca acórdãos que se referem ao<br/>número de recurso informado.
+	</div>
+
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Consulta Completa
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaInteiroTeor';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="top">
+
+
+
+
+				<label for="iddados.buscaInteiroTeor" class="" style="float:left;font-weight:bold;margin-top:3px;">Pesquisa livre</label><div style="text-align:right;font-weight:bold;margin-top:3px;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="top">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaInteiroTeor" size="100" value="dano moral" formatType="TEXT" formato="120" obrigatorio="" rotulo="Pesquisa livre" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaInteiroTeor" title="" alt="">
+
+
+
+
+
+
+
+						<div class="botoesOperadores" style="margin-top: 3px;">
+							<input type="button" value=" E " name="E" />
+							<input type="button" value=" OU " name="OU" />
+							<input type="button" value=" N&Atilde;O " name="NAO" />
+							<input type="button" value='"&nbsp;&nbsp;"' name="ASP" />
+							<a style="font-size: 11px; font-weight: bold; padding-left: 10px; padding-right: 2px;" href="https://esaj.tjac.jus.br/WebHelp//#id_operadores_logicos.htm" target="_blank">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="">
+
+
+
+	<span id="">Como utilizar os filtros</span>
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+							</a>
+							<input type="checkbox" name="dados.pesquisarComSinonimos" value="S" checked="checked" uncheckedValue="N"  onclick="CH_updateHiddenValue(this);" style="width: 10px" id="checkBoxSinonimos"><input type="hidden" value="S" name="dados.pesquisarComSinonimos" inputCheckBox="true">
+							<label for="checkBoxSinonimos" >
+								Pesquisar por sinônimos
+							</label>
+							&nbsp;&nbsp;&nbsp;
+						</div>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Pesquisa por campos específicos
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaEmenta';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.buscaEmenta" class="" style="float:left;font-weight:bold;">Ementa</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaEmenta" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Ementa" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaEmenta" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuProcOrigem';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.nuProcOrigem" class="" style="float:left;font-weight:bold;">Número do recurso</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuProcOrigem" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do recurso" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuProcOrigem" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuRegistro';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.nuRegistro" class="" style="float:left;font-weight:bold;">Número do registro</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuRegistro" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do registro" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuRegistro" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.relator" class="" style="float:left;font-weight:bold;">Relator(a)</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var agenteNomeCamposArray = new Array();
+ agenteNomeCamposArray[0] = 'codigoCr';
+ agenteNomeCamposArray[1] = 'codigoTr';
+ agenteNomeCamposArray[2] = 'nmAgente';
+ var codigoCrNomeCamposArray = agenteNomeCamposArray;
+ var codigoTrNomeCamposArray = agenteNomeCamposArray;
+ var nmAgenteNomeCamposArray = agenteNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="agente" idPai="null" filtroPai="null" url="jsp/search/searchAgente.jsp" input-select="agente" property="dados.agentes" name="codigoCr" title="Relatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="agenteSelectedEntitiesList"  value="" id="agenteSelectedEntitiesList" />
+<input type="hidden" name="contadoragente"  value="0" id="contadoragente" />
+<input type="hidden" name="contadorMaioragente"  value="0" id="contadorMaioragente" />
+    <tr>
+								<td >
+            <input type="text" name="codigoCr" id="codigoCr" bindingReference="codigoCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoTr" id="codigoTr" bindingReference="codigoTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoTr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="nmAgente" id="nmAgente" bindingReference="nmAgente" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'nmAgente', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="agente" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr','','/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('agente');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="agenteLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.juizProlator" class="" style="float:left;font-weight:bold;">Magistrado prolator</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var juizProlatorNomeCamposArray = new Array();
+ juizProlatorNomeCamposArray[0] = 'codigoJuizCr';
+ juizProlatorNomeCamposArray[1] = 'codigoJuizTr';
+ juizProlatorNomeCamposArray[2] = 'nmJuiz';
+ var codigoJuizCrNomeCamposArray = juizProlatorNomeCamposArray;
+ var codigoJuizTrNomeCamposArray = juizProlatorNomeCamposArray;
+ var nmJuizNomeCamposArray = juizProlatorNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="juizProlator" idPai="null" filtroPai="null" url="jsp/search/searchJuizProlator.jsp" input-select="juizProlator" property="dados.juizesProlatores" name="codigoJuizCr" title="Juizes prolatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="juizProlatorSelectedEntitiesList"  value="" id="juizProlatorSelectedEntitiesList" />
+<input type="hidden" name="contadorjuizProlator"  value="0" id="contadorjuizProlator" />
+<input type="hidden" name="contadorMaiorjuizProlator"  value="0" id="contadorMaiorjuizProlator" />
+    <tr>
+								<td >
+            <input type="text" name="codigoJuizCr" id="codigoJuizCr" bindingReference="codigoJuizCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoJuizTr" id="codigoJuizTr" bindingReference="codigoJuizTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizTr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="nmJuiz" id="nmJuiz" bindingReference="nmJuiz" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'nmJuiz', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="juizProlator" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr','','/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('juizProlator');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="juizLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="classes_selectionText" class="" style="float:left;font-weight:bold;">Classe</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="classesId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="classesTreeSelection.values" value="" id="classes">
+						<span id="classes_action" value="/cjsg/classesTreeSelect.do" />
+
+						<input type="text" name="classesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'classes',
+								treeSelectId: 'classesId',
+								url: '/cjsg/classesTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="classes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_classes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_classes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'classes',
+				treeSelectId: 'classesId',
+				url: '/cjsg/classesTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_classes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_classes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="assuntos_selectionText" class="" style="float:left;font-weight:bold;">Assunto</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="assuntosId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="assuntosTreeSelection.values" value="" id="assuntos">
+						<span id="assuntos_action" value="/cjsg/assuntosTreeSelect.do" />
+
+						<input type="text" name="assuntosTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'assuntos',
+								treeSelectId: 'assuntosId',
+								url: '/cjsg/assuntosTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="assuntos_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_assuntos"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_assuntos"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'assuntos',
+				treeSelectId: 'assuntosId',
+				url: '/cjsg/assuntosTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_assuntos').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_assuntos').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="secoes_selectionText" class="" style="float:left;font-weight:bold;">Órgão julgador</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="secaoId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="secoesTreeSelection.values" value="" id="secoes">
+						<span id="secoes_action" value="/cjsg/secaoTreeSelect.do" />
+
+						<input type="text" name="secoesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'secoes',
+								treeSelectId: 'secaoId',
+								url: '/cjsg/secaoTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="secoes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_secoes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_secoes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'secoes',
+				treeSelectId: 'secaoId',
+				url: '/cjsg/secaoTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_secoes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_secoes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtJulgamento" class="" style="float:left;font-weight:bold;">Data do julgamento</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoInicio">
+
+
+
+	<input type="text" name="dados.dtJulgamentoInicio" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoFim">
+
+
+
+	<input type="text" name="dados.dtJulgamentoFim" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							<span id="dtJulgamentoFormato">
+								(dd/mm/aaaa)
+							</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtPublicacao" class="" style="float:left;font-weight:bold;">Data de publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoInicio">
+
+
+
+	<input type="text" name="dados.dtPublicacaoInicio" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoFim">
+
+
+
+	<input type="text" name="dados.dtPublicacaoFim" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						<span id="dtPublicacaoFormato">
+							(dd/mm/aaaa)
+						</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.origem" class="" style="float:left;font-weight:bold;">Origem</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<input type="checkbox" name="dados.origensSelecionadas" value="T" checked="checked" id="origem2grau">
+						<label for="origem2grau">
+							2° grau
+						</label>
+						<input type="checkbox" name="dados.origensSelecionadas" value="R" id="origemRecursal">
+						<label for="origemRecursal">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Colégios Recursais
+
+
+						</label>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.tpDecisao" class="" style="float:left;font-weight:bold;">Tipo de Publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<div id="linhaTipoDecisao">
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="A" checked="checked" id="Acheckbox">
+								<label for="Acheckbox">
+									Acórdãos
+								</label>
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="D" id="Dcheckbox">
+								<label for="Dcheckbox">
+									Decisões Monocráticas
+								</label>
+
+						</div>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.ordenar" class="" style="float:left;font-weight:bold;">Ordenar por</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenardtPublicacao">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenardtPublicacao" value="dtPublicacao" style="vertical-align:middle;" onclick="" class="" title=""  checked/>
+			Data de publicação
+		</label>
+
+	</span>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenarRelevancia">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenarRelevancia" value="relevancia" style="vertical-align:middle;" onclick="" class="" title=""  />
+			Relevância
+		</label>
+
+	</span>
+
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<table id="" class="secaoBotoesBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+		<tr>
+
+ 				<td width="150">&nbsp;</td>
+
+			<td align="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="submit" name="pbSubmit" value="Pesquisar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotaoDefault " id="pbSubmit">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="button" name="pbLimpar" value="Limpar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotao " id="pbLimpar">
+
+
+
+			</td>
+		</tr>
+	</table>
+
+
+
+
+
+
+</form>
+
+
+
+
+			<!-- Resultado consulta -->
+
+				<!-- Tabs -->
+				<div id="tabs">
+					<ul>
+
+							<li tipo="A" >
+								<a href="A">
+									<span  id="nomeAba-A" >Acórdãos(13929)</span>
+									<input id="totalResultadoAba-A" type="hidden" value="13929" />
+								</a>
+							</li>
+
+					</ul>
+
+						<div id="tabs-A">
+
+
+
+
+
+
+
+
+
+
+<div id="paginacaoSuperior-A" style="padding-bottom: 15px;" >
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 20
+			</strong>
+			de 13929
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr>
+		<td height="1" valign="top" id="tdResultados" width="*" >
+			<div id="divDadosResultado-A" >
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503707" cdForo="0" >
+										1000233-68.2026.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503707" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503707);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503707" style="display: none;" >
+	<div id="textAreaDados_2503707" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTEN&Ccedil;A. IMPUGNA&Ccedil;&Atilde;O INTEMPESTIVA. MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA. ASTREINTES. NECESSIDADE DE INTIMA&Ccedil;&Atilde;O PESSOAL. S&Uacute;MULA 410 DO STJ. EXCE&Ccedil;&Atilde;O DE PR&Eacute;-EXECUTIVIDADE. INEXIGIBILIDADE DA MULTA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento interposto contra decis&atilde;o que, em cumprimento de senten&ccedil;a, rejeitou impugna&ccedil;&atilde;o apresentada por institui&ccedil;&atilde;o financeira ao fundamento de intempestividade e determinou o prosseguimento da execu&ccedil;&atilde;o, com levantamento de valores bloqueados via SISBAJUD, incluindo montante expressivo a t&iacute;tulo de astreintes.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se mat&eacute;rias de ordem p&uacute;blica, especialmente relativas &agrave; exigibilidade de astreintes, podem ser analisadas apesar da intempestividade da impugna&ccedil;&atilde;o ao cumprimento de senten&ccedil;a; (ii) estabelecer se &eacute; exig&iacute;vel a multa cominat&oacute;ria sem pr&eacute;via intima&ccedil;&atilde;o pessoal do devedor para cumprimento da obriga&ccedil;&atilde;o de fazer.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O ordenamento jur&iacute;dico admite o conhecimento de mat&eacute;rias de ordem p&uacute;blica a qualquer tempo, n&atilde;o se sujeitando &agrave; preclus&atilde;o, inclusive na fase de cumprimento de senten&ccedil;a.
+4. A manifesta&ccedil;&atilde;o apresentada, ainda que intempestiva como impugna&ccedil;&atilde;o, deve ser recebida como exce&ccedil;&atilde;o de pr&eacute;-executividade, em observ&acirc;ncia aos princ&iacute;pios da instrumentalidade das formas e da primazia do julgamento de m&eacute;rito.
+5. A exigibilidade das astreintes constitui mat&eacute;ria de ordem p&uacute;blica e pode ser apreciada independentemente de provoca&ccedil;&atilde;o formal adequada.
+6. A multa cominat&oacute;ria possui natureza coercitiva e depende da caracteriza&ccedil;&atilde;o do descumprimento da obriga&ccedil;&atilde;o ap&oacute;s a regular constitui&ccedil;&atilde;o em mora do devedor.
+7. A jurisprud&ecirc;ncia do STJ, consubstanciada na S&uacute;mula 410, exige a pr&eacute;via intima&ccedil;&atilde;o pessoal do devedor como condi&ccedil;&atilde;o para a cobran&ccedil;a de multa por descumprimento de obriga&ccedil;&atilde;o de fazer ou n&atilde;o fazer.
+8. A intima&ccedil;&atilde;o realizada apenas na pessoa do advogado n&atilde;o supre a exig&ecirc;ncia de intima&ccedil;&atilde;o pessoal para fins de incid&ecirc;ncia das astreintes.
+9. Ausente a intima&ccedil;&atilde;o pessoal do devedor na fase executiva, mostra-se inexig&iacute;vel a cobran&ccedil;a das astreintes, bem como de seus consect&aacute;rios legais (multa do art. 523, &sect;1&ordm;, do CPC e honor&aacute;rios).
+IV. DISPOSITIVO E TESE
+10. Recurso provido.
+Tese de julgamento: A manifesta&ccedil;&atilde;o intempestiva pode ser recebida como exce&ccedil;&atilde;o de pr&eacute;-executividade quando versar sobre mat&eacute;rias cognosc&iacute;veis de of&iacute;cio e que n&atilde;o demandem dila&ccedil;&atilde;o probat&oacute;ria. A cobran&ccedil;a de astreintes por descumprimento de obriga&ccedil;&atilde;o de fazer exige pr&eacute;via intima&ccedil;&atilde;o pessoal do devedor, sendo inexig&iacute;vel a multa na sua aus&ecirc;ncia.
+____________
+Dispositivos relevantes citados: CPC, arts. 513, &sect;2&ordm;, I; 523, &sect;1&ordm;; 525; 537.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no REsp 1.929.909/SP, Rel. Min. Moura Ribeiro, 3&ordf; Turma, j. 08.06.2021; STJ, AgInt no AREsp 2.690.787/SP, Rel. Min. Raul Ara&uacute;jo, 4&ordf; Turma, j. 24.02.2025; STJ, AgInt no REsp 2.079.082/SP, Rel. Min. Marco Aur&eacute;lio Bellizze, 3&ordf; Turma, j. 11.09.2023; S&uacute;mula 410/STJ.  &nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:1000233-68.2026.8.01.0000;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTENÇA. IMPUGNAÇÃO INTEMPESTIVA. MATÉRIA DE ORDEM PÚBLICA. ASTREINTES. NECESSIDADE DE INTIMAÇÃO PESSOAL. SÚMULA 410 DO STJ. EXCEÇÃO DE PRÉ-EXECUTIVIDADE. INEXIGIBILIDADE DA MULTA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento interposto contra decisão que, em cumprimento de sentença, rejeitou impugnação apresentada
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTENÇA. IMPUGNAÇÃO INTEMPESTIVA. MATÉRIA DE ORDEM PÚBLICA. ASTREINTES. NECESSIDADE DE INTIMAÇÃO PESSOAL. SÚMULA 410 DO STJ. EXCEÇÃO DE PRÉ-EXECUTIVIDADE. INEXIGIBILIDADE DA MULTA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento interposto contra decisão que, em cumprimento de sentença, rejeitou impugnação apresentada por instituição financeira ao fundamento de intempestividade e determinou o prosseguimento da execução, com levantamento de valores bloqueados via SISBAJUD, incluindo montante expressivo a título de astreintes.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se matérias de ordem pública, especialmente relativas à exigibilidade de astreintes, podem ser analisadas apesar da intempestividade da impugnação ao cumprimento de sentença; (ii) estabelecer se é exigível a multa cominatória sem prévia intimação pessoal do devedor para cumprimento da obrigação de fazer.
+III. RAZÕES DE DECIDIR
+3. O ordenamento jurídico admite o conhecimento de matérias de ordem pública a qualquer tempo, não se sujeitando à preclusão, inclusive na fase de cumprimento de sentença.
+4. A manifestação apresentada, ainda que intempestiva como impugnação, deve ser recebida como exceção de pré-executividade, em observância aos princípios da instrumentalidade das formas e da primazia do julgamento de mérito.
+5. A exigibilidade das astreintes constitui matéria de ordem pública e pode ser apreciada independentemente de provocação formal adequada.
+6. A multa cominatória possui natureza coercitiva e depende da caracterização do descumprimento da obrigação após a regular constituição em mora do devedor.
+7. A jurisprudência do STJ, consubstanciada na Súmula 410, exige a prévia intimação pessoal do devedor como condição para a cobrança de multa por descumprimento de obrigação de fazer ou não fazer.
+8. A intimação realizada apenas na pessoa do advogado não supre a exigência de intimação pessoal para fins de incidência das astreintes.
+9. Ausente a intimação pessoal do devedor na fase executiva, mostra-se inexigível a cobrança das astreintes, bem como de seus consectários legais (multa do art. 523, §1º, do CPC e honorários).
+IV. DISPOSITIVO E TESE
+10. Recurso provido.
+Tese de julgamento: A manifestação intempestiva pode ser recebida como exceção de pré-executividade quando versar sobre matérias cognoscíveis de ofício e que não demandem dilação probatória. A cobrança de astreintes por descumprimento de obrigação de fazer exige prévia intimação pessoal do devedor, sendo inexigível a multa na sua ausência.
+____________
+Dispositivos relevantes citados: CPC, arts. 513, §2º, I; 523, §1º; 525; 537.
+Jurisprudência relevante citada: STJ, AgInt no REsp 1.929.909/SP, Rel. Min. Moura Ribeiro, 3ª Turma, j. 08.06.2021; STJ, AgInt no AREsp 2.690.787/SP, Rel. Min. Raul Araújo, 4ª Turma, j. 24.02.2025; STJ, AgInt no REsp 2.079.082/SP, Rel. Min. Marco Aurélio Bellizze, 3ª Turma, j. 11.09.2023; Súmula 410/STJ.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503706" cdForo="0" >
+										0702879-60.2022.8.01.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503706" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503706);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503706" style="display: none;" >
+	<div id="textAreaDados_2503706" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O MONIT&Oacute;RIA. EMBARGOS MONIT&Oacute;RIOS. CONTRATO BANC&Aacute;RIO. CAPITAL DE GIRO. RELA&Ccedil;&Atilde;O DE INSUMO. INAPLICABILIDADE DO CDC. DOCUMENTO H&Aacute;BIL. S&Uacute;MULA 247 DO STJ. ENCARGOS FINANCEIROS. JUROS REMUNERAT&Oacute;RIOS. AUS&Ecirc;NCIA DE ABUSIVIDADE. CAPITALIZA&Ccedil;&Atilde;O DE JUROS. POSSIBILIDADE. COMISS&Atilde;O FLAT. LEGALIDADE. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o C&iacute;vel interposta contra senten&ccedil;a que, em A&ccedil;&atilde;o Monit&oacute;ria, rejeitou embargos monit&oacute;rios e julgou procedente a pretens&atilde;o, constituindo t&iacute;tulo executivo judicial fundado em contrato de abertura de cr&eacute;dito, com condena&ccedil;&atilde;o ao pagamento do d&eacute;bito e honor&aacute;rios advocat&iacute;cios.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se os documentos apresentados pelo banco s&atilde;o aptos a embasar a a&ccedil;&atilde;o monit&oacute;ria; (ii) estabelecer se incide o C&oacute;digo de Defesa do Consumidor na rela&ccedil;&atilde;o contratual; (iii) determinar se h&aacute; abusividade nos juros remunerat&oacute;rios e na capitaliza&ccedil;&atilde;o; (iv) verificar a legalidade da cobran&ccedil;a de comiss&atilde;o flat e eventual venda casada.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O contrato de abertura de cr&eacute;dito acompanhado de demonstrativo de d&eacute;bito constitui documento h&aacute;bil &agrave; propositura da a&ccedil;&atilde;o monit&oacute;ria, nos termos da S&uacute;mula 247 do STJ.
+4. A rela&ccedil;&atilde;o jur&iacute;dica possui natureza de insumo, pois o cr&eacute;dito foi destinado ao fomento de atividade empresarial, afastando a incid&ecirc;ncia do C&oacute;digo de Defesa do Consumidor.
+5. A alega&ccedil;&atilde;o gen&eacute;rica de aus&ecirc;ncia de discrimina&ccedil;&atilde;o do d&eacute;bito n&atilde;o afasta a validade dos documentos apresentados, sobretudo quando n&atilde;o demonstrado concretamente o excesso de execu&ccedil;&atilde;o.
+6. As institui&ccedil;&otilde;es financeiras n&atilde;o se submetem &agrave; limita&ccedil;&atilde;o da Lei de Usura, sendo admiss&iacute;vel a pactua&ccedil;&atilde;o de juros superiores a 12% ao ano, conforme S&uacute;mula 596 do STF.
+7. A taxa de juros remunerat&oacute;rios n&atilde;o se revela abusiva quando n&atilde;o demonstrada discrep&acirc;ncia significativa em rela&ccedil;&atilde;o &agrave; m&eacute;dia de mercado, a qual serve apenas como par&acirc;metro referencial, nos termos da jurisprud&ecirc;ncia do STJ.
+8. A revis&atilde;o judicial dos juros exige comprova&ccedil;&atilde;o de desvantagem exagerada, o que n&atilde;o ocorreu, diante da aus&ecirc;ncia de demonstra&ccedil;&atilde;o t&eacute;cnica pelos apelantes.
+9. A capitaliza&ccedil;&atilde;o de juros &eacute; admitida quando expressamente pactuada, sendo suficiente a previs&atilde;o contratual de taxa anual superior ao duod&eacute;cuplo da mensal, conforme S&uacute;mulas 539 e 541 do STJ.
+10. A comiss&atilde;o flat &eacute; v&aacute;lida quando prevista contratualmente, correspondente a servi&ccedil;o de assessoria financeira, e n&atilde;o demonstrada abusividade ou desequil&iacute;brio contratual.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento: O contrato de abertura de cr&eacute;dito acompanhado de demonstrativo de d&eacute;bito &eacute; documento h&aacute;bil &agrave; a&ccedil;&atilde;o monit&oacute;ria. Em empr&eacute;stimo destinado &agrave; atividade empresarial, configura-se rela&ccedil;&atilde;o de insumo, afastando a incid&ecirc;ncia do CDC. A revis&atilde;o de juros remunerat&oacute;rios exige demonstra&ccedil;&atilde;o concreta de abusividade, n&atilde;o sendo a taxa m&eacute;dia do BACEN limite absoluto. A capitaliza&ccedil;&atilde;o de juros &eacute; v&aacute;lida quando expressamente pactuada. A comiss&atilde;o flat &eacute; l&iacute;cita quando prevista contratualmente e n&atilde;o evidenciado desequil&iacute;brio contratual.
+____________
+Dispositivos relevantes citados: CPC, art. 702, &sect;&sect;2&ordm; e 3&ordm;; 85, &sect;&sect;2&ordm; e 11. CC, art. 421.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula 247; STF, S&uacute;mula 596; STJ, S&uacute;mulas 382, 539 e 541; STJ, REsp 1.599.042/SP, Rel. Min. Luis Felipe Salom&atilde;o, j. 14.03.2017; STJ, AgInt no AREsp 1.987.137/SP, Rel. Min. Maria Isabel Gallotti, j. 03.10.2022; TJ-TO - Apela&ccedil;&atilde;o C&iacute;vel: 00037287420238272731, Relator.: JACQUELINE ADORNO DE LA CRUZ BARBOSA, Data de Julgamento: 12/03/2025, TURMAS DAS CAMARAS CIVEIS; TJ-MG - Apela&ccedil;&atilde;o C&iacute;vel: 02059551620138130105 1 .0000.23.350809-2/001, Relator.: Des.(a) Jos&eacute; Am&eacute;rico Martins da Costa, Data de Julgamento: 12/07/2024, 12&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 16/07/2024; TJ-DF 07053156120218070001 1655205, Relator.: GET&Uacute;LIO DE MORAES OLIVEIRA, Data de Julgamento: 25/01/2023, 7&ordf; Turma C&iacute;vel, Data de Publica&ccedil;&atilde;o: 08/02/2023.  &nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:0702879-60.2022.8.01.0002;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO MONITÓRIA. EMBARGOS MONITÓRIOS. CONTRATO BANCÁRIO. CAPITAL DE GIRO. RELAÇÃO DE INSUMO. INAPLICABILIDADE DO CDC. DOCUMENTO HÁBIL. SÚMULA 247 DO STJ. ENCARGOS FINANCEIROS. JUROS REMUNERATÓRIOS. AUSÊNCIA DE ABUSIVIDADE. CAPITALIZAÇÃO DE JUROS. POSSIBILIDADE. COMISSÃO FLAT. LEGALIDADE. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO MONITÓRIA. EMBARGOS MONITÓRIOS. CONTRATO BANCÁRIO. CAPITAL DE GIRO. RELAÇÃO DE INSUMO. INAPLICABILIDADE DO CDC. DOCUMENTO HÁBIL. SÚMULA 247 DO STJ. ENCARGOS FINANCEIROS. JUROS REMUNERATÓRIOS. AUSÊNCIA DE ABUSIVIDADE. CAPITALIZAÇÃO DE JUROS. POSSIBILIDADE. COMISSÃO FLAT. LEGALIDADE. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta contra sentença que, em Ação Monitória, rejeitou embargos monitórios e julgou procedente a pretensão, constituindo título executivo judicial fundado em contrato de abertura de crédito, com condenação ao pagamento do débito e honorários advocatícios.
+II. QUESTÃO EM DISCUSSÃO
+2. Há quatro questões em discussão: (i) definir se os documentos apresentados pelo banco são aptos a embasar a ação monitória; (ii) estabelecer se incide o Código de Defesa do Consumidor na relação contratual; (iii) determinar se há abusividade nos juros remuneratórios e na capitalização; (iv) verificar a legalidade da cobrança de comissão flat e eventual venda casada.
+III. RAZÕES DE DECIDIR
+3. O contrato de abertura de crédito acompanhado de demonstrativo de débito constitui documento hábil à propositura da ação monitória, nos termos da Súmula 247 do STJ.
+4. A relação jurídica possui natureza de insumo, pois o crédito foi destinado ao fomento de atividade empresarial, afastando a incidência do Código de Defesa do Consumidor.
+5. A alegação genérica de ausência de discriminação do débito não afasta a validade dos documentos apresentados, sobretudo quando não demonstrado concretamente o excesso de execução.
+6. As instituições financeiras não se submetem à limitação da Lei de Usura, sendo admissível a pactuação de juros superiores a 12% ao ano, conforme Súmula 596 do STF.
+7. A taxa de juros remuneratórios não se revela abusiva quando não demonstrada discrepância significativa em relação à média de mercado, a qual serve apenas como parâmetro referencial, nos termos da jurisprudência do STJ.
+8. A revisão judicial dos juros exige comprovação de desvantagem exagerada, o que não ocorreu, diante da ausência de demonstração técnica pelos apelantes.
+9. A capitalização de juros é admitida quando expressamente pactuada, sendo suficiente a previsão contratual de taxa anual superior ao duodécuplo da mensal, conforme Súmulas 539 e 541 do STJ.
+10. A comissão flat é válida quando prevista contratualmente, correspondente a serviço de assessoria financeira, e não demonstrada abusividade ou desequilíbrio contratual.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento: O contrato de abertura de crédito acompanhado de demonstrativo de débito é documento hábil à ação monitória. Em empréstimo destinado à atividade empresarial, configura-se relação de insumo, afastando a incidência do CDC. A revisão de juros remuneratórios exige demonstração concreta de abusividade, não sendo a taxa média do BACEN limite absoluto. A capitalização de juros é válida quando expressamente pactuada. A comissão flat é lícita quando prevista contratualmente e não evidenciado desequilíbrio contratual.
+____________
+Dispositivos relevantes citados: CPC, art. 702, §§2º e 3º; 85, §§2º e 11. CC, art. 421.
+Jurisprudência relevante citada: STJ, Súmula 247; STF, Súmula 596; STJ, Súmulas 382, 539 e 541; STJ, REsp 1.599.042/SP, Rel. Min. Luis Felipe Salomão, j. 14.03.2017; STJ, AgInt no AREsp 1.987.137/SP, Rel. Min. Maria Isabel Gallotti, j. 03.10.2022; TJ-TO - Apelação Cível: 00037287420238272731, Relator.: JACQUELINE ADORNO DE LA CRUZ BARBOSA, Data de Julgamento: 12/03/2025, TURMAS DAS CAMARAS CIVEIS; TJ-MG - Apelação Cível: 02059551620138130105 1 .0000.23.350809-2/001, Relator.: Des.(a) José Américo Martins da Costa, Data de Julgamento: 12/07/2024, 12ª CÂMARA CÍVEL, Data de Publicação: 16/07/2024; TJ-DF 07053156120218070001 1655205, Relator.: GETÚLIO DE MORAES OLIVEIRA, Data de Julgamento: 25/01/2023, 7ª Turma Cível, Data de Publicação: 08/02/2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503712" cdForo="0" >
+										0710985-09.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503712" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503712);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503712" style="display: none;" >
+	<div id="textAreaDados_2503712" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. CONTRATO BANC&Aacute;RIO. REFINANCIAMENTO DE EMPR&Eacute;STIMO CONSIGNADO. BIOMETRIA FACIAL. COMPROVA&Ccedil;&Atilde;O DO CR&Eacute;DITO DO &quot;TROCO&quot;. &Ocirc;NUS DA PROVA. ART. 373, II, CPC. AUS&Ecirc;NCIA DE V&Iacute;CIO DE CONSENTIMENTO. IMPROCED&Ecirc;NCIA DOS PEDIDOS INICIAIS. REFORMA INTEGRAL DA SENTEN&Ccedil;A. RECURSO CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o C&iacute;vel interposta contra senten&ccedil;a proferida pelo Ju&iacute;zo da 6&ordf; Vara C&iacute;vel da Comarca de Rio Branco, que, nos autos de a&ccedil;&atilde;o declarat&oacute;ria de nulidade contratual cumulada com indeniza&ccedil;&atilde;o por danos morais, julgou procedentes os pedidos iniciais para declarar a nulidade de contrato de refinanciamento consignado, determinar a cessa&ccedil;&atilde;o dos descontos, condenar a institui&ccedil;&atilde;o financeira &agrave; restitui&ccedil;&atilde;o em dobro dos valores descontados e ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 8.000,00, al&eacute;m do pagamento de custas e honor&aacute;rios advocat&iacute;cios.
+2. A institui&ccedil;&atilde;o financeira apelante sustentou a regularidade da contrata&ccedil;&atilde;o, alegando que o contrato foi celebrado mediante valida&ccedil;&atilde;o por biometria facial e que houve efetiva disponibiliza&ccedil;&atilde;o do cr&eacute;dito ao consumidor, inclusive com destina&ccedil;&atilde;o parcial &agrave; quita&ccedil;&atilde;o de contratos anteriores e libera&ccedil;&atilde;o do valor remanescente (&quot;troco&quot;) em conta banc&aacute;ria de titularidade do autor.
+3. O apelado apresentou contrarraz&otilde;es, defendendo a manuten&ccedil;&atilde;o integral da senten&ccedil;a, ao argumento de que incumbia &agrave; institui&ccedil;&atilde;o financeira comprovar n&atilde;o apenas a formaliza&ccedil;&atilde;o do contrato, mas tamb&eacute;m a efetiva disponibiliza&ccedil;&atilde;o do valor ao consumidor.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+4. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) saber se restou comprovada a regularidade do contrato de refinanciamento consignado impugnado; (ii) saber se houve efetiva disponibiliza&ccedil;&atilde;o do valor denominado &quot;troco&quot; ao consumidor; (iii) saber se subsiste o dever de restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais; (iv) saber se a manuten&ccedil;&atilde;o da senten&ccedil;a implicaria enriquecimento sem causa do consumidor.
+III. RAZ&Otilde;ES DE DECIDIR
+5. A controv&eacute;rsia foi solucionada &agrave; luz das normas consumeristas e das regras de distribui&ccedil;&atilde;o do &ocirc;nus da prova previstas no art. 373, inciso II, do C&oacute;digo de Processo Civil, incumbindo &agrave; institui&ccedil;&atilde;o financeira demonstrar a regularidade da contrata&ccedil;&atilde;o e a efetiva disponibiliza&ccedil;&atilde;o do cr&eacute;dito.
+6. A an&aacute;lise do acervo probat&oacute;rio evidenciou que os documentos juntados demonstraram a realiza&ccedil;&atilde;o de opera&ccedil;&otilde;es sucessivas de empr&eacute;stimo e refinanciamento, com cr&eacute;ditos efetivamente disponibilizados na conta do consumidor, incluindo o valor final de R$ 1.333,85, referente ao refinanciamento impugnado.
+7. Restou comprovado, ainda, que os contratos anteriores foram quitados mediante substitui&ccedil;&atilde;o por nova opera&ccedil;&atilde;o financeira, circunst&acirc;ncia que evidencia a din&acirc;mica t&iacute;pica dos contratos de refinanciamento e demonstra a exist&ecirc;ncia de proveito econ&ocirc;mico em favor do consumidor.
+8. A comprova&ccedil;&atilde;o da valida&ccedil;&atilde;o por biometria facial e do ingresso dos valores na esfera patrimonial do consumidor afasta a alega&ccedil;&atilde;o de v&iacute;cio de consentimento, caracterizando comportamento concludente apto a ratificar a contrata&ccedil;&atilde;o e afastar a nulidade pretendida.
+9. Demonstrada a regularidade da contrata&ccedil;&atilde;o e a disponibiliza&ccedil;&atilde;o do numer&aacute;rio, inexiste ato il&iacute;cito imput&aacute;vel &agrave; institui&ccedil;&atilde;o financeira, circunst&acirc;ncia que afasta o dever de repeti&ccedil;&atilde;o do ind&eacute;bito, seja em sua forma simples ou em dobro, bem como a configura&ccedil;&atilde;o de dano moral indeniz&aacute;vel.
+10. A manuten&ccedil;&atilde;o da senten&ccedil;a, diante da prova do recebimento dos valores e da quita&ccedil;&atilde;o de d&eacute;bitos pret&eacute;ritos, configuraria enriquecimento sem causa do consumidor, em afronta aos princ&iacute;pios da boa-f&eacute; objetiva e da veda&ccedil;&atilde;o ao enriquecimento indevido.
+11. Reformada integralmente a senten&ccedil;a, imp&ocirc;s-se a redistribui&ccedil;&atilde;o dos encargos sucumbenciais, com condena&ccedil;&atilde;o da parte autora ao pagamento das custas processuais e honor&aacute;rios advocat&iacute;cios fixados em 10% sobre o valor atualizado da causa, com suspens&atilde;o da exigibilidade em raz&atilde;o da gratuidade da justi&ccedil;a, nos termos do art. 98, &sect; 3&ordm;, do C&oacute;digo de Processo Civil.
+IV. DISPOSITIVO E TESE
+10. Recurso conhecido e provido, para reformar integralmente a senten&ccedil;a e julgar improcedentes os pedidos iniciais, reconhecendo a validade do contrato de refinanciamento consignado discutido nos autos.
+Tese de julgamento: A comprova&ccedil;&atilde;o da valida&ccedil;&atilde;o biom&eacute;trica da contrata&ccedil;&atilde;o e da efetiva disponibiliza&ccedil;&atilde;o dos valores ao consumidor afasta a alega&ccedil;&atilde;o de v&iacute;cio de consentimento, inexistindo nulidade contratual, repeti&ccedil;&atilde;o de ind&eacute;bito ou dano moral, sob pena de enriquecimento sem causa do contratante.
+Dispositivos relevantes citados
+CPC, art. 85, &sect; 2&ordm;
+CPC, art. 98, &sect; 3&ordm;
+CPC, art. 373, inciso II &nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0710985-09.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;6&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(18 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. CONTRATO BANCÁRIO. REFINANCIAMENTO DE EMPRÉSTIMO CONSIGNADO. BIOMETRIA FACIAL. COMPROVAÇÃO DO CRÉDITO DO "TROCO". ÔNUS DA PROVA. ART. 373, II, CPC. AUSÊNCIA DE VÍCIO DE CONSENTIMENTO. IMPROCEDÊNCIA DOS PEDIDOS INICIAIS. REFORMA INTEGRAL DA SENTENÇA. RECURSO CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta contra sentença proferida
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. CONTRATO BANCÁRIO. REFINANCIAMENTO DE EMPRÉSTIMO CONSIGNADO. BIOMETRIA FACIAL. COMPROVAÇÃO DO CRÉDITO DO "TROCO". ÔNUS DA PROVA. ART. 373, II, CPC. AUSÊNCIA DE VÍCIO DE CONSENTIMENTO. IMPROCEDÊNCIA DOS PEDIDOS INICIAIS. REFORMA INTEGRAL DA SENTENÇA. RECURSO CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta contra sentença proferida pelo Juízo da 6ª Vara Cível da Comarca de Rio Branco, que, nos autos de ação declaratória de nulidade contratual cumulada com indenização por <em>danos</em> <em>morais</em>, julgou procedentes os pedidos iniciais para declarar a nulidade de contrato de refinanciamento consignado, determinar a cessação dos descontos, condenar a instituição financeira à restituição em dobro dos valores descontados e ao pagamento de indenização por <em>danos</em> <em>morais</em> no valor de R$ 8.000,00, além do pagamento de custas e honorários advocatícios.
+2. A instituição financeira apelante sustentou a regularidade da contratação, alegando que o contrato foi celebrado mediante validação por biometria facial e que houve efetiva disponibilização do crédito ao consumidor, inclusive com destinação parcial à quitação de contratos anteriores e liberação do valor remanescente ("troco") em conta bancária de titularidade do autor.
+3. O apelado apresentou contrarrazões, defendendo a manutenção integral da sentença, ao argumento de que incumbia à instituição financeira comprovar não apenas a formalização do contrato, mas também a efetiva disponibilização do valor ao consumidor.
+II. QUESTÕES EM DISCUSSÃO
+4. Há quatro questões em discussão: (i) saber se restou comprovada a regularidade do contrato de refinanciamento consignado impugnado; (ii) saber se houve efetiva disponibilização do valor denominado "troco" ao consumidor; (iii) saber se subsiste o dever de restituição de valores e indenização por <em>danos</em> <em>morais</em>; (iv) saber se a manutenção da sentença implicaria enriquecimento sem causa do consumidor.
+III. RAZÕES DE DECIDIR
+5. A controvérsia foi solucionada à luz das normas consumeristas e das regras de distribuição do ônus da prova previstas no art. 373, inciso II, do Código de Processo Civil, incumbindo à instituição financeira demonstrar a regularidade da contratação e a efetiva disponibilização do crédito.
+6. A análise do acervo probatório evidenciou que os documentos juntados demonstraram a realização de operações sucessivas de empréstimo e refinanciamento, com créditos efetivamente disponibilizados na conta do consumidor, incluindo o valor final de R$ 1.333,85, referente ao refinanciamento impugnado.
+7. Restou comprovado, ainda, que os contratos anteriores foram quitados mediante substituição por nova operação financeira, circunstância que evidencia a dinâmica típica dos contratos de refinanciamento e demonstra a existência de proveito econômico em favor do consumidor.
+8. A comprovação da validação por biometria facial e do ingresso dos valores na esfera patrimonial do consumidor afasta a alegação de vício de consentimento, caracterizando comportamento concludente apto a ratificar a contratação e afastar a nulidade pretendida.
+9. Demonstrada a regularidade da contratação e a disponibilização do numerário, inexiste ato ilícito imputável à instituição financeira, circunstância que afasta o dever de repetição do indébito, seja em sua forma simples ou em dobro, bem como a configuração de <em>dano</em> <em>moral</em> indenizável.
+10. A manutenção da sentença, diante da prova do recebimento dos valores e da quitação de débitos pretéritos, configuraria enriquecimento sem causa do consumidor, em afronta aos princípios da boa-fé objetiva e da vedação ao enriquecimento indevido.
+11. Reformada integralmente a sentença, impôs-se a redistribuição dos encargos sucumbenciais, com condenação da parte autora ao pagamento das custas processuais e honorários advocatícios fixados em 10% sobre o valor atualizado da causa, com suspensão da exigibilidade em razão da gratuidade da justiça, nos termos do art. 98, § 3º, do Código de Processo Civil.
+IV. DISPOSITIVO E TESE
+10. Recurso conhecido e provido, para reformar integralmente a sentença e julgar improcedentes os pedidos iniciais, reconhecendo a validade do contrato de refinanciamento consignado discutido nos autos.
+Tese de julgamento: A comprovação da validação biométrica da contratação e da efetiva disponibilização dos valores ao consumidor afasta a alegação de vício de consentimento, inexistindo nulidade contratual, repetição de indébito ou <em>dano</em> <em>moral</em>, sob pena de enriquecimento sem causa do contratante.
+Dispositivos relevantes citados
+CPC, art. 85, § 2º
+CPC, art. 98, § 3º
+CPC, art. 373, inciso II
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503711" cdForo="0" >
+										0708142-71.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503711" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503711);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503711" style="display: none;" >
+	<div id="textAreaDados_2503711" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. FRAUDE BANC&Aacute;RIA. EMPR&Eacute;STIMO CONSIGNADO. PORTABILIDADE DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. S&Uacute;MULA 479/STJ. RESTITUI&Ccedil;&Atilde;O EM DOBRO. DANOS MORAIS CONFIGURADOS. RECURSO DO BANCO CONHECIDO E DESPROVIDO. RECURSO DA AUTORA CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito cumulada com indeniza&ccedil;&atilde;o por danos morais ajuizada por consumidora em face de institui&ccedil;&atilde;o financeira, sob alega&ccedil;&atilde;o de contrata&ccedil;&atilde;o fraudulenta de empr&eacute;stimo com subsequente transfer&ecirc;ncia dos valores para terceiro desconhecido, acompanhada de descontos mensais em benef&iacute;cio previdenci&aacute;rio.
+2. O Ju&iacute;zo de Direito da Vara C&iacute;vel julgou parcialmente procedentes os pedidos para declarar a nulidade do contrato de empr&eacute;stimo, determinar a devolu&ccedil;&atilde;o simples dos valores pagos, permitir compensa&ccedil;&atilde;o com valores creditados e julgar improcedente o pedido de indeniza&ccedil;&atilde;o por danos morais, fixando sucumb&ecirc;ncia rec&iacute;proca.
+3. A institui&ccedil;&atilde;o financeira interp&ocirc;s recurso de apela&ccedil;&atilde;o sustentando a regularidade da contrata&ccedil;&atilde;o mediante biometria facial e assinatura eletr&ocirc;nica, aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o e inexist&ecirc;ncia de dever de restitui&ccedil;&atilde;o, requerendo a reforma integral da senten&ccedil;a.
+4. A autora tamb&eacute;m interp&ocirc;s apela&ccedil;&atilde;o pleiteando a restitui&ccedil;&atilde;o em dobro dos valores descontados, afastamento da compensa&ccedil;&atilde;o e condena&ccedil;&atilde;o da institui&ccedil;&atilde;o financeira ao pagamento de indeniza&ccedil;&atilde;o por danos morais, sob alega&ccedil;&atilde;o de fraude e aus&ecirc;ncia de engano justific&aacute;vel.
+5. Contrarraz&otilde;es apresentadas por ambas as partes, pugnando pela manuten&ccedil;&atilde;o dos cap&iacute;tulos da senten&ccedil;a que lhes foram favor&aacute;veis.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+6. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se a institui&ccedil;&atilde;o financeira responde pelos preju&iacute;zos decorrentes de contrata&ccedil;&atilde;o fraudulenta e subsequente transfer&ecirc;ncia de valores a terceiro; (ii) saber se a restitui&ccedil;&atilde;o dos valores descontados deve ocorrer em dobro e sem compensa&ccedil;&atilde;o; (iii) saber se a situa&ccedil;&atilde;o caracteriza dano moral indeniz&aacute;vel.
+III. RAZ&Otilde;ES DE DECIDIR
+7. A rela&ccedil;&atilde;o jur&iacute;dica estabelecida entre as partes possui natureza consumerista, sendo aplic&aacute;vel a responsabilidade objetiva do fornecedor prevista no art. 14 do C&oacute;digo de Defesa do Consumidor, segundo a qual o prestador responde independentemente de culpa pelos danos decorrentes de defeitos relativos &agrave; presta&ccedil;&atilde;o do servi&ccedil;o.
+8. Restou evidenciada falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio, consubstanciada na libera&ccedil;&atilde;o sucessiva de cr&eacute;ditos e imediata transfer&ecirc;ncia integral dos valores para conta de terceiro com hist&oacute;rico de fraude, sem a ado&ccedil;&atilde;o de mecanismos eficazes de seguran&ccedil;a.
+9. Incide, na esp&eacute;cie, a teoria do risco do empreendimento e o entendimento consolidado na S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a, segundo a qual as institui&ccedil;&otilde;es financeiras respondem objetivamente pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no &acirc;mbito de opera&ccedil;&otilde;es banc&aacute;rias.
+10. A institui&ccedil;&atilde;o financeira n&atilde;o comprovou manifesta&ccedil;&atilde;o v&aacute;lida de vontade da consumidora, tampouco demonstrou seguran&ccedil;a suficiente no procedimento de valida&ccedil;&atilde;o biom&eacute;trica, &ocirc;nus que lhe incumbia nos termos das regras de distribui&ccedil;&atilde;o din&acirc;mica do &ocirc;nus probat&oacute;rio aplic&aacute;veis &agrave;s rela&ccedil;&otilde;es consumeristas.
+11. Reconhecida a falha na presta&ccedil;&atilde;o do servi&ccedil;o, imp&otilde;e-se a nulidade do contrato e a inexigibilidade dos d&eacute;bitos decorrentes das opera&ccedil;&otilde;es fraudulentas.
+12. Quanto &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, aplica-se o art. 42, par&aacute;grafo &uacute;nico, do C&oacute;digo de Defesa do Consumidor, sendo devida a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados, uma vez ausente engano justific&aacute;vel por parte da institui&ccedil;&atilde;o financeira.
+13. O entendimento encontra respaldo no julgamento do EAREsp 676.608/RS, da Corte Especial do Superior Tribunal de Justi&ccedil;a, que consolidou a orienta&ccedil;&atilde;o quanto &agrave; restitui&ccedil;&atilde;o em dobro quando inexistente justificativa plaus&iacute;vel para a cobran&ccedil;a indevida.
+14. A compensa&ccedil;&atilde;o determinada na origem mostra-se indevida, pois a autora n&atilde;o usufruiu dos valores liberados, os quais foram imediatamente desviados por terceiros, circunst&acirc;ncia que afasta qualquer benef&iacute;cio econ&ocirc;mico &agrave; consumidora.
+15. Sobre os valores devidos incidem corre&ccedil;&atilde;o monet&aacute;ria desde o efetivo preju&iacute;zo e juros morat&oacute;rios desde o evento danoso, conforme orienta&ccedil;&otilde;es das S&uacute;mulas 43 e 54 do Superior Tribunal de Justi&ccedil;a.
+16. No tocante aos danos morais, a indevida realiza&ccedil;&atilde;o de descontos em benef&iacute;cio previdenci&aacute;rio de pessoa idosa configura viola&ccedil;&atilde;o a direitos da personalidade, caracterizando dano moral in re ipsa, dispensando prova do preju&iacute;zo concreto.
+17. A fixa&ccedil;&atilde;o da indeniza&ccedil;&atilde;o no valor de R$ 3.000,00 observa os princ&iacute;pios da razoabilidade e proporcionalidade, considerando o car&aacute;ter compensat&oacute;rio e pedag&oacute;gico da medida.
+18. A corre&ccedil;&atilde;o monet&aacute;ria da indeniza&ccedil;&atilde;o por danos morais incide a partir do arbitramento, nos termos da S&uacute;mula 362 do Superior Tribunal de Justi&ccedil;a, enquanto os juros morat&oacute;rios incidem desde o evento danoso, conforme S&uacute;mula 54 do mesmo Tribunal.
+19. O redimensionamento do julgado implica a redistribui&ccedil;&atilde;o dos &ocirc;nus sucumbenciais, impondo-se &agrave; institui&ccedil;&atilde;o financeira o pagamento integral das custas e honor&aacute;rios advocat&iacute;cios, fixados com fundamento no art. 85, &sect;&sect; 2&ordm; e 11, do C&oacute;digo de Processo Civil.
+IV. DISPOSITIVO E TESE
+20. Recurso da institui&ccedil;&atilde;o financeira conhecido e desprovido. Recurso da autora conhecido e provido para reformar a senten&ccedil;a e declarar a inexist&ecirc;ncia dos d&eacute;bitos oriundos dos contratos fraudulentos, determinar a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados, afastar a compensa&ccedil;&atilde;o e condenar a institui&ccedil;&atilde;o financeira ao pagamento de indeniza&ccedil;&atilde;o por danos morais, al&eacute;m de impor-lhe integral responsabilidade pelos &ocirc;nus sucumbenciais.
+Tese de julgamento: &quot;A institui&ccedil;&atilde;o financeira responde objetivamente por fraudes decorrentes de falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio, sendo devida a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados e a indeniza&ccedil;&atilde;o por danos morais quando comprovada vulnerabilidade do consumidor e aus&ecirc;ncia de engano justific&aacute;vel.&quot;
+Dispositivos relevantes citados
+CDC, art. 14, &sect; 1&ordm;; art. 42, par&aacute;grafo &uacute;nico.
+C&oacute;digo Civil, arts. 389 e 406.
+C&oacute;digo de Processo Civil, art. 85, &sect;&sect; 2&ordm; e 11.
+Jurisprud&ecirc;ncia relevante citada
+STJ, S&uacute;mula 43.
+STJ, S&uacute;mula 54.
+STJ, S&uacute;mula 362.
+STJ, S&uacute;mula 479.
+STJ, EAREsp 676.608/RS.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0708142-71.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(48 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE BANCÁRIA. EMPRÉSTIMO CONSIGNADO. PORTABILIDADE DE BENEFÍCIO PREVIDENCIÁRIO. FALHA NA PRESTAÇÃO DO SERVIÇO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. SÚMULA 479/STJ. RESTITUIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em> CONFIGURADOS.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE BANCÁRIA. EMPRÉSTIMO CONSIGNADO. PORTABILIDADE DE BENEFÍCIO PREVIDENCIÁRIO. FALHA NA PRESTAÇÃO DO SERVIÇO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. SÚMULA 479/STJ. RESTITUIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em> CONFIGURADOS. RECURSO DO BANCO CONHECIDO E DESPROVIDO. RECURSO DA AUTORA CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Ação declaratória de inexistência de débito cumulada com indenização por <em>danos</em> <em>morais</em> ajuizada por consumidora em face de instituição financeira, sob alegação de contratação fraudulenta de empréstimo com subsequente transferência dos valores para terceiro desconhecido, acompanhada de descontos mensais em benefício previdenciário.
+2. O Juízo de Direito da Vara Cível julgou parcialmente procedentes os pedidos para declarar a nulidade do contrato de empréstimo, determinar a devolução simples dos valores pagos, permitir compensação com valores creditados e julgar improcedente o pedido de indenização por <em>danos</em> <em>morais</em>, fixando sucumbência recíproca.
+3. A instituição financeira interpôs recurso de apelação sustentando a regularidade da contratação mediante biometria facial e assinatura eletrônica, ausência de falha na prestação do serviço e inexistência de dever de restituição, requerendo a reforma integral da sentença.
+4. A autora também interpôs apelação pleiteando a restituição em dobro dos valores descontados, afastamento da compensação e condenação da instituição financeira ao pagamento de indenização por <em>danos</em> <em>morais</em>, sob alegação de fraude e ausência de engano justificável.
+5. Contrarrazões apresentadas por ambas as partes, pugnando pela manutenção dos capítulos da sentença que lhes foram favoráveis.
+II. QUESTÕES EM DISCUSSÃO
+6. Há três questões em discussão: (i) saber se a instituição financeira responde pelos prejuízos decorrentes de contratação fraudulenta e subsequente transferência de valores a terceiro; (ii) saber se a restituição dos valores descontados deve ocorrer em dobro e sem compensação; (iii) saber se a situação caracteriza <em>dano</em> <em>moral</em> indenizável.
+III. RAZÕES DE DECIDIR
+7. A relação jurídica estabelecida entre as partes possui natureza consumerista, sendo aplicável a responsabilidade objetiva do fornecedor prevista no art. 14 do Código de Defesa do Consumidor, segundo a qual o prestador responde independentemente de culpa pelos <em>danos</em> decorrentes de defeitos relativos à prestação do serviço.
+8. Restou evidenciada falha na prestação do serviço bancário, consubstanciada na liberação sucessiva de créditos e imediata transferência integral dos valores para conta de terceiro com histórico de fraude, sem a adoção de mecanismos eficazes de segurança.
+9. Incide, na espécie, a teoria do risco do empreendimento e o entendimento consolidado na Súmula 479 do Superior Tribunal de Justiça, segundo a qual as instituições financeiras respondem objetivamente pelos <em>danos</em> gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no âmbito de operações bancárias.
+10. A instituição financeira não comprovou manifestação válida de vontade da consumidora, tampouco demonstrou segurança suficiente no procedimento de validação biométrica, ônus que lhe incumbia nos termos das regras de distribuição dinâmica do ônus probatório aplicáveis às relações consumeristas.
+11. Reconhecida a falha na prestação do serviço, impõe-se a nulidade do contrato e a inexigibilidade dos débitos decorrentes das operações fraudulentas.
+12. Quanto à repetição do indébito, aplica-se o art. 42, parágrafo único, do Código de Defesa do Consumidor, sendo devida a restituição em dobro dos valores indevidamente descontados, uma vez ausente engano justificável por parte da instituição financeira.
+13. O entendimento encontra respaldo no julgamento do EAREsp 676.608/RS, da Corte Especial do Superior Tribunal de Justiça, que consolidou a orientação quanto à restituição em dobro quando inexistente justificativa plausível para a cobrança indevida.
+14. A compensação determinada na origem mostra-se indevida, pois a autora não usufruiu dos valores liberados, os quais foram imediatamente desviados por terceiros, circunstância que afasta qualquer benefício econômico à consumidora.
+15. Sobre os valores devidos incidem correção monetária desde o efetivo prejuízo e juros moratórios desde o evento danoso, conforme orientações das Súmulas 43 e 54 do Superior Tribunal de Justiça.
+16. No tocante aos <em>danos</em> <em>morais</em>, a indevida realização de descontos em benefício previdenciário de pessoa idosa configura violação a direitos da personalidade, caracterizando <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo concreto.
+17. A fixação da indenização no valor de R$ 3.000,00 observa os princípios da razoabilidade e proporcionalidade, considerando o caráter compensatório e pedagógico da medida.
+18. A correção monetária da indenização por <em>danos</em> <em>morais</em> incide a partir do arbitramento, nos termos da Súmula 362 do Superior Tribunal de Justiça, enquanto os juros moratórios incidem desde o evento danoso, conforme Súmula 54 do mesmo Tribunal.
+19. O redimensionamento do julgado implica a redistribuição dos ônus sucumbenciais, impondo-se à instituição financeira o pagamento integral das custas e honorários advocatícios, fixados com fundamento no art. 85, §§ 2º e 11, do Código de Processo Civil.
+IV. DISPOSITIVO E TESE
+20. Recurso da instituição financeira conhecido e desprovido. Recurso da autora conhecido e provido para reformar a sentença e declarar a inexistência dos débitos oriundos dos contratos fraudulentos, determinar a restituição em dobro dos valores indevidamente descontados, afastar a compensação e condenar a instituição financeira ao pagamento de indenização por <em>danos</em> <em>morais</em>, além de impor-lhe integral responsabilidade pelos ônus sucumbenciais.
+Tese de julgamento: "A instituição financeira responde objetivamente por fraudes decorrentes de falha na prestação do serviço bancário, sendo devida a restituição em dobro dos valores indevidamente descontados e a indenização por <em>danos</em> <em>morais</em> quando comprovada vulnerabilidade do consumidor e ausência de engano justificável."
+Dispositivos relevantes citados
+CDC, art. 14, § 1º; art. 42, parágrafo único.
+Código Civil, arts. 389 e 406.
+Código de Processo Civil, art. 85, §§ 2º e 11.
+Jurisprudência relevante citada
+STJ, Súmula 43.
+STJ, Súmula 54.
+STJ, Súmula 362.
+STJ, Súmula 479.
+STJ, EAREsp 676.608/RS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503709" cdForo="0" >
+										0714133-62.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503709" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503709);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503709" style="display: none;" >
+	<div id="textAreaDados_2503709" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O CONTRATUAL C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. FRAUDE EM CONTRATO DE FINANCIAMENTO VEICULAR. BIOMETRIA FACIAL. FORTUITO INTERNO. RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. DANO MORAL IN RE IPSA. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. HONOR&Aacute;RIOS SUCUMBENCIAIS. RATEIO ENTRE DEFENSORIA P&Uacute;BLICA E ADVOGADA PARTICULAR SUCESSORA. MAJORA&Ccedil;&Atilde;O RECURSAL. RECURSOS CONHECIDOS. DESPROVIMENTO DOS RECURSOS DO BANCO E DA AUTORA. PROVIMENTO DO RECURSO DA DEFENSORIA P&Uacute;BLICA.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o de procedimento comum ajuizada pela autora em face de institui&ccedil;&atilde;o financeira e corr&eacute;us, com pedido de declara&ccedil;&atilde;o de inexist&ecirc;ncia de rela&ccedil;&atilde;o contratual, inexigibilidade de d&eacute;bito oriundo de financiamento veicular, indeniza&ccedil;&atilde;o por danos morais e absten&ccedil;&atilde;o de cobran&ccedil;as e negativa&ccedil;&atilde;o.
+2. O Ju&iacute;zo sentenciante julgou procedentes os pedidos, declarando inexistente o contrato impugnado, inexig&iacute;vel o d&eacute;bito dele decorrente, determinando a absten&ccedil;&atilde;o de cobran&ccedil;as, condenando solidariamente os r&eacute;us ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 5.000,00 e fixando honor&aacute;rios advocat&iacute;cios em 10% sobre o valor da condena&ccedil;&atilde;o, confirmando tutela de urg&ecirc;ncia anteriormente concedida.
+3. O Banco r&eacute;u interp&ocirc;s apela&ccedil;&atilde;o sustentando a regularidade da contrata&ccedil;&atilde;o realizada por biometria facial e aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o, requerendo a reforma integral da senten&ccedil;a.
+4. A autora interp&ocirc;s recurso de apela&ccedil;&atilde;o pleiteando a majora&ccedil;&atilde;o do quantum indenizat&oacute;rio fixado a t&iacute;tulo de danos morais, sob alega&ccedil;&atilde;o de insufici&ecirc;ncia do valor arbitrado.
+5. A Defensoria P&uacute;blica interp&ocirc;s recurso aut&ocirc;nomo visando ao reconhecimento do direito ao rateio proporcional dos honor&aacute;rios sucumbenciais, em raz&atilde;o de sua atua&ccedil;&atilde;o inicial no processo antes da substitui&ccedil;&atilde;o por advogada particular.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+6. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se houve falha na presta&ccedil;&atilde;o do servi&ccedil;o pela institui&ccedil;&atilde;o financeira apta a ensejar a declara&ccedil;&atilde;o de inexist&ecirc;ncia do contrato e responsabiliza&ccedil;&atilde;o civil por fraude decorrente de fortuito interno; (ii) saber se o valor fixado a t&iacute;tulo de indeniza&ccedil;&atilde;o por danos morais deve ser majorado; (iii) saber se &eacute; devido o rateio proporcional dos honor&aacute;rios sucumbenciais entre a Defensoria P&uacute;blica e a advogada particular sucessora.
+III. RAZ&Otilde;ES DE DECIDIR
+7. A responsabilidade civil da institui&ccedil;&atilde;o financeira, nas rela&ccedil;&otilde;es de consumo, &eacute; objetiva, nos termos do art. 14 do C&oacute;digo de Defesa do Consumidor, impondo ao fornecedor o dever de seguran&ccedil;a na presta&ccedil;&atilde;o dos servi&ccedil;os.
+8. A utiliza&ccedil;&atilde;o de tecnologia de biometria facial n&atilde;o afasta o dever de cautela do fornecedor, sobretudo quando demonstradas inconsist&ecirc;ncias evidentes na an&aacute;lise de cr&eacute;dito, aus&ecirc;ncia de documentos essenciais e aprova&ccedil;&atilde;o de financiamento incompat&iacute;vel com a capacidade econ&ocirc;mica da consumidora, evidenciando falha sist&ecirc;mica na presta&ccedil;&atilde;o do servi&ccedil;o.
+9. A fraude perpetrada por terceiros, inclusive por parceiros comerciais, caracteriza fortuito interno, inserindo-se no risco da atividade econ&ocirc;mica, sendo imput&aacute;vel &agrave; institui&ccedil;&atilde;o financeira, conforme entendimento consolidado na S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a.
+10. A negativa&ccedil;&atilde;o indevida do nome do consumidor configura dano moral in re ipsa, dispensando prova do preju&iacute;zo concreto, por representar viola&ccedil;&atilde;o direta &agrave; honra objetiva do indiv&iacute;duo.
+11. A fixa&ccedil;&atilde;o do valor indenizat&oacute;rio deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano e o car&aacute;ter pedag&oacute;gico da condena&ccedil;&atilde;o, sendo mantido o valor arbitrado quando compat&iacute;vel com os par&acirc;metros jurisprudenciais aplic&aacute;veis ao caso concreto.
+12. O art. 4&ordm;, inciso XXI, da Lei Complementar n&ordm; 80/1994 assegura &agrave; Defensoria P&uacute;blica o direito &agrave; percep&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais, sendo cab&iacute;vel o rateio proporcional quando comprovada sua atua&ccedil;&atilde;o relevante no curso do processo antes da substitui&ccedil;&atilde;o por advogada particular.
+13. O art. 85 do C&oacute;digo de Processo Civil disciplina a fixa&ccedil;&atilde;o e majora&ccedil;&atilde;o de honor&aacute;rios sucumbenciais, sendo devida a majora&ccedil;&atilde;o em sede recursal quando o recurso da parte vencida &eacute; desprovido, respeitado o limite legal global.
+IV. DISPOSITIVO E TESE
+14. Recursos de apela&ccedil;&atilde;o do banco r&eacute;u e da autora conhecidos e desprovidos. Recurso de apela&ccedil;&atilde;o da Defensoria P&uacute;blica conhecido e provido, para determinar o rateio dos honor&aacute;rios sucumbenciais na propor&ccedil;&atilde;o de 50% ao Fundo Especial da Defensoria P&uacute;blica e 50% &agrave; advogada particular sucessora, com majora&ccedil;&atilde;o dos honor&aacute;rios totais para 12% sobre o valor da condena&ccedil;&atilde;o, mantidos os demais termos da senten&ccedil;a.
+Tese de julgamento: &quot;A fraude contratual decorrente de falha sist&ecirc;mica na concess&atilde;o de cr&eacute;dito configura fortuito interno, ensejando a responsabilidade objetiva da institui&ccedil;&atilde;o financeira e a declara&ccedil;&atilde;o de inexist&ecirc;ncia do contrato, sendo cab&iacute;vel o rateio proporcional dos honor&aacute;rios sucumbenciais entre Defensoria P&uacute;blica e advogada particular sucessora quando ambas contribu&iacute;ram para o resultado &uacute;til do processo&quot;.
+Dispositivos relevantes citados
+C&oacute;digo de Defesa do Consumidor, art. 14.
+C&oacute;digo de Processo Civil, arts. 85, &sect; 11; 344; 487, I; 1.010; 1.012, &sect; 1&ordm;, V.
+Lei Complementar n&ordm; 80/1994, art. 4&ordm;, XXI.
+Jurisprud&ecirc;ncia relevante citada
+STJ, S&uacute;mula 479.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0714133-62.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;5&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(27 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO CONTRATUAL C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE EM CONTRATO DE FINANCIAMENTO VEICULAR. BIOMETRIA FACIAL. FORTUITO INTERNO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. HONORÁRIOS SUCUMBENCIAIS.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO CONTRATUAL C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE EM CONTRATO DE FINANCIAMENTO VEICULAR. BIOMETRIA FACIAL. FORTUITO INTERNO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. HONORÁRIOS SUCUMBENCIAIS. RATEIO ENTRE DEFENSORIA PÚBLICA E ADVOGADA PARTICULAR SUCESSORA. MAJORAÇÃO RECURSAL. RECURSOS CONHECIDOS. DESPROVIMENTO DOS RECURSOS DO BANCO E DA AUTORA. PROVIMENTO DO RECURSO DA DEFENSORIA PÚBLICA.
+I. CASO EM EXAME
+1. Ação de procedimento comum ajuizada pela autora em face de instituição financeira e corréus, com pedido de declaração de inexistência de relação contratual, inexigibilidade de débito oriundo de financiamento veicular, indenização por <em>danos</em> <em>morais</em> e abstenção de cobranças e negativação.
+2. O Juízo sentenciante julgou procedentes os pedidos, declarando inexistente o contrato impugnado, inexigível o débito dele decorrente, determinando a abstenção de cobranças, condenando solidariamente os réus ao pagamento de indenização por <em>danos</em> <em>morais</em> no valor de R$ 5.000,00 e fixando honorários advocatícios em 10% sobre o valor da condenação, confirmando tutela de urgência anteriormente concedida.
+3. O Banco réu interpôs apelação sustentando a regularidade da contratação realizada por biometria facial e ausência de falha na prestação do serviço, requerendo a reforma integral da sentença.
+4. A autora interpôs recurso de apelação pleiteando a majoração do quantum indenizatório fixado a título de <em>danos</em> <em>morais</em>, sob alegação de insuficiência do valor arbitrado.
+5. A Defensoria Pública interpôs recurso autônomo visando ao reconhecimento do direito ao rateio proporcional dos honorários sucumbenciais, em razão de sua atuação inicial no processo antes da substituição por advogada particular.
+II. QUESTÕES EM DISCUSSÃO
+6. Há três questões em discussão: (i) saber se houve falha na prestação do serviço pela instituição financeira apta a ensejar a declaração de inexistência do contrato e responsabilização civil por fraude decorrente de fortuito interno; (ii) saber se o valor fixado a título de indenização por <em>danos</em> <em>morais</em> deve ser majorado; (iii) saber se é devido o rateio proporcional dos honorários sucumbenciais entre a Defensoria Pública e a advogada particular sucessora.
+III. RAZÕES DE DECIDIR
+7. A responsabilidade civil da instituição financeira, nas relações de consumo, é objetiva, nos termos do art. 14 do Código de Defesa do Consumidor, impondo ao fornecedor o dever de segurança na prestação dos serviços.
+8. A utilização de tecnologia de biometria facial não afasta o dever de cautela do fornecedor, sobretudo quando demonstradas inconsistências evidentes na análise de crédito, ausência de documentos essenciais e aprovação de financiamento incompatível com a capacidade econômica da consumidora, evidenciando falha sistêmica na prestação do serviço.
+9. A fraude perpetrada por terceiros, inclusive por parceiros comerciais, caracteriza fortuito interno, inserindo-se no risco da atividade econômica, sendo imputável à instituição financeira, conforme entendimento consolidado na Súmula 479 do Superior Tribunal de Justiça.
+10. A negativação indevida do nome do consumidor configura <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo concreto, por representar violação direta à honra objetiva do indivíduo.
+11. A fixação do valor indenizatório deve observar os princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em> e o caráter pedagógico da condenação, sendo mantido o valor arbitrado quando compatível com os parâmetros jurisprudenciais aplicáveis ao caso concreto.
+12. O art. 4º, inciso XXI, da Lei Complementar nº 80/1994 assegura à Defensoria Pública o direito à percepção dos honorários sucumbenciais, sendo cabível o rateio proporcional quando comprovada sua atuação relevante no curso do processo antes da substituição por advogada particular.
+13. O art. 85 do Código de Processo Civil disciplina a fixação e majoração de honorários sucumbenciais, sendo devida a majoração em sede recursal quando o recurso da parte vencida é desprovido, respeitado o limite legal global.
+IV. DISPOSITIVO E TESE
+14. Recursos de apelação do banco réu e da autora conhecidos e desprovidos. Recurso de apelação da Defensoria Pública conhecido e provido, para determinar o rateio dos honorários sucumbenciais na proporção de 50% ao Fundo Especial da Defensoria Pública e 50% à advogada particular sucessora, com majoração dos honorários totais para 12% sobre o valor da condenação, mantidos os demais termos da sentença.
+Tese de julgamento: "A fraude contratual decorrente de falha sistêmica na concessão de crédito configura fortuito interno, ensejando a responsabilidade objetiva da instituição financeira e a declaração de inexistência do contrato, sendo cabível o rateio proporcional dos honorários sucumbenciais entre Defensoria Pública e advogada particular sucessora quando ambas contribuíram para o resultado útil do processo".
+Dispositivos relevantes citados
+Código de Defesa do Consumidor, art. 14.
+Código de Processo Civil, arts. 85, § 11; 344; 487, I; 1.010; 1.012, § 1º, V.
+Lei Complementar nº 80/1994, art. 4º, XXI.
+Jurisprudência relevante citada
+STJ, Súmula 479.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503710" cdForo="0" >
+										0713577-26.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503710" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503710);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503710" style="display: none;" >
+	<div id="textAreaDados_2503710" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. FRAUDE BANC&Aacute;RIA. EMPR&Eacute;STIMOS CONTRATADOS MEDIANTE ENGENHARIA SOCIAL. BIOMETRIA FACIAL REALIZADA PELA CONSUMIDORA. CULPA CONCORRENTE. NULIDADE DOS CONTRATOS MANTIDA. RESTITUI&Ccedil;&Atilde;O SIMPLES DOS VALORES. AFASTAMENTO DA REPETI&Ccedil;&Atilde;O EM DOBRO. EXCLUS&Atilde;O DA INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. SUCUMB&Ecirc;NCIA REC&Iacute;PROCA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de neg&oacute;cio jur&iacute;dico ajuizada pela autora em face de institui&ccedil;&atilde;o financeira, visando &agrave; nulidade de contratos de empr&eacute;stimo supostamente firmados mediante fraude, restitui&ccedil;&atilde;o dos valores descontados e indeniza&ccedil;&atilde;o por danos morais.
+2. A senten&ccedil;a julgou procedentes os pedidos para declarar a nulidade dos contratos, condenar a r&eacute; &agrave; restitui&ccedil;&atilde;o dos valores descontados &#150;  em parte simples e em parte em dobro &#150;  e ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 5.000,00, al&eacute;m de custas e honor&aacute;rios advocat&iacute;cios.
+3. A institui&ccedil;&atilde;o financeira interp&ocirc;s apela&ccedil;&atilde;o sustentando a regularidade da contrata&ccedil;&atilde;o, realizada mediante biometria facial da consumidora, bem como a ocorr&ecirc;ncia de culpa exclusiva da v&iacute;tima, que teria transferido voluntariamente os valores a terceiros, requerendo a reforma integral da senten&ccedil;a.
+4. A autora apresentou contrarraz&otilde;es defendendo a manuten&ccedil;&atilde;o da senten&ccedil;a, alegando falha da institui&ccedil;&atilde;o financeira ao permitir opera&ccedil;&otilde;es at&iacute;picas incompat&iacute;veis com seu perfil financeiro.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+5. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se os contratos celebrados mediante biometria facial, sob induzimento de terceiros, devem ser considerados nulos por v&iacute;cio de consentimento; (ii) saber se a responsabilidade pelos preju&iacute;zos decorrentes de fraude banc&aacute;ria deve ser atribu&iacute;da exclusivamente &agrave; consumidora ou compartilhada com a institui&ccedil;&atilde;o financeira; (iii) saber se s&atilde;o devidos restitui&ccedil;&atilde;o em dobro dos valores e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+6. A controv&eacute;rsia foi analisada sob a &oacute;tica da responsabilidade civil nas rela&ccedil;&otilde;es de consumo, reconhecendo-se que a fraude decorreu de engenharia social praticada por terceiros, com participa&ccedil;&atilde;o ativa da consumidora ao realizar biometria facial e transfer&ecirc;ncias banc&aacute;rias, caracterizando conduta imprudente apta a contribuir para o resultado danoso.
+7. Entretanto, a institui&ccedil;&atilde;o financeira tamb&eacute;m incorreu em falha na presta&ccedil;&atilde;o do servi&ccedil;o ao permitir a contrata&ccedil;&atilde;o sucessiva de empr&eacute;stimos e m&uacute;ltiplas transfer&ecirc;ncias em curto espa&ccedil;o de tempo, incompat&iacute;veis com o perfil financeiro da consumidora, o que configura viola&ccedil;&atilde;o ao dever de seguran&ccedil;a previsto no art. 4&ordm; do C&oacute;digo de Defesa do Consumidor.
+8. Nos termos da teoria do fortuito interno, consolidada na S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a, as institui&ccedil;&otilde;es financeiras respondem pelos danos decorrentes de fraudes praticadas por terceiros no &acirc;mbito de suas opera&ccedil;&otilde;es, por se tratar de risco inerente &agrave; atividade banc&aacute;ria.
+9. Diante da participa&ccedil;&atilde;o concorrente das partes na produ&ccedil;&atilde;o do evento danoso, aplicou-se o disposto no art. 945 do C&oacute;digo Civil, reconhecendo-se a culpa concorrente entre consumidora e institui&ccedil;&atilde;o financeira, com consequente redimensionamento das consequ&ecirc;ncias jur&iacute;dicas.
+10. A nulidade dos contratos foi mantida em raz&atilde;o do v&iacute;cio de consentimento decorrente de dolo de terceiro, circunst&acirc;ncia que compromete a validade do neg&oacute;cio jur&iacute;dico e imp&otilde;e a restitui&ccedil;&atilde;o dos valores indevidamente descontados.
+11. A restitui&ccedil;&atilde;o foi limitada &agrave; forma simples, por aus&ecirc;ncia de comprova&ccedil;&atilde;o de m&aacute;-f&eacute; da institui&ccedil;&atilde;o financeira, configurando-se hip&oacute;tese de engano justific&aacute;vel, nos termos do art. 42, par&aacute;grafo &uacute;nico, do C&oacute;digo de Defesa do Consumidor.
+12. A indeniza&ccedil;&atilde;o por danos morais foi afastada, considerando-se que o preju&iacute;zo suportado decorreu de culpa concorrente e que a recomposi&ccedil;&atilde;o patrimonial mediante restitui&ccedil;&atilde;o dos valores revela-se suficiente &agrave; restaura&ccedil;&atilde;o do equil&iacute;brio jur&iacute;dico, evitando enriquecimento sem causa.
+13. Reconhecida a sucumb&ecirc;ncia rec&iacute;proca, determinou-se o rateio das custas processuais e honor&aacute;rios advocat&iacute;cios entre as partes, nos termos do art. 86 do C&oacute;digo de Processo Civil, vedada a compensa&ccedil;&atilde;o de honor&aacute;rios conforme art. 85, &sect; 14, do mesmo diploma legal.
+IV. DISPOSITIVO E TESE
+14. Recurso conhecido e parcialmente provido, para manter a nulidade dos contratos, determinar a restitui&ccedil;&atilde;o simples dos valores descontados e afastar a condena&ccedil;&atilde;o por danos morais, com reconhecimento da sucumb&ecirc;ncia rec&iacute;proca e rateio das custas e honor&aacute;rios.
+Tese de julgamento: &quot;Em casos de fraude banc&aacute;ria decorrente de engenharia social, comprovada a participa&ccedil;&atilde;o ativa do consumidor e a falha da institui&ccedil;&atilde;o financeira no monitoramento de opera&ccedil;&otilde;es at&iacute;picas, configura-se culpa concorrente, impondo-se a nulidade dos contratos viciados, restitui&ccedil;&atilde;o simples dos valores indevidamente descontados e afastamento da indeniza&ccedil;&atilde;o por danos morais.&quot;
+Dispositivos relevantes citados
+CDC, art. 4&ordm;; CDC, art. 42, par&aacute;grafo &uacute;nico; CC, art. 945; CPC, art. 85, &sect; 14; CPC, art. 86; CPC, art. 98, &sect; 3&ordm;.
+Jurisprud&ecirc;ncia relevante citada
+STJ, S&uacute;mula 479.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0713577-26.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;3&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. FRAUDE BANCÁRIA. EMPRÉSTIMOS CONTRATADOS MEDIANTE ENGENHARIA SOCIAL. BIOMETRIA FACIAL REALIZADA PELA CONSUMIDORA. CULPA CONCORRENTE. NULIDADE DOS CONTRATOS MANTIDA. RESTITUIÇÃO SIMPLES DOS VALORES. AFASTAMENTO DA REPETIÇÃO EM DOBRO. EXCLUSÃO DA INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. SUCUMBÊNCIA RECÍPROCA. RECURSO CONHECIDO E PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. FRAUDE BANCÁRIA. EMPRÉSTIMOS CONTRATADOS MEDIANTE ENGENHARIA SOCIAL. BIOMETRIA FACIAL REALIZADA PELA CONSUMIDORA. CULPA CONCORRENTE. NULIDADE DOS CONTRATOS MANTIDA. RESTITUIÇÃO SIMPLES DOS VALORES. AFASTAMENTO DA REPETIÇÃO EM DOBRO. EXCLUSÃO DA INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. SUCUMBÊNCIA RECÍPROCA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Ação declaratória de inexistência de negócio jurídico ajuizada pela autora em face de instituição financeira, visando à nulidade de contratos de empréstimo supostamente firmados mediante fraude, restituição dos valores descontados e indenização por <em>danos</em> <em>morais</em>.
+2. A sentença julgou procedentes os pedidos para declarar a nulidade dos contratos, condenar a ré à restituição dos valores descontados   em parte simples e em parte em dobro   e ao pagamento de indenização por <em>danos</em> <em>morais</em> no valor de R$ 5.000,00, além de custas e honorários advocatícios.
+3. A instituição financeira interpôs apelação sustentando a regularidade da contratação, realizada mediante biometria facial da consumidora, bem como a ocorrência de culpa exclusiva da vítima, que teria transferido voluntariamente os valores a terceiros, requerendo a reforma integral da sentença.
+4. A autora apresentou contrarrazões defendendo a manutenção da sentença, alegando falha da instituição financeira ao permitir operações atípicas incompatíveis com seu perfil financeiro.
+II. QUESTÕES EM DISCUSSÃO
+5. Há três questões em discussão: (i) saber se os contratos celebrados mediante biometria facial, sob induzimento de terceiros, devem ser considerados nulos por vício de consentimento; (ii) saber se a responsabilidade pelos prejuízos decorrentes de fraude bancária deve ser atribuída exclusivamente à consumidora ou compartilhada com a instituição financeira; (iii) saber se são devidos restituição em dobro dos valores e indenização por <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+6. A controvérsia foi analisada sob a ótica da responsabilidade civil nas relações de consumo, reconhecendo-se que a fraude decorreu de engenharia social praticada por terceiros, com participação ativa da consumidora ao realizar biometria facial e transferências bancárias, caracterizando conduta imprudente apta a contribuir para o resultado danoso.
+7. Entretanto, a instituição financeira também incorreu em falha na prestação do serviço ao permitir a contratação sucessiva de empréstimos e múltiplas transferências em curto espaço de tempo, incompatíveis com o perfil financeiro da consumidora, o que configura violação ao dever de segurança previsto no art. 4º do Código de Defesa do Consumidor.
+8. Nos termos da teoria do fortuito interno, consolidada na Súmula 479 do Superior Tribunal de Justiça, as instituições financeiras respondem pelos <em>danos</em> decorrentes de fraudes praticadas por terceiros no âmbito de suas operações, por se tratar de risco inerente à atividade bancária.
+9. Diante da participação concorrente das partes na produção do evento danoso, aplicou-se o disposto no art. 945 do Código Civil, reconhecendo-se a culpa concorrente entre consumidora e instituição financeira, com consequente redimensionamento das consequências jurídicas.
+10. A nulidade dos contratos foi mantida em razão do vício de consentimento decorrente de dolo de terceiro, circunstância que compromete a validade do negócio jurídico e impõe a restituição dos valores indevidamente descontados.
+11. A restituição foi limitada à forma simples, por ausência de comprovação de má-fé da instituição financeira, configurando-se hipótese de engano justificável, nos termos do art. 42, parágrafo único, do Código de Defesa do Consumidor.
+12. A indenização por <em>danos</em> <em>morais</em> foi afastada, considerando-se que o prejuízo suportado decorreu de culpa concorrente e que a recomposição patrimonial mediante restituição dos valores revela-se suficiente à restauração do equilíbrio jurídico, evitando enriquecimento sem causa.
+13. Reconhecida a sucumbência recíproca, determinou-se o rateio das custas processuais e honorários advocatícios entre as partes, nos termos do art. 86 do Código de Processo Civil, vedada a compensação de honorários conforme art. 85, § 14, do mesmo diploma legal.
+IV. DISPOSITIVO E TESE
+14. Recurso conhecido e parcialmente provido, para manter a nulidade dos contratos, determinar a restituição simples dos valores descontados e afastar a condenação por <em>danos</em> <em>morais</em>, com reconhecimento da sucumbência recíproca e rateio das custas e honorários.
+Tese de julgamento: "Em casos de fraude bancária decorrente de engenharia social, comprovada a participação ativa do consumidor e a falha da instituição financeira no monitoramento de operações atípicas, configura-se culpa concorrente, impondo-se a nulidade dos contratos viciados, restituição simples dos valores indevidamente descontados e afastamento da indenização por <em>danos</em> <em>morais</em>."
+Dispositivos relevantes citados
+CDC, art. 4º; CDC, art. 42, parágrafo único; CC, art. 945; CPC, art. 85, § 14; CPC, art. 86; CPC, art. 98, § 3º.
+Jurisprudência relevante citada
+STJ, Súmula 479.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503708" cdForo="0" >
+										0714997-66.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503708" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503708);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503708" style="display: none;" >
+	<div id="textAreaDados_2503708" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. RESPONSABILIDADE CIVIL. RELA&Ccedil;&Atilde;O DE CONSUMO. INSCRI&Ccedil;&Atilde;O INDEVIDA EM CADASTRO DE INADIMPLENTES. DANO MORAL. PEDIDO DE MAJORA&Ccedil;&Atilde;O DO VALOR DA INDENIZA&Ccedil;&Atilde;O. TERMO INICIAL DOS JUROS DE MORA. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o c&iacute;vel interposto pela parte autora contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito cumulada com indeniza&ccedil;&atilde;o, julgou parcialmente procedente o pedido para declarar a inexigibilidade da d&iacute;vida e condenar a empresa r&eacute; ao pagamento de indeniza&ccedil;&atilde;o por danos morais. A recorrente pleiteia a majora&ccedil;&atilde;o do valor indenizat&oacute;rio, a altera&ccedil;&atilde;o do termo inicial dos juros de mora para a data do evento danoso e a fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios por aprecia&ccedil;&atilde;o equitativa.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A fixa&ccedil;&atilde;o do valor da indeniza&ccedil;&atilde;o por dano moral deve observar os princ&iacute;pios da razoabilidade e da proporcionalidade, considerando a extens&atilde;o do dano, a capacidade econ&ocirc;mica das partes e o car&aacute;ter d&uacute;plice da medida, que &eacute; compensat&oacute;rio para a v&iacute;tima e pedag&oacute;gico para o ofensor.
+4. O montante indenizat&oacute;rio fixado na primeira inst&acirc;ncia, embora n&atilde;o corresponda ao patamar almejado pela parte recorrente, n&atilde;o se revela irris&oacute;rio ou desproporcional, inserindo-se na margem de discricionariedade do julgador e em conformidade com os par&acirc;metros adotados por este Tribunal em casos an&aacute;logos, o que afasta a necessidade de interven&ccedil;&atilde;o para major&aacute;-lo.
+5. A inscri&ccedil;&atilde;o indevida do nome do consumidor em cadastros de prote&ccedil;&atilde;o ao cr&eacute;dito configura ato il&iacute;cito que gera responsabilidade de natureza extracontratual.
+6. Em se tratando de responsabilidade civil extracontratual, os juros de mora sobre a indeniza&ccedil;&atilde;o por danos morais fluem a partir da data do evento danoso, conforme o entendimento consolidado na S&uacute;mula 54 do Superior Tribunal de Justi&ccedil;a.
+7. A fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios sucumbenciais deve, como regra, seguir os percentuais estabelecidos no &sect; 2&ordm; do art. 85 do C&oacute;digo de Processo Civil, incidentes sobre o valor da condena&ccedil;&atilde;o, do proveito econ&ocirc;mico ou do valor da causa.
+8. A aplica&ccedil;&atilde;o do crit&eacute;rio de aprecia&ccedil;&atilde;o equitativa, previsto no &sect; 8&ordm; do art. 85 do CPC, &eacute; medida excepcional, restrita &agrave;s hip&oacute;teses em que o proveito econ&ocirc;mico for inestim&aacute;vel ou irris&oacute;rio, ou o valor da causa for muito baixo, n&atilde;o se aplicando quando o valor da condena&ccedil;&atilde;o, ainda que modesto, for mensur&aacute;vel e n&atilde;o &iacute;nfimo.
+IV. DISPOSITIVO E TESE
+9. Recurso conhecido e parcialmente provido
+Tese de julgamento: &quot;Em casos de indeniza&ccedil;&atilde;o por dano moral decorrente de inscri&ccedil;&atilde;o indevida em cadastro de inadimplentes, por se tratar de responsabilidade extracontratual, o termo inicial dos juros de mora &eacute; a data do evento danoso, nos termos da S&uacute;mula 54 do STJ; A fixa&ccedil;&atilde;o de honor&aacute;rios advocat&iacute;cios por equidade &eacute; subsidi&aacute;ria, n&atilde;o sendo cab&iacute;vel quando o valor da condena&ccedil;&atilde;o, ainda que n&atilde;o elevado, n&atilde;o se configura como irris&oacute;rio, devendo-se aplicar a regra geral de fixa&ccedil;&atilde;o percentual sobre a condena&ccedil;&atilde;o; A revis&atilde;o do valor da indeniza&ccedil;&atilde;o por danos morais em sede de apela&ccedil;&atilde;o somente se justifica quando a quantia fixada na origem se mostrar manifestamente irris&oacute;ria ou exorbitante, em descompasso com os princ&iacute;pios da razoabilidade e da proporcionalidade.&quot;
+Dispositivos relevantes citados:
+C&oacute;digo de Defesa do Consumidor, Art. 14;
+C&oacute;digo de Processo Civil, Art. 85, &sect;&sect; 2&ordm;, 8&ordm;
+Jurisprud&ecirc;ncia relevante citada:
+S&uacute;mula 54 do STJ.
+S&uacute;mula 362 do STJ.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0714997-66.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(49 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. RESPONSABILIDADE CIVIL. RELAÇÃO DE CONSUMO. INSCRIÇÃO INDEVIDA EM CADASTRO DE INADIMPLENTES. <em>DANO</em> <em>MORAL</em>. PEDIDO DE MAJORAÇÃO DO VALOR DA INDENIZAÇÃO. TERMO INICIAL DOS JUROS DE MORA. HONORÁRIOS ADVOCATÍCIOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apelação cível interposto pela parte autora contra sentença que,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. RESPONSABILIDADE CIVIL. RELAÇÃO DE CONSUMO. INSCRIÇÃO INDEVIDA EM CADASTRO DE INADIMPLENTES. <em>DANO</em> <em>MORAL</em>. PEDIDO DE MAJORAÇÃO DO VALOR DA INDENIZAÇÃO. TERMO INICIAL DOS JUROS DE MORA. HONORÁRIOS ADVOCATÍCIOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apelação cível interposto pela parte autora contra sentença que, em ação declaratória de inexistência de débito cumulada com indenização, julgou parcialmente procedente o pedido para declarar a inexigibilidade da dívida e condenar a empresa ré ao pagamento de indenização por <em>danos</em> <em>morais</em>. A recorrente pleiteia a majoração do valor indenizatório, a alteração do termo inicial dos juros de mora para a data do evento danoso e a fixação dos honorários advocatícios por apreciação equitativa.
+III. RAZÕES DE DECIDIR
+3. A fixação do valor da indenização por <em>dano</em> <em>moral</em> deve observar os princípios da razoabilidade e da proporcionalidade, considerando a extensão do <em>dano</em>, a capacidade econômica das partes e o caráter dúplice da medida, que é compensatório para a vítima e pedagógico para o ofensor.
+4. O montante indenizatório fixado na primeira instância, embora não corresponda ao patamar almejado pela parte recorrente, não se revela irrisório ou desproporcional, inserindo-se na margem de discricionariedade do julgador e em conformidade com os parâmetros adotados por este Tribunal em casos análogos, o que afasta a necessidade de intervenção para majorá-lo.
+5. A inscrição indevida do nome do consumidor em cadastros de proteção ao crédito configura ato ilícito que gera responsabilidade de natureza extracontratual.
+6. Em se tratando de responsabilidade civil extracontratual, os juros de mora sobre a indenização por <em>danos</em> <em>morais</em> fluem a partir da data do evento danoso, conforme o entendimento consolidado na Súmula 54 do Superior Tribunal de Justiça.
+7. A fixação dos honorários advocatícios sucumbenciais deve, como regra, seguir os percentuais estabelecidos no § 2º do art. 85 do Código de Processo Civil, incidentes sobre o valor da condenação, do proveito econômico ou do valor da causa.
+8. A aplicação do critério de apreciação equitativa, previsto no § 8º do art. 85 do CPC, é medida excepcional, restrita às hipóteses em que o proveito econômico for inestimável ou irrisório, ou o valor da causa for muito baixo, não se aplicando quando o valor da condenação, ainda que modesto, for mensurável e não ínfimo.
+IV. DISPOSITIVO E TESE
+9. Recurso conhecido e parcialmente provido
+Tese de julgamento: "Em casos de indenização por <em>dano</em> <em>moral</em> decorrente de inscrição indevida em cadastro de inadimplentes, por se tratar de responsabilidade extracontratual, o termo inicial dos juros de mora é a data do evento danoso, nos termos da Súmula 54 do STJ; A fixação de honorários advocatícios por equidade é subsidiária, não sendo cabível quando o valor da condenação, ainda que não elevado, não se configura como irrisório, devendo-se aplicar a regra geral de fixação percentual sobre a condenação; A revisão do valor da indenização por <em>danos</em> <em>morais</em> em sede de apelação somente se justifica quando a quantia fixada na origem se mostrar manifestamente irrisória ou exorbitante, em descompasso com os princípios da razoabilidade e da proporcionalidade."
+Dispositivos relevantes citados:
+Código de Defesa do Consumidor, Art. 14;
+Código de Processo Civil, Art. 85, §§ 2º, 8º
+Jurisprudência relevante citada:
+Súmula 54 do STJ.
+Súmula 362 do STJ.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503740" cdForo="0" >
+										0715050-81.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503740" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503740);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503740" style="display: none;" >
+	<div id="textAreaDados_2503740" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. PORTABILIDADE DE BENEF&Iacute;CIO ASSISTENCIAL (BPC/LOAS). ENTRAVES ADMINISTRATIVOS IMPOSTOS POR INSTITUI&Ccedil;&Atilde;O FINANCEIRA. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. DANO MORAL IN RE IPSA. DESVIO PRODUTIVO DO CONSUMIDOR. MENOR EM CONDI&Ccedil;&Atilde;O DE VULNERABILIDADE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por menor representado por sua genitora contra senten&ccedil;a que, nos autos de a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer cumulada com indeniza&ccedil;&atilde;o por danos morais, julgou parcialmente procedente o pedido para determinar a portabilidade de benef&iacute;cio assistencial (BPC/LOAS), mas afastou a condena&ccedil;&atilde;o por danos morais, sob fundamento de aus&ecirc;ncia de prova suficiente do abalo extrapatrimonial.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em definir se a imposi&ccedil;&atilde;o de entraves administrativos &agrave; portabilidade de benef&iacute;cio assistencial por institui&ccedil;&atilde;o financeira, especialmente quando efetivada apenas ap&oacute;s interven&ccedil;&atilde;o judicial, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o apta a ensejar indeniza&ccedil;&atilde;o por dano moral.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A rela&ccedil;&atilde;o jur&iacute;dica entre as partes &eacute; de consumo, sendo objetiva a responsabilidade da institui&ccedil;&atilde;o financeira pelos danos causados, nos termos do art. 14 do CDC.
+4. A efetiva&ccedil;&atilde;o da portabilidade apenas ap&oacute;s interven&ccedil;&atilde;o judicial evidencia resist&ecirc;ncia indevida e caracteriza falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+5. A exig&ecirc;ncia de comparecimento presencial e a imposi&ccedil;&atilde;o de obst&aacute;culos administrativos injustificados violam normas do Banco Central (Resolu&ccedil;&otilde;es n&ordm; 3.402/2006 e 4.539/2016), configurando conduta il&iacute;cita.
+6. A restri&ccedil;&atilde;o ao exerc&iacute;cio de direito relacionado a verba de natureza alimentar agrava a ilicitude da conduta e potencializa o dano.
+7. A necessidade de a representante legal do menor despender tempo e esfor&ccedil;o para solucionar problema causado pelo fornecedor caracteriza desvio produtivo do consumidor.
+8. O dano moral, na hip&oacute;tese, &eacute; presumido (in re ipsa), sendo desnecess&aacute;ria a comprova&ccedil;&atilde;o de preju&iacute;zo concreto diante da falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+9. A condi&ccedil;&atilde;o de vulnerabilidade do autor, menor portador de necessidades especiais, refor&ccedil;a a gravidade da conduta e justifica a repara&ccedil;&atilde;o.
+10. O valor da indeniza&ccedil;&atilde;o deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, sendo adequado o arbitramento em R$ 3.000,00.
+11. A fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios deve incidir sobre o valor da condena&ccedil;&atilde;o, nos termos do art. 85, &sect;2&ordm;, do CPC, com percentual de 15%.
+IV. DISPOSITIVO E TESE
+12. Recurso parcialmente provido.
+Tese de julgamento:
+1. A imposi&ccedil;&atilde;o de entraves injustificados por institui&ccedil;&atilde;o financeira &agrave; portabilidade de benef&iacute;cio assistencial configura falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+2. O dano moral decorrente da indevida restri&ccedil;&atilde;o ao recebimento de verba alimentar &eacute; presumido, dispensando prova do preju&iacute;zo.
+3. A teoria do desvio produtivo do consumidor aplica-se quando o usu&aacute;rio &eacute; compelido a despender tempo e recursos para solucionar falha do fornecedor.
+4. A indeniza&ccedil;&atilde;o por dano moral deve ser fixada com base na razoabilidade e proporcionalidade, considerando o car&aacute;ter compensat&oacute;rio e pedag&oacute;gico.
+Dispositivos relevantes citados: CDC, art. 14; CPC, arts. 85, &sect; 2&ordm;, 86, par&aacute;grafo &uacute;nico, e 178, II; Resolu&ccedil;&otilde;es BACEN n&ordm; 3.402/2006 e n&ordm; 4.539/2016.
+Jurisprud&ecirc;ncia relevante citada: TJSP, AC n&ordm; 1003203-40.2019.8.26.0566, Rel. Denise Andr&eacute;a Martins Retamero, j. 30.06.2020; TJAM, AC n&ordm; 0682270-75.2022.8.04.0001, Rel. Cezar Luiz Bandiera, j. 31.10.2024; TJAC, AI n&ordm; 1001984-61.2024.8.01.0000, Rel. Des. J&uacute;nior Alberto, j. 31.01.2025.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0715050-81.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;5&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(57 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PORTABILIDADE DE BENEFÍCIO ASSISTENCIAL (BPC/LOAS). ENTRAVES ADMINISTRATIVOS IMPOSTOS POR INSTITUIÇÃO FINANCEIRA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. DESVIO PRODUTIVO DO CONSUMIDOR. MENOR EM CONDIÇÃO DE VULNERABILIDADE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por menor representado por
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PORTABILIDADE DE BENEFÍCIO ASSISTENCIAL (BPC/LOAS). ENTRAVES ADMINISTRATIVOS IMPOSTOS POR INSTITUIÇÃO FINANCEIRA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. DESVIO PRODUTIVO DO CONSUMIDOR. MENOR EM CONDIÇÃO DE VULNERABILIDADE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por menor representado por sua genitora contra sentença que, nos autos de ação de obrigação de fazer cumulada com indenização por <em>danos</em> <em>morais</em>, julgou parcialmente procedente o pedido para determinar a portabilidade de benefício assistencial (BPC/LOAS), mas afastou a condenação por <em>danos</em> <em>morais</em>, sob fundamento de ausência de prova suficiente do abalo extrapatrimonial.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em definir se a imposição de entraves administrativos à portabilidade de benefício assistencial por instituição financeira, especialmente quando efetivada apenas após intervenção judicial, configura falha na prestação do serviço apta a ensejar indenização por <em>dano</em> <em>moral</em>.
+III. RAZÕES DE DECIDIR
+3. A relação jurídica entre as partes é de consumo, sendo objetiva a responsabilidade da instituição financeira pelos <em>danos</em> causados, nos termos do art. 14 do CDC.
+4. A efetivação da portabilidade apenas após intervenção judicial evidencia resistência indevida e caracteriza falha na prestação do serviço.
+5. A exigência de comparecimento presencial e a imposição de obstáculos administrativos injustificados violam normas do Banco Central (Resoluções nº 3.402/2006 e 4.539/2016), configurando conduta ilícita.
+6. A restrição ao exercício de direito relacionado a verba de natureza alimentar agrava a ilicitude da conduta e potencializa o <em>dano</em>.
+7. A necessidade de a representante legal do menor despender tempo e esforço para solucionar problema causado pelo fornecedor caracteriza desvio produtivo do consumidor.
+8. O <em>dano</em> <em>moral</em>, na hipótese, é presumido (in re ipsa), sendo desnecessária a comprovação de prejuízo concreto diante da falha na prestação do serviço.
+9. A condição de vulnerabilidade do autor, menor portador de necessidades especiais, reforça a gravidade da conduta e justifica a reparação.
+10. O valor da indenização deve observar os princípios da razoabilidade e proporcionalidade, sendo adequado o arbitramento em R$ 3.000,00.
+11. A fixação dos honorários advocatícios deve incidir sobre o valor da condenação, nos termos do art. 85, §2º, do CPC, com percentual de 15%.
+IV. DISPOSITIVO E TESE
+12. Recurso parcialmente provido.
+Tese de julgamento:
+1. A imposição de entraves injustificados por instituição financeira à portabilidade de benefício assistencial configura falha na prestação do serviço.
+2. O <em>dano</em> <em>moral</em> decorrente da indevida restrição ao recebimento de verba alimentar é presumido, dispensando prova do prejuízo.
+3. A teoria do desvio produtivo do consumidor aplica-se quando o usuário é compelido a despender tempo e recursos para solucionar falha do fornecedor.
+4. A indenização por <em>dano</em> <em>moral</em> deve ser fixada com base na razoabilidade e proporcionalidade, considerando o caráter compensatório e pedagógico.
+Dispositivos relevantes citados: CDC, art. 14; CPC, arts. 85, § 2º, 86, parágrafo único, e 178, II; Resoluções BACEN nº 3.402/2006 e nº 4.539/2016.
+Jurisprudência relevante citada: TJSP, AC nº 1003203-40.2019.8.26.0566, Rel. Denise Andréa Martins Retamero, j. 30.06.2020; TJAM, AC nº 0682270-75.2022.8.04.0001, Rel. Cezar Luiz Bandiera, j. 31.10.2024; TJAC, AI nº 1001984-61.2024.8.01.0000, Rel. Des. Júnior Alberto, j. 31.01.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503739" cdForo="0" >
+										1000278-72.2026.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503739" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503739);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503739" style="display: none;" >
+	<div id="textAreaDados_2503739" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. GRATUIDADE DE JUSTI&Ccedil;A. ENTIDADE FILANTR&Oacute;PICA. ISEN&Ccedil;&Atilde;O DE CUSTAS. TAXATIVIDADE MITIGADA DO ART. 1.015 DO CPC. CABIMENTO. PROVA PERICIAL. ERRO M&Eacute;DICO. NECESSIDADE DE PER&Iacute;CIA ESPECIALIZADA EM ANESTESIOLOGIA. CERCEAMENTO DE DEFESA CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo de instrumento interposto contra decis&atilde;o que, em a&ccedil;&atilde;o indenizat&oacute;ria por alegado erro m&eacute;dico, revogou a determina&ccedil;&atilde;o de realiza&ccedil;&atilde;o de nova per&iacute;cia m&eacute;dica especializada e determinou o prosseguimento do feito com possibilidade de julgamento antecipado, al&eacute;m de impugnar o pedido de gratuidade de justi&ccedil;a, pleiteando a concess&atilde;o do benef&iacute;cio e a reabertura da instru&ccedil;&atilde;o com produ&ccedil;&atilde;o de prova pericial adequada.
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; cab&iacute;vel o agravo de instrumento &agrave; luz da taxatividade mitigada do art. 1.015 do CPC; (ii) estabelecer se a revoga&ccedil;&atilde;o da per&iacute;cia m&eacute;dica especializada em anestesiologia configura cerceamento de defesa em demanda por erro m&eacute;dico.
+Reconhece-se a gratuidade de justi&ccedil;a, pois a agravante, entidade filantr&oacute;pica sem fins lucrativos, &eacute; isenta do pagamento de custas nos termos do art. 2&ordm;, VII, da Lei Estadual n&ordm; 1.422/2001.
+Admite-se o agravo de instrumento com base na taxatividade mitigada do art. 1.015 do CPC, conforme Tema 988 do STJ, diante do risco de inutilidade do exame da mat&eacute;ria em apela&ccedil;&atilde;o.
+A controv&eacute;rsia envolve mat&eacute;ria t&eacute;cnica complexa relativa a erro m&eacute;dico, exigindo prova pericial especializada para adequada elucida&ccedil;&atilde;o dos fatos.
+Considera-se relevante o fato de o pr&oacute;prio ju&iacute;zo de origem ter previamente reconhecido a necessidade de per&iacute;cia por especialista em anestesiologia, evidenciando a imprescindibilidade da prova.
+O poder do magistrado de indeferir provas n&atilde;o autoriza a supress&atilde;o de meio probat&oacute;rio essencial &agrave; solu&ccedil;&atilde;o da lide, especialmente quando a prova existente &eacute; insuficiente.
+Rejeita-se a justificativa de dificuldade na nomea&ccedil;&atilde;o de perito como fundamento suficiente para afastar a produ&ccedil;&atilde;o da prova t&eacute;cnica necess&aacute;ria.
+Conclui-se que a aus&ecirc;ncia de per&iacute;cia especializada compromete a forma&ccedil;&atilde;o do convencimento judicial e viola os princ&iacute;pios do contradit&oacute;rio e da ampla defesa.
+Reconhece-se o cerceamento de defesa diante da supress&atilde;o de prova essencial ao deslinde da controv&eacute;rsia.
+Recurso provido.
+A taxatividade do art. 1.015 do CPC &eacute; mitigada, admitindo agravo de instrumento quando houver risco de inutilidade do julgamento da quest&atilde;o em apela&ccedil;&atilde;o.
+A revoga&ccedil;&atilde;o de prova pericial previamente reconhecida como necess&aacute;ria configura cerceamento de defesa quando a mat&eacute;ria exige conhecimento t&eacute;cnico especializado.
+A dificuldade na nomea&ccedil;&atilde;o de perito n&atilde;o justifica a supress&atilde;o de prova essencial &agrave; adequada instru&ccedil;&atilde;o do processo.
+Em demandas de erro m&eacute;dico, a per&iacute;cia deve ser realizada por profissional com especialidade compat&iacute;vel com o objeto da controv&eacute;rsia.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp 1.704.520/MT, Rel. Min. Nancy Andrighi, Corte Especial, DJe 19.12.2018 (Tema 988). &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: N/A;N&uacute;mero do Processo:1000278-72.2026.8.01.0000;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;N/A&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. GRATUIDADE DE JUSTIÇA. ENTIDADE FILANTRÓPICA. ISENÇÃO DE CUSTAS. TAXATIVIDADE MITIGADA DO ART. 1.015 DO CPC. CABIMENTO. PROVA PERICIAL. ERRO MÉDICO. NECESSIDADE DE PERÍCIA ESPECIALIZADA EM ANESTESIOLOGIA. CERCEAMENTO DE DEFESA CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo de instrumento interposto contra decisão que, em ação indenizatória
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. GRATUIDADE DE JUSTIÇA. ENTIDADE FILANTRÓPICA. ISENÇÃO DE CUSTAS. TAXATIVIDADE MITIGADA DO ART. 1.015 DO CPC. CABIMENTO. PROVA PERICIAL. ERRO MÉDICO. NECESSIDADE DE PERÍCIA ESPECIALIZADA EM ANESTESIOLOGIA. CERCEAMENTO DE DEFESA CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo de instrumento interposto contra decisão que, em ação indenizatória por alegado erro médico, revogou a determinação de realização de nova perícia médica especializada e determinou o prosseguimento do feito com possibilidade de julgamento antecipado, além de impugnar o pedido de gratuidade de justiça, pleiteando a concessão do benefício e a reabertura da instrução com produção de prova pericial adequada.
+Há duas questões em discussão: (i) definir se é cabível o agravo de instrumento à luz da taxatividade mitigada do art. 1.015 do CPC; (ii) estabelecer se a revogação da perícia médica especializada em anestesiologia configura cerceamento de defesa em demanda por erro médico.
+Reconhece-se a gratuidade de justiça, pois a agravante, entidade filantrópica sem fins lucrativos, é isenta do pagamento de custas nos termos do art. 2º, VII, da Lei Estadual nº 1.422/2001.
+Admite-se o agravo de instrumento com base na taxatividade mitigada do art. 1.015 do CPC, conforme Tema 988 do STJ, diante do risco de inutilidade do exame da matéria em apelação.
+A controvérsia envolve matéria técnica complexa relativa a erro médico, exigindo prova pericial especializada para adequada elucidação dos fatos.
+Considera-se relevante o fato de o próprio juízo de origem ter previamente reconhecido a necessidade de perícia por especialista em anestesiologia, evidenciando a imprescindibilidade da prova.
+O poder do magistrado de indeferir provas não autoriza a supressão de meio probatório essencial à solução da lide, especialmente quando a prova existente é insuficiente.
+Rejeita-se a justificativa de dificuldade na nomeação de perito como fundamento suficiente para afastar a produção da prova técnica necessária.
+Conclui-se que a ausência de perícia especializada compromete a formação do convencimento judicial e viola os princípios do contraditório e da ampla defesa.
+Reconhece-se o cerceamento de defesa diante da supressão de prova essencial ao deslinde da controvérsia.
+Recurso provido.
+A taxatividade do art. 1.015 do CPC é mitigada, admitindo agravo de instrumento quando houver risco de inutilidade do julgamento da questão em apelação.
+A revogação de prova pericial previamente reconhecida como necessária configura cerceamento de defesa quando a matéria exige conhecimento técnico especializado.
+A dificuldade na nomeação de perito não justifica a supressão de prova essencial à adequada instrução do processo.
+Em demandas de erro médico, a perícia deve ser realizada por profissional com especialidade compatível com o objeto da controvérsia.
+Jurisprudência relevante citada: STJ, REsp 1.704.520/MT, Rel. Min. Nancy Andrighi, Corte Especial, DJe 19.12.2018 (Tema 988).
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503744" cdForo="0" >
+										0715964-14.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503744" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503744);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503744" style="display: none;" >
+	<div id="textAreaDados_2503744" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. SERVI&Ccedil;O BANC&Aacute;RIO. BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. AUS&Ecirc;NCIA DE EMISS&Atilde;O DE NOVA VIA DE CART&Atilde;O MAGN&Eacute;TICO. RESIST&Ecirc;NCIA INDEVIDA &Agrave; PORTABILIDADE. RETEN&Ccedil;&Atilde;O F&Aacute;TICA DE VERBA ALIMENTAR. DANO MORAL. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o c&iacute;vel interposta por institui&ccedil;&atilde;o financeira contra senten&ccedil;a que julgou procedentes os pedidos para confirmar a portabilidade do benef&iacute;cio previdenci&aacute;rio do autor para a Caixa Econ&ocirc;mica Federal e condenar a institui&ccedil;&atilde;o financeira ao pagamento de R$ 3.000,00 por danos morais. O banco sustenta aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o, inexist&ecirc;ncia de ato il&iacute;cito, dano e nexo causal, bem como requer, subsidiariamente, a redu&ccedil;&atilde;o da indeniza&ccedil;&atilde;o.
+H&aacute; 3 quest&otilde;es em discuss&atilde;o: (i) definir se o banco apelante responde pela falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio consistente na n&atilde;o emiss&atilde;o de nova via do cart&atilde;o magn&eacute;tico por per&iacute;odo prolongado e na resist&ecirc;ncia indevida &agrave; portabilidade do benef&iacute;cio previdenci&aacute;rio; (ii) estabelecer se a restri&ccedil;&atilde;o injusta ao acesso de verba alimentar por consumidor idoso configura dano moral indeniz&aacute;vel; e (iii) determinar se o valor de R$ 3.000,00 fixado a t&iacute;tulo de repara&ccedil;&atilde;o comporta redu&ccedil;&atilde;o.
+A apela&ccedil;&atilde;o &eacute; conhecida, porque a reprodu&ccedil;&atilde;o de argumentos j&aacute; deduzidos n&atilde;o impede, por si s&oacute;, o conhecimento do recurso quando h&aacute; impugna&ccedil;&atilde;o minimamente identific&aacute;vel aos fundamentos da senten&ccedil;a.
+A rela&ccedil;&atilde;o entre as partes &eacute; de consumo, de modo que o banco responde objetivamente pelos defeitos na presta&ccedil;&atilde;o do servi&ccedil;o, nos termos do art. 14 do CDC e da S&uacute;mula 297 do STJ.
+O servi&ccedil;o banc&aacute;rio abrange n&atilde;o apenas o cr&eacute;dito formal do benef&iacute;cio, mas tamb&eacute;m a garantia de acesso regular, seguro e desimpedido aos valores depositados, especialmente quando se trata de verba alimentar recebida por consumidor idoso.
+O banco n&atilde;o demonstra justificativa id&ocirc;nea para a aus&ecirc;ncia de emiss&atilde;o de nova via do cart&atilde;o magn&eacute;tico, o que obriga o autor, por aproximadamente seis meses, a comparecer mensalmente &agrave; ag&ecirc;ncia para movimentar sua aposentadoria.
+A documenta&ccedil;&atilde;o da pr&oacute;pria institui&ccedil;&atilde;o revela que a transfer&ecirc;ncia do benef&iacute;cio somente &eacute; processada ap&oacute;s o ajuizamento da a&ccedil;&atilde;o, o que confirma a inefic&aacute;cia da via administrativa e corrobora a resist&ecirc;ncia indevida &agrave; portabilidade.
+A conduta da institui&ccedil;&atilde;o financeira viola os deveres anexos de lealdade, coopera&ccedil;&atilde;o e boa-f&eacute; objetiva, porque imp&otilde;e restri&ccedil;&atilde;o injusta ao exerc&iacute;cio da autonomia patrimonial m&iacute;nima do consumidor em contexto de hipervulnerabilidade.
+A priva&ccedil;&atilde;o prolongada e injustificada do acesso pleno a verba alimentar ultrapassa o mero aborrecimento e configura dano moral indeniz&aacute;vel, diante da gravidade concreta da les&atilde;o e da natureza existencial do preju&iacute;zo.
+Recurso desprovido.
+ 2. A restri&ccedil;&atilde;o injusta ao acesso de verba alimentar percebida por consumidor idoso configura dano moral indeniz&aacute;vel, por exceder o mero dissabor contratual.
+3. N&atilde;o se reduz a indeniza&ccedil;&atilde;o por dano moral quando o montante fixado se mostra moderado e proporcional &agrave;s circunst&acirc;ncias do caso.
+ 4. A mera reitera&ccedil;&atilde;o de argumentos anteriores n&atilde;o impede o conhecimento da apela&ccedil;&atilde;o quando h&aacute; pertin&ecirc;ncia tem&aacute;tica com os fundamentos da senten&ccedil;a.
+ 5. O simples exerc&iacute;cio do direito de recorrer, sem demonstra&ccedil;&atilde;o de dolo processual, n&atilde;o configura litig&acirc;ncia de m&aacute;-f&eacute;.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, X; CC, arts. 186, 422 e 927; CDC, art. 14; CPC, arts. 80, 85, &sect;&sect; 2&ordm; e 11, e 355, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula 297; TJSP, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 1000393-98.2025.8.26.0205, Rel. Des. M&ocirc;nica Soares Machado, N&uacute;cleo de Justi&ccedil;a 4.0 em Segundo Grau &#150; Turma VIII (Direito Privado 2), j. 15.12.2025; TJAM, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0682270-75.2022.8.04.0001, Rel. Des. Cezar Luiz Bandiera, Segunda C&acirc;mara C&iacute;vel, j. 31.10.2024.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0715964-14.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(53 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. SERVIÇO BANCÁRIO. BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE EMISSÃO DE NOVA VIA DE CARTÃO MAGNÉTICO. RESISTÊNCIA INDEVIDA À PORTABILIDADE. RETENÇÃO FÁTICA DE VERBA ALIMENTAR. <em>DANO</em> <em>MORAL</em>. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação cível interposta por instituição financeira contra sentença que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. SERVIÇO BANCÁRIO. BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE EMISSÃO DE NOVA VIA DE CARTÃO MAGNÉTICO. RESISTÊNCIA INDEVIDA À PORTABILIDADE. RETENÇÃO FÁTICA DE VERBA ALIMENTAR. <em>DANO</em> <em>MORAL</em>. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação cível interposta por instituição financeira contra sentença que julgou procedentes os pedidos para confirmar a portabilidade do benefício previdenciário do autor para a Caixa Econômica Federal e condenar a instituição financeira ao pagamento de R$ 3.000,00 por <em>danos</em> <em>morais</em>. O banco sustenta ausência de falha na prestação do serviço, inexistência de ato ilícito, <em>dano</em> e nexo causal, bem como requer, subsidiariamente, a redução da indenização.
+Há 3 questões em discussão: (i) definir se o banco apelante responde pela falha na prestação do serviço bancário consistente na não emissão de nova via do cartão magnético por período prolongado e na resistência indevida à portabilidade do benefício previdenciário; (ii) estabelecer se a restrição injusta ao acesso de verba alimentar por consumidor idoso configura <em>dano</em> <em>moral</em> indenizável; e (iii) determinar se o valor de R$ 3.000,00 fixado a título de reparação comporta redução.
+A apelação é conhecida, porque a reprodução de argumentos já deduzidos não impede, por si só, o conhecimento do recurso quando há impugnação minimamente identificável aos fundamentos da sentença.
+A relação entre as partes é de consumo, de modo que o banco responde objetivamente pelos defeitos na prestação do serviço, nos termos do art. 14 do CDC e da Súmula 297 do STJ.
+O serviço bancário abrange não apenas o crédito formal do benefício, mas também a garantia de acesso regular, seguro e desimpedido aos valores depositados, especialmente quando se trata de verba alimentar recebida por consumidor idoso.
+O banco não demonstra justificativa idônea para a ausência de emissão de nova via do cartão magnético, o que obriga o autor, por aproximadamente seis meses, a comparecer mensalmente à agência para movimentar sua aposentadoria.
+A documentação da própria instituição revela que a transferência do benefício somente é processada após o ajuizamento da ação, o que confirma a ineficácia da via administrativa e corrobora a resistência indevida à portabilidade.
+A conduta da instituição financeira viola os deveres anexos de lealdade, cooperação e boa-fé objetiva, porque impõe restrição injusta ao exercício da autonomia patrimonial mínima do consumidor em contexto de hipervulnerabilidade.
+A privação prolongada e injustificada do acesso pleno a verba alimentar ultrapassa o mero aborrecimento e configura <em>dano</em> <em>moral</em> indenizável, diante da gravidade concreta da lesão e da natureza existencial do prejuízo.
+Recurso desprovido.
+ 2. A restrição injusta ao acesso de verba alimentar percebida por consumidor idoso configura <em>dano</em> <em>moral</em> indenizável, por exceder o mero dissabor contratual.
+3. Não se reduz a indenização por <em>dano</em> <em>moral</em> quando o montante fixado se mostra moderado e proporcional às circunstâncias do caso.
+ 4. A mera reiteração de argumentos anteriores não impede o conhecimento da apelação quando há pertinência temática com os fundamentos da sentença.
+ 5. O simples exercício do direito de recorrer, sem demonstração de dolo processual, não configura litigância de má-fé.
+Dispositivos relevantes citados: CF/1988, art. 5º, X; CC, arts. 186, 422 e 927; CDC, art. 14; CPC, arts. 80, 85, §§ 2º e 11, e 355, I.
+Jurisprudência relevante citada: STJ, Súmula 297; TJSP, Apelação Cível nº 1000393-98.2025.8.26.0205, Rel. Des. Mônica Soares Machado, Núcleo de Justiça 4.0 em Segundo Grau  Turma VIII (Direito Privado 2), j. 15.12.2025; TJAM, Apelação Cível nº 0682270-75.2022.8.04.0001, Rel. Des. Cezar Luiz Bandiera, Segunda Câmara Cível, j. 31.10.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503737" cdForo="0" >
+										0711986-29.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503737" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503737);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503737" style="display: none;" >
+	<div id="textAreaDados_2503737" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE EXIBI&Ccedil;&Atilde;O DE DOCUMENTOS. APRESENTA&Ccedil;&Atilde;O DOS DOCUMENTOS NO CURSO DO PROCESSO. AUS&Ecirc;NCIA DE PRETENS&Atilde;O RESISTIDA. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS INDEVIDOS. ASTREINTES INCAB&Iacute;VEIS. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que, em a&ccedil;&atilde;o de exibi&ccedil;&atilde;o de documentos ajuizada em face de institui&ccedil;&atilde;o financeira, homologou a prova produzida e extinguiu o feito, sem condena&ccedil;&atilde;o em honor&aacute;rios advocat&iacute;cios ou multa, ap&oacute;s a juntada dos contratos e autoriza&ccedil;&otilde;es de desconto no curso do processo. O apelante requer a reforma da senten&ccedil;a para condenar a parte r&eacute; ao pagamento de honor&aacute;rios, custas e astreintes.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se houve pretens&atilde;o resistida apta a justificar a condena&ccedil;&atilde;o da institui&ccedil;&atilde;o financeira ao pagamento de honor&aacute;rios advocat&iacute;cios e custas processuais; e (ii) estabelecer se &eacute; cab&iacute;vel a fixa&ccedil;&atilde;o de multa coercitiva pela apresenta&ccedil;&atilde;o dos documentos apenas no curso do processo.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os documentos reclamados foram apresentados pela institui&ccedil;&atilde;o financeira no curso do processo, com satisfa&ccedil;&atilde;o da provid&ecirc;ncia pleiteada.
+4. A condena&ccedil;&atilde;o em honor&aacute;rios advocat&iacute;cios, em a&ccedil;&otilde;es dessa natureza, exige demonstra&ccedil;&atilde;o de resist&ecirc;ncia efetiva &agrave; pretens&atilde;o, o que n&atilde;o se verifica quando os documentos s&atilde;o juntados aos autos sem comprova&ccedil;&atilde;o de recusa administrativa.
+5. A aus&ecirc;ncia de pretens&atilde;o resistida afasta a imposi&ccedil;&atilde;o de &ocirc;nus sucumbenciais &agrave; parte r&eacute;.
+6. A multa coercitiva prevista no art. 537 do CPC pressup&otilde;e descumprimento de ordem judicial e n&atilde;o pode ser aplicada quando n&atilde;o h&aacute; recalcitr&acirc;ncia processual.
+7. Quest&otilde;es relativas &agrave; nulidade contratual, legalidade dos descontos, repeti&ccedil;&atilde;o de ind&eacute;bito e dano moral n&atilde;o integram o objeto da presente demanda.
+8. O simples exerc&iacute;cio do direito de recorrer n&atilde;o configura litig&acirc;ncia de m&aacute;-f&eacute;.
+IV. DISPOSITIVO E TESE
+9. Recurso desprovido.
+Tese de julgamento:
+A apresenta&ccedil;&atilde;o dos documentos no curso do processo, sem comprova&ccedil;&atilde;o de recusa administrativa, afasta a caracteriza&ccedil;&atilde;o de pretens&atilde;o resistida.
+A aus&ecirc;ncia de resist&ecirc;ncia efetiva impede a condena&ccedil;&atilde;o da parte r&eacute; ao pagamento de honor&aacute;rios advocat&iacute;cios em a&ccedil;&atilde;o de exibi&ccedil;&atilde;o de documentos.
+ A multa coercitiva exige descumprimento de ordem judicial e n&atilde;o se aplica quando a obriga&ccedil;&atilde;o &eacute; satisfeita no curso da demanda.
+Jurisprud&ecirc;ncia relevante citada: TJPR, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0008241-85.2023.8.16.0017, Rel. Des. Hayton Lee Swain Filho, 15&ordf; C&acirc;mara C&iacute;vel, j. 10.08.2024, pub. 12.08.2024; STJ, AgInt no REsp n&ordm; 1.757.147/SP, Rel. Min. Antonio Carlos Ferreira, 4&ordf; Turma, j. 24.08.2020, DJe 31.08.2020; STJ, AgInt no AgInt no AREsp n&ordm; 2.389.142/BA, Rel. Min. Marco Buzzi, 4&ordf; Turma, j. 29.04.2024, DJe 02.05.2024.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0711986-29.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DE EXIBIÇÃO DE DOCUMENTOS. APRESENTAÇÃO DOS DOCUMENTOS NO CURSO DO PROCESSO. AUSÊNCIA DE PRETENSÃO RESISTIDA. HONORÁRIOS ADVOCATÍCIOS INDEVIDOS. ASTREINTES INCABÍVEIS. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que, em ação de exibição de documentos ajuizada em face de instituição financeira, homologou a prova
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DE EXIBIÇÃO DE DOCUMENTOS. APRESENTAÇÃO DOS DOCUMENTOS NO CURSO DO PROCESSO. AUSÊNCIA DE PRETENSÃO RESISTIDA. HONORÁRIOS ADVOCATÍCIOS INDEVIDOS. ASTREINTES INCABÍVEIS. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que, em ação de exibição de documentos ajuizada em face de instituição financeira, homologou a prova produzida e extinguiu o feito, sem condenação em honorários advocatícios ou multa, após a juntada dos contratos e autorizações de desconto no curso do processo. O apelante requer a reforma da sentença para condenar a parte ré ao pagamento de honorários, custas e astreintes.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se houve pretensão resistida apta a justificar a condenação da instituição financeira ao pagamento de honorários advocatícios e custas processuais; e (ii) estabelecer se é cabível a fixação de multa coercitiva pela apresentação dos documentos apenas no curso do processo.
+III. RAZÕES DE DECIDIR
+3. Os documentos reclamados foram apresentados pela instituição financeira no curso do processo, com satisfação da providência pleiteada.
+4. A condenação em honorários advocatícios, em ações dessa natureza, exige demonstração de resistência efetiva à pretensão, o que não se verifica quando os documentos são juntados aos autos sem comprovação de recusa administrativa.
+5. A ausência de pretensão resistida afasta a imposição de ônus sucumbenciais à parte ré.
+6. A multa coercitiva prevista no art. 537 do CPC pressupõe descumprimento de ordem judicial e não pode ser aplicada quando não há recalcitrância processual.
+7. Questões relativas à nulidade contratual, legalidade dos descontos, repetição de indébito e <em>dano</em> <em>moral</em> não integram o objeto da presente demanda.
+8. O simples exercício do direito de recorrer não configura litigância de má-fé.
+IV. DISPOSITIVO E TESE
+9. Recurso desprovido.
+Tese de julgamento:
+A apresentação dos documentos no curso do processo, sem comprovação de recusa administrativa, afasta a caracterização de pretensão resistida.
+A ausência de resistência efetiva impede a condenação da parte ré ao pagamento de honorários advocatícios em ação de exibição de documentos.
+ A multa coercitiva exige descumprimento de ordem judicial e não se aplica quando a obrigação é satisfeita no curso da demanda.
+Jurisprudência relevante citada: TJPR, Apelação Cível nº 0008241-85.2023.8.16.0017, Rel. Des. Hayton Lee Swain Filho, 15ª Câmara Cível, j. 10.08.2024, pub. 12.08.2024; STJ, AgInt no REsp nº 1.757.147/SP, Rel. Min. Antonio Carlos Ferreira, 4ª Turma, j. 24.08.2020, DJe 31.08.2020; STJ, AgInt no AgInt no AREsp nº 2.389.142/BA, Rel. Min. Marco Buzzi, 4ª Turma, j. 29.04.2024, DJe 02.05.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503729" cdForo="0" >
+										0700150-63.2024.8.01.0011
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503729" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503729);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503729" style="display: none;" >
+	<div id="textAreaDados_2503729" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL E DIREITO DO CONSUMIDOR. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. CONTRATA&Ccedil;&Atilde;O DIGITAL. CART&Atilde;O DE CR&Eacute;DITO. VALIDADE DA PROVA. INEXIST&Ecirc;NCIA DE OMISS&Atilde;O, CONTRADI&Ccedil;&Atilde;O OU OBSCURIDADE. REDISCUSS&Atilde;O DO M&Eacute;RITO. TEMA 1.061 DO STJ. INAPLICABILIDADE AO CASO CONCRETO. REJEI&Ccedil;&Atilde;O DOS EMBARGOS.
+I. CASO EM EXAME
+Embargos de declara&ccedil;&atilde;o com efeitos infringentes opostos contra ac&oacute;rd&atilde;o que negou provimento &agrave; apela&ccedil;&atilde;o e manteve a improced&ecirc;ncia de a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito c/c indeniza&ccedil;&atilde;o por danos morais, reconhecendo a validade da contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito e a legitimidade da negativa&ccedil;&atilde;o, bem como a configura&ccedil;&atilde;o de litig&acirc;ncia de m&aacute;-f&eacute;, sob o fundamento de que a autora n&atilde;o comprovou a alegada fraude e que a institui&ccedil;&atilde;o financeira demonstrou a rela&ccedil;&atilde;o jur&iacute;dica mediante provas documentais e biometria facial .
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se o ac&oacute;rd&atilde;o embargado padece de omiss&atilde;o, contradi&ccedil;&atilde;o ou obscuridade quanto &agrave; comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o digital e &agrave; aplica&ccedil;&atilde;o do Tema 1.061 do STJ; (ii) estabelecer se &eacute; poss&iacute;vel atribuir efeitos infringentes aos embargos para reformar o julgado.
+O ac&oacute;rd&atilde;o enfrenta expressamente todas as quest&otilde;es relevantes, analisando de forma fundamentada a comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o e a legitimidade da negativa&ccedil;&atilde;o, afastando a alega&ccedil;&atilde;o de v&iacute;cios previstos no art. 1.022 do CPC.
+A institui&ccedil;&atilde;o financeira comprova a rela&ccedil;&atilde;o jur&iacute;dica mediante conjunto probat&oacute;rio consistente, incluindo prints sist&ecirc;micos, faturas, hist&oacute;rico de utiliza&ccedil;&atilde;o do cart&atilde;o e biometria facial, suficientes para demonstrar a contrata&ccedil;&atilde;o digital.
+A parte autora n&atilde;o se desincumbe do &ocirc;nus probat&oacute;rio previsto no art. 373, II, do CPC, ao apresentar alega&ccedil;&otilde;es gen&eacute;ricas de fraude desacompanhadas de elementos m&iacute;nimos de prova.
+O Tema 1.061 do STJ n&atilde;o se aplica automaticamente, pois o caso n&atilde;o se limita &agrave; impugna&ccedil;&atilde;o de assinatura em contrato f&iacute;sico, envolvendo contrata&ccedil;&atilde;o digital acompanhada de robusto conjunto probat&oacute;rio.
+A alega&ccedil;&atilde;o de aus&ecirc;ncia de dados como IP, geolocaliza&ccedil;&atilde;o e hor&aacute;rio n&atilde;o configura omiss&atilde;o, pois o ac&oacute;rd&atilde;o considera suficientes os elementos probat&oacute;rios existentes para forma&ccedil;&atilde;o do convencimento.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito, sendo incab&iacute;veis quando ausentes os v&iacute;cios legais, ainda que com finalidade de prequestionamento.
+Os efeitos infringentes s&atilde;o excepcionais e dependem da constata&ccedil;&atilde;o de v&iacute;cio no julgado, o que n&atilde;o ocorre na hip&oacute;tese.
+Recurso desprovido.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o s&atilde;o cab&iacute;veis para rediscuss&atilde;o do m&eacute;rito quando o ac&oacute;rd&atilde;o enfrenta adequadamente as quest&otilde;es controvertidas.
+A comprova&ccedil;&atilde;o de contrata&ccedil;&atilde;o digital pode ser realizada por conjunto probat&oacute;rio que inclua biometria facial, registros sist&ecirc;micos e hist&oacute;rico de utiliza&ccedil;&atilde;o do servi&ccedil;o.
+O Tema 1.061 do STJ n&atilde;o se aplica automaticamente a contrata&ccedil;&otilde;es digitais quando h&aacute; elementos probat&oacute;rios adicionais que demonstram a rela&ccedil;&atilde;o jur&iacute;dica.
+A atribui&ccedil;&atilde;o de efeitos infringentes aos embargos de declara&ccedil;&atilde;o exige a demonstra&ccedil;&atilde;o de v&iacute;cio no julgado, n&atilde;o configurado pela mera inconformidade da parte.
+Jurisprud&ecirc;ncia relevante citada: STJ, Tema 1.061; STJ, AgInt no AREsp 844.804/MG, Rel. Min. Humberto Martins, j. 15.04.2016; STJ, EDcl no REsp 1.583.696/RS, Rel. Min. Herman Benjamin, j. 05.10.2017; STJ, EDcl no AgInt no REsp 1.661.261/SP, Rel. Min. Rogerio Schietti Cruz, j. 26.09.2017.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Sena Madureira;N&uacute;mero do Processo:0700150-63.2024.8.01.0011;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sena Madureira
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO DO CONSUMIDOR. EMBARGOS DE DECLARAÇÃO. CONTRATAÇÃO DIGITAL. CARTÃO DE CRÉDITO. VALIDADE DA PROVA. INEXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. REDISCUSSÃO DO MÉRITO. TEMA 1.061 DO STJ. INAPLICABILIDADE AO CASO CONCRETO. REJEIÇÃO DOS EMBARGOS.
+I. CASO EM EXAME
+Embargos de declaração com efeitos infringentes opostos contra acórdão que negou provimento à
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO DO CONSUMIDOR. EMBARGOS DE DECLARAÇÃO. CONTRATAÇÃO DIGITAL. CARTÃO DE CRÉDITO. VALIDADE DA PROVA. INEXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. REDISCUSSÃO DO MÉRITO. TEMA 1.061 DO STJ. INAPLICABILIDADE AO CASO CONCRETO. REJEIÇÃO DOS EMBARGOS.
+I. CASO EM EXAME
+Embargos de declaração com efeitos infringentes opostos contra acórdão que negou provimento à apelação e manteve a improcedência de ação declaratória de inexistência de débito c/c indenização por <em>danos</em> <em>morais</em>, reconhecendo a validade da contratação de cartão de crédito e a legitimidade da negativação, bem como a configuração de litigância de má-fé, sob o fundamento de que a autora não comprovou a alegada fraude e que a instituição financeira demonstrou a relação jurídica mediante provas documentais e biometria facial .
+Há duas questões em discussão: (i) definir se o acórdão embargado padece de omissão, contradição ou obscuridade quanto à comprovação da contratação digital e à aplicação do Tema 1.061 do STJ; (ii) estabelecer se é possível atribuir efeitos infringentes aos embargos para reformar o julgado.
+O acórdão enfrenta expressamente todas as questões relevantes, analisando de forma fundamentada a comprovação da contratação e a legitimidade da negativação, afastando a alegação de vícios previstos no art. 1.022 do CPC.
+A instituição financeira comprova a relação jurídica mediante conjunto probatório consistente, incluindo prints sistêmicos, faturas, histórico de utilização do cartão e biometria facial, suficientes para demonstrar a contratação digital.
+A parte autora não se desincumbe do ônus probatório previsto no art. 373, II, do CPC, ao apresentar alegações genéricas de fraude desacompanhadas de elementos mínimos de prova.
+O Tema 1.061 do STJ não se aplica automaticamente, pois o caso não se limita à impugnação de assinatura em contrato físico, envolvendo contratação digital acompanhada de robusto conjunto probatório.
+A alegação de ausência de dados como IP, geolocalização e horário não configura omissão, pois o acórdão considera suficientes os elementos probatórios existentes para formação do convencimento.
+Os embargos de declaração não se prestam à rediscussão do mérito, sendo incabíveis quando ausentes os vícios legais, ainda que com finalidade de prequestionamento.
+Os efeitos infringentes são excepcionais e dependem da constatação de vício no julgado, o que não ocorre na hipótese.
+Recurso desprovido.
+Os embargos de declaração não são cabíveis para rediscussão do mérito quando o acórdão enfrenta adequadamente as questões controvertidas.
+A comprovação de contratação digital pode ser realizada por conjunto probatório que inclua biometria facial, registros sistêmicos e histórico de utilização do serviço.
+O Tema 1.061 do STJ não se aplica automaticamente a contratações digitais quando há elementos probatórios adicionais que demonstram a relação jurídica.
+A atribuição de efeitos infringentes aos embargos de declaração exige a demonstração de vício no julgado, não configurado pela mera inconformidade da parte.
+Jurisprudência relevante citada: STJ, Tema 1.061; STJ, AgInt no AREsp 844.804/MG, Rel. Min. Humberto Martins, j. 15.04.2016; STJ, EDcl no REsp 1.583.696/RS, Rel. Min. Herman Benjamin, j. 05.10.2017; STJ, EDcl no AgInt no REsp 1.661.261/SP, Rel. Min. Rogerio Schietti Cruz, j. 26.09.2017.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503723" cdForo="0" >
+										1002456-28.2025.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503723" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503723);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503723" style="display: none;" >
+	<div id="textAreaDados_2503723" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM AGRAVO DE INSTRUMENTO. REDISCUSS&Atilde;O DA MAT&Eacute;RIA. AUS&Ecirc;NCIA DE OBSCURIDADE, CONTRADI&Ccedil;&Atilde;O, OMISS&Atilde;O OU ERRO MATERIAL. CONSEQUENTE INEXIST&Ecirc;NCIA DE V&Iacute;CIOS. PREQUESTIONAMENTO. N&Atilde;O VIOLA&Ccedil;&Atilde;O DO ART. 1.022 DO CPC/2015. ACLARAT&Oacute;RIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que, por unanimidade, negou provimento ao recurso de agravo de instrumento da parte embargante.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Avalia-se a ocorr&ecirc;ncia de omiss&atilde;o e contradi&ccedil;&atilde;o no ac&oacute;rd&atilde;o recorrido, por supostamente n&atilde;o ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequa&ccedil;&atilde;o do recurso para fins de prequestionamento &agrave;s inst&acirc;ncias superiores.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Inexist&ecirc;ncia de omiss&atilde;o/contradi&ccedil;&atilde;o: O ac&oacute;rd&atilde;o recorrido analisou de forma clara e exauriente a controv&eacute;rsia, bem como as quest&otilde;es suscitadas pelas partes, sobretudo quanto &agrave; aus&ecirc;ncia de probabilidade do direito invocado, quest&otilde;es essas que j&aacute; foram apreciadas e decididas no ac&oacute;rd&atilde;o embargado, sendo despicienda nova manifesta&ccedil;&atilde;o deste Colegiado. O ju&iacute;zo n&atilde;o est&aacute; obrigado a responder a um question&aacute;rio, mas a fundamentar sua decis&atilde;o.
+4. Rediscuss&atilde;o de m&eacute;rito: A parte embargante, a pretexto de sanar pretensa omiss&atilde;o/contradi&ccedil;&atilde;o, busca, na verdade, a rediscuss&atilde;o do m&eacute;rito da causa e a reforma do julgado, finalidade para a qual os embargos de declara&ccedil;&atilde;o s&atilde;o via inadequada, conforme pac&iacute;fica jurisprud&ecirc;ncia do STJ.
+5. Prequestionamento: A aus&ecirc;ncia dos v&iacute;cios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, S&uacute;mula n.&ordm; 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando inclu&iacute;dos no ac&oacute;rd&atilde;o os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordin&aacute;rio, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: &quot;N&atilde;o h&aacute; que se falar em omiss&atilde;o/contradi&ccedil;&atilde;o quando o ac&oacute;rd&atilde;o analisa suficientemente a mat&eacute;ria posta em debate, com fundamenta&ccedil;&atilde;o clara e coerente, sendo desnecess&aacute;rio o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito da causa, e sua rejei&ccedil;&atilde;o &eacute; medida impositiva quando ausentes os v&iacute;cios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento&quot;. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:1002456-28.2025.8.01.0000;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Indenização por Dano Material
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO DE INSTRUMENTO. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO DE INSTRUMENTO. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao recurso de agravo de instrumento da parte embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Avalia-se a ocorrência de omissão e contradição no acórdão recorrido, por supostamente não ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequação do recurso para fins de prequestionamento às instâncias superiores.
+III. RAZÕES DE DECIDIR
+3. Inexistência de omissão/contradição: O acórdão recorrido analisou de forma clara e exauriente a controvérsia, bem como as questões suscitadas pelas partes, sobretudo quanto à ausência de probabilidade do direito invocado, questões essas que já foram apreciadas e decididas no acórdão embargado, sendo despicienda nova manifestação deste Colegiado. O juízo não está obrigado a responder a um questionário, mas a fundamentar sua decisão.
+4. Rediscussão de mérito: A parte embargante, a pretexto de sanar pretensa omissão/contradição, busca, na verdade, a rediscussão do mérito da causa e a reforma do julgado, finalidade para a qual os embargos de declaração são via inadequada, conforme pacífica jurisprudência do STJ.
+5. Prequestionamento: A ausência dos vícios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, Súmula n.º 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando incluídos no acórdão os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordinário, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: "Não há que se falar em omissão/contradição quando o acórdão analisa suficientemente a matéria posta em debate, com fundamentação clara e coerente, sendo desnecessário o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declaração não se prestam à rediscussão do mérito da causa, e sua rejeição é medida impositiva quando ausentes os vícios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503732" cdForo="0" >
+										0703836-90.2024.8.01.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503732" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503732);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503732" style="display: none;" >
+	<div id="textAreaDados_2503732" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. SUPERENDIVIDAMENTO. LEI N. 14.181/2021. M&Iacute;NIMO EXISTENCIAL. EXCLUS&Atilde;O DE D&Iacute;VIDAS CONSIGNADAS. INEXIST&Ecirc;NCIA DE OMISS&Atilde;O OU CONTRADI&Ccedil;&Atilde;O. REDISCUSS&Atilde;O DO M&Eacute;RITO. PREQUESTIONAMENTO FICTO. REJEI&Ccedil;&Atilde;O.
+I. CASO EM EXAME
+1) Embargos de declara&ccedil;&atilde;o opostos contra ac&oacute;rd&atilde;o que reformou senten&ccedil;a de proced&ecirc;ncia parcial para julgar improcedente a&ccedil;&atilde;o de repactua&ccedil;&atilde;o de d&iacute;vidas, ao fundamento de inocorr&ecirc;ncia de superendividamento, diante da exclus&atilde;o das d&iacute;vidas oriundas de cr&eacute;dito consignado do c&aacute;lculo do m&iacute;nimo existencial, nos termos da Lei n. 14.181/2021 e do Decreto n. 11.150/2022, com pedido de saneamento de alegadas omiss&atilde;o e contradi&ccedil;&atilde;o e de prequestionamento de dispositivos legais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) H&aacute; 2 quest&otilde;es em discuss&atilde;o: (i) definir se o ac&oacute;rd&atilde;o embargado incorreu em omiss&atilde;o ou contradi&ccedil;&atilde;o ao afastar a caracteriza&ccedil;&atilde;o do superendividamento, especialmente quanto &agrave; considera&ccedil;&atilde;o das d&iacute;vidas consignadas no c&aacute;lculo do m&iacute;nimo existencial; e (ii) estabelecer se cabe acolher pedido de prequestionamento quando inexistentes v&iacute;cios integrativos no julgado.
+III. RAZ&Otilde;ES DE DECIDIR
+3) Os embargos de declara&ccedil;&atilde;o possuem fun&ccedil;&atilde;o integrativa restrita, sendo cab&iacute;veis apenas nas hip&oacute;teses do art. 1.022 do CPC, n&atilde;o se prestando &agrave; rediscuss&atilde;o do m&eacute;rito ou &agrave; inova&ccedil;&atilde;o recursal.
+4) O ac&oacute;rd&atilde;o embargado enfrenta de forma expressa e suficiente as quest&otilde;es essenciais da controv&eacute;rsia, inclusive a caracteriza&ccedil;&atilde;o do superendividamento e a impossibilidade de computar d&iacute;vidas consignadas para aferi&ccedil;&atilde;o do m&iacute;nimo existencial.
+5) A decis&atilde;o aplica o art. 54-A, &sect; 1&ordm;, do CDC em conjunto com o Decreto n. 11.150/2022, que fixava o m&iacute;nimo existencial em R$ 600,00 e exclu&iacute;a, expressamente, as d&iacute;vidas oriundas de cr&eacute;dito consignado do c&aacute;lculo pertinente.
+6) A constata&ccedil;&atilde;o de que 99,86% do passivo decorre de contratos de cr&eacute;dito consignado afasta, no quadro normativo adotado, a caracteriza&ccedil;&atilde;o do superendividamento apto a justificar a repactua&ccedil;&atilde;o judicial.
+7) N&atilde;o h&aacute; omiss&atilde;o quando o &oacute;rg&atilde;o julgador aprecia a tese e a rejeita de forma fundamentada, ainda que em sentido contr&aacute;rio ao interesse da parte.
+8) N&atilde;o h&aacute; contradi&ccedil;&atilde;o quando o julgado apresenta coer&ecirc;ncia l&oacute;gica entre premissas normativas e conclus&atilde;o, sendo incab&iacute;vel confundir contradi&ccedil;&atilde;o interna com mera discord&acirc;ncia interpretativa.
+9) O dever de fundamenta&ccedil;&atilde;o n&atilde;o imp&otilde;e resposta exaustiva a todos os argumentos ou dispositivos invocados pelas partes, bastando o enfrentamento suficiente da mat&eacute;ria controvertida.
+10) O pedido de prequestionamento n&atilde;o autoriza o acolhimento dos embargos sem a demonstra&ccedil;&atilde;o de v&iacute;cio integrativo, embora a mera oposi&ccedil;&atilde;o dos aclarat&oacute;rios viabilize, em tese, o prequestionamento ficto previsto no art. 1.025 do CPC.
+11) A jurisprud&ecirc;ncia do STJ e do pr&oacute;prio tribunal afasta o uso dos embargos de declara&ccedil;&atilde;o como suced&acirc;neo recursal destinado ao reexame da mat&eacute;ria j&aacute; decidida.
+IV. DISPOSITIVO E TESE
+12) Embargos de declara&ccedil;&atilde;o rejeitados.
+Tese de julgamento:
+1. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito quando ausentes omiss&atilde;o, contradi&ccedil;&atilde;o, obscuridade ou erro material.
+2. A caracteriza&ccedil;&atilde;o do superendividamento deve observar os par&acirc;metros legais e regulamentares vigentes, inclusive a exclus&atilde;o das d&iacute;vidas consignadas do c&aacute;lculo do m&iacute;nimo existencial.
+3. O enfrentamento fundamentado das quest&otilde;es essenciais da controv&eacute;rsia afasta a alega&ccedil;&atilde;o de negativa de presta&ccedil;&atilde;o jurisdicional.
+4. O pedido de prequestionamento n&atilde;o dispensa a presen&ccedil;a dos v&iacute;cios do art. 1.022 do CPC, sem preju&iacute;zo da incid&ecirc;ncia do art. 1.025 do CPC.
+Dispositivos relevantes citados: CPC, arts. 489, &sect; 1&ordm;, IV, 1.022, 1.025 e 1.026, &sect; 2&ordm;; CDC, art. 54-A, &sect; 1&ordm;; Decreto n. 11.150/2022, arts. 3&ordm; e 4&ordm;, par&aacute;grafo &uacute;nico, I, &quot;h&quot;; CC, arts. 104, 108, 166, IV, 171, II, 1.791 e 1.793.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no REsp 1.549.458/SP, Rel. Min. Herman Benjamin, j. 11.04.2022; STJ, EDcl no REsp 2024/0415063-8, Rel. Min. Humberto Martins, j. 09.02.2026; STJ, EDcl no AgRg no AREsp 2.578.606/SP, Rel. Min. Daniela Teixeira, j. 23.10.2024; TJ-AC, Apela&ccedil;&atilde;o C&iacute;vel 0700359-32.2024.8.01.0011, Rel. Des&ordf; Waldirene Cordeiro, j. 25.02.2026; TJ-AC, Apela&ccedil;&atilde;o C&iacute;vel 0700047-96.2014.8.01.0014, Rel. Des. Lois Arruda, j. 24.11.2025; TJ-AC, Embargos de Declara&ccedil;&atilde;o C&iacute;vel 0101135-17.2024.8.01.0000, Rel. Des. Lu&iacute;s Camolez, j. 27.09.2024.  &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:0703836-90.2024.8.01.0002;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. SUPERENDIVIDAMENTO. LEI N. 14.181/2021. MÍNIMO EXISTENCIAL. EXCLUSÃO DE DÍVIDAS CONSIGNADAS. INEXISTÊNCIA DE OMISSÃO OU CONTRADIÇÃO. REDISCUSSÃO DO MÉRITO. PREQUESTIONAMENTO FICTO. REJEIÇÃO.
+I. CASO EM EXAME
+1) Embargos de declaração opostos contra acórdão que reformou sentença de procedência parcial para julgar improcedente ação de repactuação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. SUPERENDIVIDAMENTO. LEI N. 14.181/2021. MÍNIMO EXISTENCIAL. EXCLUSÃO DE DÍVIDAS CONSIGNADAS. INEXISTÊNCIA DE OMISSÃO OU CONTRADIÇÃO. REDISCUSSÃO DO MÉRITO. PREQUESTIONAMENTO FICTO. REJEIÇÃO.
+I. CASO EM EXAME
+1) Embargos de declaração opostos contra acórdão que reformou sentença de procedência parcial para julgar improcedente ação de repactuação de dívidas, ao fundamento de inocorrência de superendividamento, diante da exclusão das dívidas oriundas de crédito consignado do cálculo do mínimo existencial, nos termos da Lei n. 14.181/2021 e do Decreto n. 11.150/2022, com pedido de saneamento de alegadas omissão e contradição e de prequestionamento de dispositivos legais.
+II. QUESTÃO EM DISCUSSÃO
+2) Há 2 questões em discussão: (i) definir se o acórdão embargado incorreu em omissão ou contradição ao afastar a caracterização do superendividamento, especialmente quanto à consideração das dívidas consignadas no cálculo do mínimo existencial; e (ii) estabelecer se cabe acolher pedido de prequestionamento quando inexistentes vícios integrativos no julgado.
+III. RAZÕES DE DECIDIR
+3) Os embargos de declaração possuem função integrativa restrita, sendo cabíveis apenas nas hipóteses do art. 1.022 do CPC, não se prestando à rediscussão do mérito ou à inovação recursal.
+4) O acórdão embargado enfrenta de forma expressa e suficiente as questões essenciais da controvérsia, inclusive a caracterização do superendividamento e a impossibilidade de computar dívidas consignadas para aferição do mínimo existencial.
+5) A decisão aplica o art. 54-A, § 1º, do CDC em conjunto com o Decreto n. 11.150/2022, que fixava o mínimo existencial em R$ 600,00 e excluía, expressamente, as dívidas oriundas de crédito consignado do cálculo pertinente.
+6) A constatação de que 99,86% do passivo decorre de contratos de crédito consignado afasta, no quadro normativo adotado, a caracterização do superendividamento apto a justificar a repactuação judicial.
+7) Não há omissão quando o órgão julgador aprecia a tese e a rejeita de forma fundamentada, ainda que em sentido contrário ao interesse da parte.
+8) Não há contradição quando o julgado apresenta coerência lógica entre premissas normativas e conclusão, sendo incabível confundir contradição interna com mera discordância interpretativa.
+9) O dever de fundamentação não impõe resposta exaustiva a todos os argumentos ou dispositivos invocados pelas partes, bastando o enfrentamento suficiente da matéria controvertida.
+10) O pedido de prequestionamento não autoriza o acolhimento dos embargos sem a demonstração de vício integrativo, embora a mera oposição dos aclaratórios viabilize, em tese, o prequestionamento ficto previsto no art. 1.025 do CPC.
+11) A jurisprudência do STJ e do próprio tribunal afasta o uso dos embargos de declaração como sucedâneo recursal destinado ao reexame da matéria já decidida.
+IV. DISPOSITIVO E TESE
+12) Embargos de declaração rejeitados.
+Tese de julgamento:
+1. Os embargos de declaração não se prestam à rediscussão do mérito quando ausentes omissão, contradição, obscuridade ou erro material.
+2. A caracterização do superendividamento deve observar os parâmetros legais e regulamentares vigentes, inclusive a exclusão das dívidas consignadas do cálculo do mínimo existencial.
+3. O enfrentamento fundamentado das questões essenciais da controvérsia afasta a alegação de negativa de prestação jurisdicional.
+4. O pedido de prequestionamento não dispensa a presença dos vícios do art. 1.022 do CPC, sem prejuízo da incidência do art. 1.025 do CPC.
+Dispositivos relevantes citados: CPC, arts. 489, § 1º, IV, 1.022, 1.025 e 1.026, § 2º; CDC, art. 54-A, § 1º; Decreto n. 11.150/2022, arts. 3º e 4º, parágrafo único, I, "h"; CC, arts. 104, 108, 166, IV, 171, II, 1.791 e 1.793.
+Jurisprudência relevante citada: STJ, EDcl no REsp 1.549.458/SP, Rel. Min. Herman Benjamin, j. 11.04.2022; STJ, EDcl no REsp 2024/0415063-8, Rel. Min. Humberto Martins, j. 09.02.2026; STJ, EDcl no AgRg no AREsp 2.578.606/SP, Rel. Min. Daniela Teixeira, j. 23.10.2024; TJ-AC, Apelação Cível 0700359-32.2024.8.01.0011, Rel. Desª Waldirene Cordeiro, j. 25.02.2026; TJ-AC, Apelação Cível 0700047-96.2014.8.01.0014, Rel. Des. Lois Arruda, j. 24.11.2025; TJ-AC, Embargos de Declaração Cível 0101135-17.2024.8.01.0000, Rel. Des. Luís Camolez, j. 27.09.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503725" cdForo="0" >
+										0706552-59.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503725" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503725);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503725" style="display: none;" >
+	<div id="textAreaDados_2503725" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. AUS&Ecirc;NCIA DE OMISS&Atilde;O, CONTRADI&Ccedil;&Atilde;O OU OBSCURIDADE. PRETENS&Atilde;O DE REDISCUSS&Atilde;O DA MAT&Eacute;RIA. EMBARGOS REJEITADOS
+I. CASO EM EXAME
+Embargos de declara&ccedil;&atilde;o interpostos contra ac&oacute;rd&atilde;o que, deu parcial provimento ao recurso para afastar a condena&ccedil;&atilde;o por danos morais, ajustar juros remunerat&oacute;rios e reconhecer sucumb&ecirc;ncia rec&iacute;proca, sob alega&ccedil;&atilde;o de omiss&otilde;es, contradi&ccedil;&otilde;es e obscuridades quanto &agrave; an&aacute;lise dos danos morais, distribui&ccedil;&atilde;o da sucumb&ecirc;ncia, fixa&ccedil;&atilde;o de honor&aacute;rios e crit&eacute;rios de juros .
+H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se o ac&oacute;rd&atilde;o embargado incorre em omiss&atilde;o quanto &agrave; an&aacute;lise dos danos morais; (ii) estabelecer se h&aacute; contradi&ccedil;&atilde;o na fixa&ccedil;&atilde;o da sucumb&ecirc;ncia rec&iacute;proca; (iii) determinar se houve omiss&atilde;o ou inadequa&ccedil;&atilde;o na fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios; e (iv) verificar eventual obscuridade na defini&ccedil;&atilde;o dos juros remunerat&oacute;rios .
+Os embargos de declara&ccedil;&atilde;o possuem finalidade integrativa e se limitam &agrave;s hip&oacute;teses do art. 1.022 do CPC, n&atilde;o se prestando &agrave; rediscuss&atilde;o do m&eacute;rito da decis&atilde;o.
+O ac&oacute;rd&atilde;o enfrenta expressamente a quest&atilde;o dos danos morais e afasta a indeniza&ccedil;&atilde;o por aus&ecirc;ncia de prova de les&atilde;o extrapatrimonial relevante.
+A decis&atilde;o reconhece o &ecirc;xito parcial de ambas as partes, o que justifica a fixa&ccedil;&atilde;o da sucumb&ecirc;ncia rec&iacute;proca, inexistindo contradi&ccedil;&atilde;o.
+O ac&oacute;rd&atilde;o analisa a fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios e adota o crit&eacute;rio de equidade diante da impossibilidade de mensura&ccedil;&atilde;o do proveito econ&ocirc;mico.
+N&atilde;o h&aacute; obscuridade quanto aos juros remunerat&oacute;rios, pois o julgado define a aplica&ccedil;&atilde;o da taxa m&eacute;dia de mercado divulgada pelo Banco Central.
+A insurg&ecirc;ncia da parte embargante revela mero inconformismo com o resultado do julgamento, caracterizando tentativa de reexame da mat&eacute;ria.
+O &oacute;rg&atilde;o julgador n&atilde;o est&aacute; obrigado a rebater todos os argumentos das partes quando j&aacute; apresenta fundamenta&ccedil;&atilde;o suficiente para a conclus&atilde;o adotada.
+Recurso desprovido.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito, sendo cab&iacute;veis apenas para sanar v&iacute;cios previstos no art. 1.022 do CPC.
+N&atilde;o h&aacute; omiss&atilde;o quando o ac&oacute;rd&atilde;o enfrenta de forma suficiente as quest&otilde;es essenciais ao deslinde da controvimento.
+A sucumb&ecirc;ncia rec&iacute;proca &eacute; adequada quando ambas as partes obt&ecirc;m &ecirc;xito parcial na demanda.
+A fixa&ccedil;&atilde;o de honor&aacute;rios por equidade &eacute; v&aacute;lida quando invi&aacute;vel a mensura&ccedil;&atilde;o do proveito econ&ocirc;mico.
+A defini&ccedil;&atilde;o expressa de crit&eacute;rios de juros no ac&oacute;rd&atilde;o afasta alega&ccedil;&atilde;o de obscuridade.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no AgInt na SLS n&ordm; 3294/RJ, Rel. Min. Maria Thereza de Assis Moura, Corte Especial, j. 07.02.2024, DJe 14.02.2024 .&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0706552-59.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(16 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Interpretação / Revisão de Contrato
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. AUSÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. PRETENSÃO DE REDISCUSSÃO DA MATÉRIA. EMBARGOS REJEITADOS
+I. CASO EM EXAME
+Embargos de declaração interpostos contra acórdão que, deu parcial provimento ao recurso para afastar a condenação por <em>danos</em> <em>morais</em>, ajustar juros remuneratórios e reconhecer sucumbência recíproca, sob
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. AUSÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. PRETENSÃO DE REDISCUSSÃO DA MATÉRIA. EMBARGOS REJEITADOS
+I. CASO EM EXAME
+Embargos de declaração interpostos contra acórdão que, deu parcial provimento ao recurso para afastar a condenação por <em>danos</em> <em>morais</em>, ajustar juros remuneratórios e reconhecer sucumbência recíproca, sob alegação de omissões, contradições e obscuridades quanto à análise dos <em>danos</em> <em>morais</em>, distribuição da sucumbência, fixação de honorários e critérios de juros .
+Há quatro questões em discussão: (i) definir se o acórdão embargado incorre em omissão quanto à análise dos <em>danos</em> <em>morais</em>; (ii) estabelecer se há contradição na fixação da sucumbência recíproca; (iii) determinar se houve omissão ou inadequação na fixação dos honorários advocatícios; e (iv) verificar eventual obscuridade na definição dos juros remuneratórios .
+Os embargos de declaração possuem finalidade integrativa e se limitam às hipóteses do art. 1.022 do CPC, não se prestando à rediscussão do mérito da decisão.
+O acórdão enfrenta expressamente a questão dos <em>danos</em> <em>morais</em> e afasta a indenização por ausência de prova de lesão extrapatrimonial relevante.
+A decisão reconhece o êxito parcial de ambas as partes, o que justifica a fixação da sucumbência recíproca, inexistindo contradição.
+O acórdão analisa a fixação dos honorários advocatícios e adota o critério de equidade diante da impossibilidade de mensuração do proveito econômico.
+Não há obscuridade quanto aos juros remuneratórios, pois o julgado define a aplicação da taxa média de mercado divulgada pelo Banco Central.
+A insurgência da parte embargante revela mero inconformismo com o resultado do julgamento, caracterizando tentativa de reexame da matéria.
+O órgão julgador não está obrigado a rebater todos os argumentos das partes quando já apresenta fundamentação suficiente para a conclusão adotada.
+Recurso desprovido.
+Os embargos de declaração não se prestam à rediscussão do mérito, sendo cabíveis apenas para sanar vícios previstos no art. 1.022 do CPC.
+Não há omissão quando o acórdão enfrenta de forma suficiente as questões essenciais ao deslinde da controvimento.
+A sucumbência recíproca é adequada quando ambas as partes obtêm êxito parcial na demanda.
+A fixação de honorários por equidade é válida quando inviável a mensuração do proveito econômico.
+A definição expressa de critérios de juros no acórdão afasta alegação de obscuridade.
+Jurisprudência relevante citada: STJ, EDcl no AgInt na SLS nº 3294/RJ, Rel. Min. Maria Thereza de Assis Moura, Corte Especial, j. 07.02.2024, DJe 14.02.2024 .
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503730" cdForo="0" >
+										0702356-77.2024.8.01.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503730" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503730);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503730" style="display: none;" >
+	<div id="textAreaDados_2503730" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O DE AC&Oacute;RD&Atilde;O UN&Acirc;NIME EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. INCONFORMISMO. PRETENS&Atilde;O DE REDISCUSS&Atilde;O DE MAT&Eacute;RIA J&Aacute; DECIDIDA. EMBARGOS DE DECLARA&Ccedil;&Atilde;O REJEITADOS.
+I. CASO EM EXAME
+1. Embargos de declara&ccedil;&atilde;o opostos contra ac&oacute;rd&atilde;o que, por unanimidade, deu provimento &agrave; apela&ccedil;&atilde;o interposta pela parte embargada.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Verificar a ocorr&ecirc;ncia de v&iacute;cio no ac&oacute;rd&atilde;o que justifique a oposi&ccedil;&atilde;o de embargos de declara&ccedil;&atilde;o, ou se os embargos foram manipulados para rediscutir mat&eacute;ria j&aacute; decidida.
+III. RAZ&Otilde;ES DE DECIDIR
+3. N&atilde;o h&aacute; omiss&atilde;o, contradi&ccedil;&atilde;o, obscuridade ou erro material no ac&oacute;rd&atilde;o embargado, sendo despicienda nova manifesta&ccedil;&atilde;o deste Colegiado. Os embargos de declara&ccedil;&atilde;o n&atilde;o s&atilde;o cab&iacute;veis para rediscuss&atilde;o do m&eacute;rito.
+4. O julgador n&atilde;o &eacute; obrigado a responder todos os pontos, artigos de lei e s&uacute;mulas apontados pelas partes, desde que a decis&atilde;o seja devidamente fundamentada.
+IV. DISPOSITIVO E TESE
+5. Embargos de Declara&ccedil;&atilde;o rejeitados. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:0702356-77.2024.8.01.0002;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO DE ACÓRDÃO UNÂNIME EM APELAÇÃO CÍVEL. INCONFORMISMO. PRETENSÃO DE REDISCUSSÃO DE MATÉRIA JÁ DECIDIDA. EMBARGOS DE DECLARAÇÃO REJEITADOS.
+I. CASO EM EXAME
+1. Embargos de declaração opostos contra acórdão que, por unanimidade, deu provimento à apelação interposta pela parte embargada.
+II. QUESTÃO EM DISCUSSÃO
+2. Verificar a ocorrência de vício no
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO DE ACÓRDÃO UNÂNIME EM APELAÇÃO CÍVEL. INCONFORMISMO. PRETENSÃO DE REDISCUSSÃO DE MATÉRIA JÁ DECIDIDA. EMBARGOS DE DECLARAÇÃO REJEITADOS.
+I. CASO EM EXAME
+1. Embargos de declaração opostos contra acórdão que, por unanimidade, deu provimento à apelação interposta pela parte embargada.
+II. QUESTÃO EM DISCUSSÃO
+2. Verificar a ocorrência de vício no acórdão que justifique a oposição de embargos de declaração, ou se os embargos foram manipulados para rediscutir matéria já decidida.
+III. RAZÕES DE DECIDIR
+3. Não há omissão, contradição, obscuridade ou erro material no acórdão embargado, sendo despicienda nova manifestação deste Colegiado. Os embargos de declaração não são cabíveis para rediscussão do mérito.
+4. O julgador não é obrigado a responder todos os pontos, artigos de lei e súmulas apontados pelas partes, desde que a decisão seja devidamente fundamentada.
+IV. DISPOSITIVO E TESE
+5. Embargos de Declaração rejeitados.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503722" cdForo="0" >
+										0713956-98.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503722" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503722);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503722" style="display: none;" >
+	<div id="textAreaDados_2503722" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. REDISCUSS&Atilde;O DA MAT&Eacute;RIA. AUS&Ecirc;NCIA DE OBSCURIDADE, CONTRADI&Ccedil;&Atilde;O, OMISS&Atilde;O OU ERRO MATERIAL. CONSEQUENTE INEXIST&Ecirc;NCIA DE V&Iacute;CIOS. PREQUESTIONAMENTO. N&Atilde;O VIOLA&Ccedil;&Atilde;O DO ART. 1.022 DO CPC/2015. ACLARAT&Oacute;RIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que, por unanimidade, negou provimento ao recurso de apela&ccedil;&atilde;o da parte embargante.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Avalia-se a ocorr&ecirc;ncia de omiss&atilde;o e contradi&ccedil;&atilde;o no ac&oacute;rd&atilde;o recorrido, por supostamente n&atilde;o ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequa&ccedil;&atilde;o do recurso para fins de prequestionamento &agrave;s inst&acirc;ncias superiores.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Inexist&ecirc;ncia de omiss&atilde;o/contradi&ccedil;&atilde;o: O ac&oacute;rd&atilde;o recorrido analisou de forma clara e exauriente a controv&eacute;rsia, bem como as quest&otilde;es suscitadas pelas partes, sobretudo quanto aos efeitos relativos da revelia e &agrave; aus&ecirc;ncia de cautela do autor, quest&otilde;es essas que j&aacute; foram apreciadas e decididas no ac&oacute;rd&atilde;o embargado, sendo despicienda nova manifesta&ccedil;&atilde;o deste Colegiado. O ju&iacute;zo n&atilde;o est&aacute; obrigado a responder a um question&aacute;rio, mas a fundamentar sua decis&atilde;o.
+4. Rediscuss&atilde;o de m&eacute;rito: A parte embargante, a pretexto de sanar pretensa omiss&atilde;o/contradi&ccedil;&atilde;o, busca, na verdade, a rediscuss&atilde;o do m&eacute;rito da causa e a reforma do julgado, finalidade para a qual os embargos de declara&ccedil;&atilde;o s&atilde;o via inadequada, conforme pac&iacute;fica jurisprud&ecirc;ncia do STJ.
+5. Prequestionamento: A aus&ecirc;ncia dos v&iacute;cios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, S&uacute;mula n.&ordm; 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando inclu&iacute;dos no ac&oacute;rd&atilde;o os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordin&aacute;rio, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: &quot;N&atilde;o h&aacute; que se falar em omiss&atilde;o/contradi&ccedil;&atilde;o quando o ac&oacute;rd&atilde;o analisa suficientemente a mat&eacute;ria posta em debate, com fundamenta&ccedil;&atilde;o clara e coerente, sendo desnecess&aacute;rio o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito da causa, e sua rejei&ccedil;&atilde;o &eacute; medida impositiva quando ausentes os v&iacute;cios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento&quot;. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0713956-98.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao recurso
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao recurso de apelação da parte embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Avalia-se a ocorrência de omissão e contradição no acórdão recorrido, por supostamente não ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequação do recurso para fins de prequestionamento às instâncias superiores.
+III. RAZÕES DE DECIDIR
+3. Inexistência de omissão/contradição: O acórdão recorrido analisou de forma clara e exauriente a controvérsia, bem como as questões suscitadas pelas partes, sobretudo quanto aos efeitos relativos da revelia e à ausência de cautela do autor, questões essas que já foram apreciadas e decididas no acórdão embargado, sendo despicienda nova manifestação deste Colegiado. O juízo não está obrigado a responder a um questionário, mas a fundamentar sua decisão.
+4. Rediscussão de mérito: A parte embargante, a pretexto de sanar pretensa omissão/contradição, busca, na verdade, a rediscussão do mérito da causa e a reforma do julgado, finalidade para a qual os embargos de declaração são via inadequada, conforme pacífica jurisprudência do STJ.
+5. Prequestionamento: A ausência dos vícios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, Súmula n.º 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando incluídos no acórdão os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordinário, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: "Não há que se falar em omissão/contradição quando o acórdão analisa suficientemente a matéria posta em debate, com fundamentação clara e coerente, sendo desnecessário o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declaração não se prestam à rediscussão do mérito da causa, e sua rejeição é medida impositiva quando ausentes os vícios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503721" cdForo="0" >
+										0709275-90.2021.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503721" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503721);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503721" style="display: none;" >
+	<div id="textAreaDados_2503721" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. DUPLA INTERPOSI&Ccedil;&Atilde;O CONTRA O MESMO AC&Oacute;RD&Atilde;O. PRINC&Iacute;PIO DA UNIRRECORRIBILIDADE. PRECLUS&Atilde;O CONSUMATIVA. RESPONSABILIDADE SOLID&Aacute;RIA ENTRE LITISCONSORTES. ART. 87, &sect;2&ordm;, DO CPC. INEXIST&Ecirc;NCIA DE V&Iacute;CIOS. REDISCUSS&Atilde;O DO M&Eacute;RITO. IMPOSSIBILIDADE. REJEI&Ccedil;&Atilde;O.
+I. CASO EM EXAME
+Embargos de declara&ccedil;&atilde;o opostos por Banco Daycoval S.A. contra ac&oacute;rd&atilde;o da Segunda C&acirc;mara C&iacute;vel do TJAC que negou provimento &agrave; apela&ccedil;&atilde;o e manteve senten&ccedil;a proferida em cumprimento de senten&ccedil;a, reconhecendo a quita&ccedil;&atilde;o de honor&aacute;rios sucumbenciais e aplicando a responsabilidade solid&aacute;ria entre litisconsortes, sendo constatada a interposi&ccedil;&atilde;o de dois embargos contra o mesmo decisum.
+H&aacute; cinco quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; admiss&iacute;vel a oposi&ccedil;&atilde;o de m&uacute;ltiplos embargos de declara&ccedil;&atilde;o contra a mesma decis&atilde;o &agrave; luz do princ&iacute;pio da unirrecorribilidade; (ii) verificar a exist&ecirc;ncia de omiss&atilde;o, contradi&ccedil;&atilde;o ou obscuridade no ac&oacute;rd&atilde;o; (iii) estabelecer se houve viola&ccedil;&atilde;o &agrave; coisa julgada e ao princ&iacute;pio da n&atilde;o surpresa pela aplica&ccedil;&atilde;o do art. 87, &sect;2&ordm;, do CPC; (iv) determinar se houve cerceamento de defesa; e (v) aferir a ocorr&ecirc;ncia de excesso de execu&ccedil;&atilde;o e a limita&ccedil;&atilde;o da responsabilidade do embargante.
+O princ&iacute;pio da unirrecorribilidade impede a interposi&ccedil;&atilde;o de mais de um recurso contra a mesma decis&atilde;o, operando-se a preclus&atilde;o consumativa com o primeiro recurso, o que torna inadmiss&iacute;vel o segundo embargo declarat&oacute;rio.
+O ac&oacute;rd&atilde;o embargado enfrenta de forma expressa todas as teses suscitadas, inexistindo omiss&atilde;o, contradi&ccedil;&atilde;o, obscuridade ou erro material, nos termos do art. 1.022 do CPC.
+A aus&ecirc;ncia de previs&atilde;o expressa de rateio na senten&ccedil;a autoriza a aplica&ccedil;&atilde;o da responsabilidade solid&aacute;ria entre litisconsortes, conforme art. 87, &sect;2&ordm;, do CPC.
+A incid&ecirc;ncia da solidariedade legal n&atilde;o configura amplia&ccedil;&atilde;o da coisa julgada nem cria&ccedil;&atilde;o de obriga&ccedil;&atilde;o nova, mas aplica&ccedil;&atilde;o autom&aacute;tica de norma jur&iacute;dica.
+N&atilde;o h&aacute; viola&ccedil;&atilde;o ao princ&iacute;pio da n&atilde;o surpresa, pois a mat&eacute;ria foi devidamente debatida e apreciada.
+Afasta-se o cerceamento de defesa, diante da ampla devolu&ccedil;&atilde;o e aprecia&ccedil;&atilde;o da controv&eacute;rsia.
+N&atilde;o h&aacute; excesso de execu&ccedil;&atilde;o, pois a cobran&ccedil;a integral decorre da solidariedade legal.
+Os embargos de declara&ccedil;&atilde;o possuem natureza integrativa e n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito ou &agrave; reforma da decis&atilde;o por mero inconformismo.
+Recurso desprovido.
+Tese de julgamento:
+A interposi&ccedil;&atilde;o de mais de um recurso contra a mesma decis&atilde;o viola o princ&iacute;pio da unirrecorribilidade e enseja preclus&atilde;o consumativa.
+A aus&ecirc;ncia de rateio expresso dos honor&aacute;rios sucumbenciais imp&otilde;e a responsabilidade solid&aacute;ria entre litisconsortes, nos termos do art. 87, &sect;2&ordm;, do CPC.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito, sendo cab&iacute;veis apenas para sanar v&iacute;cios do art. 1.022 do CPC.
+A aplica&ccedil;&atilde;o da solidariedade legal em cumprimento de senten&ccedil;a n&atilde;o viola a coisa julgada nem configura decis&atilde;o surpresa.
+A cobran&ccedil;a integral do d&eacute;bito, fundada na solidariedade, afasta a alega&ccedil;&atilde;o de excesso de execu&ccedil;&atilde;o.
+Dispositivos relevantes citados: CPC/2015, arts. 87, &sect;2&ordm;; 1.022; 1.023; 1.024, &sect;2&ordm;; 1.025; 1.026, &sect;2&ordm;.
+Jurisprud&ecirc;ncia relevante citada: TJ-SP, EMBDECCV 0511079-57.2010.8.26.0554, Rel. M&ocirc;nica Serrano, j. 02.03.2023; TJ-PR, ED 0005614-02.2019.8.16.0130, Rel. Marcel Guimar&atilde;es Rotoli de Macedo, j. 11.02.2022; TJ-MS, EMBDECCV 0800596-36.2018.8.12.0025, Rel. Des. Jo&atilde;o Maria L&oacute;s, j. 15.12.2021; TJ-CE, EMBDECCV 0111467-46.2017.8.06.0001, Rel. Teodoro Silva Santos, j. 26.07.2021; TJ-RS, EMBDECCV 70084891183, Rel. Francesco Conti, j. 29.03.2021; TJ-MT, EMBDECCV 00084308320108110041, Rel. Gilberto Lopes Bussiki, j. 12.08.2020; TJ-SC, ED 4000098-10.2019.8.24.0000, Rel. Marcus Tulio Sartorato, j. 06.08.2019; STJ, ED/EDAgRgREsp 1.326.841/PR, 2&ordf; T., Rel&ordf; Min&ordf; Diva Malerbi, j. 21.06.2016. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0709275-90.2021.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. DUPLA INTERPOSIÇÃO CONTRA O MESMO ACÓRDÃO. PRINCÍPIO DA UNIRRECORRIBILIDADE. PRECLUSÃO CONSUMATIVA. RESPONSABILIDADE SOLIDÁRIA ENTRE LITISCONSORTES. ART. 87, §2º, DO CPC. INEXISTÊNCIA DE VÍCIOS. REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. REJEIÇÃO.
+I. CASO EM EXAME
+Embargos de declaração opostos por Banco Daycoval S.A. contra acórdão da Segunda
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. DUPLA INTERPOSIÇÃO CONTRA O MESMO ACÓRDÃO. PRINCÍPIO DA UNIRRECORRIBILIDADE. PRECLUSÃO CONSUMATIVA. RESPONSABILIDADE SOLIDÁRIA ENTRE LITISCONSORTES. ART. 87, §2º, DO CPC. INEXISTÊNCIA DE VÍCIOS. REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. REJEIÇÃO.
+I. CASO EM EXAME
+Embargos de declaração opostos por Banco Daycoval S.A. contra acórdão da Segunda Câmara Cível do TJAC que negou provimento à apelação e manteve sentença proferida em cumprimento de sentença, reconhecendo a quitação de honorários sucumbenciais e aplicando a responsabilidade solidária entre litisconsortes, sendo constatada a interposição de dois embargos contra o mesmo decisum.
+Há cinco questões em discussão: (i) definir se é admissível a oposição de múltiplos embargos de declaração contra a mesma decisão à luz do princípio da unirrecorribilidade; (ii) verificar a existência de omissão, contradição ou obscuridade no acórdão; (iii) estabelecer se houve violação à coisa julgada e ao princípio da não surpresa pela aplicação do art. 87, §2º, do CPC; (iv) determinar se houve cerceamento de defesa; e (v) aferir a ocorrência de excesso de execução e a limitação da responsabilidade do embargante.
+O princípio da unirrecorribilidade impede a interposição de mais de um recurso contra a mesma decisão, operando-se a preclusão consumativa com o primeiro recurso, o que torna inadmissível o segundo embargo declaratório.
+O acórdão embargado enfrenta de forma expressa todas as teses suscitadas, inexistindo omissão, contradição, obscuridade ou erro material, nos termos do art. 1.022 do CPC.
+A ausência de previsão expressa de rateio na sentença autoriza a aplicação da responsabilidade solidária entre litisconsortes, conforme art. 87, §2º, do CPC.
+A incidência da solidariedade legal não configura ampliação da coisa julgada nem criação de obrigação nova, mas aplicação automática de norma jurídica.
+Não há violação ao princípio da não surpresa, pois a matéria foi devidamente debatida e apreciada.
+Afasta-se o cerceamento de defesa, diante da ampla devolução e apreciação da controvérsia.
+Não há excesso de execução, pois a cobrança integral decorre da solidariedade legal.
+Os embargos de declaração possuem natureza integrativa e não se prestam à rediscussão do mérito ou à reforma da decisão por mero inconformismo.
+Recurso desprovido.
+Tese de julgamento:
+A interposição de mais de um recurso contra a mesma decisão viola o princípio da unirrecorribilidade e enseja preclusão consumativa.
+A ausência de rateio expresso dos honorários sucumbenciais impõe a responsabilidade solidária entre litisconsortes, nos termos do art. 87, §2º, do CPC.
+Os embargos de declaração não se prestam à rediscussão do mérito, sendo cabíveis apenas para sanar vícios do art. 1.022 do CPC.
+A aplicação da solidariedade legal em cumprimento de sentença não viola a coisa julgada nem configura decisão surpresa.
+A cobrança integral do débito, fundada na solidariedade, afasta a alegação de excesso de execução.
+Dispositivos relevantes citados: CPC/2015, arts. 87, §2º; 1.022; 1.023; 1.024, §2º; 1.025; 1.026, §2º.
+Jurisprudência relevante citada: TJ-SP, EMBDECCV 0511079-57.2010.8.26.0554, Rel. Mônica Serrano, j. 02.03.2023; TJ-PR, ED 0005614-02.2019.8.16.0130, Rel. Marcel Guimarães Rotoli de Macedo, j. 11.02.2022; TJ-MS, EMBDECCV 0800596-36.2018.8.12.0025, Rel. Des. João Maria Lós, j. 15.12.2021; TJ-CE, EMBDECCV 0111467-46.2017.8.06.0001, Rel. Teodoro Silva Santos, j. 26.07.2021; TJ-RS, EMBDECCV 70084891183, Rel. Francesco Conti, j. 29.03.2021; TJ-MT, EMBDECCV 00084308320108110041, Rel. Gilberto Lopes Bussiki, j. 12.08.2020; TJ-SC, ED 4000098-10.2019.8.24.0000, Rel. Marcus Tulio Sartorato, j. 06.08.2019; STJ, ED/EDAgRgREsp 1.326.841/PR, 2ª T., Relª Minª Diva Malerbi, j. 21.06.2016.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503767" cdForo="0" >
+										0723261-09.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503767" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503767);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503767" style="display: none;" >
+	<div id="textAreaDados_2503767" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO CUMULADA COM INDENIZA&Ccedil;&Atilde;O. FRAUDE BANC&Aacute;RIA. SERVI&Ccedil;OS DE PLATAFORMA DIGITAL DE PAGAMENTOS. TRANSA&Ccedil;&Otilde;ES REALIZADAS POR TERCEIRO MEDIANTE USO DE SENHA PESSOAL E DUPLO FATOR DE AUTENTICA&Ccedil;&Atilde;O. FRAUDE PERPETRADA POR TERCEIRO. CULPA EXCLUSIVA DO CONSUMIDOR. DEVER DE GUARDA E SIGILO DAS CREDENCIAIS. RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. INOCORR&Ecirc;NCIA. EXCLUDENTE DE RESPONSABILIDADE. ART. 14, &sect; 3&ordm;, INC. II, DO CDC/1990. CULPA EXCLUSIVA DO CONSUMIDOR. CONFIGURA&Ccedil;&Atilde;O. FORTUITO EXTERNO. INAPLICABILIDADE DA S&Uacute;MULA 479/STJ. INEXIST&Ecirc;NCIA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. NEXO DE CAUSALIDADE ROMPIDO. DEVER DE INDENIZAR AFASTADO. SENTEN&Ccedil;A REFORMADA. RECURSO PROVIDO. SENTEN&Ccedil;A REFORMADA.
+I. CASO EM EXAME
+1. Trata-se de recurso de apela&ccedil;&atilde;o interposto por uma institui&ccedil;&atilde;o de pagamento digital contra senten&ccedil;a que a condenou a anular transa&ccedil;&otilde;es e restituir valores a um consumidor.
+2. O autor alegou ter sido v&iacute;tima de fraude em sua conta, com opera&ccedil;&otilde;es que n&atilde;o reconhece, sustentando a responsabilidade objetiva da empresa por falha na seguran&ccedil;a.
+3. A institui&ccedil;&atilde;o financeira, por sua vez, defendeu que as transa&ccedil;&otilde;es foram validadas com senha pessoal e intransfer&iacute;vel, al&eacute;m de um segundo fator de autentica&ccedil;&atilde;o, configurando culpa exclusiva da v&iacute;tima.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. A controv&eacute;rsia consiste em definir a responsabilidade da institui&ccedil;&atilde;o financeira por transa&ccedil;&otilde;es fraudulentas realizadas por terceiros quando a autentica&ccedil;&atilde;o ocorre mediante o uso de senha pessoal do correntista e confirma&ccedil;&atilde;o por duplo fator de seguran&ccedil;a (2FA); ou se tal fato caracteriza culpa exclusiva do consumidor, afastando o dever de indenizar.
+III. RAZ&Otilde;ES DE DECIDIR
+5. A responsabilidade das institui&ccedil;&otilde;es financeiras por danos decorrentes de fraudes praticadas por terceiros &eacute;, em regra, objetiva, conforme a S&uacute;mula n.&ordm; 479 do STJ, por se tratar de fortuito interno.
+6. Contudo, o CDC/1990, em seu art. 14, &sect; 3&ordm;, inc. II, prev&ecirc; como excludente de responsabilidade a culpa exclusiva do consumidor ou de terceiro.
+7. No caso concreto, ficou demonstrado que as opera&ccedil;&otilde;es contestadas foram autenticadas mediante o uso de credenciais sigilosas (senha pessoal) e um segundo fator de verifica&ccedil;&atilde;o (biometria facial), um mecanismo de seguran&ccedil;a robusto que indica que o fraudador s&oacute; obteve &ecirc;xito por ter acesso a dados fornecidos pela pr&oacute;pria v&iacute;tima.
+8. Essa situa&ccedil;&atilde;o, conhecida como &quot;engenharia social&quot; ou &quot;phishing&quot;, em que o consumidor &eacute; ludibriado a fornecer seus dados sigilosos, caracteriza fortuito externo, rompendo o nexo de causalidade entre a conduta da institui&ccedil;&atilde;o financeira e o dano sofrido.
+9. A jurisprud&ecirc;ncia do STJ e deste Tribunal de Justi&ccedil;a (TJ-AC) reconhece que, ao descumprir o dever de guarda e sigilo de suas senhas e credenciais, o consumidor assume a responsabilidade pelos atos praticados, afastando a responsabilidade da institui&ccedil;&atilde;o por aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+IV. DISPOSITIVO
+10. Recurso provido, para reformar integralmente a senten&ccedil;a recorrida no sentido de julgar improcedentes os pedidos formulados na peti&ccedil;&atilde;o inicial.
+TESE DE JULGAMENTO
+&quot;1. A responsabilidade objetiva da institui&ccedil;&atilde;o financeira por fraudes praticadas por terceiros &eacute; afastada quando o dano decorre de fortuito externo, configurado pela culpa exclusiva do consumidor que, por meio de engenharia social, viabiliza as transa&ccedil;&otilde;es ao fornecer voluntariamente seus dados sigilosos e senhas.
+2. A utiliza&ccedil;&atilde;o de senha pessoal e de um segundo fator de autentica&ccedil;&atilde;o para validar as opera&ccedil;&otilde;es evidencia a aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o e rompe o nexo de causalidade, afastando o dever de indenizar&quot;.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0723261-09.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 14/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;3&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO CUMULADA COM INDENIZAÇÃO. FRAUDE BANCÁRIA. SERVIÇOS DE PLATAFORMA DIGITAL DE PAGAMENTOS. TRANSAÇÕES REALIZADAS POR TERCEIRO MEDIANTE USO DE SENHA PESSOAL E DUPLO FATOR DE AUTENTICAÇÃO. FRAUDE PERPETRADA POR TERCEIRO. CULPA EXCLUSIVA DO CONSUMIDOR. DEVER DE GUARDA E SIGILO DAS CREDENCIAIS. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO CUMULADA COM INDENIZAÇÃO. FRAUDE BANCÁRIA. SERVIÇOS DE PLATAFORMA DIGITAL DE PAGAMENTOS. TRANSAÇÕES REALIZADAS POR TERCEIRO MEDIANTE USO DE SENHA PESSOAL E DUPLO FATOR DE AUTENTICAÇÃO. FRAUDE PERPETRADA POR TERCEIRO. CULPA EXCLUSIVA DO CONSUMIDOR. DEVER DE GUARDA E SIGILO DAS CREDENCIAIS. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. INOCORRÊNCIA. EXCLUDENTE DE RESPONSABILIDADE. ART. 14, § 3º, INC. II, DO CDC/1990. CULPA EXCLUSIVA DO CONSUMIDOR. CONFIGURAÇÃO. FORTUITO EXTERNO. INAPLICABILIDADE DA SÚMULA 479/STJ. INEXISTÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO. NEXO DE CAUSALIDADE ROMPIDO. DEVER DE INDENIZAR AFASTADO. SENTENÇA REFORMADA. RECURSO PROVIDO. SENTENÇA REFORMADA.
+I. CASO EM EXAME
+1. Trata-se de recurso de apelação interposto por uma instituição de pagamento digital contra sentença que a condenou a anular transações e restituir valores a um consumidor.
+2. O autor alegou ter sido vítima de fraude em sua conta, com operações que não reconhece, sustentando a responsabilidade objetiva da empresa por falha na segurança.
+3. A instituição financeira, por sua vez, defendeu que as transações foram validadas com senha pessoal e intransferível, além de um segundo fator de autenticação, configurando culpa exclusiva da vítima.
+II. QUESTÃO EM DISCUSSÃO
+4. A controvérsia consiste em definir a responsabilidade da instituição financeira por transações fraudulentas realizadas por terceiros quando a autenticação ocorre mediante o uso de senha pessoal do correntista e confirmação por duplo fator de segurança (2FA); ou se tal fato caracteriza culpa exclusiva do consumidor, afastando o dever de indenizar.
+III. RAZÕES DE DECIDIR
+5. A responsabilidade das instituições financeiras por <em>danos</em> decorrentes de fraudes praticadas por terceiros é, em regra, objetiva, conforme a Súmula n.º 479 do STJ, por se tratar de fortuito interno.
+6. Contudo, o CDC/1990, em seu art. 14, § 3º, inc. II, prevê como excludente de responsabilidade a culpa exclusiva do consumidor ou de terceiro.
+7. No caso concreto, ficou demonstrado que as operações contestadas foram autenticadas mediante o uso de credenciais sigilosas (senha pessoal) e um segundo fator de verificação (biometria facial), um mecanismo de segurança robusto que indica que o fraudador só obteve êxito por ter acesso a dados fornecidos pela própria vítima.
+8. Essa situação, conhecida como "engenharia social" ou "phishing", em que o consumidor é ludibriado a fornecer seus dados sigilosos, caracteriza fortuito externo, rompendo o nexo de causalidade entre a conduta da instituição financeira e o <em>dano</em> sofrido.
+9. A jurisprudência do STJ e deste Tribunal de Justiça (TJ-AC) reconhece que, ao descumprir o dever de guarda e sigilo de suas senhas e credenciais, o consumidor assume a responsabilidade pelos atos praticados, afastando a responsabilidade da instituição por ausência de falha na prestação do serviço.
+IV. DISPOSITIVO
+10. Recurso provido, para reformar integralmente a sentença recorrida no sentido de julgar improcedentes os pedidos formulados na petição inicial.
+TESE DE JULGAMENTO
+"1. A responsabilidade objetiva da instituição financeira por fraudes praticadas por terceiros é afastada quando o <em>dano</em> decorre de fortuito externo, configurado pela culpa exclusiva do consumidor que, por meio de engenharia social, viabiliza as transações ao fornecer voluntariamente seus dados sigilosos e senhas.
+2. A utilização de senha pessoal e de um segundo fator de autenticação para validar as operações evidencia a ausência de falha na prestação do serviço e rompe o nexo de causalidade, afastando o dever de indenizar".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503763" cdForo="0" >
+										0700550-73.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503763" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503763);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503763" style="display: none;" >
+	<div id="textAreaDados_2503763" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. ACIDENTE EM DEPEND&Ecirc;NCIA DE HOSPITAL P&Uacute;BLICO. QUEDA DE PORT&Atilde;O SOBRE SERVIDORA. OMISS&Atilde;O NO DEVER DE MANUTEN&Ccedil;&Atilde;O E SEGURAN&Ccedil;A. &quot;FAUTE DU SERVICE&quot;. RESPONSABILIDADE OBJETIVA. NEXO DE CAUSALIDADE COMPROVADO. DANO MORAL &quot;IN RE IPSA&quot;. DEVER DE INDENIZAR. VALOR DA INDENIZA&Ccedil;&Atilde;O. MANUTEN&Ccedil;&Atilde;O. PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. DESPROVIMENTO DO RECURSO.
+I. CASO EM EXAME
+1. Trata-se de recurso de apela&ccedil;&atilde;o interposto pela Fazenda P&uacute;blica contra senten&ccedil;a que o condenou ao pagamento de indeniza&ccedil;&atilde;o por danos morais, no valor de R$ 10.000,00 (dez mil reais), em favor de servidora p&uacute;blica que sofreu acidente nas depend&ecirc;ncias de hospital da rede p&uacute;blica, ao ser atingida pela queda de um port&atilde;o.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A controv&eacute;rsia consiste em definir a responsabilidade civil do Estado pelo acidente ocorrido, analisando a presen&ccedil;a de seus pressupostos &#150;  conduta, dano e nexo de causalidade; e, em caso de confirma&ccedil;&atilde;o, avaliar se o montante fixado a t&iacute;tulo de danos morais atende aos crit&eacute;rios da razoabilidade e da proporcionalidade.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A responsabilidade civil do Estado &eacute;, em regra, objetiva, fundamentada na teoria do risco administrativo, conforme o art. 37, &sect; 6&ordm;, da CF/1988.
+3.1. Tal responsabilidade se aplica tamb&eacute;m aos casos de omiss&atilde;o, quando o Estado descumpre um dever legal espec&iacute;fico de agir, configurando a &quot;faute du servisse&quot; (falta do servi&ccedil;o).
+4. No caso concreto, a queda de um port&atilde;o sobre a servidora em uma unidade hospitalar p&uacute;blica evidencia a omiss&atilde;o do Estado em seu dever de garantir a manuten&ccedil;&atilde;o e a seguran&ccedil;a de suas instala&ccedil;&otilde;es.
+4.1. A falta de conserva&ccedil;&atilde;o adequada foi a causa direta do acidente, estabelecendo o nexo de causalidade entre a omiss&atilde;o estatal e o dano sofrido pela v&iacute;tima.
+5. O dano moral &eacute; presumido (&quot;in re ipsa&quot;), decorrendo do pr&oacute;prio evento e das les&otilde;es f&iacute;sicas e do abalo psicol&oacute;gico sofridos pela servidora, que ultrapassam o mero dissabor cotidiano.
+6. Embora o dever de indenizar seja inquestion&aacute;vel, o valor da indeniza&ccedil;&atilde;o deve ser pautado pelos princ&iacute;pios da razoabilidade e da proporcionalidade, considerando a extens&atilde;o do dano, a capacidade econ&ocirc;mica das partes e a dupla finalidade da medida: compensat&oacute;ria para a v&iacute;tima e pedag&oacute;gica para o ofensor.
+6.1. O valor de R$ 10.000,00 (dez mil reais) mostra-se adequado ao caso concreto.
+IV. DISPOSITIVO
+7. Recurso n&atilde;o provido, para manter a senten&ccedil;a recorrida.
+TESE DE JULGAMENTO
+&quot;A omiss&atilde;o do Estado no dever de manuten&ccedil;&atilde;o e seguran&ccedil;a de suas instala&ccedil;&otilde;es, resultando em acidente com dano a servidor p&uacute;blico, configura &quot;faute du servisse&quot; e gera a obriga&ccedil;&atilde;o de indenizar com base na responsabilidade civil objetiva, devendo o valor da indeniza&ccedil;&atilde;o por danos morais ser fixado em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e da proporcionalidade&quot;.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0700550-73.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 14/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara da Fazenda P&uacute;blica&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(41 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. ACIDENTE EM DEPENDÊNCIA DE HOSPITAL PÚBLICO. QUEDA DE PORTÃO SOBRE SERVIDORA. OMISSÃO NO DEVER DE MANUTENÇÃO E SEGURANÇA. "FAUTE DU SERVICE". RESPONSABILIDADE OBJETIVA. NEXO DE CAUSALIDADE COMPROVADO. <em>DANO</em> <em>MORAL</em> "IN RE IPSA". DEVER DE INDENIZAR. VALOR DA INDENIZAÇÃO. MANUTENÇÃO. PRINCÍPIOS DA RAZOABILIDADE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. ACIDENTE EM DEPENDÊNCIA DE HOSPITAL PÚBLICO. QUEDA DE PORTÃO SOBRE SERVIDORA. OMISSÃO NO DEVER DE MANUTENÇÃO E SEGURANÇA. "FAUTE DU SERVICE". RESPONSABILIDADE OBJETIVA. NEXO DE CAUSALIDADE COMPROVADO. <em>DANO</em> <em>MORAL</em> "IN RE IPSA". DEVER DE INDENIZAR. VALOR DA INDENIZAÇÃO. MANUTENÇÃO. PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. DESPROVIMENTO DO RECURSO.
+I. CASO EM EXAME
+1. Trata-se de recurso de apelação interposto pela Fazenda Pública contra sentença que o condenou ao pagamento de indenização por <em>danos</em> <em>morais</em>, no valor de R$ 10.000,00 (dez mil reais), em favor de servidora pública que sofreu acidente nas dependências de hospital da rede pública, ao ser atingida pela queda de um portão.
+II. QUESTÃO EM DISCUSSÃO
+2. A controvérsia consiste em definir a responsabilidade civil do Estado pelo acidente ocorrido, analisando a presença de seus pressupostos   conduta, <em>dano</em> e nexo de causalidade; e, em caso de confirmação, avaliar se o montante fixado a título de <em>danos</em> <em>morais</em> atende aos critérios da razoabilidade e da proporcionalidade.
+III. RAZÕES DE DECIDIR
+3. A responsabilidade civil do Estado é, em regra, objetiva, fundamentada na teoria do risco administrativo, conforme o art. 37, § 6º, da CF/1988.
+3.1. Tal responsabilidade se aplica também aos casos de omissão, quando o Estado descumpre um dever legal específico de agir, configurando a "faute du servisse" (falta do serviço).
+4. No caso concreto, a queda de um portão sobre a servidora em uma unidade hospitalar pública evidencia a omissão do Estado em seu dever de garantir a manutenção e a segurança de suas instalações.
+4.1. A falta de conservação adequada foi a causa direta do acidente, estabelecendo o nexo de causalidade entre a omissão estatal e o <em>dano</em> sofrido pela vítima.
+5. O <em>dano</em> <em>moral</em> é presumido ("in re ipsa"), decorrendo do próprio evento e das lesões físicas e do abalo psicológico sofridos pela servidora, que ultrapassam o mero dissabor cotidiano.
+6. Embora o dever de indenizar seja inquestionável, o valor da indenização deve ser pautado pelos princípios da razoabilidade e da proporcionalidade, considerando a extensão do <em>dano</em>, a capacidade econômica das partes e a dupla finalidade da medida: compensatória para a vítima e pedagógica para o ofensor.
+6.1. O valor de R$ 10.000,00 (dez mil reais) mostra-se adequado ao caso concreto.
+IV. DISPOSITIVO
+7. Recurso não provido, para manter a sentença recorrida.
+TESE DE JULGAMENTO
+"A omissão do Estado no dever de manutenção e segurança de suas instalações, resultando em acidente com <em>dano</em> a servidor público, configura "faute du servisse" e gera a obrigação de indenizar com base na responsabilidade civil objetiva, devendo o valor da indenização por <em>danos</em> <em>morais</em> ser fixado em observância aos princípios da razoabilidade e da proporcionalidade".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			</div>
+		</td>
+		<td width="20px">
+			&nbsp;
+		</td>
+		<td valign="top" width="230px">
+			<div id="adicionarPesquisa-A">
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="APELAÇÃO">
+									<label for="ckTermo1">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="CIVIL">
+									<label for="ckTermo2">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="DIREITO">
+									<label for="ckTermo3">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="RECURSO">
+									<label for="ckTermo4">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="CÍVEL">
+									<label for="ckTermo5">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="Recurso">
+									<label for="ckTermo6">
+										Recurso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="parte">
+									<label for="ckTermo7">
+										parte
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="danos">
+									<label for="ckTermo8">
+										danos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="AÇÃO">
+									<label for="ckTermo9">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="desprovido">
+									<label for="ckTermo10">
+										desprovido
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="autos">
+									<label for="ckTermo11">
+										autos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="caso">
+									<label for="ckTermo12">
+										caso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="Código">
+									<label for="ckTermo13">
+										Código
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="Apelação">
+									<label for="ckTermo14">
+										Apelação
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="sentença">
+									<label for="ckTermo15">
+										sentença
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			</div>
+
+
+
+
+
+
+
+<table width="100%" border="0" cellpadding="0" cellspacing="0"
+	align="center">
+	<tr>
+		<td bgcolor="#FFFFFF" height="10"></td>
+	</tr>
+</table>
+<table id="abaFiltrar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC" >
+	<tr>
+		<td height="20" bgcolor="#CCCCCC">
+			<strong>Filtrar no resultado</strong>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgFiltrar-A" src="imagens/saj/fecharFiltro.gif" border="0" align="middle">
+		</td>
+	</tr>
+</table>
+<div id="filtrarResultado-A">
+	<table id="tabelaFiltro-A" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC" class="filtrarResultado">
+		<tr>
+			<td align="justify" bgcolor="EEEEEE">
+				Selecione os itens que deseja filtrar e clique no botão "Refinar resultado"
+			</td>
+		</tr>
+		<tr>
+			<td height="18" bgcolor="DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0" border="0" name="Classe" >
+					<tr>
+						<td width="*">
+							<a id="linkMenuFiltroClasse-A" >
+								&nbsp;<img id="icoClasse-A" src="imagens/spw/icoMais.gif" align="absmiddle" border="0">&nbsp;
+								<span id="filtroClasse-A"><b>Classe </b></span>
+								<span id="spanClasse-A" style="display: inline;" ></span>
+							</a>
+						</td>
+						<td width="16px" align="right" style="cursor: pointer;" >
+							<img id="filtroLimparClasse-A" src="imagens/saj/limpar.gif" border="0" />
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+		<tr>
+			<td bgcolor="#EEEEEE">
+				<div id="divClasse-A" name="Classe" style="display: none; height: 200px; overflow: auto;">
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td height="18" bgcolor="DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0" name="Relator" >
+					<tr>
+						<td>
+							<a id="linkMenuFiltroRelator-A" >
+								&nbsp;<img id="icoRelator-A" src="imagens/spw/icoMais.gif" align="absmiddle"border="0" >&nbsp;
+								<span id="filtroRelator-A"><b>Relator</b></span>
+								<span id="spanRelator-A" style="display: inline;" ></span>
+							</a>
+						</td>
+						<td width="16px" align="right" style="cursor: pointer;" >
+							<img id="filtroLimparRelator-A" src="imagens/saj/limpar.gif" border="0" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+		<tr>
+			<td bgcolor="#EEEEEE">
+				<div id="divRelator-A" name="Relator" style="display: none; height: 200px; overflow: auto;">
+				</div>
+			</td>
+		</tr>
+
+		<tr>
+			<td height="18" bgcolor="DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0" border="0" name="OrgaoJulgador" >
+					<tr>
+						<td>
+							<a id="linkMenuFiltroOrgaoJulgador-A" >
+								&nbsp;<img id="icoOrgaoJulgador-A" src="imagens/spw/icoMais.gif"align="absmiddle" border="0" >&nbsp;
+								<span id="filtroOrgaoJulgador-A"><b>Órgão Julgador</b></span>
+								<span id="spanOrgaoJulgador-A" style="display: inline;" ></span>
+							</a>
+						</td>
+						<td width="16px" align="right" style="cursor: pointer;">
+							<img id="filtroLimparOrgaoJulgador-A" src="imagens/saj/limpar.gif" border="0" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+		<tr>
+			<td bgcolor="#EEEEEE">
+				<div id="divOrgaoJulgador-A" name="OrgaoJulgador" style="display: none; height: 200px; overflow: auto;">
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td height="18" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="left" style="padding-left: 12px;">
+							<input id="botaoRefinarResultado-A" type="button" name="Refinar" value="Refinar resultado"
+								class="conJurisBotaoSec"
+								onmouseover="this.className = 'conJurisBotaoSec-o'"
+								onmouseout="this.className = 'conJurisBotaoSec'">
+						</td>
+						<td align="right" style="padding-right: 12px;">
+							<input id="botaoLimparComponente-A" type="button" name="LimparFiltros" value="Limpar"
+								class="conJurisBotaoSec"
+								onmouseover="this.className = 'conJurisBotaoSec-o'"
+								onmouseout="this.className = 'conJurisBotaoSec'">
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</div>
+
+
+		</td>
+	</tr>
+</table>
+<div id="paginacaoInferior-A">
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 20
+			</strong>
+			de 13929
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+							<script>
+							$(function(){
+								$.saj.cjsg.bindsAbaInicial('A');
+							});
+							</script>
+
+
+
+						</div>
+
+				</div>
+
+			<!-- Resultado consulta -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</td>
+</tr>
+</table>
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaRodape" summary=" " role="presentation">
+    <tr>
+        <td class="esajCelulaRodapeCentro">
+            Desenvolvido pela Softplan em parceria com o Tribunal de Justiça do Acre
+
+        </td>
+    </tr>
+</table>
+<link href="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/css/saj-popup-modal.css" rel="stylesheet" type="text/css">
+<link href="https://esaj.tjac.jus.br/esaj-layout/tema/padrao/css/popup-beta.css" rel="stylesheet" type="text/css">
+
+
+<script>
+    var appEsajLayout = appEsajLayout || {};
+    appEsajLayout.tituloCertificadoDigital = 'Certificado digital';
+    appEsajLayout.cliente = 'AC';
+    appEsajLayout.emailParaContato = '';
+    appEsajLayout.utilizarBotaoContato = 'false';
+    appEsajLayout.contexto = 'https://esaj.tjac.jus.br/esaj-layout';
+    appEsajLayout.webSignerParametro = '';
+
+    if(window.jQuery) {
+        jQuery.saj = jQuery.saj || {};
+        jQuery.saj.certificado = jQuery.saj.certificado || {};
+        jQuery.saj.certificado.cliente = 'AC';
+        jQuery.saj.certificado.urlConteudoAjudaWebSigner = appEsajLayout.contexto + '/ajudaWebSigner.do';
+        jQuery.saj.certificado.licenca = 'AqYAKi5zYWphZG0udGpzcC5qdXMuYnIsKi5zZWEuc2MuZ292LmJyLCouc29mdHBsYW4uY29tLmJyLCoudGphYy5qdXMuYnIsKi50amFsLmp1cy5iciwqLnRqYW0uanVzLmJyLCoudGpjZS5qdXMuYnIsKi50am1zLmp1cy5iciwqLnRqcHIuanVzLmJyLCoudGpzYy5qdXMuYnIsKi50anNwLmp1cy5ickMAaXA0OjEwLjAuMC4wLzgsaXA0OjEyNy4wLjAuMC84LGlwNDoxNzIuMTYuMC4wLzEyLGlwNDoxOTIuMTY4LjAuMC8xNggAU3RhbmRhcmQAAAABcfpZUu/QD3s2bqedB8v9T7MiMQxcHNu0pUzGzO+7Ta++o+BbAVgPau7lzj6IUFI7RPFkPSnm0ZbCFAVBnKrqinyvE8MwEvmQhFcjlhGK+FfVV5mhVkkxSC3khDEUR8gsAPVvFncyyW2vTU2ODkyGdU0S/g62wHFtSwfGP6OFqlWpZTqbxbEGd1vfe9yHHulTYI7RcsGxaTMD6XgtPlStbOn9DxSYhN3S+4oTtIq7pUR6ETavPqYlXh5hwkxIpTe3Sf4awQucSigQ95sS9g7QpcGyVUVscm0J/rah9YwPCnHShzsttWA9aCmKrNdgFSTTo8TUOmESEP93TH6Z3dss+A==';
+        jQuery.saj.certificado.webSignerParametro = '';
+        jQuery.saj.certificado.cofreDigital = jQuery.saj.certificado.cofreDigital || {};
+        jQuery.saj.certificado.cofreDigital.habilitado = 'false' === 'true';
+        jQuery.saj.certificado.cofreDigital.enderecoBase = 'https://esaj.tjac.jus.br/esaj-layout';
+    }
+
+</script>
+<script src="https://esaj.tjac.jus.br/esaj-layout/js/app-bundle.js?n=2978165087"></script>
+<script src="https://esaj.tjac.jus.br/esaj-layout/seletorVersaoBeta.js?n=32db3647-04d8-4058-8c7b-79513d6c2143&versao=1"></script>
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjac.jus.br/esaj-layout/js/softplan-websigner-2.5.1.js?n=736057767"></script>
+<script language="javascript" type="text/JavaScript" src=""></script>
+
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjac.jus.br/esaj-layout/js/saj-certificado.js?n=47741893"></script>
+
+
+
+<div id="webSignerNaoInstalado" style="display: none;">
+    <p>Para utilização do certificado digital no Portal e-SAJ é necessário a instalação do plug-in Web Signer. Por favor, realize a instalação antes de continuar.</p>
+    <div class="footer_certificado">
+        <button id="redirecionarParaPaginaInstalacao" class="actionPrincipal spwBotaoDefault">Instalar</button>
+        <button class="fecharModalInstalacao spwBotao">Cancelar</button>
+        <button class="spwBotao" onclick="window.open('https://esaj.tjac.jus.br/WebHelp//#id_instalacao_lacuna.htm','_blank')">Ajuda</button>
+    </div>
+</div>
+
+<div id="webSignerNaoSuportado" style="display: none;">
+    <p>O navegador utilizado não é compatível com a tecnologia (Web Signer) necessária para utilização do certificado digital. Por favor, utilize um dos navegadores homologados. Em caso de dúvidas, efetue a validação de requisitos <a href="https://esaj.tjac.jus.br/petpg/abrirVerificacaoRequisitosPet.do" target="_blank">aqui</a>.</p>
+    <div class="footer_certificado">
+        <button class="fecharModalInstalacao spwBotaoDefault actionPrincipal">OK</button>
+    </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+	</body>
+</html>

--- a/tests/tjac/samples/cjsg/results_normal_page_01.html
+++ b/tests/tjac/samples/cjsg/results_normal_page_01.html
@@ -1,0 +1,3903 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(13929)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="13929" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503707" cdForo="0" >
+										1000233-68.2026.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503707" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503707);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503707" style="display: none;" >
+	<div id="textAreaDados_2503707" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTEN&Ccedil;A. IMPUGNA&Ccedil;&Atilde;O INTEMPESTIVA. MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA. ASTREINTES. NECESSIDADE DE INTIMA&Ccedil;&Atilde;O PESSOAL. S&Uacute;MULA 410 DO STJ. EXCE&Ccedil;&Atilde;O DE PR&Eacute;-EXECUTIVIDADE. INEXIGIBILIDADE DA MULTA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento interposto contra decis&atilde;o que, em cumprimento de senten&ccedil;a, rejeitou impugna&ccedil;&atilde;o apresentada por institui&ccedil;&atilde;o financeira ao fundamento de intempestividade e determinou o prosseguimento da execu&ccedil;&atilde;o, com levantamento de valores bloqueados via SISBAJUD, incluindo montante expressivo a t&iacute;tulo de astreintes.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se mat&eacute;rias de ordem p&uacute;blica, especialmente relativas &agrave; exigibilidade de astreintes, podem ser analisadas apesar da intempestividade da impugna&ccedil;&atilde;o ao cumprimento de senten&ccedil;a; (ii) estabelecer se &eacute; exig&iacute;vel a multa cominat&oacute;ria sem pr&eacute;via intima&ccedil;&atilde;o pessoal do devedor para cumprimento da obriga&ccedil;&atilde;o de fazer.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O ordenamento jur&iacute;dico admite o conhecimento de mat&eacute;rias de ordem p&uacute;blica a qualquer tempo, n&atilde;o se sujeitando &agrave; preclus&atilde;o, inclusive na fase de cumprimento de senten&ccedil;a.
+4. A manifesta&ccedil;&atilde;o apresentada, ainda que intempestiva como impugna&ccedil;&atilde;o, deve ser recebida como exce&ccedil;&atilde;o de pr&eacute;-executividade, em observ&acirc;ncia aos princ&iacute;pios da instrumentalidade das formas e da primazia do julgamento de m&eacute;rito.
+5. A exigibilidade das astreintes constitui mat&eacute;ria de ordem p&uacute;blica e pode ser apreciada independentemente de provoca&ccedil;&atilde;o formal adequada.
+6. A multa cominat&oacute;ria possui natureza coercitiva e depende da caracteriza&ccedil;&atilde;o do descumprimento da obriga&ccedil;&atilde;o ap&oacute;s a regular constitui&ccedil;&atilde;o em mora do devedor.
+7. A jurisprud&ecirc;ncia do STJ, consubstanciada na S&uacute;mula 410, exige a pr&eacute;via intima&ccedil;&atilde;o pessoal do devedor como condi&ccedil;&atilde;o para a cobran&ccedil;a de multa por descumprimento de obriga&ccedil;&atilde;o de fazer ou n&atilde;o fazer.
+8. A intima&ccedil;&atilde;o realizada apenas na pessoa do advogado n&atilde;o supre a exig&ecirc;ncia de intima&ccedil;&atilde;o pessoal para fins de incid&ecirc;ncia das astreintes.
+9. Ausente a intima&ccedil;&atilde;o pessoal do devedor na fase executiva, mostra-se inexig&iacute;vel a cobran&ccedil;a das astreintes, bem como de seus consect&aacute;rios legais (multa do art. 523, &sect;1&ordm;, do CPC e honor&aacute;rios).
+IV. DISPOSITIVO E TESE
+10. Recurso provido.
+Tese de julgamento: A manifesta&ccedil;&atilde;o intempestiva pode ser recebida como exce&ccedil;&atilde;o de pr&eacute;-executividade quando versar sobre mat&eacute;rias cognosc&iacute;veis de of&iacute;cio e que n&atilde;o demandem dila&ccedil;&atilde;o probat&oacute;ria. A cobran&ccedil;a de astreintes por descumprimento de obriga&ccedil;&atilde;o de fazer exige pr&eacute;via intima&ccedil;&atilde;o pessoal do devedor, sendo inexig&iacute;vel a multa na sua aus&ecirc;ncia.
+____________
+Dispositivos relevantes citados: CPC, arts. 513, &sect;2&ordm;, I; 523, &sect;1&ordm;; 525; 537.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no REsp 1.929.909/SP, Rel. Min. Moura Ribeiro, 3&ordf; Turma, j. 08.06.2021; STJ, AgInt no AREsp 2.690.787/SP, Rel. Min. Raul Ara&uacute;jo, 4&ordf; Turma, j. 24.02.2025; STJ, AgInt no REsp 2.079.082/SP, Rel. Min. Marco Aur&eacute;lio Bellizze, 3&ordf; Turma, j. 11.09.2023; S&uacute;mula 410/STJ.  &nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:1000233-68.2026.8.01.0000;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTENÇA. IMPUGNAÇÃO INTEMPESTIVA. MATÉRIA DE ORDEM PÚBLICA. ASTREINTES. NECESSIDADE DE INTIMAÇÃO PESSOAL. SÚMULA 410 DO STJ. EXCEÇÃO DE PRÉ-EXECUTIVIDADE. INEXIGIBILIDADE DA MULTA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento interposto contra decisão que, em cumprimento de sentença, rejeitou impugnação apresentada
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTENÇA. IMPUGNAÇÃO INTEMPESTIVA. MATÉRIA DE ORDEM PÚBLICA. ASTREINTES. NECESSIDADE DE INTIMAÇÃO PESSOAL. SÚMULA 410 DO STJ. EXCEÇÃO DE PRÉ-EXECUTIVIDADE. INEXIGIBILIDADE DA MULTA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento interposto contra decisão que, em cumprimento de sentença, rejeitou impugnação apresentada por instituição financeira ao fundamento de intempestividade e determinou o prosseguimento da execução, com levantamento de valores bloqueados via SISBAJUD, incluindo montante expressivo a título de astreintes.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se matérias de ordem pública, especialmente relativas à exigibilidade de astreintes, podem ser analisadas apesar da intempestividade da impugnação ao cumprimento de sentença; (ii) estabelecer se é exigível a multa cominatória sem prévia intimação pessoal do devedor para cumprimento da obrigação de fazer.
+III. RAZÕES DE DECIDIR
+3. O ordenamento jurídico admite o conhecimento de matérias de ordem pública a qualquer tempo, não se sujeitando à preclusão, inclusive na fase de cumprimento de sentença.
+4. A manifestação apresentada, ainda que intempestiva como impugnação, deve ser recebida como exceção de pré-executividade, em observância aos princípios da instrumentalidade das formas e da primazia do julgamento de mérito.
+5. A exigibilidade das astreintes constitui matéria de ordem pública e pode ser apreciada independentemente de provocação formal adequada.
+6. A multa cominatória possui natureza coercitiva e depende da caracterização do descumprimento da obrigação após a regular constituição em mora do devedor.
+7. A jurisprudência do STJ, consubstanciada na Súmula 410, exige a prévia intimação pessoal do devedor como condição para a cobrança de multa por descumprimento de obrigação de fazer ou não fazer.
+8. A intimação realizada apenas na pessoa do advogado não supre a exigência de intimação pessoal para fins de incidência das astreintes.
+9. Ausente a intimação pessoal do devedor na fase executiva, mostra-se inexigível a cobrança das astreintes, bem como de seus consectários legais (multa do art. 523, §1º, do CPC e honorários).
+IV. DISPOSITIVO E TESE
+10. Recurso provido.
+Tese de julgamento: A manifestação intempestiva pode ser recebida como exceção de pré-executividade quando versar sobre matérias cognoscíveis de ofício e que não demandem dilação probatória. A cobrança de astreintes por descumprimento de obrigação de fazer exige prévia intimação pessoal do devedor, sendo inexigível a multa na sua ausência.
+____________
+Dispositivos relevantes citados: CPC, arts. 513, §2º, I; 523, §1º; 525; 537.
+Jurisprudência relevante citada: STJ, AgInt no REsp 1.929.909/SP, Rel. Min. Moura Ribeiro, 3ª Turma, j. 08.06.2021; STJ, AgInt no AREsp 2.690.787/SP, Rel. Min. Raul Araújo, 4ª Turma, j. 24.02.2025; STJ, AgInt no REsp 2.079.082/SP, Rel. Min. Marco Aurélio Bellizze, 3ª Turma, j. 11.09.2023; Súmula 410/STJ.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503706" cdForo="0" >
+										0702879-60.2022.8.01.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503706" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503706);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503706" style="display: none;" >
+	<div id="textAreaDados_2503706" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O MONIT&Oacute;RIA. EMBARGOS MONIT&Oacute;RIOS. CONTRATO BANC&Aacute;RIO. CAPITAL DE GIRO. RELA&Ccedil;&Atilde;O DE INSUMO. INAPLICABILIDADE DO CDC. DOCUMENTO H&Aacute;BIL. S&Uacute;MULA 247 DO STJ. ENCARGOS FINANCEIROS. JUROS REMUNERAT&Oacute;RIOS. AUS&Ecirc;NCIA DE ABUSIVIDADE. CAPITALIZA&Ccedil;&Atilde;O DE JUROS. POSSIBILIDADE. COMISS&Atilde;O FLAT. LEGALIDADE. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o C&iacute;vel interposta contra senten&ccedil;a que, em A&ccedil;&atilde;o Monit&oacute;ria, rejeitou embargos monit&oacute;rios e julgou procedente a pretens&atilde;o, constituindo t&iacute;tulo executivo judicial fundado em contrato de abertura de cr&eacute;dito, com condena&ccedil;&atilde;o ao pagamento do d&eacute;bito e honor&aacute;rios advocat&iacute;cios.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se os documentos apresentados pelo banco s&atilde;o aptos a embasar a a&ccedil;&atilde;o monit&oacute;ria; (ii) estabelecer se incide o C&oacute;digo de Defesa do Consumidor na rela&ccedil;&atilde;o contratual; (iii) determinar se h&aacute; abusividade nos juros remunerat&oacute;rios e na capitaliza&ccedil;&atilde;o; (iv) verificar a legalidade da cobran&ccedil;a de comiss&atilde;o flat e eventual venda casada.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O contrato de abertura de cr&eacute;dito acompanhado de demonstrativo de d&eacute;bito constitui documento h&aacute;bil &agrave; propositura da a&ccedil;&atilde;o monit&oacute;ria, nos termos da S&uacute;mula 247 do STJ.
+4. A rela&ccedil;&atilde;o jur&iacute;dica possui natureza de insumo, pois o cr&eacute;dito foi destinado ao fomento de atividade empresarial, afastando a incid&ecirc;ncia do C&oacute;digo de Defesa do Consumidor.
+5. A alega&ccedil;&atilde;o gen&eacute;rica de aus&ecirc;ncia de discrimina&ccedil;&atilde;o do d&eacute;bito n&atilde;o afasta a validade dos documentos apresentados, sobretudo quando n&atilde;o demonstrado concretamente o excesso de execu&ccedil;&atilde;o.
+6. As institui&ccedil;&otilde;es financeiras n&atilde;o se submetem &agrave; limita&ccedil;&atilde;o da Lei de Usura, sendo admiss&iacute;vel a pactua&ccedil;&atilde;o de juros superiores a 12% ao ano, conforme S&uacute;mula 596 do STF.
+7. A taxa de juros remunerat&oacute;rios n&atilde;o se revela abusiva quando n&atilde;o demonstrada discrep&acirc;ncia significativa em rela&ccedil;&atilde;o &agrave; m&eacute;dia de mercado, a qual serve apenas como par&acirc;metro referencial, nos termos da jurisprud&ecirc;ncia do STJ.
+8. A revis&atilde;o judicial dos juros exige comprova&ccedil;&atilde;o de desvantagem exagerada, o que n&atilde;o ocorreu, diante da aus&ecirc;ncia de demonstra&ccedil;&atilde;o t&eacute;cnica pelos apelantes.
+9. A capitaliza&ccedil;&atilde;o de juros &eacute; admitida quando expressamente pactuada, sendo suficiente a previs&atilde;o contratual de taxa anual superior ao duod&eacute;cuplo da mensal, conforme S&uacute;mulas 539 e 541 do STJ.
+10. A comiss&atilde;o flat &eacute; v&aacute;lida quando prevista contratualmente, correspondente a servi&ccedil;o de assessoria financeira, e n&atilde;o demonstrada abusividade ou desequil&iacute;brio contratual.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento: O contrato de abertura de cr&eacute;dito acompanhado de demonstrativo de d&eacute;bito &eacute; documento h&aacute;bil &agrave; a&ccedil;&atilde;o monit&oacute;ria. Em empr&eacute;stimo destinado &agrave; atividade empresarial, configura-se rela&ccedil;&atilde;o de insumo, afastando a incid&ecirc;ncia do CDC. A revis&atilde;o de juros remunerat&oacute;rios exige demonstra&ccedil;&atilde;o concreta de abusividade, n&atilde;o sendo a taxa m&eacute;dia do BACEN limite absoluto. A capitaliza&ccedil;&atilde;o de juros &eacute; v&aacute;lida quando expressamente pactuada. A comiss&atilde;o flat &eacute; l&iacute;cita quando prevista contratualmente e n&atilde;o evidenciado desequil&iacute;brio contratual.
+____________
+Dispositivos relevantes citados: CPC, art. 702, &sect;&sect;2&ordm; e 3&ordm;; 85, &sect;&sect;2&ordm; e 11. CC, art. 421.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula 247; STF, S&uacute;mula 596; STJ, S&uacute;mulas 382, 539 e 541; STJ, REsp 1.599.042/SP, Rel. Min. Luis Felipe Salom&atilde;o, j. 14.03.2017; STJ, AgInt no AREsp 1.987.137/SP, Rel. Min. Maria Isabel Gallotti, j. 03.10.2022; TJ-TO - Apela&ccedil;&atilde;o C&iacute;vel: 00037287420238272731, Relator.: JACQUELINE ADORNO DE LA CRUZ BARBOSA, Data de Julgamento: 12/03/2025, TURMAS DAS CAMARAS CIVEIS; TJ-MG - Apela&ccedil;&atilde;o C&iacute;vel: 02059551620138130105 1 .0000.23.350809-2/001, Relator.: Des.(a) Jos&eacute; Am&eacute;rico Martins da Costa, Data de Julgamento: 12/07/2024, 12&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 16/07/2024; TJ-DF 07053156120218070001 1655205, Relator.: GET&Uacute;LIO DE MORAES OLIVEIRA, Data de Julgamento: 25/01/2023, 7&ordf; Turma C&iacute;vel, Data de Publica&ccedil;&atilde;o: 08/02/2023.  &nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:0702879-60.2022.8.01.0002;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO MONITÓRIA. EMBARGOS MONITÓRIOS. CONTRATO BANCÁRIO. CAPITAL DE GIRO. RELAÇÃO DE INSUMO. INAPLICABILIDADE DO CDC. DOCUMENTO HÁBIL. SÚMULA 247 DO STJ. ENCARGOS FINANCEIROS. JUROS REMUNERATÓRIOS. AUSÊNCIA DE ABUSIVIDADE. CAPITALIZAÇÃO DE JUROS. POSSIBILIDADE. COMISSÃO FLAT. LEGALIDADE. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO MONITÓRIA. EMBARGOS MONITÓRIOS. CONTRATO BANCÁRIO. CAPITAL DE GIRO. RELAÇÃO DE INSUMO. INAPLICABILIDADE DO CDC. DOCUMENTO HÁBIL. SÚMULA 247 DO STJ. ENCARGOS FINANCEIROS. JUROS REMUNERATÓRIOS. AUSÊNCIA DE ABUSIVIDADE. CAPITALIZAÇÃO DE JUROS. POSSIBILIDADE. COMISSÃO FLAT. LEGALIDADE. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta contra sentença que, em Ação Monitória, rejeitou embargos monitórios e julgou procedente a pretensão, constituindo título executivo judicial fundado em contrato de abertura de crédito, com condenação ao pagamento do débito e honorários advocatícios.
+II. QUESTÃO EM DISCUSSÃO
+2. Há quatro questões em discussão: (i) definir se os documentos apresentados pelo banco são aptos a embasar a ação monitória; (ii) estabelecer se incide o Código de Defesa do Consumidor na relação contratual; (iii) determinar se há abusividade nos juros remuneratórios e na capitalização; (iv) verificar a legalidade da cobrança de comissão flat e eventual venda casada.
+III. RAZÕES DE DECIDIR
+3. O contrato de abertura de crédito acompanhado de demonstrativo de débito constitui documento hábil à propositura da ação monitória, nos termos da Súmula 247 do STJ.
+4. A relação jurídica possui natureza de insumo, pois o crédito foi destinado ao fomento de atividade empresarial, afastando a incidência do Código de Defesa do Consumidor.
+5. A alegação genérica de ausência de discriminação do débito não afasta a validade dos documentos apresentados, sobretudo quando não demonstrado concretamente o excesso de execução.
+6. As instituições financeiras não se submetem à limitação da Lei de Usura, sendo admissível a pactuação de juros superiores a 12% ao ano, conforme Súmula 596 do STF.
+7. A taxa de juros remuneratórios não se revela abusiva quando não demonstrada discrepância significativa em relação à média de mercado, a qual serve apenas como parâmetro referencial, nos termos da jurisprudência do STJ.
+8. A revisão judicial dos juros exige comprovação de desvantagem exagerada, o que não ocorreu, diante da ausência de demonstração técnica pelos apelantes.
+9. A capitalização de juros é admitida quando expressamente pactuada, sendo suficiente a previsão contratual de taxa anual superior ao duodécuplo da mensal, conforme Súmulas 539 e 541 do STJ.
+10. A comissão flat é válida quando prevista contratualmente, correspondente a serviço de assessoria financeira, e não demonstrada abusividade ou desequilíbrio contratual.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento: O contrato de abertura de crédito acompanhado de demonstrativo de débito é documento hábil à ação monitória. Em empréstimo destinado à atividade empresarial, configura-se relação de insumo, afastando a incidência do CDC. A revisão de juros remuneratórios exige demonstração concreta de abusividade, não sendo a taxa média do BACEN limite absoluto. A capitalização de juros é válida quando expressamente pactuada. A comissão flat é lícita quando prevista contratualmente e não evidenciado desequilíbrio contratual.
+____________
+Dispositivos relevantes citados: CPC, art. 702, §§2º e 3º; 85, §§2º e 11. CC, art. 421.
+Jurisprudência relevante citada: STJ, Súmula 247; STF, Súmula 596; STJ, Súmulas 382, 539 e 541; STJ, REsp 1.599.042/SP, Rel. Min. Luis Felipe Salomão, j. 14.03.2017; STJ, AgInt no AREsp 1.987.137/SP, Rel. Min. Maria Isabel Gallotti, j. 03.10.2022; TJ-TO - Apelação Cível: 00037287420238272731, Relator.: JACQUELINE ADORNO DE LA CRUZ BARBOSA, Data de Julgamento: 12/03/2025, TURMAS DAS CAMARAS CIVEIS; TJ-MG - Apelação Cível: 02059551620138130105 1 .0000.23.350809-2/001, Relator.: Des.(a) José Américo Martins da Costa, Data de Julgamento: 12/07/2024, 12ª CÂMARA CÍVEL, Data de Publicação: 16/07/2024; TJ-DF 07053156120218070001 1655205, Relator.: GETÚLIO DE MORAES OLIVEIRA, Data de Julgamento: 25/01/2023, 7ª Turma Cível, Data de Publicação: 08/02/2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503712" cdForo="0" >
+										0710985-09.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503712" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503712);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503712" style="display: none;" >
+	<div id="textAreaDados_2503712" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. CONTRATO BANC&Aacute;RIO. REFINANCIAMENTO DE EMPR&Eacute;STIMO CONSIGNADO. BIOMETRIA FACIAL. COMPROVA&Ccedil;&Atilde;O DO CR&Eacute;DITO DO &quot;TROCO&quot;. &Ocirc;NUS DA PROVA. ART. 373, II, CPC. AUS&Ecirc;NCIA DE V&Iacute;CIO DE CONSENTIMENTO. IMPROCED&Ecirc;NCIA DOS PEDIDOS INICIAIS. REFORMA INTEGRAL DA SENTEN&Ccedil;A. RECURSO CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o C&iacute;vel interposta contra senten&ccedil;a proferida pelo Ju&iacute;zo da 6&ordf; Vara C&iacute;vel da Comarca de Rio Branco, que, nos autos de a&ccedil;&atilde;o declarat&oacute;ria de nulidade contratual cumulada com indeniza&ccedil;&atilde;o por danos morais, julgou procedentes os pedidos iniciais para declarar a nulidade de contrato de refinanciamento consignado, determinar a cessa&ccedil;&atilde;o dos descontos, condenar a institui&ccedil;&atilde;o financeira &agrave; restitui&ccedil;&atilde;o em dobro dos valores descontados e ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 8.000,00, al&eacute;m do pagamento de custas e honor&aacute;rios advocat&iacute;cios.
+2. A institui&ccedil;&atilde;o financeira apelante sustentou a regularidade da contrata&ccedil;&atilde;o, alegando que o contrato foi celebrado mediante valida&ccedil;&atilde;o por biometria facial e que houve efetiva disponibiliza&ccedil;&atilde;o do cr&eacute;dito ao consumidor, inclusive com destina&ccedil;&atilde;o parcial &agrave; quita&ccedil;&atilde;o de contratos anteriores e libera&ccedil;&atilde;o do valor remanescente (&quot;troco&quot;) em conta banc&aacute;ria de titularidade do autor.
+3. O apelado apresentou contrarraz&otilde;es, defendendo a manuten&ccedil;&atilde;o integral da senten&ccedil;a, ao argumento de que incumbia &agrave; institui&ccedil;&atilde;o financeira comprovar n&atilde;o apenas a formaliza&ccedil;&atilde;o do contrato, mas tamb&eacute;m a efetiva disponibiliza&ccedil;&atilde;o do valor ao consumidor.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+4. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) saber se restou comprovada a regularidade do contrato de refinanciamento consignado impugnado; (ii) saber se houve efetiva disponibiliza&ccedil;&atilde;o do valor denominado &quot;troco&quot; ao consumidor; (iii) saber se subsiste o dever de restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais; (iv) saber se a manuten&ccedil;&atilde;o da senten&ccedil;a implicaria enriquecimento sem causa do consumidor.
+III. RAZ&Otilde;ES DE DECIDIR
+5. A controv&eacute;rsia foi solucionada &agrave; luz das normas consumeristas e das regras de distribui&ccedil;&atilde;o do &ocirc;nus da prova previstas no art. 373, inciso II, do C&oacute;digo de Processo Civil, incumbindo &agrave; institui&ccedil;&atilde;o financeira demonstrar a regularidade da contrata&ccedil;&atilde;o e a efetiva disponibiliza&ccedil;&atilde;o do cr&eacute;dito.
+6. A an&aacute;lise do acervo probat&oacute;rio evidenciou que os documentos juntados demonstraram a realiza&ccedil;&atilde;o de opera&ccedil;&otilde;es sucessivas de empr&eacute;stimo e refinanciamento, com cr&eacute;ditos efetivamente disponibilizados na conta do consumidor, incluindo o valor final de R$ 1.333,85, referente ao refinanciamento impugnado.
+7. Restou comprovado, ainda, que os contratos anteriores foram quitados mediante substitui&ccedil;&atilde;o por nova opera&ccedil;&atilde;o financeira, circunst&acirc;ncia que evidencia a din&acirc;mica t&iacute;pica dos contratos de refinanciamento e demonstra a exist&ecirc;ncia de proveito econ&ocirc;mico em favor do consumidor.
+8. A comprova&ccedil;&atilde;o da valida&ccedil;&atilde;o por biometria facial e do ingresso dos valores na esfera patrimonial do consumidor afasta a alega&ccedil;&atilde;o de v&iacute;cio de consentimento, caracterizando comportamento concludente apto a ratificar a contrata&ccedil;&atilde;o e afastar a nulidade pretendida.
+9. Demonstrada a regularidade da contrata&ccedil;&atilde;o e a disponibiliza&ccedil;&atilde;o do numer&aacute;rio, inexiste ato il&iacute;cito imput&aacute;vel &agrave; institui&ccedil;&atilde;o financeira, circunst&acirc;ncia que afasta o dever de repeti&ccedil;&atilde;o do ind&eacute;bito, seja em sua forma simples ou em dobro, bem como a configura&ccedil;&atilde;o de dano moral indeniz&aacute;vel.
+10. A manuten&ccedil;&atilde;o da senten&ccedil;a, diante da prova do recebimento dos valores e da quita&ccedil;&atilde;o de d&eacute;bitos pret&eacute;ritos, configuraria enriquecimento sem causa do consumidor, em afronta aos princ&iacute;pios da boa-f&eacute; objetiva e da veda&ccedil;&atilde;o ao enriquecimento indevido.
+11. Reformada integralmente a senten&ccedil;a, imp&ocirc;s-se a redistribui&ccedil;&atilde;o dos encargos sucumbenciais, com condena&ccedil;&atilde;o da parte autora ao pagamento das custas processuais e honor&aacute;rios advocat&iacute;cios fixados em 10% sobre o valor atualizado da causa, com suspens&atilde;o da exigibilidade em raz&atilde;o da gratuidade da justi&ccedil;a, nos termos do art. 98, &sect; 3&ordm;, do C&oacute;digo de Processo Civil.
+IV. DISPOSITIVO E TESE
+10. Recurso conhecido e provido, para reformar integralmente a senten&ccedil;a e julgar improcedentes os pedidos iniciais, reconhecendo a validade do contrato de refinanciamento consignado discutido nos autos.
+Tese de julgamento: A comprova&ccedil;&atilde;o da valida&ccedil;&atilde;o biom&eacute;trica da contrata&ccedil;&atilde;o e da efetiva disponibiliza&ccedil;&atilde;o dos valores ao consumidor afasta a alega&ccedil;&atilde;o de v&iacute;cio de consentimento, inexistindo nulidade contratual, repeti&ccedil;&atilde;o de ind&eacute;bito ou dano moral, sob pena de enriquecimento sem causa do contratante.
+Dispositivos relevantes citados
+CPC, art. 85, &sect; 2&ordm;
+CPC, art. 98, &sect; 3&ordm;
+CPC, art. 373, inciso II &nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0710985-09.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;6&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(18 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. CONTRATO BANCÁRIO. REFINANCIAMENTO DE EMPRÉSTIMO CONSIGNADO. BIOMETRIA FACIAL. COMPROVAÇÃO DO CRÉDITO DO "TROCO". ÔNUS DA PROVA. ART. 373, II, CPC. AUSÊNCIA DE VÍCIO DE CONSENTIMENTO. IMPROCEDÊNCIA DOS PEDIDOS INICIAIS. REFORMA INTEGRAL DA SENTENÇA. RECURSO CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta contra sentença proferida
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. CONTRATO BANCÁRIO. REFINANCIAMENTO DE EMPRÉSTIMO CONSIGNADO. BIOMETRIA FACIAL. COMPROVAÇÃO DO CRÉDITO DO "TROCO". ÔNUS DA PROVA. ART. 373, II, CPC. AUSÊNCIA DE VÍCIO DE CONSENTIMENTO. IMPROCEDÊNCIA DOS PEDIDOS INICIAIS. REFORMA INTEGRAL DA SENTENÇA. RECURSO CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta contra sentença proferida pelo Juízo da 6ª Vara Cível da Comarca de Rio Branco, que, nos autos de ação declaratória de nulidade contratual cumulada com indenização por <em>danos</em> <em>morais</em>, julgou procedentes os pedidos iniciais para declarar a nulidade de contrato de refinanciamento consignado, determinar a cessação dos descontos, condenar a instituição financeira à restituição em dobro dos valores descontados e ao pagamento de indenização por <em>danos</em> <em>morais</em> no valor de R$ 8.000,00, além do pagamento de custas e honorários advocatícios.
+2. A instituição financeira apelante sustentou a regularidade da contratação, alegando que o contrato foi celebrado mediante validação por biometria facial e que houve efetiva disponibilização do crédito ao consumidor, inclusive com destinação parcial à quitação de contratos anteriores e liberação do valor remanescente ("troco") em conta bancária de titularidade do autor.
+3. O apelado apresentou contrarrazões, defendendo a manutenção integral da sentença, ao argumento de que incumbia à instituição financeira comprovar não apenas a formalização do contrato, mas também a efetiva disponibilização do valor ao consumidor.
+II. QUESTÕES EM DISCUSSÃO
+4. Há quatro questões em discussão: (i) saber se restou comprovada a regularidade do contrato de refinanciamento consignado impugnado; (ii) saber se houve efetiva disponibilização do valor denominado "troco" ao consumidor; (iii) saber se subsiste o dever de restituição de valores e indenização por <em>danos</em> <em>morais</em>; (iv) saber se a manutenção da sentença implicaria enriquecimento sem causa do consumidor.
+III. RAZÕES DE DECIDIR
+5. A controvérsia foi solucionada à luz das normas consumeristas e das regras de distribuição do ônus da prova previstas no art. 373, inciso II, do Código de Processo Civil, incumbindo à instituição financeira demonstrar a regularidade da contratação e a efetiva disponibilização do crédito.
+6. A análise do acervo probatório evidenciou que os documentos juntados demonstraram a realização de operações sucessivas de empréstimo e refinanciamento, com créditos efetivamente disponibilizados na conta do consumidor, incluindo o valor final de R$ 1.333,85, referente ao refinanciamento impugnado.
+7. Restou comprovado, ainda, que os contratos anteriores foram quitados mediante substituição por nova operação financeira, circunstância que evidencia a dinâmica típica dos contratos de refinanciamento e demonstra a existência de proveito econômico em favor do consumidor.
+8. A comprovação da validação por biometria facial e do ingresso dos valores na esfera patrimonial do consumidor afasta a alegação de vício de consentimento, caracterizando comportamento concludente apto a ratificar a contratação e afastar a nulidade pretendida.
+9. Demonstrada a regularidade da contratação e a disponibilização do numerário, inexiste ato ilícito imputável à instituição financeira, circunstância que afasta o dever de repetição do indébito, seja em sua forma simples ou em dobro, bem como a configuração de <em>dano</em> <em>moral</em> indenizável.
+10. A manutenção da sentença, diante da prova do recebimento dos valores e da quitação de débitos pretéritos, configuraria enriquecimento sem causa do consumidor, em afronta aos princípios da boa-fé objetiva e da vedação ao enriquecimento indevido.
+11. Reformada integralmente a sentença, impôs-se a redistribuição dos encargos sucumbenciais, com condenação da parte autora ao pagamento das custas processuais e honorários advocatícios fixados em 10% sobre o valor atualizado da causa, com suspensão da exigibilidade em razão da gratuidade da justiça, nos termos do art. 98, § 3º, do Código de Processo Civil.
+IV. DISPOSITIVO E TESE
+10. Recurso conhecido e provido, para reformar integralmente a sentença e julgar improcedentes os pedidos iniciais, reconhecendo a validade do contrato de refinanciamento consignado discutido nos autos.
+Tese de julgamento: A comprovação da validação biométrica da contratação e da efetiva disponibilização dos valores ao consumidor afasta a alegação de vício de consentimento, inexistindo nulidade contratual, repetição de indébito ou <em>dano</em> <em>moral</em>, sob pena de enriquecimento sem causa do contratante.
+Dispositivos relevantes citados
+CPC, art. 85, § 2º
+CPC, art. 98, § 3º
+CPC, art. 373, inciso II
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503711" cdForo="0" >
+										0708142-71.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503711" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503711);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503711" style="display: none;" >
+	<div id="textAreaDados_2503711" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. FRAUDE BANC&Aacute;RIA. EMPR&Eacute;STIMO CONSIGNADO. PORTABILIDADE DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. S&Uacute;MULA 479/STJ. RESTITUI&Ccedil;&Atilde;O EM DOBRO. DANOS MORAIS CONFIGURADOS. RECURSO DO BANCO CONHECIDO E DESPROVIDO. RECURSO DA AUTORA CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito cumulada com indeniza&ccedil;&atilde;o por danos morais ajuizada por consumidora em face de institui&ccedil;&atilde;o financeira, sob alega&ccedil;&atilde;o de contrata&ccedil;&atilde;o fraudulenta de empr&eacute;stimo com subsequente transfer&ecirc;ncia dos valores para terceiro desconhecido, acompanhada de descontos mensais em benef&iacute;cio previdenci&aacute;rio.
+2. O Ju&iacute;zo de Direito da Vara C&iacute;vel julgou parcialmente procedentes os pedidos para declarar a nulidade do contrato de empr&eacute;stimo, determinar a devolu&ccedil;&atilde;o simples dos valores pagos, permitir compensa&ccedil;&atilde;o com valores creditados e julgar improcedente o pedido de indeniza&ccedil;&atilde;o por danos morais, fixando sucumb&ecirc;ncia rec&iacute;proca.
+3. A institui&ccedil;&atilde;o financeira interp&ocirc;s recurso de apela&ccedil;&atilde;o sustentando a regularidade da contrata&ccedil;&atilde;o mediante biometria facial e assinatura eletr&ocirc;nica, aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o e inexist&ecirc;ncia de dever de restitui&ccedil;&atilde;o, requerendo a reforma integral da senten&ccedil;a.
+4. A autora tamb&eacute;m interp&ocirc;s apela&ccedil;&atilde;o pleiteando a restitui&ccedil;&atilde;o em dobro dos valores descontados, afastamento da compensa&ccedil;&atilde;o e condena&ccedil;&atilde;o da institui&ccedil;&atilde;o financeira ao pagamento de indeniza&ccedil;&atilde;o por danos morais, sob alega&ccedil;&atilde;o de fraude e aus&ecirc;ncia de engano justific&aacute;vel.
+5. Contrarraz&otilde;es apresentadas por ambas as partes, pugnando pela manuten&ccedil;&atilde;o dos cap&iacute;tulos da senten&ccedil;a que lhes foram favor&aacute;veis.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+6. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se a institui&ccedil;&atilde;o financeira responde pelos preju&iacute;zos decorrentes de contrata&ccedil;&atilde;o fraudulenta e subsequente transfer&ecirc;ncia de valores a terceiro; (ii) saber se a restitui&ccedil;&atilde;o dos valores descontados deve ocorrer em dobro e sem compensa&ccedil;&atilde;o; (iii) saber se a situa&ccedil;&atilde;o caracteriza dano moral indeniz&aacute;vel.
+III. RAZ&Otilde;ES DE DECIDIR
+7. A rela&ccedil;&atilde;o jur&iacute;dica estabelecida entre as partes possui natureza consumerista, sendo aplic&aacute;vel a responsabilidade objetiva do fornecedor prevista no art. 14 do C&oacute;digo de Defesa do Consumidor, segundo a qual o prestador responde independentemente de culpa pelos danos decorrentes de defeitos relativos &agrave; presta&ccedil;&atilde;o do servi&ccedil;o.
+8. Restou evidenciada falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio, consubstanciada na libera&ccedil;&atilde;o sucessiva de cr&eacute;ditos e imediata transfer&ecirc;ncia integral dos valores para conta de terceiro com hist&oacute;rico de fraude, sem a ado&ccedil;&atilde;o de mecanismos eficazes de seguran&ccedil;a.
+9. Incide, na esp&eacute;cie, a teoria do risco do empreendimento e o entendimento consolidado na S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a, segundo a qual as institui&ccedil;&otilde;es financeiras respondem objetivamente pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no &acirc;mbito de opera&ccedil;&otilde;es banc&aacute;rias.
+10. A institui&ccedil;&atilde;o financeira n&atilde;o comprovou manifesta&ccedil;&atilde;o v&aacute;lida de vontade da consumidora, tampouco demonstrou seguran&ccedil;a suficiente no procedimento de valida&ccedil;&atilde;o biom&eacute;trica, &ocirc;nus que lhe incumbia nos termos das regras de distribui&ccedil;&atilde;o din&acirc;mica do &ocirc;nus probat&oacute;rio aplic&aacute;veis &agrave;s rela&ccedil;&otilde;es consumeristas.
+11. Reconhecida a falha na presta&ccedil;&atilde;o do servi&ccedil;o, imp&otilde;e-se a nulidade do contrato e a inexigibilidade dos d&eacute;bitos decorrentes das opera&ccedil;&otilde;es fraudulentas.
+12. Quanto &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, aplica-se o art. 42, par&aacute;grafo &uacute;nico, do C&oacute;digo de Defesa do Consumidor, sendo devida a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados, uma vez ausente engano justific&aacute;vel por parte da institui&ccedil;&atilde;o financeira.
+13. O entendimento encontra respaldo no julgamento do EAREsp 676.608/RS, da Corte Especial do Superior Tribunal de Justi&ccedil;a, que consolidou a orienta&ccedil;&atilde;o quanto &agrave; restitui&ccedil;&atilde;o em dobro quando inexistente justificativa plaus&iacute;vel para a cobran&ccedil;a indevida.
+14. A compensa&ccedil;&atilde;o determinada na origem mostra-se indevida, pois a autora n&atilde;o usufruiu dos valores liberados, os quais foram imediatamente desviados por terceiros, circunst&acirc;ncia que afasta qualquer benef&iacute;cio econ&ocirc;mico &agrave; consumidora.
+15. Sobre os valores devidos incidem corre&ccedil;&atilde;o monet&aacute;ria desde o efetivo preju&iacute;zo e juros morat&oacute;rios desde o evento danoso, conforme orienta&ccedil;&otilde;es das S&uacute;mulas 43 e 54 do Superior Tribunal de Justi&ccedil;a.
+16. No tocante aos danos morais, a indevida realiza&ccedil;&atilde;o de descontos em benef&iacute;cio previdenci&aacute;rio de pessoa idosa configura viola&ccedil;&atilde;o a direitos da personalidade, caracterizando dano moral in re ipsa, dispensando prova do preju&iacute;zo concreto.
+17. A fixa&ccedil;&atilde;o da indeniza&ccedil;&atilde;o no valor de R$ 3.000,00 observa os princ&iacute;pios da razoabilidade e proporcionalidade, considerando o car&aacute;ter compensat&oacute;rio e pedag&oacute;gico da medida.
+18. A corre&ccedil;&atilde;o monet&aacute;ria da indeniza&ccedil;&atilde;o por danos morais incide a partir do arbitramento, nos termos da S&uacute;mula 362 do Superior Tribunal de Justi&ccedil;a, enquanto os juros morat&oacute;rios incidem desde o evento danoso, conforme S&uacute;mula 54 do mesmo Tribunal.
+19. O redimensionamento do julgado implica a redistribui&ccedil;&atilde;o dos &ocirc;nus sucumbenciais, impondo-se &agrave; institui&ccedil;&atilde;o financeira o pagamento integral das custas e honor&aacute;rios advocat&iacute;cios, fixados com fundamento no art. 85, &sect;&sect; 2&ordm; e 11, do C&oacute;digo de Processo Civil.
+IV. DISPOSITIVO E TESE
+20. Recurso da institui&ccedil;&atilde;o financeira conhecido e desprovido. Recurso da autora conhecido e provido para reformar a senten&ccedil;a e declarar a inexist&ecirc;ncia dos d&eacute;bitos oriundos dos contratos fraudulentos, determinar a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados, afastar a compensa&ccedil;&atilde;o e condenar a institui&ccedil;&atilde;o financeira ao pagamento de indeniza&ccedil;&atilde;o por danos morais, al&eacute;m de impor-lhe integral responsabilidade pelos &ocirc;nus sucumbenciais.
+Tese de julgamento: &quot;A institui&ccedil;&atilde;o financeira responde objetivamente por fraudes decorrentes de falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio, sendo devida a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados e a indeniza&ccedil;&atilde;o por danos morais quando comprovada vulnerabilidade do consumidor e aus&ecirc;ncia de engano justific&aacute;vel.&quot;
+Dispositivos relevantes citados
+CDC, art. 14, &sect; 1&ordm;; art. 42, par&aacute;grafo &uacute;nico.
+C&oacute;digo Civil, arts. 389 e 406.
+C&oacute;digo de Processo Civil, art. 85, &sect;&sect; 2&ordm; e 11.
+Jurisprud&ecirc;ncia relevante citada
+STJ, S&uacute;mula 43.
+STJ, S&uacute;mula 54.
+STJ, S&uacute;mula 362.
+STJ, S&uacute;mula 479.
+STJ, EAREsp 676.608/RS.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0708142-71.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(48 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE BANCÁRIA. EMPRÉSTIMO CONSIGNADO. PORTABILIDADE DE BENEFÍCIO PREVIDENCIÁRIO. FALHA NA PRESTAÇÃO DO SERVIÇO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. SÚMULA 479/STJ. RESTITUIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em> CONFIGURADOS.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE BANCÁRIA. EMPRÉSTIMO CONSIGNADO. PORTABILIDADE DE BENEFÍCIO PREVIDENCIÁRIO. FALHA NA PRESTAÇÃO DO SERVIÇO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. SÚMULA 479/STJ. RESTITUIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em> CONFIGURADOS. RECURSO DO BANCO CONHECIDO E DESPROVIDO. RECURSO DA AUTORA CONHECIDO E PROVIDO.
+I. CASO EM EXAME
+1. Ação declaratória de inexistência de débito cumulada com indenização por <em>danos</em> <em>morais</em> ajuizada por consumidora em face de instituição financeira, sob alegação de contratação fraudulenta de empréstimo com subsequente transferência dos valores para terceiro desconhecido, acompanhada de descontos mensais em benefício previdenciário.
+2. O Juízo de Direito da Vara Cível julgou parcialmente procedentes os pedidos para declarar a nulidade do contrato de empréstimo, determinar a devolução simples dos valores pagos, permitir compensação com valores creditados e julgar improcedente o pedido de indenização por <em>danos</em> <em>morais</em>, fixando sucumbência recíproca.
+3. A instituição financeira interpôs recurso de apelação sustentando a regularidade da contratação mediante biometria facial e assinatura eletrônica, ausência de falha na prestação do serviço e inexistência de dever de restituição, requerendo a reforma integral da sentença.
+4. A autora também interpôs apelação pleiteando a restituição em dobro dos valores descontados, afastamento da compensação e condenação da instituição financeira ao pagamento de indenização por <em>danos</em> <em>morais</em>, sob alegação de fraude e ausência de engano justificável.
+5. Contrarrazões apresentadas por ambas as partes, pugnando pela manutenção dos capítulos da sentença que lhes foram favoráveis.
+II. QUESTÕES EM DISCUSSÃO
+6. Há três questões em discussão: (i) saber se a instituição financeira responde pelos prejuízos decorrentes de contratação fraudulenta e subsequente transferência de valores a terceiro; (ii) saber se a restituição dos valores descontados deve ocorrer em dobro e sem compensação; (iii) saber se a situação caracteriza <em>dano</em> <em>moral</em> indenizável.
+III. RAZÕES DE DECIDIR
+7. A relação jurídica estabelecida entre as partes possui natureza consumerista, sendo aplicável a responsabilidade objetiva do fornecedor prevista no art. 14 do Código de Defesa do Consumidor, segundo a qual o prestador responde independentemente de culpa pelos <em>danos</em> decorrentes de defeitos relativos à prestação do serviço.
+8. Restou evidenciada falha na prestação do serviço bancário, consubstanciada na liberação sucessiva de créditos e imediata transferência integral dos valores para conta de terceiro com histórico de fraude, sem a adoção de mecanismos eficazes de segurança.
+9. Incide, na espécie, a teoria do risco do empreendimento e o entendimento consolidado na Súmula 479 do Superior Tribunal de Justiça, segundo a qual as instituições financeiras respondem objetivamente pelos <em>danos</em> gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no âmbito de operações bancárias.
+10. A instituição financeira não comprovou manifestação válida de vontade da consumidora, tampouco demonstrou segurança suficiente no procedimento de validação biométrica, ônus que lhe incumbia nos termos das regras de distribuição dinâmica do ônus probatório aplicáveis às relações consumeristas.
+11. Reconhecida a falha na prestação do serviço, impõe-se a nulidade do contrato e a inexigibilidade dos débitos decorrentes das operações fraudulentas.
+12. Quanto à repetição do indébito, aplica-se o art. 42, parágrafo único, do Código de Defesa do Consumidor, sendo devida a restituição em dobro dos valores indevidamente descontados, uma vez ausente engano justificável por parte da instituição financeira.
+13. O entendimento encontra respaldo no julgamento do EAREsp 676.608/RS, da Corte Especial do Superior Tribunal de Justiça, que consolidou a orientação quanto à restituição em dobro quando inexistente justificativa plausível para a cobrança indevida.
+14. A compensação determinada na origem mostra-se indevida, pois a autora não usufruiu dos valores liberados, os quais foram imediatamente desviados por terceiros, circunstância que afasta qualquer benefício econômico à consumidora.
+15. Sobre os valores devidos incidem correção monetária desde o efetivo prejuízo e juros moratórios desde o evento danoso, conforme orientações das Súmulas 43 e 54 do Superior Tribunal de Justiça.
+16. No tocante aos <em>danos</em> <em>morais</em>, a indevida realização de descontos em benefício previdenciário de pessoa idosa configura violação a direitos da personalidade, caracterizando <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo concreto.
+17. A fixação da indenização no valor de R$ 3.000,00 observa os princípios da razoabilidade e proporcionalidade, considerando o caráter compensatório e pedagógico da medida.
+18. A correção monetária da indenização por <em>danos</em> <em>morais</em> incide a partir do arbitramento, nos termos da Súmula 362 do Superior Tribunal de Justiça, enquanto os juros moratórios incidem desde o evento danoso, conforme Súmula 54 do mesmo Tribunal.
+19. O redimensionamento do julgado implica a redistribuição dos ônus sucumbenciais, impondo-se à instituição financeira o pagamento integral das custas e honorários advocatícios, fixados com fundamento no art. 85, §§ 2º e 11, do Código de Processo Civil.
+IV. DISPOSITIVO E TESE
+20. Recurso da instituição financeira conhecido e desprovido. Recurso da autora conhecido e provido para reformar a sentença e declarar a inexistência dos débitos oriundos dos contratos fraudulentos, determinar a restituição em dobro dos valores indevidamente descontados, afastar a compensação e condenar a instituição financeira ao pagamento de indenização por <em>danos</em> <em>morais</em>, além de impor-lhe integral responsabilidade pelos ônus sucumbenciais.
+Tese de julgamento: "A instituição financeira responde objetivamente por fraudes decorrentes de falha na prestação do serviço bancário, sendo devida a restituição em dobro dos valores indevidamente descontados e a indenização por <em>danos</em> <em>morais</em> quando comprovada vulnerabilidade do consumidor e ausência de engano justificável."
+Dispositivos relevantes citados
+CDC, art. 14, § 1º; art. 42, parágrafo único.
+Código Civil, arts. 389 e 406.
+Código de Processo Civil, art. 85, §§ 2º e 11.
+Jurisprudência relevante citada
+STJ, Súmula 43.
+STJ, Súmula 54.
+STJ, Súmula 362.
+STJ, Súmula 479.
+STJ, EAREsp 676.608/RS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503709" cdForo="0" >
+										0714133-62.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503709" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503709);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503709" style="display: none;" >
+	<div id="textAreaDados_2503709" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O CONTRATUAL C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. FRAUDE EM CONTRATO DE FINANCIAMENTO VEICULAR. BIOMETRIA FACIAL. FORTUITO INTERNO. RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. DANO MORAL IN RE IPSA. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. HONOR&Aacute;RIOS SUCUMBENCIAIS. RATEIO ENTRE DEFENSORIA P&Uacute;BLICA E ADVOGADA PARTICULAR SUCESSORA. MAJORA&Ccedil;&Atilde;O RECURSAL. RECURSOS CONHECIDOS. DESPROVIMENTO DOS RECURSOS DO BANCO E DA AUTORA. PROVIMENTO DO RECURSO DA DEFENSORIA P&Uacute;BLICA.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o de procedimento comum ajuizada pela autora em face de institui&ccedil;&atilde;o financeira e corr&eacute;us, com pedido de declara&ccedil;&atilde;o de inexist&ecirc;ncia de rela&ccedil;&atilde;o contratual, inexigibilidade de d&eacute;bito oriundo de financiamento veicular, indeniza&ccedil;&atilde;o por danos morais e absten&ccedil;&atilde;o de cobran&ccedil;as e negativa&ccedil;&atilde;o.
+2. O Ju&iacute;zo sentenciante julgou procedentes os pedidos, declarando inexistente o contrato impugnado, inexig&iacute;vel o d&eacute;bito dele decorrente, determinando a absten&ccedil;&atilde;o de cobran&ccedil;as, condenando solidariamente os r&eacute;us ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 5.000,00 e fixando honor&aacute;rios advocat&iacute;cios em 10% sobre o valor da condena&ccedil;&atilde;o, confirmando tutela de urg&ecirc;ncia anteriormente concedida.
+3. O Banco r&eacute;u interp&ocirc;s apela&ccedil;&atilde;o sustentando a regularidade da contrata&ccedil;&atilde;o realizada por biometria facial e aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o, requerendo a reforma integral da senten&ccedil;a.
+4. A autora interp&ocirc;s recurso de apela&ccedil;&atilde;o pleiteando a majora&ccedil;&atilde;o do quantum indenizat&oacute;rio fixado a t&iacute;tulo de danos morais, sob alega&ccedil;&atilde;o de insufici&ecirc;ncia do valor arbitrado.
+5. A Defensoria P&uacute;blica interp&ocirc;s recurso aut&ocirc;nomo visando ao reconhecimento do direito ao rateio proporcional dos honor&aacute;rios sucumbenciais, em raz&atilde;o de sua atua&ccedil;&atilde;o inicial no processo antes da substitui&ccedil;&atilde;o por advogada particular.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+6. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se houve falha na presta&ccedil;&atilde;o do servi&ccedil;o pela institui&ccedil;&atilde;o financeira apta a ensejar a declara&ccedil;&atilde;o de inexist&ecirc;ncia do contrato e responsabiliza&ccedil;&atilde;o civil por fraude decorrente de fortuito interno; (ii) saber se o valor fixado a t&iacute;tulo de indeniza&ccedil;&atilde;o por danos morais deve ser majorado; (iii) saber se &eacute; devido o rateio proporcional dos honor&aacute;rios sucumbenciais entre a Defensoria P&uacute;blica e a advogada particular sucessora.
+III. RAZ&Otilde;ES DE DECIDIR
+7. A responsabilidade civil da institui&ccedil;&atilde;o financeira, nas rela&ccedil;&otilde;es de consumo, &eacute; objetiva, nos termos do art. 14 do C&oacute;digo de Defesa do Consumidor, impondo ao fornecedor o dever de seguran&ccedil;a na presta&ccedil;&atilde;o dos servi&ccedil;os.
+8. A utiliza&ccedil;&atilde;o de tecnologia de biometria facial n&atilde;o afasta o dever de cautela do fornecedor, sobretudo quando demonstradas inconsist&ecirc;ncias evidentes na an&aacute;lise de cr&eacute;dito, aus&ecirc;ncia de documentos essenciais e aprova&ccedil;&atilde;o de financiamento incompat&iacute;vel com a capacidade econ&ocirc;mica da consumidora, evidenciando falha sist&ecirc;mica na presta&ccedil;&atilde;o do servi&ccedil;o.
+9. A fraude perpetrada por terceiros, inclusive por parceiros comerciais, caracteriza fortuito interno, inserindo-se no risco da atividade econ&ocirc;mica, sendo imput&aacute;vel &agrave; institui&ccedil;&atilde;o financeira, conforme entendimento consolidado na S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a.
+10. A negativa&ccedil;&atilde;o indevida do nome do consumidor configura dano moral in re ipsa, dispensando prova do preju&iacute;zo concreto, por representar viola&ccedil;&atilde;o direta &agrave; honra objetiva do indiv&iacute;duo.
+11. A fixa&ccedil;&atilde;o do valor indenizat&oacute;rio deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano e o car&aacute;ter pedag&oacute;gico da condena&ccedil;&atilde;o, sendo mantido o valor arbitrado quando compat&iacute;vel com os par&acirc;metros jurisprudenciais aplic&aacute;veis ao caso concreto.
+12. O art. 4&ordm;, inciso XXI, da Lei Complementar n&ordm; 80/1994 assegura &agrave; Defensoria P&uacute;blica o direito &agrave; percep&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais, sendo cab&iacute;vel o rateio proporcional quando comprovada sua atua&ccedil;&atilde;o relevante no curso do processo antes da substitui&ccedil;&atilde;o por advogada particular.
+13. O art. 85 do C&oacute;digo de Processo Civil disciplina a fixa&ccedil;&atilde;o e majora&ccedil;&atilde;o de honor&aacute;rios sucumbenciais, sendo devida a majora&ccedil;&atilde;o em sede recursal quando o recurso da parte vencida &eacute; desprovido, respeitado o limite legal global.
+IV. DISPOSITIVO E TESE
+14. Recursos de apela&ccedil;&atilde;o do banco r&eacute;u e da autora conhecidos e desprovidos. Recurso de apela&ccedil;&atilde;o da Defensoria P&uacute;blica conhecido e provido, para determinar o rateio dos honor&aacute;rios sucumbenciais na propor&ccedil;&atilde;o de 50% ao Fundo Especial da Defensoria P&uacute;blica e 50% &agrave; advogada particular sucessora, com majora&ccedil;&atilde;o dos honor&aacute;rios totais para 12% sobre o valor da condena&ccedil;&atilde;o, mantidos os demais termos da senten&ccedil;a.
+Tese de julgamento: &quot;A fraude contratual decorrente de falha sist&ecirc;mica na concess&atilde;o de cr&eacute;dito configura fortuito interno, ensejando a responsabilidade objetiva da institui&ccedil;&atilde;o financeira e a declara&ccedil;&atilde;o de inexist&ecirc;ncia do contrato, sendo cab&iacute;vel o rateio proporcional dos honor&aacute;rios sucumbenciais entre Defensoria P&uacute;blica e advogada particular sucessora quando ambas contribu&iacute;ram para o resultado &uacute;til do processo&quot;.
+Dispositivos relevantes citados
+C&oacute;digo de Defesa do Consumidor, art. 14.
+C&oacute;digo de Processo Civil, arts. 85, &sect; 11; 344; 487, I; 1.010; 1.012, &sect; 1&ordm;, V.
+Lei Complementar n&ordm; 80/1994, art. 4&ordm;, XXI.
+Jurisprud&ecirc;ncia relevante citada
+STJ, S&uacute;mula 479.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0714133-62.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;5&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(27 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO CONTRATUAL C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE EM CONTRATO DE FINANCIAMENTO VEICULAR. BIOMETRIA FACIAL. FORTUITO INTERNO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. HONORÁRIOS SUCUMBENCIAIS.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO CONTRATUAL C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FRAUDE EM CONTRATO DE FINANCIAMENTO VEICULAR. BIOMETRIA FACIAL. FORTUITO INTERNO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. HONORÁRIOS SUCUMBENCIAIS. RATEIO ENTRE DEFENSORIA PÚBLICA E ADVOGADA PARTICULAR SUCESSORA. MAJORAÇÃO RECURSAL. RECURSOS CONHECIDOS. DESPROVIMENTO DOS RECURSOS DO BANCO E DA AUTORA. PROVIMENTO DO RECURSO DA DEFENSORIA PÚBLICA.
+I. CASO EM EXAME
+1. Ação de procedimento comum ajuizada pela autora em face de instituição financeira e corréus, com pedido de declaração de inexistência de relação contratual, inexigibilidade de débito oriundo de financiamento veicular, indenização por <em>danos</em> <em>morais</em> e abstenção de cobranças e negativação.
+2. O Juízo sentenciante julgou procedentes os pedidos, declarando inexistente o contrato impugnado, inexigível o débito dele decorrente, determinando a abstenção de cobranças, condenando solidariamente os réus ao pagamento de indenização por <em>danos</em> <em>morais</em> no valor de R$ 5.000,00 e fixando honorários advocatícios em 10% sobre o valor da condenação, confirmando tutela de urgência anteriormente concedida.
+3. O Banco réu interpôs apelação sustentando a regularidade da contratação realizada por biometria facial e ausência de falha na prestação do serviço, requerendo a reforma integral da sentença.
+4. A autora interpôs recurso de apelação pleiteando a majoração do quantum indenizatório fixado a título de <em>danos</em> <em>morais</em>, sob alegação de insuficiência do valor arbitrado.
+5. A Defensoria Pública interpôs recurso autônomo visando ao reconhecimento do direito ao rateio proporcional dos honorários sucumbenciais, em razão de sua atuação inicial no processo antes da substituição por advogada particular.
+II. QUESTÕES EM DISCUSSÃO
+6. Há três questões em discussão: (i) saber se houve falha na prestação do serviço pela instituição financeira apta a ensejar a declaração de inexistência do contrato e responsabilização civil por fraude decorrente de fortuito interno; (ii) saber se o valor fixado a título de indenização por <em>danos</em> <em>morais</em> deve ser majorado; (iii) saber se é devido o rateio proporcional dos honorários sucumbenciais entre a Defensoria Pública e a advogada particular sucessora.
+III. RAZÕES DE DECIDIR
+7. A responsabilidade civil da instituição financeira, nas relações de consumo, é objetiva, nos termos do art. 14 do Código de Defesa do Consumidor, impondo ao fornecedor o dever de segurança na prestação dos serviços.
+8. A utilização de tecnologia de biometria facial não afasta o dever de cautela do fornecedor, sobretudo quando demonstradas inconsistências evidentes na análise de crédito, ausência de documentos essenciais e aprovação de financiamento incompatível com a capacidade econômica da consumidora, evidenciando falha sistêmica na prestação do serviço.
+9. A fraude perpetrada por terceiros, inclusive por parceiros comerciais, caracteriza fortuito interno, inserindo-se no risco da atividade econômica, sendo imputável à instituição financeira, conforme entendimento consolidado na Súmula 479 do Superior Tribunal de Justiça.
+10. A negativação indevida do nome do consumidor configura <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo concreto, por representar violação direta à honra objetiva do indivíduo.
+11. A fixação do valor indenizatório deve observar os princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em> e o caráter pedagógico da condenação, sendo mantido o valor arbitrado quando compatível com os parâmetros jurisprudenciais aplicáveis ao caso concreto.
+12. O art. 4º, inciso XXI, da Lei Complementar nº 80/1994 assegura à Defensoria Pública o direito à percepção dos honorários sucumbenciais, sendo cabível o rateio proporcional quando comprovada sua atuação relevante no curso do processo antes da substituição por advogada particular.
+13. O art. 85 do Código de Processo Civil disciplina a fixação e majoração de honorários sucumbenciais, sendo devida a majoração em sede recursal quando o recurso da parte vencida é desprovido, respeitado o limite legal global.
+IV. DISPOSITIVO E TESE
+14. Recursos de apelação do banco réu e da autora conhecidos e desprovidos. Recurso de apelação da Defensoria Pública conhecido e provido, para determinar o rateio dos honorários sucumbenciais na proporção de 50% ao Fundo Especial da Defensoria Pública e 50% à advogada particular sucessora, com majoração dos honorários totais para 12% sobre o valor da condenação, mantidos os demais termos da sentença.
+Tese de julgamento: "A fraude contratual decorrente de falha sistêmica na concessão de crédito configura fortuito interno, ensejando a responsabilidade objetiva da instituição financeira e a declaração de inexistência do contrato, sendo cabível o rateio proporcional dos honorários sucumbenciais entre Defensoria Pública e advogada particular sucessora quando ambas contribuíram para o resultado útil do processo".
+Dispositivos relevantes citados
+Código de Defesa do Consumidor, art. 14.
+Código de Processo Civil, arts. 85, § 11; 344; 487, I; 1.010; 1.012, § 1º, V.
+Lei Complementar nº 80/1994, art. 4º, XXI.
+Jurisprudência relevante citada
+STJ, Súmula 479.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503710" cdForo="0" >
+										0713577-26.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503710" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503710);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503710" style="display: none;" >
+	<div id="textAreaDados_2503710" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. FRAUDE BANC&Aacute;RIA. EMPR&Eacute;STIMOS CONTRATADOS MEDIANTE ENGENHARIA SOCIAL. BIOMETRIA FACIAL REALIZADA PELA CONSUMIDORA. CULPA CONCORRENTE. NULIDADE DOS CONTRATOS MANTIDA. RESTITUI&Ccedil;&Atilde;O SIMPLES DOS VALORES. AFASTAMENTO DA REPETI&Ccedil;&Atilde;O EM DOBRO. EXCLUS&Atilde;O DA INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. SUCUMB&Ecirc;NCIA REC&Iacute;PROCA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de neg&oacute;cio jur&iacute;dico ajuizada pela autora em face de institui&ccedil;&atilde;o financeira, visando &agrave; nulidade de contratos de empr&eacute;stimo supostamente firmados mediante fraude, restitui&ccedil;&atilde;o dos valores descontados e indeniza&ccedil;&atilde;o por danos morais.
+2. A senten&ccedil;a julgou procedentes os pedidos para declarar a nulidade dos contratos, condenar a r&eacute; &agrave; restitui&ccedil;&atilde;o dos valores descontados &#150;  em parte simples e em parte em dobro &#150;  e ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 5.000,00, al&eacute;m de custas e honor&aacute;rios advocat&iacute;cios.
+3. A institui&ccedil;&atilde;o financeira interp&ocirc;s apela&ccedil;&atilde;o sustentando a regularidade da contrata&ccedil;&atilde;o, realizada mediante biometria facial da consumidora, bem como a ocorr&ecirc;ncia de culpa exclusiva da v&iacute;tima, que teria transferido voluntariamente os valores a terceiros, requerendo a reforma integral da senten&ccedil;a.
+4. A autora apresentou contrarraz&otilde;es defendendo a manuten&ccedil;&atilde;o da senten&ccedil;a, alegando falha da institui&ccedil;&atilde;o financeira ao permitir opera&ccedil;&otilde;es at&iacute;picas incompat&iacute;veis com seu perfil financeiro.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+5. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se os contratos celebrados mediante biometria facial, sob induzimento de terceiros, devem ser considerados nulos por v&iacute;cio de consentimento; (ii) saber se a responsabilidade pelos preju&iacute;zos decorrentes de fraude banc&aacute;ria deve ser atribu&iacute;da exclusivamente &agrave; consumidora ou compartilhada com a institui&ccedil;&atilde;o financeira; (iii) saber se s&atilde;o devidos restitui&ccedil;&atilde;o em dobro dos valores e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+6. A controv&eacute;rsia foi analisada sob a &oacute;tica da responsabilidade civil nas rela&ccedil;&otilde;es de consumo, reconhecendo-se que a fraude decorreu de engenharia social praticada por terceiros, com participa&ccedil;&atilde;o ativa da consumidora ao realizar biometria facial e transfer&ecirc;ncias banc&aacute;rias, caracterizando conduta imprudente apta a contribuir para o resultado danoso.
+7. Entretanto, a institui&ccedil;&atilde;o financeira tamb&eacute;m incorreu em falha na presta&ccedil;&atilde;o do servi&ccedil;o ao permitir a contrata&ccedil;&atilde;o sucessiva de empr&eacute;stimos e m&uacute;ltiplas transfer&ecirc;ncias em curto espa&ccedil;o de tempo, incompat&iacute;veis com o perfil financeiro da consumidora, o que configura viola&ccedil;&atilde;o ao dever de seguran&ccedil;a previsto no art. 4&ordm; do C&oacute;digo de Defesa do Consumidor.
+8. Nos termos da teoria do fortuito interno, consolidada na S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a, as institui&ccedil;&otilde;es financeiras respondem pelos danos decorrentes de fraudes praticadas por terceiros no &acirc;mbito de suas opera&ccedil;&otilde;es, por se tratar de risco inerente &agrave; atividade banc&aacute;ria.
+9. Diante da participa&ccedil;&atilde;o concorrente das partes na produ&ccedil;&atilde;o do evento danoso, aplicou-se o disposto no art. 945 do C&oacute;digo Civil, reconhecendo-se a culpa concorrente entre consumidora e institui&ccedil;&atilde;o financeira, com consequente redimensionamento das consequ&ecirc;ncias jur&iacute;dicas.
+10. A nulidade dos contratos foi mantida em raz&atilde;o do v&iacute;cio de consentimento decorrente de dolo de terceiro, circunst&acirc;ncia que compromete a validade do neg&oacute;cio jur&iacute;dico e imp&otilde;e a restitui&ccedil;&atilde;o dos valores indevidamente descontados.
+11. A restitui&ccedil;&atilde;o foi limitada &agrave; forma simples, por aus&ecirc;ncia de comprova&ccedil;&atilde;o de m&aacute;-f&eacute; da institui&ccedil;&atilde;o financeira, configurando-se hip&oacute;tese de engano justific&aacute;vel, nos termos do art. 42, par&aacute;grafo &uacute;nico, do C&oacute;digo de Defesa do Consumidor.
+12. A indeniza&ccedil;&atilde;o por danos morais foi afastada, considerando-se que o preju&iacute;zo suportado decorreu de culpa concorrente e que a recomposi&ccedil;&atilde;o patrimonial mediante restitui&ccedil;&atilde;o dos valores revela-se suficiente &agrave; restaura&ccedil;&atilde;o do equil&iacute;brio jur&iacute;dico, evitando enriquecimento sem causa.
+13. Reconhecida a sucumb&ecirc;ncia rec&iacute;proca, determinou-se o rateio das custas processuais e honor&aacute;rios advocat&iacute;cios entre as partes, nos termos do art. 86 do C&oacute;digo de Processo Civil, vedada a compensa&ccedil;&atilde;o de honor&aacute;rios conforme art. 85, &sect; 14, do mesmo diploma legal.
+IV. DISPOSITIVO E TESE
+14. Recurso conhecido e parcialmente provido, para manter a nulidade dos contratos, determinar a restitui&ccedil;&atilde;o simples dos valores descontados e afastar a condena&ccedil;&atilde;o por danos morais, com reconhecimento da sucumb&ecirc;ncia rec&iacute;proca e rateio das custas e honor&aacute;rios.
+Tese de julgamento: &quot;Em casos de fraude banc&aacute;ria decorrente de engenharia social, comprovada a participa&ccedil;&atilde;o ativa do consumidor e a falha da institui&ccedil;&atilde;o financeira no monitoramento de opera&ccedil;&otilde;es at&iacute;picas, configura-se culpa concorrente, impondo-se a nulidade dos contratos viciados, restitui&ccedil;&atilde;o simples dos valores indevidamente descontados e afastamento da indeniza&ccedil;&atilde;o por danos morais.&quot;
+Dispositivos relevantes citados
+CDC, art. 4&ordm;; CDC, art. 42, par&aacute;grafo &uacute;nico; CC, art. 945; CPC, art. 85, &sect; 14; CPC, art. 86; CPC, art. 98, &sect; 3&ordm;.
+Jurisprud&ecirc;ncia relevante citada
+STJ, S&uacute;mula 479.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0713577-26.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;3&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. FRAUDE BANCÁRIA. EMPRÉSTIMOS CONTRATADOS MEDIANTE ENGENHARIA SOCIAL. BIOMETRIA FACIAL REALIZADA PELA CONSUMIDORA. CULPA CONCORRENTE. NULIDADE DOS CONTRATOS MANTIDA. RESTITUIÇÃO SIMPLES DOS VALORES. AFASTAMENTO DA REPETIÇÃO EM DOBRO. EXCLUSÃO DA INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. SUCUMBÊNCIA RECÍPROCA. RECURSO CONHECIDO E PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. FRAUDE BANCÁRIA. EMPRÉSTIMOS CONTRATADOS MEDIANTE ENGENHARIA SOCIAL. BIOMETRIA FACIAL REALIZADA PELA CONSUMIDORA. CULPA CONCORRENTE. NULIDADE DOS CONTRATOS MANTIDA. RESTITUIÇÃO SIMPLES DOS VALORES. AFASTAMENTO DA REPETIÇÃO EM DOBRO. EXCLUSÃO DA INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. SUCUMBÊNCIA RECÍPROCA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Ação declaratória de inexistência de negócio jurídico ajuizada pela autora em face de instituição financeira, visando à nulidade de contratos de empréstimo supostamente firmados mediante fraude, restituição dos valores descontados e indenização por <em>danos</em> <em>morais</em>.
+2. A sentença julgou procedentes os pedidos para declarar a nulidade dos contratos, condenar a ré à restituição dos valores descontados   em parte simples e em parte em dobro   e ao pagamento de indenização por <em>danos</em> <em>morais</em> no valor de R$ 5.000,00, além de custas e honorários advocatícios.
+3. A instituição financeira interpôs apelação sustentando a regularidade da contratação, realizada mediante biometria facial da consumidora, bem como a ocorrência de culpa exclusiva da vítima, que teria transferido voluntariamente os valores a terceiros, requerendo a reforma integral da sentença.
+4. A autora apresentou contrarrazões defendendo a manutenção da sentença, alegando falha da instituição financeira ao permitir operações atípicas incompatíveis com seu perfil financeiro.
+II. QUESTÕES EM DISCUSSÃO
+5. Há três questões em discussão: (i) saber se os contratos celebrados mediante biometria facial, sob induzimento de terceiros, devem ser considerados nulos por vício de consentimento; (ii) saber se a responsabilidade pelos prejuízos decorrentes de fraude bancária deve ser atribuída exclusivamente à consumidora ou compartilhada com a instituição financeira; (iii) saber se são devidos restituição em dobro dos valores e indenização por <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+6. A controvérsia foi analisada sob a ótica da responsabilidade civil nas relações de consumo, reconhecendo-se que a fraude decorreu de engenharia social praticada por terceiros, com participação ativa da consumidora ao realizar biometria facial e transferências bancárias, caracterizando conduta imprudente apta a contribuir para o resultado danoso.
+7. Entretanto, a instituição financeira também incorreu em falha na prestação do serviço ao permitir a contratação sucessiva de empréstimos e múltiplas transferências em curto espaço de tempo, incompatíveis com o perfil financeiro da consumidora, o que configura violação ao dever de segurança previsto no art. 4º do Código de Defesa do Consumidor.
+8. Nos termos da teoria do fortuito interno, consolidada na Súmula 479 do Superior Tribunal de Justiça, as instituições financeiras respondem pelos <em>danos</em> decorrentes de fraudes praticadas por terceiros no âmbito de suas operações, por se tratar de risco inerente à atividade bancária.
+9. Diante da participação concorrente das partes na produção do evento danoso, aplicou-se o disposto no art. 945 do Código Civil, reconhecendo-se a culpa concorrente entre consumidora e instituição financeira, com consequente redimensionamento das consequências jurídicas.
+10. A nulidade dos contratos foi mantida em razão do vício de consentimento decorrente de dolo de terceiro, circunstância que compromete a validade do negócio jurídico e impõe a restituição dos valores indevidamente descontados.
+11. A restituição foi limitada à forma simples, por ausência de comprovação de má-fé da instituição financeira, configurando-se hipótese de engano justificável, nos termos do art. 42, parágrafo único, do Código de Defesa do Consumidor.
+12. A indenização por <em>danos</em> <em>morais</em> foi afastada, considerando-se que o prejuízo suportado decorreu de culpa concorrente e que a recomposição patrimonial mediante restituição dos valores revela-se suficiente à restauração do equilíbrio jurídico, evitando enriquecimento sem causa.
+13. Reconhecida a sucumbência recíproca, determinou-se o rateio das custas processuais e honorários advocatícios entre as partes, nos termos do art. 86 do Código de Processo Civil, vedada a compensação de honorários conforme art. 85, § 14, do mesmo diploma legal.
+IV. DISPOSITIVO E TESE
+14. Recurso conhecido e parcialmente provido, para manter a nulidade dos contratos, determinar a restituição simples dos valores descontados e afastar a condenação por <em>danos</em> <em>morais</em>, com reconhecimento da sucumbência recíproca e rateio das custas e honorários.
+Tese de julgamento: "Em casos de fraude bancária decorrente de engenharia social, comprovada a participação ativa do consumidor e a falha da instituição financeira no monitoramento de operações atípicas, configura-se culpa concorrente, impondo-se a nulidade dos contratos viciados, restituição simples dos valores indevidamente descontados e afastamento da indenização por <em>danos</em> <em>morais</em>."
+Dispositivos relevantes citados
+CDC, art. 4º; CDC, art. 42, parágrafo único; CC, art. 945; CPC, art. 85, § 14; CPC, art. 86; CPC, art. 98, § 3º.
+Jurisprudência relevante citada
+STJ, Súmula 479.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503708" cdForo="0" >
+										0714997-66.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503708" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503708);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503708" style="display: none;" >
+	<div id="textAreaDados_2503708" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. RESPONSABILIDADE CIVIL. RELA&Ccedil;&Atilde;O DE CONSUMO. INSCRI&Ccedil;&Atilde;O INDEVIDA EM CADASTRO DE INADIMPLENTES. DANO MORAL. PEDIDO DE MAJORA&Ccedil;&Atilde;O DO VALOR DA INDENIZA&Ccedil;&Atilde;O. TERMO INICIAL DOS JUROS DE MORA. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o c&iacute;vel interposto pela parte autora contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito cumulada com indeniza&ccedil;&atilde;o, julgou parcialmente procedente o pedido para declarar a inexigibilidade da d&iacute;vida e condenar a empresa r&eacute; ao pagamento de indeniza&ccedil;&atilde;o por danos morais. A recorrente pleiteia a majora&ccedil;&atilde;o do valor indenizat&oacute;rio, a altera&ccedil;&atilde;o do termo inicial dos juros de mora para a data do evento danoso e a fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios por aprecia&ccedil;&atilde;o equitativa.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A fixa&ccedil;&atilde;o do valor da indeniza&ccedil;&atilde;o por dano moral deve observar os princ&iacute;pios da razoabilidade e da proporcionalidade, considerando a extens&atilde;o do dano, a capacidade econ&ocirc;mica das partes e o car&aacute;ter d&uacute;plice da medida, que &eacute; compensat&oacute;rio para a v&iacute;tima e pedag&oacute;gico para o ofensor.
+4. O montante indenizat&oacute;rio fixado na primeira inst&acirc;ncia, embora n&atilde;o corresponda ao patamar almejado pela parte recorrente, n&atilde;o se revela irris&oacute;rio ou desproporcional, inserindo-se na margem de discricionariedade do julgador e em conformidade com os par&acirc;metros adotados por este Tribunal em casos an&aacute;logos, o que afasta a necessidade de interven&ccedil;&atilde;o para major&aacute;-lo.
+5. A inscri&ccedil;&atilde;o indevida do nome do consumidor em cadastros de prote&ccedil;&atilde;o ao cr&eacute;dito configura ato il&iacute;cito que gera responsabilidade de natureza extracontratual.
+6. Em se tratando de responsabilidade civil extracontratual, os juros de mora sobre a indeniza&ccedil;&atilde;o por danos morais fluem a partir da data do evento danoso, conforme o entendimento consolidado na S&uacute;mula 54 do Superior Tribunal de Justi&ccedil;a.
+7. A fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios sucumbenciais deve, como regra, seguir os percentuais estabelecidos no &sect; 2&ordm; do art. 85 do C&oacute;digo de Processo Civil, incidentes sobre o valor da condena&ccedil;&atilde;o, do proveito econ&ocirc;mico ou do valor da causa.
+8. A aplica&ccedil;&atilde;o do crit&eacute;rio de aprecia&ccedil;&atilde;o equitativa, previsto no &sect; 8&ordm; do art. 85 do CPC, &eacute; medida excepcional, restrita &agrave;s hip&oacute;teses em que o proveito econ&ocirc;mico for inestim&aacute;vel ou irris&oacute;rio, ou o valor da causa for muito baixo, n&atilde;o se aplicando quando o valor da condena&ccedil;&atilde;o, ainda que modesto, for mensur&aacute;vel e n&atilde;o &iacute;nfimo.
+IV. DISPOSITIVO E TESE
+9. Recurso conhecido e parcialmente provido
+Tese de julgamento: &quot;Em casos de indeniza&ccedil;&atilde;o por dano moral decorrente de inscri&ccedil;&atilde;o indevida em cadastro de inadimplentes, por se tratar de responsabilidade extracontratual, o termo inicial dos juros de mora &eacute; a data do evento danoso, nos termos da S&uacute;mula 54 do STJ; A fixa&ccedil;&atilde;o de honor&aacute;rios advocat&iacute;cios por equidade &eacute; subsidi&aacute;ria, n&atilde;o sendo cab&iacute;vel quando o valor da condena&ccedil;&atilde;o, ainda que n&atilde;o elevado, n&atilde;o se configura como irris&oacute;rio, devendo-se aplicar a regra geral de fixa&ccedil;&atilde;o percentual sobre a condena&ccedil;&atilde;o; A revis&atilde;o do valor da indeniza&ccedil;&atilde;o por danos morais em sede de apela&ccedil;&atilde;o somente se justifica quando a quantia fixada na origem se mostrar manifestamente irris&oacute;ria ou exorbitante, em descompasso com os princ&iacute;pios da razoabilidade e da proporcionalidade.&quot;
+Dispositivos relevantes citados:
+C&oacute;digo de Defesa do Consumidor, Art. 14;
+C&oacute;digo de Processo Civil, Art. 85, &sect;&sect; 2&ordm;, 8&ordm;
+Jurisprud&ecirc;ncia relevante citada:
+S&uacute;mula 54 do STJ.
+S&uacute;mula 362 do STJ.&nbsp;<br>(Relator (a): Des. Roberto Barros; Comarca: Rio Branco;N&uacute;mero do Processo:0714997-66.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(49 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Roberto Barros
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. RESPONSABILIDADE CIVIL. RELAÇÃO DE CONSUMO. INSCRIÇÃO INDEVIDA EM CADASTRO DE INADIMPLENTES. <em>DANO</em> <em>MORAL</em>. PEDIDO DE MAJORAÇÃO DO VALOR DA INDENIZAÇÃO. TERMO INICIAL DOS JUROS DE MORA. HONORÁRIOS ADVOCATÍCIOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apelação cível interposto pela parte autora contra sentença que,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. RESPONSABILIDADE CIVIL. RELAÇÃO DE CONSUMO. INSCRIÇÃO INDEVIDA EM CADASTRO DE INADIMPLENTES. <em>DANO</em> <em>MORAL</em>. PEDIDO DE MAJORAÇÃO DO VALOR DA INDENIZAÇÃO. TERMO INICIAL DOS JUROS DE MORA. HONORÁRIOS ADVOCATÍCIOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apelação cível interposto pela parte autora contra sentença que, em ação declaratória de inexistência de débito cumulada com indenização, julgou parcialmente procedente o pedido para declarar a inexigibilidade da dívida e condenar a empresa ré ao pagamento de indenização por <em>danos</em> <em>morais</em>. A recorrente pleiteia a majoração do valor indenizatório, a alteração do termo inicial dos juros de mora para a data do evento danoso e a fixação dos honorários advocatícios por apreciação equitativa.
+III. RAZÕES DE DECIDIR
+3. A fixação do valor da indenização por <em>dano</em> <em>moral</em> deve observar os princípios da razoabilidade e da proporcionalidade, considerando a extensão do <em>dano</em>, a capacidade econômica das partes e o caráter dúplice da medida, que é compensatório para a vítima e pedagógico para o ofensor.
+4. O montante indenizatório fixado na primeira instância, embora não corresponda ao patamar almejado pela parte recorrente, não se revela irrisório ou desproporcional, inserindo-se na margem de discricionariedade do julgador e em conformidade com os parâmetros adotados por este Tribunal em casos análogos, o que afasta a necessidade de intervenção para majorá-lo.
+5. A inscrição indevida do nome do consumidor em cadastros de proteção ao crédito configura ato ilícito que gera responsabilidade de natureza extracontratual.
+6. Em se tratando de responsabilidade civil extracontratual, os juros de mora sobre a indenização por <em>danos</em> <em>morais</em> fluem a partir da data do evento danoso, conforme o entendimento consolidado na Súmula 54 do Superior Tribunal de Justiça.
+7. A fixação dos honorários advocatícios sucumbenciais deve, como regra, seguir os percentuais estabelecidos no § 2º do art. 85 do Código de Processo Civil, incidentes sobre o valor da condenação, do proveito econômico ou do valor da causa.
+8. A aplicação do critério de apreciação equitativa, previsto no § 8º do art. 85 do CPC, é medida excepcional, restrita às hipóteses em que o proveito econômico for inestimável ou irrisório, ou o valor da causa for muito baixo, não se aplicando quando o valor da condenação, ainda que modesto, for mensurável e não ínfimo.
+IV. DISPOSITIVO E TESE
+9. Recurso conhecido e parcialmente provido
+Tese de julgamento: "Em casos de indenização por <em>dano</em> <em>moral</em> decorrente de inscrição indevida em cadastro de inadimplentes, por se tratar de responsabilidade extracontratual, o termo inicial dos juros de mora é a data do evento danoso, nos termos da Súmula 54 do STJ; A fixação de honorários advocatícios por equidade é subsidiária, não sendo cabível quando o valor da condenação, ainda que não elevado, não se configura como irrisório, devendo-se aplicar a regra geral de fixação percentual sobre a condenação; A revisão do valor da indenização por <em>danos</em> <em>morais</em> em sede de apelação somente se justifica quando a quantia fixada na origem se mostrar manifestamente irrisória ou exorbitante, em descompasso com os princípios da razoabilidade e da proporcionalidade."
+Dispositivos relevantes citados:
+Código de Defesa do Consumidor, Art. 14;
+Código de Processo Civil, Art. 85, §§ 2º, 8º
+Jurisprudência relevante citada:
+Súmula 54 do STJ.
+Súmula 362 do STJ.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503740" cdForo="0" >
+										0715050-81.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503740" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503740);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503740" style="display: none;" >
+	<div id="textAreaDados_2503740" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. PORTABILIDADE DE BENEF&Iacute;CIO ASSISTENCIAL (BPC/LOAS). ENTRAVES ADMINISTRATIVOS IMPOSTOS POR INSTITUI&Ccedil;&Atilde;O FINANCEIRA. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. DANO MORAL IN RE IPSA. DESVIO PRODUTIVO DO CONSUMIDOR. MENOR EM CONDI&Ccedil;&Atilde;O DE VULNERABILIDADE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por menor representado por sua genitora contra senten&ccedil;a que, nos autos de a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer cumulada com indeniza&ccedil;&atilde;o por danos morais, julgou parcialmente procedente o pedido para determinar a portabilidade de benef&iacute;cio assistencial (BPC/LOAS), mas afastou a condena&ccedil;&atilde;o por danos morais, sob fundamento de aus&ecirc;ncia de prova suficiente do abalo extrapatrimonial.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em definir se a imposi&ccedil;&atilde;o de entraves administrativos &agrave; portabilidade de benef&iacute;cio assistencial por institui&ccedil;&atilde;o financeira, especialmente quando efetivada apenas ap&oacute;s interven&ccedil;&atilde;o judicial, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o apta a ensejar indeniza&ccedil;&atilde;o por dano moral.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A rela&ccedil;&atilde;o jur&iacute;dica entre as partes &eacute; de consumo, sendo objetiva a responsabilidade da institui&ccedil;&atilde;o financeira pelos danos causados, nos termos do art. 14 do CDC.
+4. A efetiva&ccedil;&atilde;o da portabilidade apenas ap&oacute;s interven&ccedil;&atilde;o judicial evidencia resist&ecirc;ncia indevida e caracteriza falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+5. A exig&ecirc;ncia de comparecimento presencial e a imposi&ccedil;&atilde;o de obst&aacute;culos administrativos injustificados violam normas do Banco Central (Resolu&ccedil;&otilde;es n&ordm; 3.402/2006 e 4.539/2016), configurando conduta il&iacute;cita.
+6. A restri&ccedil;&atilde;o ao exerc&iacute;cio de direito relacionado a verba de natureza alimentar agrava a ilicitude da conduta e potencializa o dano.
+7. A necessidade de a representante legal do menor despender tempo e esfor&ccedil;o para solucionar problema causado pelo fornecedor caracteriza desvio produtivo do consumidor.
+8. O dano moral, na hip&oacute;tese, &eacute; presumido (in re ipsa), sendo desnecess&aacute;ria a comprova&ccedil;&atilde;o de preju&iacute;zo concreto diante da falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+9. A condi&ccedil;&atilde;o de vulnerabilidade do autor, menor portador de necessidades especiais, refor&ccedil;a a gravidade da conduta e justifica a repara&ccedil;&atilde;o.
+10. O valor da indeniza&ccedil;&atilde;o deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, sendo adequado o arbitramento em R$ 3.000,00.
+11. A fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios deve incidir sobre o valor da condena&ccedil;&atilde;o, nos termos do art. 85, &sect;2&ordm;, do CPC, com percentual de 15%.
+IV. DISPOSITIVO E TESE
+12. Recurso parcialmente provido.
+Tese de julgamento:
+1. A imposi&ccedil;&atilde;o de entraves injustificados por institui&ccedil;&atilde;o financeira &agrave; portabilidade de benef&iacute;cio assistencial configura falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+2. O dano moral decorrente da indevida restri&ccedil;&atilde;o ao recebimento de verba alimentar &eacute; presumido, dispensando prova do preju&iacute;zo.
+3. A teoria do desvio produtivo do consumidor aplica-se quando o usu&aacute;rio &eacute; compelido a despender tempo e recursos para solucionar falha do fornecedor.
+4. A indeniza&ccedil;&atilde;o por dano moral deve ser fixada com base na razoabilidade e proporcionalidade, considerando o car&aacute;ter compensat&oacute;rio e pedag&oacute;gico.
+Dispositivos relevantes citados: CDC, art. 14; CPC, arts. 85, &sect; 2&ordm;, 86, par&aacute;grafo &uacute;nico, e 178, II; Resolu&ccedil;&otilde;es BACEN n&ordm; 3.402/2006 e n&ordm; 4.539/2016.
+Jurisprud&ecirc;ncia relevante citada: TJSP, AC n&ordm; 1003203-40.2019.8.26.0566, Rel. Denise Andr&eacute;a Martins Retamero, j. 30.06.2020; TJAM, AC n&ordm; 0682270-75.2022.8.04.0001, Rel. Cezar Luiz Bandiera, j. 31.10.2024; TJAC, AI n&ordm; 1001984-61.2024.8.01.0000, Rel. Des. J&uacute;nior Alberto, j. 31.01.2025.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0715050-81.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;5&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(57 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PORTABILIDADE DE BENEFÍCIO ASSISTENCIAL (BPC/LOAS). ENTRAVES ADMINISTRATIVOS IMPOSTOS POR INSTITUIÇÃO FINANCEIRA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. DESVIO PRODUTIVO DO CONSUMIDOR. MENOR EM CONDIÇÃO DE VULNERABILIDADE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por menor representado por
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PORTABILIDADE DE BENEFÍCIO ASSISTENCIAL (BPC/LOAS). ENTRAVES ADMINISTRATIVOS IMPOSTOS POR INSTITUIÇÃO FINANCEIRA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. DESVIO PRODUTIVO DO CONSUMIDOR. MENOR EM CONDIÇÃO DE VULNERABILIDADE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por menor representado por sua genitora contra sentença que, nos autos de ação de obrigação de fazer cumulada com indenização por <em>danos</em> <em>morais</em>, julgou parcialmente procedente o pedido para determinar a portabilidade de benefício assistencial (BPC/LOAS), mas afastou a condenação por <em>danos</em> <em>morais</em>, sob fundamento de ausência de prova suficiente do abalo extrapatrimonial.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em definir se a imposição de entraves administrativos à portabilidade de benefício assistencial por instituição financeira, especialmente quando efetivada apenas após intervenção judicial, configura falha na prestação do serviço apta a ensejar indenização por <em>dano</em> <em>moral</em>.
+III. RAZÕES DE DECIDIR
+3. A relação jurídica entre as partes é de consumo, sendo objetiva a responsabilidade da instituição financeira pelos <em>danos</em> causados, nos termos do art. 14 do CDC.
+4. A efetivação da portabilidade apenas após intervenção judicial evidencia resistência indevida e caracteriza falha na prestação do serviço.
+5. A exigência de comparecimento presencial e a imposição de obstáculos administrativos injustificados violam normas do Banco Central (Resoluções nº 3.402/2006 e 4.539/2016), configurando conduta ilícita.
+6. A restrição ao exercício de direito relacionado a verba de natureza alimentar agrava a ilicitude da conduta e potencializa o <em>dano</em>.
+7. A necessidade de a representante legal do menor despender tempo e esforço para solucionar problema causado pelo fornecedor caracteriza desvio produtivo do consumidor.
+8. O <em>dano</em> <em>moral</em>, na hipótese, é presumido (in re ipsa), sendo desnecessária a comprovação de prejuízo concreto diante da falha na prestação do serviço.
+9. A condição de vulnerabilidade do autor, menor portador de necessidades especiais, reforça a gravidade da conduta e justifica a reparação.
+10. O valor da indenização deve observar os princípios da razoabilidade e proporcionalidade, sendo adequado o arbitramento em R$ 3.000,00.
+11. A fixação dos honorários advocatícios deve incidir sobre o valor da condenação, nos termos do art. 85, §2º, do CPC, com percentual de 15%.
+IV. DISPOSITIVO E TESE
+12. Recurso parcialmente provido.
+Tese de julgamento:
+1. A imposição de entraves injustificados por instituição financeira à portabilidade de benefício assistencial configura falha na prestação do serviço.
+2. O <em>dano</em> <em>moral</em> decorrente da indevida restrição ao recebimento de verba alimentar é presumido, dispensando prova do prejuízo.
+3. A teoria do desvio produtivo do consumidor aplica-se quando o usuário é compelido a despender tempo e recursos para solucionar falha do fornecedor.
+4. A indenização por <em>dano</em> <em>moral</em> deve ser fixada com base na razoabilidade e proporcionalidade, considerando o caráter compensatório e pedagógico.
+Dispositivos relevantes citados: CDC, art. 14; CPC, arts. 85, § 2º, 86, parágrafo único, e 178, II; Resoluções BACEN nº 3.402/2006 e nº 4.539/2016.
+Jurisprudência relevante citada: TJSP, AC nº 1003203-40.2019.8.26.0566, Rel. Denise Andréa Martins Retamero, j. 30.06.2020; TJAM, AC nº 0682270-75.2022.8.04.0001, Rel. Cezar Luiz Bandiera, j. 31.10.2024; TJAC, AI nº 1001984-61.2024.8.01.0000, Rel. Des. Júnior Alberto, j. 31.01.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503739" cdForo="0" >
+										1000278-72.2026.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503739" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503739);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503739" style="display: none;" >
+	<div id="textAreaDados_2503739" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. GRATUIDADE DE JUSTI&Ccedil;A. ENTIDADE FILANTR&Oacute;PICA. ISEN&Ccedil;&Atilde;O DE CUSTAS. TAXATIVIDADE MITIGADA DO ART. 1.015 DO CPC. CABIMENTO. PROVA PERICIAL. ERRO M&Eacute;DICO. NECESSIDADE DE PER&Iacute;CIA ESPECIALIZADA EM ANESTESIOLOGIA. CERCEAMENTO DE DEFESA CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo de instrumento interposto contra decis&atilde;o que, em a&ccedil;&atilde;o indenizat&oacute;ria por alegado erro m&eacute;dico, revogou a determina&ccedil;&atilde;o de realiza&ccedil;&atilde;o de nova per&iacute;cia m&eacute;dica especializada e determinou o prosseguimento do feito com possibilidade de julgamento antecipado, al&eacute;m de impugnar o pedido de gratuidade de justi&ccedil;a, pleiteando a concess&atilde;o do benef&iacute;cio e a reabertura da instru&ccedil;&atilde;o com produ&ccedil;&atilde;o de prova pericial adequada.
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; cab&iacute;vel o agravo de instrumento &agrave; luz da taxatividade mitigada do art. 1.015 do CPC; (ii) estabelecer se a revoga&ccedil;&atilde;o da per&iacute;cia m&eacute;dica especializada em anestesiologia configura cerceamento de defesa em demanda por erro m&eacute;dico.
+Reconhece-se a gratuidade de justi&ccedil;a, pois a agravante, entidade filantr&oacute;pica sem fins lucrativos, &eacute; isenta do pagamento de custas nos termos do art. 2&ordm;, VII, da Lei Estadual n&ordm; 1.422/2001.
+Admite-se o agravo de instrumento com base na taxatividade mitigada do art. 1.015 do CPC, conforme Tema 988 do STJ, diante do risco de inutilidade do exame da mat&eacute;ria em apela&ccedil;&atilde;o.
+A controv&eacute;rsia envolve mat&eacute;ria t&eacute;cnica complexa relativa a erro m&eacute;dico, exigindo prova pericial especializada para adequada elucida&ccedil;&atilde;o dos fatos.
+Considera-se relevante o fato de o pr&oacute;prio ju&iacute;zo de origem ter previamente reconhecido a necessidade de per&iacute;cia por especialista em anestesiologia, evidenciando a imprescindibilidade da prova.
+O poder do magistrado de indeferir provas n&atilde;o autoriza a supress&atilde;o de meio probat&oacute;rio essencial &agrave; solu&ccedil;&atilde;o da lide, especialmente quando a prova existente &eacute; insuficiente.
+Rejeita-se a justificativa de dificuldade na nomea&ccedil;&atilde;o de perito como fundamento suficiente para afastar a produ&ccedil;&atilde;o da prova t&eacute;cnica necess&aacute;ria.
+Conclui-se que a aus&ecirc;ncia de per&iacute;cia especializada compromete a forma&ccedil;&atilde;o do convencimento judicial e viola os princ&iacute;pios do contradit&oacute;rio e da ampla defesa.
+Reconhece-se o cerceamento de defesa diante da supress&atilde;o de prova essencial ao deslinde da controv&eacute;rsia.
+Recurso provido.
+A taxatividade do art. 1.015 do CPC &eacute; mitigada, admitindo agravo de instrumento quando houver risco de inutilidade do julgamento da quest&atilde;o em apela&ccedil;&atilde;o.
+A revoga&ccedil;&atilde;o de prova pericial previamente reconhecida como necess&aacute;ria configura cerceamento de defesa quando a mat&eacute;ria exige conhecimento t&eacute;cnico especializado.
+A dificuldade na nomea&ccedil;&atilde;o de perito n&atilde;o justifica a supress&atilde;o de prova essencial &agrave; adequada instru&ccedil;&atilde;o do processo.
+Em demandas de erro m&eacute;dico, a per&iacute;cia deve ser realizada por profissional com especialidade compat&iacute;vel com o objeto da controv&eacute;rsia.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp 1.704.520/MT, Rel. Min. Nancy Andrighi, Corte Especial, DJe 19.12.2018 (Tema 988). &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: N/A;N&uacute;mero do Processo:1000278-72.2026.8.01.0000;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;N/A&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. GRATUIDADE DE JUSTIÇA. ENTIDADE FILANTRÓPICA. ISENÇÃO DE CUSTAS. TAXATIVIDADE MITIGADA DO ART. 1.015 DO CPC. CABIMENTO. PROVA PERICIAL. ERRO MÉDICO. NECESSIDADE DE PERÍCIA ESPECIALIZADA EM ANESTESIOLOGIA. CERCEAMENTO DE DEFESA CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo de instrumento interposto contra decisão que, em ação indenizatória
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. GRATUIDADE DE JUSTIÇA. ENTIDADE FILANTRÓPICA. ISENÇÃO DE CUSTAS. TAXATIVIDADE MITIGADA DO ART. 1.015 DO CPC. CABIMENTO. PROVA PERICIAL. ERRO MÉDICO. NECESSIDADE DE PERÍCIA ESPECIALIZADA EM ANESTESIOLOGIA. CERCEAMENTO DE DEFESA CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo de instrumento interposto contra decisão que, em ação indenizatória por alegado erro médico, revogou a determinação de realização de nova perícia médica especializada e determinou o prosseguimento do feito com possibilidade de julgamento antecipado, além de impugnar o pedido de gratuidade de justiça, pleiteando a concessão do benefício e a reabertura da instrução com produção de prova pericial adequada.
+Há duas questões em discussão: (i) definir se é cabível o agravo de instrumento à luz da taxatividade mitigada do art. 1.015 do CPC; (ii) estabelecer se a revogação da perícia médica especializada em anestesiologia configura cerceamento de defesa em demanda por erro médico.
+Reconhece-se a gratuidade de justiça, pois a agravante, entidade filantrópica sem fins lucrativos, é isenta do pagamento de custas nos termos do art. 2º, VII, da Lei Estadual nº 1.422/2001.
+Admite-se o agravo de instrumento com base na taxatividade mitigada do art. 1.015 do CPC, conforme Tema 988 do STJ, diante do risco de inutilidade do exame da matéria em apelação.
+A controvérsia envolve matéria técnica complexa relativa a erro médico, exigindo prova pericial especializada para adequada elucidação dos fatos.
+Considera-se relevante o fato de o próprio juízo de origem ter previamente reconhecido a necessidade de perícia por especialista em anestesiologia, evidenciando a imprescindibilidade da prova.
+O poder do magistrado de indeferir provas não autoriza a supressão de meio probatório essencial à solução da lide, especialmente quando a prova existente é insuficiente.
+Rejeita-se a justificativa de dificuldade na nomeação de perito como fundamento suficiente para afastar a produção da prova técnica necessária.
+Conclui-se que a ausência de perícia especializada compromete a formação do convencimento judicial e viola os princípios do contraditório e da ampla defesa.
+Reconhece-se o cerceamento de defesa diante da supressão de prova essencial ao deslinde da controvérsia.
+Recurso provido.
+A taxatividade do art. 1.015 do CPC é mitigada, admitindo agravo de instrumento quando houver risco de inutilidade do julgamento da questão em apelação.
+A revogação de prova pericial previamente reconhecida como necessária configura cerceamento de defesa quando a matéria exige conhecimento técnico especializado.
+A dificuldade na nomeação de perito não justifica a supressão de prova essencial à adequada instrução do processo.
+Em demandas de erro médico, a perícia deve ser realizada por profissional com especialidade compatível com o objeto da controvérsia.
+Jurisprudência relevante citada: STJ, REsp 1.704.520/MT, Rel. Min. Nancy Andrighi, Corte Especial, DJe 19.12.2018 (Tema 988).
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503744" cdForo="0" >
+										0715964-14.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503744" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503744);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503744" style="display: none;" >
+	<div id="textAreaDados_2503744" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. SERVI&Ccedil;O BANC&Aacute;RIO. BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. AUS&Ecirc;NCIA DE EMISS&Atilde;O DE NOVA VIA DE CART&Atilde;O MAGN&Eacute;TICO. RESIST&Ecirc;NCIA INDEVIDA &Agrave; PORTABILIDADE. RETEN&Ccedil;&Atilde;O F&Aacute;TICA DE VERBA ALIMENTAR. DANO MORAL. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o c&iacute;vel interposta por institui&ccedil;&atilde;o financeira contra senten&ccedil;a que julgou procedentes os pedidos para confirmar a portabilidade do benef&iacute;cio previdenci&aacute;rio do autor para a Caixa Econ&ocirc;mica Federal e condenar a institui&ccedil;&atilde;o financeira ao pagamento de R$ 3.000,00 por danos morais. O banco sustenta aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o, inexist&ecirc;ncia de ato il&iacute;cito, dano e nexo causal, bem como requer, subsidiariamente, a redu&ccedil;&atilde;o da indeniza&ccedil;&atilde;o.
+H&aacute; 3 quest&otilde;es em discuss&atilde;o: (i) definir se o banco apelante responde pela falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio consistente na n&atilde;o emiss&atilde;o de nova via do cart&atilde;o magn&eacute;tico por per&iacute;odo prolongado e na resist&ecirc;ncia indevida &agrave; portabilidade do benef&iacute;cio previdenci&aacute;rio; (ii) estabelecer se a restri&ccedil;&atilde;o injusta ao acesso de verba alimentar por consumidor idoso configura dano moral indeniz&aacute;vel; e (iii) determinar se o valor de R$ 3.000,00 fixado a t&iacute;tulo de repara&ccedil;&atilde;o comporta redu&ccedil;&atilde;o.
+A apela&ccedil;&atilde;o &eacute; conhecida, porque a reprodu&ccedil;&atilde;o de argumentos j&aacute; deduzidos n&atilde;o impede, por si s&oacute;, o conhecimento do recurso quando h&aacute; impugna&ccedil;&atilde;o minimamente identific&aacute;vel aos fundamentos da senten&ccedil;a.
+A rela&ccedil;&atilde;o entre as partes &eacute; de consumo, de modo que o banco responde objetivamente pelos defeitos na presta&ccedil;&atilde;o do servi&ccedil;o, nos termos do art. 14 do CDC e da S&uacute;mula 297 do STJ.
+O servi&ccedil;o banc&aacute;rio abrange n&atilde;o apenas o cr&eacute;dito formal do benef&iacute;cio, mas tamb&eacute;m a garantia de acesso regular, seguro e desimpedido aos valores depositados, especialmente quando se trata de verba alimentar recebida por consumidor idoso.
+O banco n&atilde;o demonstra justificativa id&ocirc;nea para a aus&ecirc;ncia de emiss&atilde;o de nova via do cart&atilde;o magn&eacute;tico, o que obriga o autor, por aproximadamente seis meses, a comparecer mensalmente &agrave; ag&ecirc;ncia para movimentar sua aposentadoria.
+A documenta&ccedil;&atilde;o da pr&oacute;pria institui&ccedil;&atilde;o revela que a transfer&ecirc;ncia do benef&iacute;cio somente &eacute; processada ap&oacute;s o ajuizamento da a&ccedil;&atilde;o, o que confirma a inefic&aacute;cia da via administrativa e corrobora a resist&ecirc;ncia indevida &agrave; portabilidade.
+A conduta da institui&ccedil;&atilde;o financeira viola os deveres anexos de lealdade, coopera&ccedil;&atilde;o e boa-f&eacute; objetiva, porque imp&otilde;e restri&ccedil;&atilde;o injusta ao exerc&iacute;cio da autonomia patrimonial m&iacute;nima do consumidor em contexto de hipervulnerabilidade.
+A priva&ccedil;&atilde;o prolongada e injustificada do acesso pleno a verba alimentar ultrapassa o mero aborrecimento e configura dano moral indeniz&aacute;vel, diante da gravidade concreta da les&atilde;o e da natureza existencial do preju&iacute;zo.
+Recurso desprovido.
+ 2. A restri&ccedil;&atilde;o injusta ao acesso de verba alimentar percebida por consumidor idoso configura dano moral indeniz&aacute;vel, por exceder o mero dissabor contratual.
+3. N&atilde;o se reduz a indeniza&ccedil;&atilde;o por dano moral quando o montante fixado se mostra moderado e proporcional &agrave;s circunst&acirc;ncias do caso.
+ 4. A mera reitera&ccedil;&atilde;o de argumentos anteriores n&atilde;o impede o conhecimento da apela&ccedil;&atilde;o quando h&aacute; pertin&ecirc;ncia tem&aacute;tica com os fundamentos da senten&ccedil;a.
+ 5. O simples exerc&iacute;cio do direito de recorrer, sem demonstra&ccedil;&atilde;o de dolo processual, n&atilde;o configura litig&acirc;ncia de m&aacute;-f&eacute;.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, X; CC, arts. 186, 422 e 927; CDC, art. 14; CPC, arts. 80, 85, &sect;&sect; 2&ordm; e 11, e 355, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula 297; TJSP, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 1000393-98.2025.8.26.0205, Rel. Des. M&ocirc;nica Soares Machado, N&uacute;cleo de Justi&ccedil;a 4.0 em Segundo Grau &#150; Turma VIII (Direito Privado 2), j. 15.12.2025; TJAM, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0682270-75.2022.8.04.0001, Rel. Des. Cezar Luiz Bandiera, Segunda C&acirc;mara C&iacute;vel, j. 31.10.2024.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0715964-14.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(53 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. SERVIÇO BANCÁRIO. BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE EMISSÃO DE NOVA VIA DE CARTÃO MAGNÉTICO. RESISTÊNCIA INDEVIDA À PORTABILIDADE. RETENÇÃO FÁTICA DE VERBA ALIMENTAR. <em>DANO</em> <em>MORAL</em>. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação cível interposta por instituição financeira contra sentença que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. SERVIÇO BANCÁRIO. BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE EMISSÃO DE NOVA VIA DE CARTÃO MAGNÉTICO. RESISTÊNCIA INDEVIDA À PORTABILIDADE. RETENÇÃO FÁTICA DE VERBA ALIMENTAR. <em>DANO</em> <em>MORAL</em>. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação cível interposta por instituição financeira contra sentença que julgou procedentes os pedidos para confirmar a portabilidade do benefício previdenciário do autor para a Caixa Econômica Federal e condenar a instituição financeira ao pagamento de R$ 3.000,00 por <em>danos</em> <em>morais</em>. O banco sustenta ausência de falha na prestação do serviço, inexistência de ato ilícito, <em>dano</em> e nexo causal, bem como requer, subsidiariamente, a redução da indenização.
+Há 3 questões em discussão: (i) definir se o banco apelante responde pela falha na prestação do serviço bancário consistente na não emissão de nova via do cartão magnético por período prolongado e na resistência indevida à portabilidade do benefício previdenciário; (ii) estabelecer se a restrição injusta ao acesso de verba alimentar por consumidor idoso configura <em>dano</em> <em>moral</em> indenizável; e (iii) determinar se o valor de R$ 3.000,00 fixado a título de reparação comporta redução.
+A apelação é conhecida, porque a reprodução de argumentos já deduzidos não impede, por si só, o conhecimento do recurso quando há impugnação minimamente identificável aos fundamentos da sentença.
+A relação entre as partes é de consumo, de modo que o banco responde objetivamente pelos defeitos na prestação do serviço, nos termos do art. 14 do CDC e da Súmula 297 do STJ.
+O serviço bancário abrange não apenas o crédito formal do benefício, mas também a garantia de acesso regular, seguro e desimpedido aos valores depositados, especialmente quando se trata de verba alimentar recebida por consumidor idoso.
+O banco não demonstra justificativa idônea para a ausência de emissão de nova via do cartão magnético, o que obriga o autor, por aproximadamente seis meses, a comparecer mensalmente à agência para movimentar sua aposentadoria.
+A documentação da própria instituição revela que a transferência do benefício somente é processada após o ajuizamento da ação, o que confirma a ineficácia da via administrativa e corrobora a resistência indevida à portabilidade.
+A conduta da instituição financeira viola os deveres anexos de lealdade, cooperação e boa-fé objetiva, porque impõe restrição injusta ao exercício da autonomia patrimonial mínima do consumidor em contexto de hipervulnerabilidade.
+A privação prolongada e injustificada do acesso pleno a verba alimentar ultrapassa o mero aborrecimento e configura <em>dano</em> <em>moral</em> indenizável, diante da gravidade concreta da lesão e da natureza existencial do prejuízo.
+Recurso desprovido.
+ 2. A restrição injusta ao acesso de verba alimentar percebida por consumidor idoso configura <em>dano</em> <em>moral</em> indenizável, por exceder o mero dissabor contratual.
+3. Não se reduz a indenização por <em>dano</em> <em>moral</em> quando o montante fixado se mostra moderado e proporcional às circunstâncias do caso.
+ 4. A mera reiteração de argumentos anteriores não impede o conhecimento da apelação quando há pertinência temática com os fundamentos da sentença.
+ 5. O simples exercício do direito de recorrer, sem demonstração de dolo processual, não configura litigância de má-fé.
+Dispositivos relevantes citados: CF/1988, art. 5º, X; CC, arts. 186, 422 e 927; CDC, art. 14; CPC, arts. 80, 85, §§ 2º e 11, e 355, I.
+Jurisprudência relevante citada: STJ, Súmula 297; TJSP, Apelação Cível nº 1000393-98.2025.8.26.0205, Rel. Des. Mônica Soares Machado, Núcleo de Justiça 4.0 em Segundo Grau  Turma VIII (Direito Privado 2), j. 15.12.2025; TJAM, Apelação Cível nº 0682270-75.2022.8.04.0001, Rel. Des. Cezar Luiz Bandiera, Segunda Câmara Cível, j. 31.10.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503737" cdForo="0" >
+										0711986-29.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503737" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503737);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503737" style="display: none;" >
+	<div id="textAreaDados_2503737" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE EXIBI&Ccedil;&Atilde;O DE DOCUMENTOS. APRESENTA&Ccedil;&Atilde;O DOS DOCUMENTOS NO CURSO DO PROCESSO. AUS&Ecirc;NCIA DE PRETENS&Atilde;O RESISTIDA. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS INDEVIDOS. ASTREINTES INCAB&Iacute;VEIS. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que, em a&ccedil;&atilde;o de exibi&ccedil;&atilde;o de documentos ajuizada em face de institui&ccedil;&atilde;o financeira, homologou a prova produzida e extinguiu o feito, sem condena&ccedil;&atilde;o em honor&aacute;rios advocat&iacute;cios ou multa, ap&oacute;s a juntada dos contratos e autoriza&ccedil;&otilde;es de desconto no curso do processo. O apelante requer a reforma da senten&ccedil;a para condenar a parte r&eacute; ao pagamento de honor&aacute;rios, custas e astreintes.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se houve pretens&atilde;o resistida apta a justificar a condena&ccedil;&atilde;o da institui&ccedil;&atilde;o financeira ao pagamento de honor&aacute;rios advocat&iacute;cios e custas processuais; e (ii) estabelecer se &eacute; cab&iacute;vel a fixa&ccedil;&atilde;o de multa coercitiva pela apresenta&ccedil;&atilde;o dos documentos apenas no curso do processo.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os documentos reclamados foram apresentados pela institui&ccedil;&atilde;o financeira no curso do processo, com satisfa&ccedil;&atilde;o da provid&ecirc;ncia pleiteada.
+4. A condena&ccedil;&atilde;o em honor&aacute;rios advocat&iacute;cios, em a&ccedil;&otilde;es dessa natureza, exige demonstra&ccedil;&atilde;o de resist&ecirc;ncia efetiva &agrave; pretens&atilde;o, o que n&atilde;o se verifica quando os documentos s&atilde;o juntados aos autos sem comprova&ccedil;&atilde;o de recusa administrativa.
+5. A aus&ecirc;ncia de pretens&atilde;o resistida afasta a imposi&ccedil;&atilde;o de &ocirc;nus sucumbenciais &agrave; parte r&eacute;.
+6. A multa coercitiva prevista no art. 537 do CPC pressup&otilde;e descumprimento de ordem judicial e n&atilde;o pode ser aplicada quando n&atilde;o h&aacute; recalcitr&acirc;ncia processual.
+7. Quest&otilde;es relativas &agrave; nulidade contratual, legalidade dos descontos, repeti&ccedil;&atilde;o de ind&eacute;bito e dano moral n&atilde;o integram o objeto da presente demanda.
+8. O simples exerc&iacute;cio do direito de recorrer n&atilde;o configura litig&acirc;ncia de m&aacute;-f&eacute;.
+IV. DISPOSITIVO E TESE
+9. Recurso desprovido.
+Tese de julgamento:
+A apresenta&ccedil;&atilde;o dos documentos no curso do processo, sem comprova&ccedil;&atilde;o de recusa administrativa, afasta a caracteriza&ccedil;&atilde;o de pretens&atilde;o resistida.
+A aus&ecirc;ncia de resist&ecirc;ncia efetiva impede a condena&ccedil;&atilde;o da parte r&eacute; ao pagamento de honor&aacute;rios advocat&iacute;cios em a&ccedil;&atilde;o de exibi&ccedil;&atilde;o de documentos.
+ A multa coercitiva exige descumprimento de ordem judicial e n&atilde;o se aplica quando a obriga&ccedil;&atilde;o &eacute; satisfeita no curso da demanda.
+Jurisprud&ecirc;ncia relevante citada: TJPR, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0008241-85.2023.8.16.0017, Rel. Des. Hayton Lee Swain Filho, 15&ordf; C&acirc;mara C&iacute;vel, j. 10.08.2024, pub. 12.08.2024; STJ, AgInt no REsp n&ordm; 1.757.147/SP, Rel. Min. Antonio Carlos Ferreira, 4&ordf; Turma, j. 24.08.2020, DJe 31.08.2020; STJ, AgInt no AgInt no AREsp n&ordm; 2.389.142/BA, Rel. Min. Marco Buzzi, 4&ordf; Turma, j. 29.04.2024, DJe 02.05.2024.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0711986-29.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DE EXIBIÇÃO DE DOCUMENTOS. APRESENTAÇÃO DOS DOCUMENTOS NO CURSO DO PROCESSO. AUSÊNCIA DE PRETENSÃO RESISTIDA. HONORÁRIOS ADVOCATÍCIOS INDEVIDOS. ASTREINTES INCABÍVEIS. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que, em ação de exibição de documentos ajuizada em face de instituição financeira, homologou a prova
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DE EXIBIÇÃO DE DOCUMENTOS. APRESENTAÇÃO DOS DOCUMENTOS NO CURSO DO PROCESSO. AUSÊNCIA DE PRETENSÃO RESISTIDA. HONORÁRIOS ADVOCATÍCIOS INDEVIDOS. ASTREINTES INCABÍVEIS. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que, em ação de exibição de documentos ajuizada em face de instituição financeira, homologou a prova produzida e extinguiu o feito, sem condenação em honorários advocatícios ou multa, após a juntada dos contratos e autorizações de desconto no curso do processo. O apelante requer a reforma da sentença para condenar a parte ré ao pagamento de honorários, custas e astreintes.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se houve pretensão resistida apta a justificar a condenação da instituição financeira ao pagamento de honorários advocatícios e custas processuais; e (ii) estabelecer se é cabível a fixação de multa coercitiva pela apresentação dos documentos apenas no curso do processo.
+III. RAZÕES DE DECIDIR
+3. Os documentos reclamados foram apresentados pela instituição financeira no curso do processo, com satisfação da providência pleiteada.
+4. A condenação em honorários advocatícios, em ações dessa natureza, exige demonstração de resistência efetiva à pretensão, o que não se verifica quando os documentos são juntados aos autos sem comprovação de recusa administrativa.
+5. A ausência de pretensão resistida afasta a imposição de ônus sucumbenciais à parte ré.
+6. A multa coercitiva prevista no art. 537 do CPC pressupõe descumprimento de ordem judicial e não pode ser aplicada quando não há recalcitrância processual.
+7. Questões relativas à nulidade contratual, legalidade dos descontos, repetição de indébito e <em>dano</em> <em>moral</em> não integram o objeto da presente demanda.
+8. O simples exercício do direito de recorrer não configura litigância de má-fé.
+IV. DISPOSITIVO E TESE
+9. Recurso desprovido.
+Tese de julgamento:
+A apresentação dos documentos no curso do processo, sem comprovação de recusa administrativa, afasta a caracterização de pretensão resistida.
+A ausência de resistência efetiva impede a condenação da parte ré ao pagamento de honorários advocatícios em ação de exibição de documentos.
+ A multa coercitiva exige descumprimento de ordem judicial e não se aplica quando a obrigação é satisfeita no curso da demanda.
+Jurisprudência relevante citada: TJPR, Apelação Cível nº 0008241-85.2023.8.16.0017, Rel. Des. Hayton Lee Swain Filho, 15ª Câmara Cível, j. 10.08.2024, pub. 12.08.2024; STJ, AgInt no REsp nº 1.757.147/SP, Rel. Min. Antonio Carlos Ferreira, 4ª Turma, j. 24.08.2020, DJe 31.08.2020; STJ, AgInt no AgInt no AREsp nº 2.389.142/BA, Rel. Min. Marco Buzzi, 4ª Turma, j. 29.04.2024, DJe 02.05.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503729" cdForo="0" >
+										0700150-63.2024.8.01.0011
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503729" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503729);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503729" style="display: none;" >
+	<div id="textAreaDados_2503729" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL E DIREITO DO CONSUMIDOR. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. CONTRATA&Ccedil;&Atilde;O DIGITAL. CART&Atilde;O DE CR&Eacute;DITO. VALIDADE DA PROVA. INEXIST&Ecirc;NCIA DE OMISS&Atilde;O, CONTRADI&Ccedil;&Atilde;O OU OBSCURIDADE. REDISCUSS&Atilde;O DO M&Eacute;RITO. TEMA 1.061 DO STJ. INAPLICABILIDADE AO CASO CONCRETO. REJEI&Ccedil;&Atilde;O DOS EMBARGOS.
+I. CASO EM EXAME
+Embargos de declara&ccedil;&atilde;o com efeitos infringentes opostos contra ac&oacute;rd&atilde;o que negou provimento &agrave; apela&ccedil;&atilde;o e manteve a improced&ecirc;ncia de a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito c/c indeniza&ccedil;&atilde;o por danos morais, reconhecendo a validade da contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito e a legitimidade da negativa&ccedil;&atilde;o, bem como a configura&ccedil;&atilde;o de litig&acirc;ncia de m&aacute;-f&eacute;, sob o fundamento de que a autora n&atilde;o comprovou a alegada fraude e que a institui&ccedil;&atilde;o financeira demonstrou a rela&ccedil;&atilde;o jur&iacute;dica mediante provas documentais e biometria facial .
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se o ac&oacute;rd&atilde;o embargado padece de omiss&atilde;o, contradi&ccedil;&atilde;o ou obscuridade quanto &agrave; comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o digital e &agrave; aplica&ccedil;&atilde;o do Tema 1.061 do STJ; (ii) estabelecer se &eacute; poss&iacute;vel atribuir efeitos infringentes aos embargos para reformar o julgado.
+O ac&oacute;rd&atilde;o enfrenta expressamente todas as quest&otilde;es relevantes, analisando de forma fundamentada a comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o e a legitimidade da negativa&ccedil;&atilde;o, afastando a alega&ccedil;&atilde;o de v&iacute;cios previstos no art. 1.022 do CPC.
+A institui&ccedil;&atilde;o financeira comprova a rela&ccedil;&atilde;o jur&iacute;dica mediante conjunto probat&oacute;rio consistente, incluindo prints sist&ecirc;micos, faturas, hist&oacute;rico de utiliza&ccedil;&atilde;o do cart&atilde;o e biometria facial, suficientes para demonstrar a contrata&ccedil;&atilde;o digital.
+A parte autora n&atilde;o se desincumbe do &ocirc;nus probat&oacute;rio previsto no art. 373, II, do CPC, ao apresentar alega&ccedil;&otilde;es gen&eacute;ricas de fraude desacompanhadas de elementos m&iacute;nimos de prova.
+O Tema 1.061 do STJ n&atilde;o se aplica automaticamente, pois o caso n&atilde;o se limita &agrave; impugna&ccedil;&atilde;o de assinatura em contrato f&iacute;sico, envolvendo contrata&ccedil;&atilde;o digital acompanhada de robusto conjunto probat&oacute;rio.
+A alega&ccedil;&atilde;o de aus&ecirc;ncia de dados como IP, geolocaliza&ccedil;&atilde;o e hor&aacute;rio n&atilde;o configura omiss&atilde;o, pois o ac&oacute;rd&atilde;o considera suficientes os elementos probat&oacute;rios existentes para forma&ccedil;&atilde;o do convencimento.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito, sendo incab&iacute;veis quando ausentes os v&iacute;cios legais, ainda que com finalidade de prequestionamento.
+Os efeitos infringentes s&atilde;o excepcionais e dependem da constata&ccedil;&atilde;o de v&iacute;cio no julgado, o que n&atilde;o ocorre na hip&oacute;tese.
+Recurso desprovido.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o s&atilde;o cab&iacute;veis para rediscuss&atilde;o do m&eacute;rito quando o ac&oacute;rd&atilde;o enfrenta adequadamente as quest&otilde;es controvertidas.
+A comprova&ccedil;&atilde;o de contrata&ccedil;&atilde;o digital pode ser realizada por conjunto probat&oacute;rio que inclua biometria facial, registros sist&ecirc;micos e hist&oacute;rico de utiliza&ccedil;&atilde;o do servi&ccedil;o.
+O Tema 1.061 do STJ n&atilde;o se aplica automaticamente a contrata&ccedil;&otilde;es digitais quando h&aacute; elementos probat&oacute;rios adicionais que demonstram a rela&ccedil;&atilde;o jur&iacute;dica.
+A atribui&ccedil;&atilde;o de efeitos infringentes aos embargos de declara&ccedil;&atilde;o exige a demonstra&ccedil;&atilde;o de v&iacute;cio no julgado, n&atilde;o configurado pela mera inconformidade da parte.
+Jurisprud&ecirc;ncia relevante citada: STJ, Tema 1.061; STJ, AgInt no AREsp 844.804/MG, Rel. Min. Humberto Martins, j. 15.04.2016; STJ, EDcl no REsp 1.583.696/RS, Rel. Min. Herman Benjamin, j. 05.10.2017; STJ, EDcl no AgInt no REsp 1.661.261/SP, Rel. Min. Rogerio Schietti Cruz, j. 26.09.2017.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Sena Madureira;N&uacute;mero do Processo:0700150-63.2024.8.01.0011;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sena Madureira
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO DO CONSUMIDOR. EMBARGOS DE DECLARAÇÃO. CONTRATAÇÃO DIGITAL. CARTÃO DE CRÉDITO. VALIDADE DA PROVA. INEXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. REDISCUSSÃO DO MÉRITO. TEMA 1.061 DO STJ. INAPLICABILIDADE AO CASO CONCRETO. REJEIÇÃO DOS EMBARGOS.
+I. CASO EM EXAME
+Embargos de declaração com efeitos infringentes opostos contra acórdão que negou provimento à
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO DO CONSUMIDOR. EMBARGOS DE DECLARAÇÃO. CONTRATAÇÃO DIGITAL. CARTÃO DE CRÉDITO. VALIDADE DA PROVA. INEXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. REDISCUSSÃO DO MÉRITO. TEMA 1.061 DO STJ. INAPLICABILIDADE AO CASO CONCRETO. REJEIÇÃO DOS EMBARGOS.
+I. CASO EM EXAME
+Embargos de declaração com efeitos infringentes opostos contra acórdão que negou provimento à apelação e manteve a improcedência de ação declaratória de inexistência de débito c/c indenização por <em>danos</em> <em>morais</em>, reconhecendo a validade da contratação de cartão de crédito e a legitimidade da negativação, bem como a configuração de litigância de má-fé, sob o fundamento de que a autora não comprovou a alegada fraude e que a instituição financeira demonstrou a relação jurídica mediante provas documentais e biometria facial .
+Há duas questões em discussão: (i) definir se o acórdão embargado padece de omissão, contradição ou obscuridade quanto à comprovação da contratação digital e à aplicação do Tema 1.061 do STJ; (ii) estabelecer se é possível atribuir efeitos infringentes aos embargos para reformar o julgado.
+O acórdão enfrenta expressamente todas as questões relevantes, analisando de forma fundamentada a comprovação da contratação e a legitimidade da negativação, afastando a alegação de vícios previstos no art. 1.022 do CPC.
+A instituição financeira comprova a relação jurídica mediante conjunto probatório consistente, incluindo prints sistêmicos, faturas, histórico de utilização do cartão e biometria facial, suficientes para demonstrar a contratação digital.
+A parte autora não se desincumbe do ônus probatório previsto no art. 373, II, do CPC, ao apresentar alegações genéricas de fraude desacompanhadas de elementos mínimos de prova.
+O Tema 1.061 do STJ não se aplica automaticamente, pois o caso não se limita à impugnação de assinatura em contrato físico, envolvendo contratação digital acompanhada de robusto conjunto probatório.
+A alegação de ausência de dados como IP, geolocalização e horário não configura omissão, pois o acórdão considera suficientes os elementos probatórios existentes para formação do convencimento.
+Os embargos de declaração não se prestam à rediscussão do mérito, sendo incabíveis quando ausentes os vícios legais, ainda que com finalidade de prequestionamento.
+Os efeitos infringentes são excepcionais e dependem da constatação de vício no julgado, o que não ocorre na hipótese.
+Recurso desprovido.
+Os embargos de declaração não são cabíveis para rediscussão do mérito quando o acórdão enfrenta adequadamente as questões controvertidas.
+A comprovação de contratação digital pode ser realizada por conjunto probatório que inclua biometria facial, registros sistêmicos e histórico de utilização do serviço.
+O Tema 1.061 do STJ não se aplica automaticamente a contratações digitais quando há elementos probatórios adicionais que demonstram a relação jurídica.
+A atribuição de efeitos infringentes aos embargos de declaração exige a demonstração de vício no julgado, não configurado pela mera inconformidade da parte.
+Jurisprudência relevante citada: STJ, Tema 1.061; STJ, AgInt no AREsp 844.804/MG, Rel. Min. Humberto Martins, j. 15.04.2016; STJ, EDcl no REsp 1.583.696/RS, Rel. Min. Herman Benjamin, j. 05.10.2017; STJ, EDcl no AgInt no REsp 1.661.261/SP, Rel. Min. Rogerio Schietti Cruz, j. 26.09.2017.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503723" cdForo="0" >
+										1002456-28.2025.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503723" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503723);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503723" style="display: none;" >
+	<div id="textAreaDados_2503723" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM AGRAVO DE INSTRUMENTO. REDISCUSS&Atilde;O DA MAT&Eacute;RIA. AUS&Ecirc;NCIA DE OBSCURIDADE, CONTRADI&Ccedil;&Atilde;O, OMISS&Atilde;O OU ERRO MATERIAL. CONSEQUENTE INEXIST&Ecirc;NCIA DE V&Iacute;CIOS. PREQUESTIONAMENTO. N&Atilde;O VIOLA&Ccedil;&Atilde;O DO ART. 1.022 DO CPC/2015. ACLARAT&Oacute;RIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que, por unanimidade, negou provimento ao recurso de agravo de instrumento da parte embargante.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Avalia-se a ocorr&ecirc;ncia de omiss&atilde;o e contradi&ccedil;&atilde;o no ac&oacute;rd&atilde;o recorrido, por supostamente n&atilde;o ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequa&ccedil;&atilde;o do recurso para fins de prequestionamento &agrave;s inst&acirc;ncias superiores.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Inexist&ecirc;ncia de omiss&atilde;o/contradi&ccedil;&atilde;o: O ac&oacute;rd&atilde;o recorrido analisou de forma clara e exauriente a controv&eacute;rsia, bem como as quest&otilde;es suscitadas pelas partes, sobretudo quanto &agrave; aus&ecirc;ncia de probabilidade do direito invocado, quest&otilde;es essas que j&aacute; foram apreciadas e decididas no ac&oacute;rd&atilde;o embargado, sendo despicienda nova manifesta&ccedil;&atilde;o deste Colegiado. O ju&iacute;zo n&atilde;o est&aacute; obrigado a responder a um question&aacute;rio, mas a fundamentar sua decis&atilde;o.
+4. Rediscuss&atilde;o de m&eacute;rito: A parte embargante, a pretexto de sanar pretensa omiss&atilde;o/contradi&ccedil;&atilde;o, busca, na verdade, a rediscuss&atilde;o do m&eacute;rito da causa e a reforma do julgado, finalidade para a qual os embargos de declara&ccedil;&atilde;o s&atilde;o via inadequada, conforme pac&iacute;fica jurisprud&ecirc;ncia do STJ.
+5. Prequestionamento: A aus&ecirc;ncia dos v&iacute;cios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, S&uacute;mula n.&ordm; 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando inclu&iacute;dos no ac&oacute;rd&atilde;o os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordin&aacute;rio, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: &quot;N&atilde;o h&aacute; que se falar em omiss&atilde;o/contradi&ccedil;&atilde;o quando o ac&oacute;rd&atilde;o analisa suficientemente a mat&eacute;ria posta em debate, com fundamenta&ccedil;&atilde;o clara e coerente, sendo desnecess&aacute;rio o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito da causa, e sua rejei&ccedil;&atilde;o &eacute; medida impositiva quando ausentes os v&iacute;cios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento&quot;. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:1002456-28.2025.8.01.0000;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Indenização por Dano Material
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO DE INSTRUMENTO. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO DE INSTRUMENTO. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao recurso de agravo de instrumento da parte embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Avalia-se a ocorrência de omissão e contradição no acórdão recorrido, por supostamente não ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequação do recurso para fins de prequestionamento às instâncias superiores.
+III. RAZÕES DE DECIDIR
+3. Inexistência de omissão/contradição: O acórdão recorrido analisou de forma clara e exauriente a controvérsia, bem como as questões suscitadas pelas partes, sobretudo quanto à ausência de probabilidade do direito invocado, questões essas que já foram apreciadas e decididas no acórdão embargado, sendo despicienda nova manifestação deste Colegiado. O juízo não está obrigado a responder a um questionário, mas a fundamentar sua decisão.
+4. Rediscussão de mérito: A parte embargante, a pretexto de sanar pretensa omissão/contradição, busca, na verdade, a rediscussão do mérito da causa e a reforma do julgado, finalidade para a qual os embargos de declaração são via inadequada, conforme pacífica jurisprudência do STJ.
+5. Prequestionamento: A ausência dos vícios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, Súmula n.º 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando incluídos no acórdão os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordinário, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: "Não há que se falar em omissão/contradição quando o acórdão analisa suficientemente a matéria posta em debate, com fundamentação clara e coerente, sendo desnecessário o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declaração não se prestam à rediscussão do mérito da causa, e sua rejeição é medida impositiva quando ausentes os vícios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503732" cdForo="0" >
+										0703836-90.2024.8.01.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503732" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503732);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503732" style="display: none;" >
+	<div id="textAreaDados_2503732" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. SUPERENDIVIDAMENTO. LEI N. 14.181/2021. M&Iacute;NIMO EXISTENCIAL. EXCLUS&Atilde;O DE D&Iacute;VIDAS CONSIGNADAS. INEXIST&Ecirc;NCIA DE OMISS&Atilde;O OU CONTRADI&Ccedil;&Atilde;O. REDISCUSS&Atilde;O DO M&Eacute;RITO. PREQUESTIONAMENTO FICTO. REJEI&Ccedil;&Atilde;O.
+I. CASO EM EXAME
+1) Embargos de declara&ccedil;&atilde;o opostos contra ac&oacute;rd&atilde;o que reformou senten&ccedil;a de proced&ecirc;ncia parcial para julgar improcedente a&ccedil;&atilde;o de repactua&ccedil;&atilde;o de d&iacute;vidas, ao fundamento de inocorr&ecirc;ncia de superendividamento, diante da exclus&atilde;o das d&iacute;vidas oriundas de cr&eacute;dito consignado do c&aacute;lculo do m&iacute;nimo existencial, nos termos da Lei n. 14.181/2021 e do Decreto n. 11.150/2022, com pedido de saneamento de alegadas omiss&atilde;o e contradi&ccedil;&atilde;o e de prequestionamento de dispositivos legais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) H&aacute; 2 quest&otilde;es em discuss&atilde;o: (i) definir se o ac&oacute;rd&atilde;o embargado incorreu em omiss&atilde;o ou contradi&ccedil;&atilde;o ao afastar a caracteriza&ccedil;&atilde;o do superendividamento, especialmente quanto &agrave; considera&ccedil;&atilde;o das d&iacute;vidas consignadas no c&aacute;lculo do m&iacute;nimo existencial; e (ii) estabelecer se cabe acolher pedido de prequestionamento quando inexistentes v&iacute;cios integrativos no julgado.
+III. RAZ&Otilde;ES DE DECIDIR
+3) Os embargos de declara&ccedil;&atilde;o possuem fun&ccedil;&atilde;o integrativa restrita, sendo cab&iacute;veis apenas nas hip&oacute;teses do art. 1.022 do CPC, n&atilde;o se prestando &agrave; rediscuss&atilde;o do m&eacute;rito ou &agrave; inova&ccedil;&atilde;o recursal.
+4) O ac&oacute;rd&atilde;o embargado enfrenta de forma expressa e suficiente as quest&otilde;es essenciais da controv&eacute;rsia, inclusive a caracteriza&ccedil;&atilde;o do superendividamento e a impossibilidade de computar d&iacute;vidas consignadas para aferi&ccedil;&atilde;o do m&iacute;nimo existencial.
+5) A decis&atilde;o aplica o art. 54-A, &sect; 1&ordm;, do CDC em conjunto com o Decreto n. 11.150/2022, que fixava o m&iacute;nimo existencial em R$ 600,00 e exclu&iacute;a, expressamente, as d&iacute;vidas oriundas de cr&eacute;dito consignado do c&aacute;lculo pertinente.
+6) A constata&ccedil;&atilde;o de que 99,86% do passivo decorre de contratos de cr&eacute;dito consignado afasta, no quadro normativo adotado, a caracteriza&ccedil;&atilde;o do superendividamento apto a justificar a repactua&ccedil;&atilde;o judicial.
+7) N&atilde;o h&aacute; omiss&atilde;o quando o &oacute;rg&atilde;o julgador aprecia a tese e a rejeita de forma fundamentada, ainda que em sentido contr&aacute;rio ao interesse da parte.
+8) N&atilde;o h&aacute; contradi&ccedil;&atilde;o quando o julgado apresenta coer&ecirc;ncia l&oacute;gica entre premissas normativas e conclus&atilde;o, sendo incab&iacute;vel confundir contradi&ccedil;&atilde;o interna com mera discord&acirc;ncia interpretativa.
+9) O dever de fundamenta&ccedil;&atilde;o n&atilde;o imp&otilde;e resposta exaustiva a todos os argumentos ou dispositivos invocados pelas partes, bastando o enfrentamento suficiente da mat&eacute;ria controvertida.
+10) O pedido de prequestionamento n&atilde;o autoriza o acolhimento dos embargos sem a demonstra&ccedil;&atilde;o de v&iacute;cio integrativo, embora a mera oposi&ccedil;&atilde;o dos aclarat&oacute;rios viabilize, em tese, o prequestionamento ficto previsto no art. 1.025 do CPC.
+11) A jurisprud&ecirc;ncia do STJ e do pr&oacute;prio tribunal afasta o uso dos embargos de declara&ccedil;&atilde;o como suced&acirc;neo recursal destinado ao reexame da mat&eacute;ria j&aacute; decidida.
+IV. DISPOSITIVO E TESE
+12) Embargos de declara&ccedil;&atilde;o rejeitados.
+Tese de julgamento:
+1. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito quando ausentes omiss&atilde;o, contradi&ccedil;&atilde;o, obscuridade ou erro material.
+2. A caracteriza&ccedil;&atilde;o do superendividamento deve observar os par&acirc;metros legais e regulamentares vigentes, inclusive a exclus&atilde;o das d&iacute;vidas consignadas do c&aacute;lculo do m&iacute;nimo existencial.
+3. O enfrentamento fundamentado das quest&otilde;es essenciais da controv&eacute;rsia afasta a alega&ccedil;&atilde;o de negativa de presta&ccedil;&atilde;o jurisdicional.
+4. O pedido de prequestionamento n&atilde;o dispensa a presen&ccedil;a dos v&iacute;cios do art. 1.022 do CPC, sem preju&iacute;zo da incid&ecirc;ncia do art. 1.025 do CPC.
+Dispositivos relevantes citados: CPC, arts. 489, &sect; 1&ordm;, IV, 1.022, 1.025 e 1.026, &sect; 2&ordm;; CDC, art. 54-A, &sect; 1&ordm;; Decreto n. 11.150/2022, arts. 3&ordm; e 4&ordm;, par&aacute;grafo &uacute;nico, I, &quot;h&quot;; CC, arts. 104, 108, 166, IV, 171, II, 1.791 e 1.793.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no REsp 1.549.458/SP, Rel. Min. Herman Benjamin, j. 11.04.2022; STJ, EDcl no REsp 2024/0415063-8, Rel. Min. Humberto Martins, j. 09.02.2026; STJ, EDcl no AgRg no AREsp 2.578.606/SP, Rel. Min. Daniela Teixeira, j. 23.10.2024; TJ-AC, Apela&ccedil;&atilde;o C&iacute;vel 0700359-32.2024.8.01.0011, Rel. Des&ordf; Waldirene Cordeiro, j. 25.02.2026; TJ-AC, Apela&ccedil;&atilde;o C&iacute;vel 0700047-96.2014.8.01.0014, Rel. Des. Lois Arruda, j. 24.11.2025; TJ-AC, Embargos de Declara&ccedil;&atilde;o C&iacute;vel 0101135-17.2024.8.01.0000, Rel. Des. Lu&iacute;s Camolez, j. 27.09.2024.  &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:0703836-90.2024.8.01.0002;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. SUPERENDIVIDAMENTO. LEI N. 14.181/2021. MÍNIMO EXISTENCIAL. EXCLUSÃO DE DÍVIDAS CONSIGNADAS. INEXISTÊNCIA DE OMISSÃO OU CONTRADIÇÃO. REDISCUSSÃO DO MÉRITO. PREQUESTIONAMENTO FICTO. REJEIÇÃO.
+I. CASO EM EXAME
+1) Embargos de declaração opostos contra acórdão que reformou sentença de procedência parcial para julgar improcedente ação de repactuação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. SUPERENDIVIDAMENTO. LEI N. 14.181/2021. MÍNIMO EXISTENCIAL. EXCLUSÃO DE DÍVIDAS CONSIGNADAS. INEXISTÊNCIA DE OMISSÃO OU CONTRADIÇÃO. REDISCUSSÃO DO MÉRITO. PREQUESTIONAMENTO FICTO. REJEIÇÃO.
+I. CASO EM EXAME
+1) Embargos de declaração opostos contra acórdão que reformou sentença de procedência parcial para julgar improcedente ação de repactuação de dívidas, ao fundamento de inocorrência de superendividamento, diante da exclusão das dívidas oriundas de crédito consignado do cálculo do mínimo existencial, nos termos da Lei n. 14.181/2021 e do Decreto n. 11.150/2022, com pedido de saneamento de alegadas omissão e contradição e de prequestionamento de dispositivos legais.
+II. QUESTÃO EM DISCUSSÃO
+2) Há 2 questões em discussão: (i) definir se o acórdão embargado incorreu em omissão ou contradição ao afastar a caracterização do superendividamento, especialmente quanto à consideração das dívidas consignadas no cálculo do mínimo existencial; e (ii) estabelecer se cabe acolher pedido de prequestionamento quando inexistentes vícios integrativos no julgado.
+III. RAZÕES DE DECIDIR
+3) Os embargos de declaração possuem função integrativa restrita, sendo cabíveis apenas nas hipóteses do art. 1.022 do CPC, não se prestando à rediscussão do mérito ou à inovação recursal.
+4) O acórdão embargado enfrenta de forma expressa e suficiente as questões essenciais da controvérsia, inclusive a caracterização do superendividamento e a impossibilidade de computar dívidas consignadas para aferição do mínimo existencial.
+5) A decisão aplica o art. 54-A, § 1º, do CDC em conjunto com o Decreto n. 11.150/2022, que fixava o mínimo existencial em R$ 600,00 e excluía, expressamente, as dívidas oriundas de crédito consignado do cálculo pertinente.
+6) A constatação de que 99,86% do passivo decorre de contratos de crédito consignado afasta, no quadro normativo adotado, a caracterização do superendividamento apto a justificar a repactuação judicial.
+7) Não há omissão quando o órgão julgador aprecia a tese e a rejeita de forma fundamentada, ainda que em sentido contrário ao interesse da parte.
+8) Não há contradição quando o julgado apresenta coerência lógica entre premissas normativas e conclusão, sendo incabível confundir contradição interna com mera discordância interpretativa.
+9) O dever de fundamentação não impõe resposta exaustiva a todos os argumentos ou dispositivos invocados pelas partes, bastando o enfrentamento suficiente da matéria controvertida.
+10) O pedido de prequestionamento não autoriza o acolhimento dos embargos sem a demonstração de vício integrativo, embora a mera oposição dos aclaratórios viabilize, em tese, o prequestionamento ficto previsto no art. 1.025 do CPC.
+11) A jurisprudência do STJ e do próprio tribunal afasta o uso dos embargos de declaração como sucedâneo recursal destinado ao reexame da matéria já decidida.
+IV. DISPOSITIVO E TESE
+12) Embargos de declaração rejeitados.
+Tese de julgamento:
+1. Os embargos de declaração não se prestam à rediscussão do mérito quando ausentes omissão, contradição, obscuridade ou erro material.
+2. A caracterização do superendividamento deve observar os parâmetros legais e regulamentares vigentes, inclusive a exclusão das dívidas consignadas do cálculo do mínimo existencial.
+3. O enfrentamento fundamentado das questões essenciais da controvérsia afasta a alegação de negativa de prestação jurisdicional.
+4. O pedido de prequestionamento não dispensa a presença dos vícios do art. 1.022 do CPC, sem prejuízo da incidência do art. 1.025 do CPC.
+Dispositivos relevantes citados: CPC, arts. 489, § 1º, IV, 1.022, 1.025 e 1.026, § 2º; CDC, art. 54-A, § 1º; Decreto n. 11.150/2022, arts. 3º e 4º, parágrafo único, I, "h"; CC, arts. 104, 108, 166, IV, 171, II, 1.791 e 1.793.
+Jurisprudência relevante citada: STJ, EDcl no REsp 1.549.458/SP, Rel. Min. Herman Benjamin, j. 11.04.2022; STJ, EDcl no REsp 2024/0415063-8, Rel. Min. Humberto Martins, j. 09.02.2026; STJ, EDcl no AgRg no AREsp 2.578.606/SP, Rel. Min. Daniela Teixeira, j. 23.10.2024; TJ-AC, Apelação Cível 0700359-32.2024.8.01.0011, Rel. Desª Waldirene Cordeiro, j. 25.02.2026; TJ-AC, Apelação Cível 0700047-96.2014.8.01.0014, Rel. Des. Lois Arruda, j. 24.11.2025; TJ-AC, Embargos de Declaração Cível 0101135-17.2024.8.01.0000, Rel. Des. Luís Camolez, j. 27.09.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503725" cdForo="0" >
+										0706552-59.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503725" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503725);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503725" style="display: none;" >
+	<div id="textAreaDados_2503725" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. AUS&Ecirc;NCIA DE OMISS&Atilde;O, CONTRADI&Ccedil;&Atilde;O OU OBSCURIDADE. PRETENS&Atilde;O DE REDISCUSS&Atilde;O DA MAT&Eacute;RIA. EMBARGOS REJEITADOS
+I. CASO EM EXAME
+Embargos de declara&ccedil;&atilde;o interpostos contra ac&oacute;rd&atilde;o que, deu parcial provimento ao recurso para afastar a condena&ccedil;&atilde;o por danos morais, ajustar juros remunerat&oacute;rios e reconhecer sucumb&ecirc;ncia rec&iacute;proca, sob alega&ccedil;&atilde;o de omiss&otilde;es, contradi&ccedil;&otilde;es e obscuridades quanto &agrave; an&aacute;lise dos danos morais, distribui&ccedil;&atilde;o da sucumb&ecirc;ncia, fixa&ccedil;&atilde;o de honor&aacute;rios e crit&eacute;rios de juros .
+H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se o ac&oacute;rd&atilde;o embargado incorre em omiss&atilde;o quanto &agrave; an&aacute;lise dos danos morais; (ii) estabelecer se h&aacute; contradi&ccedil;&atilde;o na fixa&ccedil;&atilde;o da sucumb&ecirc;ncia rec&iacute;proca; (iii) determinar se houve omiss&atilde;o ou inadequa&ccedil;&atilde;o na fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios; e (iv) verificar eventual obscuridade na defini&ccedil;&atilde;o dos juros remunerat&oacute;rios .
+Os embargos de declara&ccedil;&atilde;o possuem finalidade integrativa e se limitam &agrave;s hip&oacute;teses do art. 1.022 do CPC, n&atilde;o se prestando &agrave; rediscuss&atilde;o do m&eacute;rito da decis&atilde;o.
+O ac&oacute;rd&atilde;o enfrenta expressamente a quest&atilde;o dos danos morais e afasta a indeniza&ccedil;&atilde;o por aus&ecirc;ncia de prova de les&atilde;o extrapatrimonial relevante.
+A decis&atilde;o reconhece o &ecirc;xito parcial de ambas as partes, o que justifica a fixa&ccedil;&atilde;o da sucumb&ecirc;ncia rec&iacute;proca, inexistindo contradi&ccedil;&atilde;o.
+O ac&oacute;rd&atilde;o analisa a fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios e adota o crit&eacute;rio de equidade diante da impossibilidade de mensura&ccedil;&atilde;o do proveito econ&ocirc;mico.
+N&atilde;o h&aacute; obscuridade quanto aos juros remunerat&oacute;rios, pois o julgado define a aplica&ccedil;&atilde;o da taxa m&eacute;dia de mercado divulgada pelo Banco Central.
+A insurg&ecirc;ncia da parte embargante revela mero inconformismo com o resultado do julgamento, caracterizando tentativa de reexame da mat&eacute;ria.
+O &oacute;rg&atilde;o julgador n&atilde;o est&aacute; obrigado a rebater todos os argumentos das partes quando j&aacute; apresenta fundamenta&ccedil;&atilde;o suficiente para a conclus&atilde;o adotada.
+Recurso desprovido.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito, sendo cab&iacute;veis apenas para sanar v&iacute;cios previstos no art. 1.022 do CPC.
+N&atilde;o h&aacute; omiss&atilde;o quando o ac&oacute;rd&atilde;o enfrenta de forma suficiente as quest&otilde;es essenciais ao deslinde da controvimento.
+A sucumb&ecirc;ncia rec&iacute;proca &eacute; adequada quando ambas as partes obt&ecirc;m &ecirc;xito parcial na demanda.
+A fixa&ccedil;&atilde;o de honor&aacute;rios por equidade &eacute; v&aacute;lida quando invi&aacute;vel a mensura&ccedil;&atilde;o do proveito econ&ocirc;mico.
+A defini&ccedil;&atilde;o expressa de crit&eacute;rios de juros no ac&oacute;rd&atilde;o afasta alega&ccedil;&atilde;o de obscuridade.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no AgInt na SLS n&ordm; 3294/RJ, Rel. Min. Maria Thereza de Assis Moura, Corte Especial, j. 07.02.2024, DJe 14.02.2024 .&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0706552-59.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(16 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Interpretação / Revisão de Contrato
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. AUSÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. PRETENSÃO DE REDISCUSSÃO DA MATÉRIA. EMBARGOS REJEITADOS
+I. CASO EM EXAME
+Embargos de declaração interpostos contra acórdão que, deu parcial provimento ao recurso para afastar a condenação por <em>danos</em> <em>morais</em>, ajustar juros remuneratórios e reconhecer sucumbência recíproca, sob
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. AUSÊNCIA DE OMISSÃO, CONTRADIÇÃO OU OBSCURIDADE. PRETENSÃO DE REDISCUSSÃO DA MATÉRIA. EMBARGOS REJEITADOS
+I. CASO EM EXAME
+Embargos de declaração interpostos contra acórdão que, deu parcial provimento ao recurso para afastar a condenação por <em>danos</em> <em>morais</em>, ajustar juros remuneratórios e reconhecer sucumbência recíproca, sob alegação de omissões, contradições e obscuridades quanto à análise dos <em>danos</em> <em>morais</em>, distribuição da sucumbência, fixação de honorários e critérios de juros .
+Há quatro questões em discussão: (i) definir se o acórdão embargado incorre em omissão quanto à análise dos <em>danos</em> <em>morais</em>; (ii) estabelecer se há contradição na fixação da sucumbência recíproca; (iii) determinar se houve omissão ou inadequação na fixação dos honorários advocatícios; e (iv) verificar eventual obscuridade na definição dos juros remuneratórios .
+Os embargos de declaração possuem finalidade integrativa e se limitam às hipóteses do art. 1.022 do CPC, não se prestando à rediscussão do mérito da decisão.
+O acórdão enfrenta expressamente a questão dos <em>danos</em> <em>morais</em> e afasta a indenização por ausência de prova de lesão extrapatrimonial relevante.
+A decisão reconhece o êxito parcial de ambas as partes, o que justifica a fixação da sucumbência recíproca, inexistindo contradição.
+O acórdão analisa a fixação dos honorários advocatícios e adota o critério de equidade diante da impossibilidade de mensuração do proveito econômico.
+Não há obscuridade quanto aos juros remuneratórios, pois o julgado define a aplicação da taxa média de mercado divulgada pelo Banco Central.
+A insurgência da parte embargante revela mero inconformismo com o resultado do julgamento, caracterizando tentativa de reexame da matéria.
+O órgão julgador não está obrigado a rebater todos os argumentos das partes quando já apresenta fundamentação suficiente para a conclusão adotada.
+Recurso desprovido.
+Os embargos de declaração não se prestam à rediscussão do mérito, sendo cabíveis apenas para sanar vícios previstos no art. 1.022 do CPC.
+Não há omissão quando o acórdão enfrenta de forma suficiente as questões essenciais ao deslinde da controvimento.
+A sucumbência recíproca é adequada quando ambas as partes obtêm êxito parcial na demanda.
+A fixação de honorários por equidade é válida quando inviável a mensuração do proveito econômico.
+A definição expressa de critérios de juros no acórdão afasta alegação de obscuridade.
+Jurisprudência relevante citada: STJ, EDcl no AgInt na SLS nº 3294/RJ, Rel. Min. Maria Thereza de Assis Moura, Corte Especial, j. 07.02.2024, DJe 14.02.2024 .
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503730" cdForo="0" >
+										0702356-77.2024.8.01.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503730" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503730);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503730" style="display: none;" >
+	<div id="textAreaDados_2503730" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O DE AC&Oacute;RD&Atilde;O UN&Acirc;NIME EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. INCONFORMISMO. PRETENS&Atilde;O DE REDISCUSS&Atilde;O DE MAT&Eacute;RIA J&Aacute; DECIDIDA. EMBARGOS DE DECLARA&Ccedil;&Atilde;O REJEITADOS.
+I. CASO EM EXAME
+1. Embargos de declara&ccedil;&atilde;o opostos contra ac&oacute;rd&atilde;o que, por unanimidade, deu provimento &agrave; apela&ccedil;&atilde;o interposta pela parte embargada.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Verificar a ocorr&ecirc;ncia de v&iacute;cio no ac&oacute;rd&atilde;o que justifique a oposi&ccedil;&atilde;o de embargos de declara&ccedil;&atilde;o, ou se os embargos foram manipulados para rediscutir mat&eacute;ria j&aacute; decidida.
+III. RAZ&Otilde;ES DE DECIDIR
+3. N&atilde;o h&aacute; omiss&atilde;o, contradi&ccedil;&atilde;o, obscuridade ou erro material no ac&oacute;rd&atilde;o embargado, sendo despicienda nova manifesta&ccedil;&atilde;o deste Colegiado. Os embargos de declara&ccedil;&atilde;o n&atilde;o s&atilde;o cab&iacute;veis para rediscuss&atilde;o do m&eacute;rito.
+4. O julgador n&atilde;o &eacute; obrigado a responder todos os pontos, artigos de lei e s&uacute;mulas apontados pelas partes, desde que a decis&atilde;o seja devidamente fundamentada.
+IV. DISPOSITIVO E TESE
+5. Embargos de Declara&ccedil;&atilde;o rejeitados. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:0702356-77.2024.8.01.0002;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO DE ACÓRDÃO UNÂNIME EM APELAÇÃO CÍVEL. INCONFORMISMO. PRETENSÃO DE REDISCUSSÃO DE MATÉRIA JÁ DECIDIDA. EMBARGOS DE DECLARAÇÃO REJEITADOS.
+I. CASO EM EXAME
+1. Embargos de declaração opostos contra acórdão que, por unanimidade, deu provimento à apelação interposta pela parte embargada.
+II. QUESTÃO EM DISCUSSÃO
+2. Verificar a ocorrência de vício no
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO DE ACÓRDÃO UNÂNIME EM APELAÇÃO CÍVEL. INCONFORMISMO. PRETENSÃO DE REDISCUSSÃO DE MATÉRIA JÁ DECIDIDA. EMBARGOS DE DECLARAÇÃO REJEITADOS.
+I. CASO EM EXAME
+1. Embargos de declaração opostos contra acórdão que, por unanimidade, deu provimento à apelação interposta pela parte embargada.
+II. QUESTÃO EM DISCUSSÃO
+2. Verificar a ocorrência de vício no acórdão que justifique a oposição de embargos de declaração, ou se os embargos foram manipulados para rediscutir matéria já decidida.
+III. RAZÕES DE DECIDIR
+3. Não há omissão, contradição, obscuridade ou erro material no acórdão embargado, sendo despicienda nova manifestação deste Colegiado. Os embargos de declaração não são cabíveis para rediscussão do mérito.
+4. O julgador não é obrigado a responder todos os pontos, artigos de lei e súmulas apontados pelas partes, desde que a decisão seja devidamente fundamentada.
+IV. DISPOSITIVO E TESE
+5. Embargos de Declaração rejeitados.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503722" cdForo="0" >
+										0713956-98.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503722" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503722);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503722" style="display: none;" >
+	<div id="textAreaDados_2503722" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. REDISCUSS&Atilde;O DA MAT&Eacute;RIA. AUS&Ecirc;NCIA DE OBSCURIDADE, CONTRADI&Ccedil;&Atilde;O, OMISS&Atilde;O OU ERRO MATERIAL. CONSEQUENTE INEXIST&Ecirc;NCIA DE V&Iacute;CIOS. PREQUESTIONAMENTO. N&Atilde;O VIOLA&Ccedil;&Atilde;O DO ART. 1.022 DO CPC/2015. ACLARAT&Oacute;RIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que, por unanimidade, negou provimento ao recurso de apela&ccedil;&atilde;o da parte embargante.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Avalia-se a ocorr&ecirc;ncia de omiss&atilde;o e contradi&ccedil;&atilde;o no ac&oacute;rd&atilde;o recorrido, por supostamente n&atilde;o ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequa&ccedil;&atilde;o do recurso para fins de prequestionamento &agrave;s inst&acirc;ncias superiores.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Inexist&ecirc;ncia de omiss&atilde;o/contradi&ccedil;&atilde;o: O ac&oacute;rd&atilde;o recorrido analisou de forma clara e exauriente a controv&eacute;rsia, bem como as quest&otilde;es suscitadas pelas partes, sobretudo quanto aos efeitos relativos da revelia e &agrave; aus&ecirc;ncia de cautela do autor, quest&otilde;es essas que j&aacute; foram apreciadas e decididas no ac&oacute;rd&atilde;o embargado, sendo despicienda nova manifesta&ccedil;&atilde;o deste Colegiado. O ju&iacute;zo n&atilde;o est&aacute; obrigado a responder a um question&aacute;rio, mas a fundamentar sua decis&atilde;o.
+4. Rediscuss&atilde;o de m&eacute;rito: A parte embargante, a pretexto de sanar pretensa omiss&atilde;o/contradi&ccedil;&atilde;o, busca, na verdade, a rediscuss&atilde;o do m&eacute;rito da causa e a reforma do julgado, finalidade para a qual os embargos de declara&ccedil;&atilde;o s&atilde;o via inadequada, conforme pac&iacute;fica jurisprud&ecirc;ncia do STJ.
+5. Prequestionamento: A aus&ecirc;ncia dos v&iacute;cios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, S&uacute;mula n.&ordm; 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando inclu&iacute;dos no ac&oacute;rd&atilde;o os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordin&aacute;rio, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: &quot;N&atilde;o h&aacute; que se falar em omiss&atilde;o/contradi&ccedil;&atilde;o quando o ac&oacute;rd&atilde;o analisa suficientemente a mat&eacute;ria posta em debate, com fundamenta&ccedil;&atilde;o clara e coerente, sendo desnecess&aacute;rio o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito da causa, e sua rejei&ccedil;&atilde;o &eacute; medida impositiva quando ausentes os v&iacute;cios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento&quot;. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0713956-98.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao recurso
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. REDISCUSSÃO DA MATÉRIA. AUSÊNCIA DE OBSCURIDADE, CONTRADIÇÃO, OMISSÃO OU ERRO MATERIAL. CONSEQUENTE INEXISTÊNCIA DE VÍCIOS. PREQUESTIONAMENTO. NÃO VIOLAÇÃO DO ART. 1.022 DO CPC/2015. ACLARATÓRIOS REJEITADOS.
+I. CASO EM EXAME
+1. Trata-se de recurso de embargos de declaração opostos em face de acórdão que, por unanimidade, negou provimento ao recurso de apelação da parte embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Avalia-se a ocorrência de omissão e contradição no acórdão recorrido, por supostamente não ter enfrentado as teses propostas e os dispositivos legais e constitucionais invocados pela parte embargante, bem como a adequação do recurso para fins de prequestionamento às instâncias superiores.
+III. RAZÕES DE DECIDIR
+3. Inexistência de omissão/contradição: O acórdão recorrido analisou de forma clara e exauriente a controvérsia, bem como as questões suscitadas pelas partes, sobretudo quanto aos efeitos relativos da revelia e à ausência de cautela do autor, questões essas que já foram apreciadas e decididas no acórdão embargado, sendo despicienda nova manifestação deste Colegiado. O juízo não está obrigado a responder a um questionário, mas a fundamentar sua decisão.
+4. Rediscussão de mérito: A parte embargante, a pretexto de sanar pretensa omissão/contradição, busca, na verdade, a rediscussão do mérito da causa e a reforma do julgado, finalidade para a qual os embargos de declaração são via inadequada, conforme pacífica jurisprudência do STJ.
+5. Prequestionamento: A ausência dos vícios do art. 1.022 do CPC/2015 impede o acolhimento dos embargos, ainda que opostos para fins de prequestionamento (STJ, Súmula n.º 98). Ademais, o art. 1.025 do CPC/2015 consagra o prequestionamento ficto, considerando incluídos no acórdão os elementos que a parte embargante suscitou, para fins de eventual recurso especial ou extraordinário, ainda que os embargos sejam inadmitidos ou rejeitados.
+IV. DISPOSITIVO
+6. Recurso rejeitado.
+Tese de julgamento: "Não há que se falar em omissão/contradição quando o acórdão analisa suficientemente a matéria posta em debate, com fundamentação clara e coerente, sendo desnecessário o exame pormenorizado de todos os argumentos e dispositivos legais invocados pela parte. Os embargos de declaração não se prestam à rediscussão do mérito da causa, e sua rejeição é medida impositiva quando ausentes os vícios do art. 1.022 do CPC, ainda que opostos para fins de prequestionamento".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503721" cdForo="0" >
+										0709275-90.2021.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503721" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503721);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503721" style="display: none;" >
+	<div id="textAreaDados_2503721" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. DUPLA INTERPOSI&Ccedil;&Atilde;O CONTRA O MESMO AC&Oacute;RD&Atilde;O. PRINC&Iacute;PIO DA UNIRRECORRIBILIDADE. PRECLUS&Atilde;O CONSUMATIVA. RESPONSABILIDADE SOLID&Aacute;RIA ENTRE LITISCONSORTES. ART. 87, &sect;2&ordm;, DO CPC. INEXIST&Ecirc;NCIA DE V&Iacute;CIOS. REDISCUSS&Atilde;O DO M&Eacute;RITO. IMPOSSIBILIDADE. REJEI&Ccedil;&Atilde;O.
+I. CASO EM EXAME
+Embargos de declara&ccedil;&atilde;o opostos por Banco Daycoval S.A. contra ac&oacute;rd&atilde;o da Segunda C&acirc;mara C&iacute;vel do TJAC que negou provimento &agrave; apela&ccedil;&atilde;o e manteve senten&ccedil;a proferida em cumprimento de senten&ccedil;a, reconhecendo a quita&ccedil;&atilde;o de honor&aacute;rios sucumbenciais e aplicando a responsabilidade solid&aacute;ria entre litisconsortes, sendo constatada a interposi&ccedil;&atilde;o de dois embargos contra o mesmo decisum.
+H&aacute; cinco quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; admiss&iacute;vel a oposi&ccedil;&atilde;o de m&uacute;ltiplos embargos de declara&ccedil;&atilde;o contra a mesma decis&atilde;o &agrave; luz do princ&iacute;pio da unirrecorribilidade; (ii) verificar a exist&ecirc;ncia de omiss&atilde;o, contradi&ccedil;&atilde;o ou obscuridade no ac&oacute;rd&atilde;o; (iii) estabelecer se houve viola&ccedil;&atilde;o &agrave; coisa julgada e ao princ&iacute;pio da n&atilde;o surpresa pela aplica&ccedil;&atilde;o do art. 87, &sect;2&ordm;, do CPC; (iv) determinar se houve cerceamento de defesa; e (v) aferir a ocorr&ecirc;ncia de excesso de execu&ccedil;&atilde;o e a limita&ccedil;&atilde;o da responsabilidade do embargante.
+O princ&iacute;pio da unirrecorribilidade impede a interposi&ccedil;&atilde;o de mais de um recurso contra a mesma decis&atilde;o, operando-se a preclus&atilde;o consumativa com o primeiro recurso, o que torna inadmiss&iacute;vel o segundo embargo declarat&oacute;rio.
+O ac&oacute;rd&atilde;o embargado enfrenta de forma expressa todas as teses suscitadas, inexistindo omiss&atilde;o, contradi&ccedil;&atilde;o, obscuridade ou erro material, nos termos do art. 1.022 do CPC.
+A aus&ecirc;ncia de previs&atilde;o expressa de rateio na senten&ccedil;a autoriza a aplica&ccedil;&atilde;o da responsabilidade solid&aacute;ria entre litisconsortes, conforme art. 87, &sect;2&ordm;, do CPC.
+A incid&ecirc;ncia da solidariedade legal n&atilde;o configura amplia&ccedil;&atilde;o da coisa julgada nem cria&ccedil;&atilde;o de obriga&ccedil;&atilde;o nova, mas aplica&ccedil;&atilde;o autom&aacute;tica de norma jur&iacute;dica.
+N&atilde;o h&aacute; viola&ccedil;&atilde;o ao princ&iacute;pio da n&atilde;o surpresa, pois a mat&eacute;ria foi devidamente debatida e apreciada.
+Afasta-se o cerceamento de defesa, diante da ampla devolu&ccedil;&atilde;o e aprecia&ccedil;&atilde;o da controv&eacute;rsia.
+N&atilde;o h&aacute; excesso de execu&ccedil;&atilde;o, pois a cobran&ccedil;a integral decorre da solidariedade legal.
+Os embargos de declara&ccedil;&atilde;o possuem natureza integrativa e n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito ou &agrave; reforma da decis&atilde;o por mero inconformismo.
+Recurso desprovido.
+Tese de julgamento:
+A interposi&ccedil;&atilde;o de mais de um recurso contra a mesma decis&atilde;o viola o princ&iacute;pio da unirrecorribilidade e enseja preclus&atilde;o consumativa.
+A aus&ecirc;ncia de rateio expresso dos honor&aacute;rios sucumbenciais imp&otilde;e a responsabilidade solid&aacute;ria entre litisconsortes, nos termos do art. 87, &sect;2&ordm;, do CPC.
+Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o do m&eacute;rito, sendo cab&iacute;veis apenas para sanar v&iacute;cios do art. 1.022 do CPC.
+A aplica&ccedil;&atilde;o da solidariedade legal em cumprimento de senten&ccedil;a n&atilde;o viola a coisa julgada nem configura decis&atilde;o surpresa.
+A cobran&ccedil;a integral do d&eacute;bito, fundada na solidariedade, afasta a alega&ccedil;&atilde;o de excesso de execu&ccedil;&atilde;o.
+Dispositivos relevantes citados: CPC/2015, arts. 87, &sect;2&ordm;; 1.022; 1.023; 1.024, &sect;2&ordm;; 1.025; 1.026, &sect;2&ordm;.
+Jurisprud&ecirc;ncia relevante citada: TJ-SP, EMBDECCV 0511079-57.2010.8.26.0554, Rel. M&ocirc;nica Serrano, j. 02.03.2023; TJ-PR, ED 0005614-02.2019.8.16.0130, Rel. Marcel Guimar&atilde;es Rotoli de Macedo, j. 11.02.2022; TJ-MS, EMBDECCV 0800596-36.2018.8.12.0025, Rel. Des. Jo&atilde;o Maria L&oacute;s, j. 15.12.2021; TJ-CE, EMBDECCV 0111467-46.2017.8.06.0001, Rel. Teodoro Silva Santos, j. 26.07.2021; TJ-RS, EMBDECCV 70084891183, Rel. Francesco Conti, j. 29.03.2021; TJ-MT, EMBDECCV 00084308320108110041, Rel. Gilberto Lopes Bussiki, j. 12.08.2020; TJ-SC, ED 4000098-10.2019.8.24.0000, Rel. Marcus Tulio Sartorato, j. 06.08.2019; STJ, ED/EDAgRgREsp 1.326.841/PR, 2&ordf; T., Rel&ordf; Min&ordf; Diva Malerbi, j. 21.06.2016. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0709275-90.2021.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 17/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. DUPLA INTERPOSIÇÃO CONTRA O MESMO ACÓRDÃO. PRINCÍPIO DA UNIRRECORRIBILIDADE. PRECLUSÃO CONSUMATIVA. RESPONSABILIDADE SOLIDÁRIA ENTRE LITISCONSORTES. ART. 87, §2º, DO CPC. INEXISTÊNCIA DE VÍCIOS. REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. REJEIÇÃO.
+I. CASO EM EXAME
+Embargos de declaração opostos por Banco Daycoval S.A. contra acórdão da Segunda
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO. DUPLA INTERPOSIÇÃO CONTRA O MESMO ACÓRDÃO. PRINCÍPIO DA UNIRRECORRIBILIDADE. PRECLUSÃO CONSUMATIVA. RESPONSABILIDADE SOLIDÁRIA ENTRE LITISCONSORTES. ART. 87, §2º, DO CPC. INEXISTÊNCIA DE VÍCIOS. REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. REJEIÇÃO.
+I. CASO EM EXAME
+Embargos de declaração opostos por Banco Daycoval S.A. contra acórdão da Segunda Câmara Cível do TJAC que negou provimento à apelação e manteve sentença proferida em cumprimento de sentença, reconhecendo a quitação de honorários sucumbenciais e aplicando a responsabilidade solidária entre litisconsortes, sendo constatada a interposição de dois embargos contra o mesmo decisum.
+Há cinco questões em discussão: (i) definir se é admissível a oposição de múltiplos embargos de declaração contra a mesma decisão à luz do princípio da unirrecorribilidade; (ii) verificar a existência de omissão, contradição ou obscuridade no acórdão; (iii) estabelecer se houve violação à coisa julgada e ao princípio da não surpresa pela aplicação do art. 87, §2º, do CPC; (iv) determinar se houve cerceamento de defesa; e (v) aferir a ocorrência de excesso de execução e a limitação da responsabilidade do embargante.
+O princípio da unirrecorribilidade impede a interposição de mais de um recurso contra a mesma decisão, operando-se a preclusão consumativa com o primeiro recurso, o que torna inadmissível o segundo embargo declaratório.
+O acórdão embargado enfrenta de forma expressa todas as teses suscitadas, inexistindo omissão, contradição, obscuridade ou erro material, nos termos do art. 1.022 do CPC.
+A ausência de previsão expressa de rateio na sentença autoriza a aplicação da responsabilidade solidária entre litisconsortes, conforme art. 87, §2º, do CPC.
+A incidência da solidariedade legal não configura ampliação da coisa julgada nem criação de obrigação nova, mas aplicação automática de norma jurídica.
+Não há violação ao princípio da não surpresa, pois a matéria foi devidamente debatida e apreciada.
+Afasta-se o cerceamento de defesa, diante da ampla devolução e apreciação da controvérsia.
+Não há excesso de execução, pois a cobrança integral decorre da solidariedade legal.
+Os embargos de declaração possuem natureza integrativa e não se prestam à rediscussão do mérito ou à reforma da decisão por mero inconformismo.
+Recurso desprovido.
+Tese de julgamento:
+A interposição de mais de um recurso contra a mesma decisão viola o princípio da unirrecorribilidade e enseja preclusão consumativa.
+A ausência de rateio expresso dos honorários sucumbenciais impõe a responsabilidade solidária entre litisconsortes, nos termos do art. 87, §2º, do CPC.
+Os embargos de declaração não se prestam à rediscussão do mérito, sendo cabíveis apenas para sanar vícios do art. 1.022 do CPC.
+A aplicação da solidariedade legal em cumprimento de sentença não viola a coisa julgada nem configura decisão surpresa.
+A cobrança integral do débito, fundada na solidariedade, afasta a alegação de excesso de execução.
+Dispositivos relevantes citados: CPC/2015, arts. 87, §2º; 1.022; 1.023; 1.024, §2º; 1.025; 1.026, §2º.
+Jurisprudência relevante citada: TJ-SP, EMBDECCV 0511079-57.2010.8.26.0554, Rel. Mônica Serrano, j. 02.03.2023; TJ-PR, ED 0005614-02.2019.8.16.0130, Rel. Marcel Guimarães Rotoli de Macedo, j. 11.02.2022; TJ-MS, EMBDECCV 0800596-36.2018.8.12.0025, Rel. Des. João Maria Lós, j. 15.12.2021; TJ-CE, EMBDECCV 0111467-46.2017.8.06.0001, Rel. Teodoro Silva Santos, j. 26.07.2021; TJ-RS, EMBDECCV 70084891183, Rel. Francesco Conti, j. 29.03.2021; TJ-MT, EMBDECCV 00084308320108110041, Rel. Gilberto Lopes Bussiki, j. 12.08.2020; TJ-SC, ED 4000098-10.2019.8.24.0000, Rel. Marcus Tulio Sartorato, j. 06.08.2019; STJ, ED/EDAgRgREsp 1.326.841/PR, 2ª T., Relª Minª Diva Malerbi, j. 21.06.2016.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503767" cdForo="0" >
+										0723261-09.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503767" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503767);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503767" style="display: none;" >
+	<div id="textAreaDados_2503767" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO CUMULADA COM INDENIZA&Ccedil;&Atilde;O. FRAUDE BANC&Aacute;RIA. SERVI&Ccedil;OS DE PLATAFORMA DIGITAL DE PAGAMENTOS. TRANSA&Ccedil;&Otilde;ES REALIZADAS POR TERCEIRO MEDIANTE USO DE SENHA PESSOAL E DUPLO FATOR DE AUTENTICA&Ccedil;&Atilde;O. FRAUDE PERPETRADA POR TERCEIRO. CULPA EXCLUSIVA DO CONSUMIDOR. DEVER DE GUARDA E SIGILO DAS CREDENCIAIS. RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. INOCORR&Ecirc;NCIA. EXCLUDENTE DE RESPONSABILIDADE. ART. 14, &sect; 3&ordm;, INC. II, DO CDC/1990. CULPA EXCLUSIVA DO CONSUMIDOR. CONFIGURA&Ccedil;&Atilde;O. FORTUITO EXTERNO. INAPLICABILIDADE DA S&Uacute;MULA 479/STJ. INEXIST&Ecirc;NCIA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. NEXO DE CAUSALIDADE ROMPIDO. DEVER DE INDENIZAR AFASTADO. SENTEN&Ccedil;A REFORMADA. RECURSO PROVIDO. SENTEN&Ccedil;A REFORMADA.
+I. CASO EM EXAME
+1. Trata-se de recurso de apela&ccedil;&atilde;o interposto por uma institui&ccedil;&atilde;o de pagamento digital contra senten&ccedil;a que a condenou a anular transa&ccedil;&otilde;es e restituir valores a um consumidor.
+2. O autor alegou ter sido v&iacute;tima de fraude em sua conta, com opera&ccedil;&otilde;es que n&atilde;o reconhece, sustentando a responsabilidade objetiva da empresa por falha na seguran&ccedil;a.
+3. A institui&ccedil;&atilde;o financeira, por sua vez, defendeu que as transa&ccedil;&otilde;es foram validadas com senha pessoal e intransfer&iacute;vel, al&eacute;m de um segundo fator de autentica&ccedil;&atilde;o, configurando culpa exclusiva da v&iacute;tima.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. A controv&eacute;rsia consiste em definir a responsabilidade da institui&ccedil;&atilde;o financeira por transa&ccedil;&otilde;es fraudulentas realizadas por terceiros quando a autentica&ccedil;&atilde;o ocorre mediante o uso de senha pessoal do correntista e confirma&ccedil;&atilde;o por duplo fator de seguran&ccedil;a (2FA); ou se tal fato caracteriza culpa exclusiva do consumidor, afastando o dever de indenizar.
+III. RAZ&Otilde;ES DE DECIDIR
+5. A responsabilidade das institui&ccedil;&otilde;es financeiras por danos decorrentes de fraudes praticadas por terceiros &eacute;, em regra, objetiva, conforme a S&uacute;mula n.&ordm; 479 do STJ, por se tratar de fortuito interno.
+6. Contudo, o CDC/1990, em seu art. 14, &sect; 3&ordm;, inc. II, prev&ecirc; como excludente de responsabilidade a culpa exclusiva do consumidor ou de terceiro.
+7. No caso concreto, ficou demonstrado que as opera&ccedil;&otilde;es contestadas foram autenticadas mediante o uso de credenciais sigilosas (senha pessoal) e um segundo fator de verifica&ccedil;&atilde;o (biometria facial), um mecanismo de seguran&ccedil;a robusto que indica que o fraudador s&oacute; obteve &ecirc;xito por ter acesso a dados fornecidos pela pr&oacute;pria v&iacute;tima.
+8. Essa situa&ccedil;&atilde;o, conhecida como &quot;engenharia social&quot; ou &quot;phishing&quot;, em que o consumidor &eacute; ludibriado a fornecer seus dados sigilosos, caracteriza fortuito externo, rompendo o nexo de causalidade entre a conduta da institui&ccedil;&atilde;o financeira e o dano sofrido.
+9. A jurisprud&ecirc;ncia do STJ e deste Tribunal de Justi&ccedil;a (TJ-AC) reconhece que, ao descumprir o dever de guarda e sigilo de suas senhas e credenciais, o consumidor assume a responsabilidade pelos atos praticados, afastando a responsabilidade da institui&ccedil;&atilde;o por aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+IV. DISPOSITIVO
+10. Recurso provido, para reformar integralmente a senten&ccedil;a recorrida no sentido de julgar improcedentes os pedidos formulados na peti&ccedil;&atilde;o inicial.
+TESE DE JULGAMENTO
+&quot;1. A responsabilidade objetiva da institui&ccedil;&atilde;o financeira por fraudes praticadas por terceiros &eacute; afastada quando o dano decorre de fortuito externo, configurado pela culpa exclusiva do consumidor que, por meio de engenharia social, viabiliza as transa&ccedil;&otilde;es ao fornecer voluntariamente seus dados sigilosos e senhas.
+2. A utiliza&ccedil;&atilde;o de senha pessoal e de um segundo fator de autentica&ccedil;&atilde;o para validar as opera&ccedil;&otilde;es evidencia a aus&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o e rompe o nexo de causalidade, afastando o dever de indenizar&quot;.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0723261-09.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 14/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;3&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO CUMULADA COM INDENIZAÇÃO. FRAUDE BANCÁRIA. SERVIÇOS DE PLATAFORMA DIGITAL DE PAGAMENTOS. TRANSAÇÕES REALIZADAS POR TERCEIRO MEDIANTE USO DE SENHA PESSOAL E DUPLO FATOR DE AUTENTICAÇÃO. FRAUDE PERPETRADA POR TERCEIRO. CULPA EXCLUSIVA DO CONSUMIDOR. DEVER DE GUARDA E SIGILO DAS CREDENCIAIS. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO CUMULADA COM INDENIZAÇÃO. FRAUDE BANCÁRIA. SERVIÇOS DE PLATAFORMA DIGITAL DE PAGAMENTOS. TRANSAÇÕES REALIZADAS POR TERCEIRO MEDIANTE USO DE SENHA PESSOAL E DUPLO FATOR DE AUTENTICAÇÃO. FRAUDE PERPETRADA POR TERCEIRO. CULPA EXCLUSIVA DO CONSUMIDOR. DEVER DE GUARDA E SIGILO DAS CREDENCIAIS. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. INOCORRÊNCIA. EXCLUDENTE DE RESPONSABILIDADE. ART. 14, § 3º, INC. II, DO CDC/1990. CULPA EXCLUSIVA DO CONSUMIDOR. CONFIGURAÇÃO. FORTUITO EXTERNO. INAPLICABILIDADE DA SÚMULA 479/STJ. INEXISTÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO. NEXO DE CAUSALIDADE ROMPIDO. DEVER DE INDENIZAR AFASTADO. SENTENÇA REFORMADA. RECURSO PROVIDO. SENTENÇA REFORMADA.
+I. CASO EM EXAME
+1. Trata-se de recurso de apelação interposto por uma instituição de pagamento digital contra sentença que a condenou a anular transações e restituir valores a um consumidor.
+2. O autor alegou ter sido vítima de fraude em sua conta, com operações que não reconhece, sustentando a responsabilidade objetiva da empresa por falha na segurança.
+3. A instituição financeira, por sua vez, defendeu que as transações foram validadas com senha pessoal e intransferível, além de um segundo fator de autenticação, configurando culpa exclusiva da vítima.
+II. QUESTÃO EM DISCUSSÃO
+4. A controvérsia consiste em definir a responsabilidade da instituição financeira por transações fraudulentas realizadas por terceiros quando a autenticação ocorre mediante o uso de senha pessoal do correntista e confirmação por duplo fator de segurança (2FA); ou se tal fato caracteriza culpa exclusiva do consumidor, afastando o dever de indenizar.
+III. RAZÕES DE DECIDIR
+5. A responsabilidade das instituições financeiras por <em>danos</em> decorrentes de fraudes praticadas por terceiros é, em regra, objetiva, conforme a Súmula n.º 479 do STJ, por se tratar de fortuito interno.
+6. Contudo, o CDC/1990, em seu art. 14, § 3º, inc. II, prevê como excludente de responsabilidade a culpa exclusiva do consumidor ou de terceiro.
+7. No caso concreto, ficou demonstrado que as operações contestadas foram autenticadas mediante o uso de credenciais sigilosas (senha pessoal) e um segundo fator de verificação (biometria facial), um mecanismo de segurança robusto que indica que o fraudador só obteve êxito por ter acesso a dados fornecidos pela própria vítima.
+8. Essa situação, conhecida como "engenharia social" ou "phishing", em que o consumidor é ludibriado a fornecer seus dados sigilosos, caracteriza fortuito externo, rompendo o nexo de causalidade entre a conduta da instituição financeira e o <em>dano</em> sofrido.
+9. A jurisprudência do STJ e deste Tribunal de Justiça (TJ-AC) reconhece que, ao descumprir o dever de guarda e sigilo de suas senhas e credenciais, o consumidor assume a responsabilidade pelos atos praticados, afastando a responsabilidade da instituição por ausência de falha na prestação do serviço.
+IV. DISPOSITIVO
+10. Recurso provido, para reformar integralmente a sentença recorrida no sentido de julgar improcedentes os pedidos formulados na petição inicial.
+TESE DE JULGAMENTO
+"1. A responsabilidade objetiva da instituição financeira por fraudes praticadas por terceiros é afastada quando o <em>dano</em> decorre de fortuito externo, configurado pela culpa exclusiva do consumidor que, por meio de engenharia social, viabiliza as transações ao fornecer voluntariamente seus dados sigilosos e senhas.
+2. A utilização de senha pessoal e de um segundo fator de autenticação para validar as operações evidencia a ausência de falha na prestação do serviço e rompe o nexo de causalidade, afastando o dever de indenizar".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503763" cdForo="0" >
+										0700550-73.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503763" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503763);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503763" style="display: none;" >
+	<div id="textAreaDados_2503763" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. ACIDENTE EM DEPEND&Ecirc;NCIA DE HOSPITAL P&Uacute;BLICO. QUEDA DE PORT&Atilde;O SOBRE SERVIDORA. OMISS&Atilde;O NO DEVER DE MANUTEN&Ccedil;&Atilde;O E SEGURAN&Ccedil;A. &quot;FAUTE DU SERVICE&quot;. RESPONSABILIDADE OBJETIVA. NEXO DE CAUSALIDADE COMPROVADO. DANO MORAL &quot;IN RE IPSA&quot;. DEVER DE INDENIZAR. VALOR DA INDENIZA&Ccedil;&Atilde;O. MANUTEN&Ccedil;&Atilde;O. PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. DESPROVIMENTO DO RECURSO.
+I. CASO EM EXAME
+1. Trata-se de recurso de apela&ccedil;&atilde;o interposto pela Fazenda P&uacute;blica contra senten&ccedil;a que o condenou ao pagamento de indeniza&ccedil;&atilde;o por danos morais, no valor de R$ 10.000,00 (dez mil reais), em favor de servidora p&uacute;blica que sofreu acidente nas depend&ecirc;ncias de hospital da rede p&uacute;blica, ao ser atingida pela queda de um port&atilde;o.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A controv&eacute;rsia consiste em definir a responsabilidade civil do Estado pelo acidente ocorrido, analisando a presen&ccedil;a de seus pressupostos &#150;  conduta, dano e nexo de causalidade; e, em caso de confirma&ccedil;&atilde;o, avaliar se o montante fixado a t&iacute;tulo de danos morais atende aos crit&eacute;rios da razoabilidade e da proporcionalidade.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A responsabilidade civil do Estado &eacute;, em regra, objetiva, fundamentada na teoria do risco administrativo, conforme o art. 37, &sect; 6&ordm;, da CF/1988.
+3.1. Tal responsabilidade se aplica tamb&eacute;m aos casos de omiss&atilde;o, quando o Estado descumpre um dever legal espec&iacute;fico de agir, configurando a &quot;faute du servisse&quot; (falta do servi&ccedil;o).
+4. No caso concreto, a queda de um port&atilde;o sobre a servidora em uma unidade hospitalar p&uacute;blica evidencia a omiss&atilde;o do Estado em seu dever de garantir a manuten&ccedil;&atilde;o e a seguran&ccedil;a de suas instala&ccedil;&otilde;es.
+4.1. A falta de conserva&ccedil;&atilde;o adequada foi a causa direta do acidente, estabelecendo o nexo de causalidade entre a omiss&atilde;o estatal e o dano sofrido pela v&iacute;tima.
+5. O dano moral &eacute; presumido (&quot;in re ipsa&quot;), decorrendo do pr&oacute;prio evento e das les&otilde;es f&iacute;sicas e do abalo psicol&oacute;gico sofridos pela servidora, que ultrapassam o mero dissabor cotidiano.
+6. Embora o dever de indenizar seja inquestion&aacute;vel, o valor da indeniza&ccedil;&atilde;o deve ser pautado pelos princ&iacute;pios da razoabilidade e da proporcionalidade, considerando a extens&atilde;o do dano, a capacidade econ&ocirc;mica das partes e a dupla finalidade da medida: compensat&oacute;ria para a v&iacute;tima e pedag&oacute;gica para o ofensor.
+6.1. O valor de R$ 10.000,00 (dez mil reais) mostra-se adequado ao caso concreto.
+IV. DISPOSITIVO
+7. Recurso n&atilde;o provido, para manter a senten&ccedil;a recorrida.
+TESE DE JULGAMENTO
+&quot;A omiss&atilde;o do Estado no dever de manuten&ccedil;&atilde;o e seguran&ccedil;a de suas instala&ccedil;&otilde;es, resultando em acidente com dano a servidor p&uacute;blico, configura &quot;faute du servisse&quot; e gera a obriga&ccedil;&atilde;o de indenizar com base na responsabilidade civil objetiva, devendo o valor da indeniza&ccedil;&atilde;o por danos morais ser fixado em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e da proporcionalidade&quot;.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0700550-73.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 14/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara da Fazenda P&uacute;blica&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(41 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. ACIDENTE EM DEPENDÊNCIA DE HOSPITAL PÚBLICO. QUEDA DE PORTÃO SOBRE SERVIDORA. OMISSÃO NO DEVER DE MANUTENÇÃO E SEGURANÇA. "FAUTE DU SERVICE". RESPONSABILIDADE OBJETIVA. NEXO DE CAUSALIDADE COMPROVADO. <em>DANO</em> <em>MORAL</em> "IN RE IPSA". DEVER DE INDENIZAR. VALOR DA INDENIZAÇÃO. MANUTENÇÃO. PRINCÍPIOS DA RAZOABILIDADE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. ACIDENTE EM DEPENDÊNCIA DE HOSPITAL PÚBLICO. QUEDA DE PORTÃO SOBRE SERVIDORA. OMISSÃO NO DEVER DE MANUTENÇÃO E SEGURANÇA. "FAUTE DU SERVICE". RESPONSABILIDADE OBJETIVA. NEXO DE CAUSALIDADE COMPROVADO. <em>DANO</em> <em>MORAL</em> "IN RE IPSA". DEVER DE INDENIZAR. VALOR DA INDENIZAÇÃO. MANUTENÇÃO. PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. DESPROVIMENTO DO RECURSO.
+I. CASO EM EXAME
+1. Trata-se de recurso de apelação interposto pela Fazenda Pública contra sentença que o condenou ao pagamento de indenização por <em>danos</em> <em>morais</em>, no valor de R$ 10.000,00 (dez mil reais), em favor de servidora pública que sofreu acidente nas dependências de hospital da rede pública, ao ser atingida pela queda de um portão.
+II. QUESTÃO EM DISCUSSÃO
+2. A controvérsia consiste em definir a responsabilidade civil do Estado pelo acidente ocorrido, analisando a presença de seus pressupostos   conduta, <em>dano</em> e nexo de causalidade; e, em caso de confirmação, avaliar se o montante fixado a título de <em>danos</em> <em>morais</em> atende aos critérios da razoabilidade e da proporcionalidade.
+III. RAZÕES DE DECIDIR
+3. A responsabilidade civil do Estado é, em regra, objetiva, fundamentada na teoria do risco administrativo, conforme o art. 37, § 6º, da CF/1988.
+3.1. Tal responsabilidade se aplica também aos casos de omissão, quando o Estado descumpre um dever legal específico de agir, configurando a "faute du servisse" (falta do serviço).
+4. No caso concreto, a queda de um portão sobre a servidora em uma unidade hospitalar pública evidencia a omissão do Estado em seu dever de garantir a manutenção e a segurança de suas instalações.
+4.1. A falta de conservação adequada foi a causa direta do acidente, estabelecendo o nexo de causalidade entre a omissão estatal e o <em>dano</em> sofrido pela vítima.
+5. O <em>dano</em> <em>moral</em> é presumido ("in re ipsa"), decorrendo do próprio evento e das lesões físicas e do abalo psicológico sofridos pela servidora, que ultrapassam o mero dissabor cotidiano.
+6. Embora o dever de indenizar seja inquestionável, o valor da indenização deve ser pautado pelos princípios da razoabilidade e da proporcionalidade, considerando a extensão do <em>dano</em>, a capacidade econômica das partes e a dupla finalidade da medida: compensatória para a vítima e pedagógica para o ofensor.
+6.1. O valor de R$ 10.000,00 (dez mil reais) mostra-se adequado ao caso concreto.
+IV. DISPOSITIVO
+7. Recurso não provido, para manter a sentença recorrida.
+TESE DE JULGAMENTO
+"A omissão do Estado no dever de manutenção e segurança de suas instalações, resultando em acidente com <em>dano</em> a servidor público, configura "faute du servisse" e gera a obrigação de indenizar com base na responsabilidade civil objetiva, devendo o valor da indenização por <em>danos</em> <em>morais</em> ser fixado em observância aos princípios da razoabilidade e da proporcionalidade".
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="APELAÇÃO">
+									<label for="ckTermo1">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="CIVIL">
+									<label for="ckTermo2">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="DIREITO">
+									<label for="ckTermo3">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="RECURSO">
+									<label for="ckTermo4">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="CÍVEL">
+									<label for="ckTermo5">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="Recurso">
+									<label for="ckTermo6">
+										Recurso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="parte">
+									<label for="ckTermo7">
+										parte
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="danos">
+									<label for="ckTermo8">
+										danos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="AÇÃO">
+									<label for="ckTermo9">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="desprovido">
+									<label for="ckTermo10">
+										desprovido
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="autos">
+									<label for="ckTermo11">
+										autos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="caso">
+									<label for="ckTermo12">
+										caso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="Código">
+									<label for="ckTermo13">
+										Código
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="Apelação">
+									<label for="ckTermo14">
+										Apelação
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="sentença">
+									<label for="ckTermo15">
+										sentença
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 20
+			</strong>
+			de 13929
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjac/samples/cjsg/results_normal_page_02.html
+++ b/tests/tjac/samples/cjsg/results_normal_page_02.html
@@ -1,0 +1,3578 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(13929)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="13929" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>21&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503769" cdForo="0" >
+										0702529-90.2013.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503769" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503769);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503769" style="display: none;" >
+	<div id="textAreaDados_2503769" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO ADMINISTRATIVO E CIVIL. RESPONSABILIDADE CIVIL DO ESTADO. PROCEDIMENTO CIR&Uacute;RGICO DE CATARATA REALIZADO NO &Acirc;MBITO DO PROGRAMA SA&Uacute;DE ITINERANTE. PERDA SIGNIFICATIVA DA CAPACIDADE VISUAL. LAUDO PERICIAL INCONCLUSIVO QUANTO AO NEXO CAUSAL. INCERTEZA PROBAT&Oacute;RIA. IMPOSSIBILIDADE DE IMPUTA&Ccedil;&Atilde;O DO &Ocirc;NUS &Agrave; V&Iacute;TIMA. CONTEXTO DIRETO DA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O P&Uacute;BLICO DE SA&Uacute;DE. CONFIGURA&Ccedil;&Atilde;O DO NEXO CAUSAL. DEVER DE INDENIZAR. DANOS MORAIS E EST&Eacute;TICOS. CUMULABILIDADE. FIXA&Ccedil;&Atilde;O DO QUANTUM. CRIT&Eacute;RIOS DE RAZOABILIDADE E PROPORCIONALIDADE. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedente pedido de indeniza&ccedil;&atilde;o por danos morais e est&eacute;ticos decorrentes de perda visual ap&oacute;s cirurgia de catarata realizada pela rede p&uacute;blica estadual.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Verificar a exist&ecirc;ncia de nexo causal entre o procedimento cir&uacute;rgico e o dano visual experimentado, bem como a eventual responsabilidade civil do Estado.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A responsabilidade civil do Estado, nos termos do art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal, &eacute; objetiva, exigindo a demonstra&ccedil;&atilde;o do dano e do nexo causal.
+4. Laudo pericial que n&atilde;o afasta, de forma conclusiva, a rela&ccedil;&atilde;o causal entre o procedimento e o dano, limitando-se a apontar a impossibilidade de determina&ccedil;&atilde;o precisa da origem da les&atilde;o.
+5. Em hip&oacute;teses em que a prova t&eacute;cnica &eacute; inconclusiva, a incerteza probat&oacute;ria n&atilde;o pode ser interpretada em desfavor da v&iacute;tima, sobretudo quando o dano surge no contexto da presta&ccedil;&atilde;o do servi&ccedil;o p&uacute;blico de sa&uacute;de.
+6. Perda significativa da capacidade visual que configura dano moral indeniz&aacute;vel.
+7. Dano est&eacute;tico caracterizado pela limita&ccedil;&atilde;o funcional permanente, sendo pass&iacute;vel de repara&ccedil;&atilde;o aut&ocirc;noma.
+8. Fixa&ccedil;&atilde;o dos danos morais em R$ 50.000,00 e dos danos est&eacute;ticos em R$ 20.000,00, observados os crit&eacute;rios de proporcionalidade e razoabilidade.
+IV. DISPOSITIVO E TESE
+11. Recurso provido.
+Tese de julgamento: &quot;Em casos de responsabilidade civil do Estado por servi&ccedil;o de sa&uacute;de, a aus&ecirc;ncia de conclus&atilde;o pericial quanto ao nexo causal, quando o dano decorre do contexto direto da atua&ccedil;&atilde;o estatal, n&atilde;o pode ser interpretada em preju&iacute;zo da v&iacute;tima, autorizando o reconhecimento do dever de indenizar.&quot;
+Dispositivos relevantes citados: CF/1988, art. 37, &sect; 6&ordm;; CC, arts. 186 e 927; CPC/2015, arts. 85, &sect; 2&ordm; e 1.025.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no REsp 1.653.046/DF; TJAC, Relator Des. J&uacute;nior Alberto, N&uacute;mero do Processo: 0700309-48.2015.8.01.0002, &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel, Data do julgamento: 30/09/2022, Data de registro: 30/09/2022; TJAC, Relator Des. Roberto Barros, N&uacute;mero do Processo:0700140-86.2014.8.01.0005, &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel, Data do julgamento: 07/11/2017, Data de registro: 09/11/2017.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0702529-90.2013.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 14/04/2026; Data de registro: 17/04/2026)<br> C&iacute;vel &nbsp;2&ordf; Vara de Fazenda P&uacute;blica de Rio Branco&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(84 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Serviços de Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO ADMINISTRATIVO E CIVIL. RESPONSABILIDADE CIVIL DO ESTADO. PROCEDIMENTO CIRÚRGICO DE CATARATA REALIZADO NO ÂMBITO DO PROGRAMA SAÚDE ITINERANTE. PERDA SIGNIFICATIVA DA CAPACIDADE VISUAL. LAUDO PERICIAL INCONCLUSIVO QUANTO AO NEXO CAUSAL. INCERTEZA PROBATÓRIA. IMPOSSIBILIDADE DE IMPUTAÇÃO DO ÔNUS À VÍTIMA. CONTEXTO DIRETO DA PRESTAÇÃO DO SERVIÇO PÚBLICO DE SAÚDE. CONFIGURAÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO ADMINISTRATIVO E CIVIL. RESPONSABILIDADE CIVIL DO ESTADO. PROCEDIMENTO CIRÚRGICO DE CATARATA REALIZADO NO ÂMBITO DO PROGRAMA SAÚDE ITINERANTE. PERDA SIGNIFICATIVA DA CAPACIDADE VISUAL. LAUDO PERICIAL INCONCLUSIVO QUANTO AO NEXO CAUSAL. INCERTEZA PROBATÓRIA. IMPOSSIBILIDADE DE IMPUTAÇÃO DO ÔNUS À VÍTIMA. CONTEXTO DIRETO DA PRESTAÇÃO DO SERVIÇO PÚBLICO DE SAÚDE. CONFIGURAÇÃO DO NEXO CAUSAL. DEVER DE INDENIZAR. <em>DANOS</em> <em>MORAIS</em> E ESTÉTICOS. CUMULABILIDADE. FIXAÇÃO DO QUANTUM. CRITÉRIOS DE RAZOABILIDADE E PROPORCIONALIDADE. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que julgou improcedente pedido de indenização por <em>danos</em> <em>morais</em> e estéticos decorrentes de perda visual após cirurgia de catarata realizada pela rede pública estadual.
+II. QUESTÃO EM DISCUSSÃO
+2. Verificar a existência de nexo causal entre o procedimento cirúrgico e o <em>dano</em> visual experimentado, bem como a eventual responsabilidade civil do Estado.
+III. RAZÕES DE DECIDIR
+3. A responsabilidade civil do Estado, nos termos do art. 37, § 6º, da Constituição Federal, é objetiva, exigindo a demonstração do <em>dano</em> e do nexo causal.
+4. Laudo pericial que não afasta, de forma conclusiva, a relação causal entre o procedimento e o <em>dano</em>, limitando-se a apontar a impossibilidade de determinação precisa da origem da lesão.
+5. Em hipóteses em que a prova técnica é inconclusiva, a incerteza probatória não pode ser interpretada em desfavor da vítima, sobretudo quando o <em>dano</em> surge no contexto da prestação do serviço público de saúde.
+6. Perda significativa da capacidade visual que configura <em>dano</em> <em>moral</em> indenizável.
+7. <em>Dano</em> estético caracterizado pela limitação funcional permanente, sendo passível de reparação autônoma.
+8. Fixação dos <em>danos</em> <em>morais</em> em R$ 50.000,00 e dos <em>danos</em> estéticos em R$ 20.000,00, observados os critérios de proporcionalidade e razoabilidade.
+IV. DISPOSITIVO E TESE
+11. Recurso provido.
+Tese de julgamento: "Em casos de responsabilidade civil do Estado por serviço de saúde, a ausência de conclusão pericial quanto ao nexo causal, quando o <em>dano</em> decorre do contexto direto da atuação estatal, não pode ser interpretada em prejuízo da vítima, autorizando o reconhecimento do dever de indenizar."
+Dispositivos relevantes citados: CF/1988, art. 37, § 6º; CC, arts. 186 e 927; CPC/2015, arts. 85, § 2º e 1.025.
+Jurisprudência relevante citada: STJ, AgInt no REsp 1.653.046/DF; TJAC, Relator Des. Júnior Alberto, Número do Processo: 0700309-48.2015.8.01.0002, Órgão julgador: Segunda Câmara Cível, Data do julgamento: 30/09/2022, Data de registro: 30/09/2022; TJAC, Relator Des. Roberto Barros, Número do Processo:0700140-86.2014.8.01.0005, Órgão julgador: Segunda Câmara Cível, Data do julgamento: 07/11/2017, Data de registro: 09/11/2017.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>22&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503651" cdForo="0" >
+										1000077-80.2026.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503651" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503651);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503651" style="display: none;" >
+	<div id="textAreaDados_2503651" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM AGRAVO DE INSTRUMENTO. A&Ccedil;&Atilde;O DE EXECU&Ccedil;&Atilde;O DE T&Iacute;TULO EXTRAJUDICIAL. EXCE&Ccedil;&Atilde;O DE PR&Eacute;-EXECUTIVIDADE JULGADA PROCEDENTE. OMISS&Atilde;O EM RELA&Ccedil;&Atilde;O A FIXA&Ccedil;&Atilde;O DE HONOR&Aacute;RIOS DE SUCUMB&Ecirc;NCIA. OCORR&Ecirc;NCIA. NECESSIDADE DE FIXA&Ccedil;&Atilde;O DE VERBA HONOR&Aacute;RIA. OBSERV&Acirc;NCIA DA REGRA DO ART. 85 DO C&Oacute;DIGO DE PROCESSO CIVIL. INVERS&Atilde;O DO &Ocirc;NUS DA SUCUMB&Ecirc;NCIA. ACOLHIMENTO.
+I. Caso em exame
+1. Embargos de Declara&ccedil;&atilde;o em face de ac&oacute;rd&atilde;o que deu provimento ao Agravo de Instrumento e acolheu a Exce&ccedil;&atilde;o de Pr&eacute;-Executividade para declarar a nulidade do t&iacute;tulo e extinguir a execu&ccedil;&atilde;o.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; omiss&atilde;o no ac&oacute;rd&atilde;o guerreado e &eacute; poss&iacute;vel fixar honor&aacute;rios em face da parte vencida.
+III. Raz&otilde;es de decidir
+3. Constatada a omiss&atilde;o, imp&otilde;e-se o acolhimento dos embargos de declara&ccedil;&atilde;o para fixar honor&aacute;rios advocat&iacute;cios sucumbenciais em desfavor da parte vencida, pois a extin&ccedil;&atilde;o da execu&ccedil;&atilde;o, em decorr&ecirc;ncia do acolhimento da exce&ccedil;&atilde;o de pr&eacute;-executividade, acarreta a condena&ccedil;&atilde;o do exequente ao pagamento da verba honor&aacute;ria, em observ&acirc;ncia ao princ&iacute;pio da sucumb&ecirc;ncia.
+IV. Dispositivo e tese
+4. Embargos de Declara&ccedil;&atilde;o acolhidos.
+__________
+Dispositivo relevante citado: art. 85 do C&oacute;digo de Processo Civil;
+Jurisprud&ecirc;ncia relevante citada:
+STJ, AgInt no AgInt no AREsp: 2038278 RS 2021/0386966-2, Relator MINISTRO ANTONIO CARLOS FERREIRA Data de Julgamento: 15/08/2022, T4 - QUARTA TURMA, Data de Publica&ccedil;&atilde;o: DJe 18/08/2022;
+AgInt no AREsp: 2286758 MG 2023/0024888-8, Relator Ministro RICARDO VILLAS B&Ocirc;AS CUEVA, Data de Julgamento: 09/09/2024, T3 - TERCEIRA TURMA, Data de Publica&ccedil;&atilde;o: DJe 12/09/2024. &nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Rio Branco;N&uacute;mero do Processo:1000077-80.2026.8.01.0000;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;5&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Honorários Advocatícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM AGRAVO DE INSTRUMENTO. AÇÃO DE EXECUÇÃO DE TÍTULO EXTRAJUDICIAL. EXCEÇÃO DE PRÉ-EXECUTIVIDADE JULGADA PROCEDENTE. OMISSÃO EM RELAÇÃO A FIXAÇÃO DE HONORÁRIOS DE SUCUMBÊNCIA. OCORRÊNCIA. NECESSIDADE DE FIXAÇÃO DE VERBA HONORÁRIA. OBSERVÂNCIA DA REGRA DO ART. 85 DO CÓDIGO DE PROCESSO CIVIL. INVERSÃO DO ÔNUS DA SUCUMBÊNCIA. ACOLHIMENTO.
+I. Caso em
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM AGRAVO DE INSTRUMENTO. AÇÃO DE EXECUÇÃO DE TÍTULO EXTRAJUDICIAL. EXCEÇÃO DE PRÉ-EXECUTIVIDADE JULGADA PROCEDENTE. OMISSÃO EM RELAÇÃO A FIXAÇÃO DE HONORÁRIOS DE SUCUMBÊNCIA. OCORRÊNCIA. NECESSIDADE DE FIXAÇÃO DE VERBA HONORÁRIA. OBSERVÂNCIA DA REGRA DO ART. 85 DO CÓDIGO DE PROCESSO CIVIL. INVERSÃO DO ÔNUS DA SUCUMBÊNCIA. ACOLHIMENTO.
+I. Caso em exame
+1. Embargos de Declaração em face de acórdão que deu provimento ao Agravo de Instrumento e acolheu a Exceção de Pré-Executividade para declarar a nulidade do título e extinguir a execução.
+II. Questão em discussão
+2. A questão em discussão consiste em saber se há omissão no acórdão guerreado e é possível fixar honorários em face da parte vencida.
+III. Razões de decidir
+3. Constatada a omissão, impõe-se o acolhimento dos embargos de declaração para fixar honorários advocatícios sucumbenciais em desfavor da parte vencida, pois a extinção da execução, em decorrência do acolhimento da exceção de pré-executividade, acarreta a condenação do exequente ao pagamento da verba honorária, em observância ao princípio da sucumbência.
+IV. Dispositivo e tese
+4. Embargos de Declaração acolhidos.
+__________
+Dispositivo relevante citado: art. 85 do Código de Processo Civil;
+Jurisprudência relevante citada:
+STJ, AgInt no AgInt no AREsp: 2038278 RS 2021/0386966-2, Relator MINISTRO ANTONIO CARLOS FERREIRA Data de Julgamento: 15/08/2022, T4 - QUARTA TURMA, Data de Publicação: DJe 18/08/2022;
+AgInt no AREsp: 2286758 MG 2023/0024888-8, Relator Ministro RICARDO VILLAS BÔAS CUEVA, Data de Julgamento: 09/09/2024, T3 - TERCEIRA TURMA, Data de Publicação: DJe 12/09/2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>23&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503693" cdForo="0" >
+										1000388-71.2026.8.01.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503693" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503693);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503693" style="display: none;" >
+	<div id="textAreaDados_2503693" class="mensagemSemFormatacao" >
+		CONSTITUCIONAL E PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. A&Ccedil;&Atilde;O DE NULIDADE CONTRATUAL. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. ASSIST&Ecirc;NCIA JUDICI&Aacute;RIA GRATUITA. PESSOA NATURAL. DECLARA&Ccedil;&Atilde;O DE HIPOSSUFICI&Ecirc;NCIA. COMPROVA&Ccedil;&Atilde;O DOCUMENTAL DA IMPOSSIBILIDADE FINANCEIRA. ACESSO &Agrave; JUSTI&Ccedil;A. CONCESS&Atilde;O DO BENEF&Iacute;CIO. DECIS&Atilde;O REFORMADA. PROVIMENTO.
+I. Caso em exame
+1. Recurso em face de decis&atilde;o que indeferiu a concess&atilde;o dos benef&iacute;cios da gratuidade judici&aacute;ria.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em aferir se as provas carreadas aos autos autorizam o deferimento da gratuidade judici&aacute;ria.
+III. Raz&otilde;es de decidir
+3. Para a concess&atilde;o da gratuidade judici&aacute;ria, a legisla&ccedil;&atilde;o n&atilde;o exige que o autor comprove estado de miserabilidade absoluta, sendo bastante a demonstra&ccedil;&atilde;o de insufici&ecirc;ncia de recursos para arcar com as custas processuais, despesas do processo e honor&aacute;rios advocat&iacute;cios sem preju&iacute;zo de seu sustento.
+IV. Dispositivo e tese
+4. Agravo de Instrumento provido.
+__________
+Dispositivos relevantes citados: art. 5&ordm;, inciso LXXIV, da Constitui&ccedil;&atilde;o Federal e art. 99 do C&oacute;digo de Processo Civil.&nbsp;
+Jurisprud&ecirc;ncia relevante citada:
+TJAC, N&uacute;mero do Processo: 1000817-72.2025.8.01.0000, Relator Des. Lu&iacute;s Camolez, &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel, Data do julgamento: 03/06/2025, Data de registro: 03/06/2025;
+N&uacute;mero do Processo: 1000660-02.2025.8.01.0000, Relator Des. J&uacute;nior Alberto, &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel, Data do julgamento: 16/05/2025, Data de registro: 16/05/2025. &nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:1000388-71.2026.8.01.0000;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Assistência Judiciária Gratuita
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>CONSTITUCIONAL E PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. AÇÃO DE NULIDADE CONTRATUAL. CARTÃO DE CRÉDITO CONSIGNADO. ASSISTÊNCIA JUDICIÁRIA GRATUITA. PESSOA NATURAL. DECLARAÇÃO DE HIPOSSUFICIÊNCIA. COMPROVAÇÃO DOCUMENTAL DA IMPOSSIBILIDADE FINANCEIRA. ACESSO À JUSTIÇA. CONCESSÃO DO BENEFÍCIO. DECISÃO REFORMADA. PROVIMENTO.
+I. Caso em exame
+1. Recurso em face de decisão que indeferiu a concessão
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>CONSTITUCIONAL E PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. AÇÃO DE NULIDADE CONTRATUAL. CARTÃO DE CRÉDITO CONSIGNADO. ASSISTÊNCIA JUDICIÁRIA GRATUITA. PESSOA NATURAL. DECLARAÇÃO DE HIPOSSUFICIÊNCIA. COMPROVAÇÃO DOCUMENTAL DA IMPOSSIBILIDADE FINANCEIRA. ACESSO À JUSTIÇA. CONCESSÃO DO BENEFÍCIO. DECISÃO REFORMADA. PROVIMENTO.
+I. Caso em exame
+1. Recurso em face de decisão que indeferiu a concessão dos benefícios da gratuidade judiciária.
+II. Questão em discussão
+2. A questão em discussão consiste em aferir se as provas carreadas aos autos autorizam o deferimento da gratuidade judiciária.
+III. Razões de decidir
+3. Para a concessão da gratuidade judiciária, a legislação não exige que o autor comprove estado de miserabilidade absoluta, sendo bastante a demonstração de insuficiência de recursos para arcar com as custas processuais, despesas do processo e honorários advocatícios sem prejuízo de seu sustento.
+IV. Dispositivo e tese
+4. Agravo de Instrumento provido.
+__________
+Dispositivos relevantes citados: art. 5º, inciso LXXIV, da Constituição Federal e art. 99 do Código de Processo Civil. 
+Jurisprudência relevante citada:
+TJAC, Número do Processo: 1000817-72.2025.8.01.0000, Relator Des. Luís Camolez, Órgão julgador: Segunda Câmara Cível, Data do julgamento: 03/06/2025, Data de registro: 03/06/2025;
+Número do Processo: 1000660-02.2025.8.01.0000, Relator Des. Júnior Alberto, Órgão julgador: Segunda Câmara Cível, Data do julgamento: 16/05/2025, Data de registro: 16/05/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>24&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503650" cdForo="0" >
+										0710496-69.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503650" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503650);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503650" style="display: none;" >
+	<div id="textAreaDados_2503650" class="mensagemSemFormatacao" >
+		DIREITO ADMINISTRATIVO. DIREITO CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O ANULAT&Oacute;RIA DE NEG&Oacute;CIO JUR&Iacute;DICO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. PRELIMINAR. ILEGITIMIDADE PASSIVA DO BANCO INTER S/A. REJEI&Ccedil;&Atilde;O. M&Eacute;RITO. VALIDADE DO NEG&Oacute;CIO JUR&Iacute;DICO. PRECLUS&Atilde;O. CONTRATOS QUITADOS. EXCLUS&Atilde;O DA CONDENA&Ccedil;&Atilde;O DO BANCO EM DANOS MORAIS. VIABILIDADE. MERO ABORRECIMENTO. N&Atilde;O COMPROVA&Ccedil;&Atilde;O DO DANO SOFRIDO. PROVIMENTO PARCIAL.
+I. Caso em exame
+1. Recurso de apela&ccedil;&atilde;o interposto contra senten&ccedil;a que julgou procedente a a&ccedil;&atilde;o e declarou a nulidade dos contratos firmados pelo autor com o Banco INTER S/A, bem ainda condenou a institui&ccedil;&atilde;o ao pagamento de R$ 6.000,00 (seis mil reais) a t&iacute;tulo de danos morais.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o, a saber: (i) preliminarmente, se &eacute; poss&iacute;vel excluir o Banco INTER do polo passivo; (ii) se &eacute; v&aacute;lida a contrata&ccedil;&atilde;o dos empr&eacute;stimos consignados; e (iii) se &eacute; poss&iacute;vel afastar ou reduzir o valor da condena&ccedil;&atilde;o por danos morais.
+III. Raz&otilde;es de decidir
+3. Realizado empr&eacute;stimo consignado pelo consumidor diretamente no aplicativo do banco Apelante, este &eacute; parte leg&iacute;tima para figurar no polo passivo da a&ccedil;&atilde;o.
+4. N&atilde;o h&aacute; nos autos elementos suficientes para caracterizar abalo moral indeniz&aacute;vel, raz&atilde;o pela qual deve ser afastado o pleito de indeniza&ccedil;&atilde;o por danos morais.
+IV. Dispositivo e tese
+5. Preliminar rejeitada. Apelo parcialmente provido.
+____________&nbsp;
+Dispositivos relevantes citados: sem cita&ccedil;&atilde;o.
+Jurisprud&ecirc;ncia relevante citada:
+TJGO, AC: 5619062-78.2021.8.09.0146, Relator Des. S&eacute;rgio Mendon&ccedil;a de Ara&uacute;jo, 7&ordf; C&acirc;mara C&iacute;vel, Data do Julgamento: 16/3/2023; Data de Publica&ccedil;&atilde;o: 16/3/2023.&nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Rio Branco;N&uacute;mero do Processo:0710496-69.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;6&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(42 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO. DIREITO CIVIL. APELAÇÃO CÍVEL. AÇÃO ANULATÓRIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. PRELIMINAR. ILEGITIMIDADE PASSIVA DO BANCO INTER S/A. REJEIÇÃO. MÉRITO. VALIDADE DO NEGÓCIO JURÍDICO. PRECLUSÃO. CONTRATOS QUITADOS. EXCLUSÃO DA CONDENAÇÃO DO BANCO EM <em>DANOS</em> <em>MORAIS</em>. VIABILIDADE. MERO ABORRECIMENTO. NÃO COMPROVAÇÃO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO. DIREITO CIVIL. APELAÇÃO CÍVEL. AÇÃO ANULATÓRIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. PRELIMINAR. ILEGITIMIDADE PASSIVA DO BANCO INTER S/A. REJEIÇÃO. MÉRITO. VALIDADE DO NEGÓCIO JURÍDICO. PRECLUSÃO. CONTRATOS QUITADOS. EXCLUSÃO DA CONDENAÇÃO DO BANCO EM <em>DANOS</em> <em>MORAIS</em>. VIABILIDADE. MERO ABORRECIMENTO. NÃO COMPROVAÇÃO DO <em>DANO</em> SOFRIDO. PROVIMENTO PARCIAL.
+I. Caso em exame
+1. Recurso de apelação interposto contra sentença que julgou procedente a ação e declarou a nulidade dos contratos firmados pelo autor com o Banco INTER S/A, bem ainda condenou a instituição ao pagamento de R$ 6.000,00 (seis mil reais) a título de <em>danos</em> <em>morais</em>.
+II. Questão em discussão
+2. Há três questões em discussão, a saber: (i) preliminarmente, se é possível excluir o Banco INTER do polo passivo; (ii) se é válida a contratação dos empréstimos consignados; e (iii) se é possível afastar ou reduzir o valor da condenação por <em>danos</em> <em>morais</em>.
+III. Razões de decidir
+3. Realizado empréstimo consignado pelo consumidor diretamente no aplicativo do banco Apelante, este é parte legítima para figurar no polo passivo da ação.
+4. Não há nos autos elementos suficientes para caracterizar abalo <em>moral</em> indenizável, razão pela qual deve ser afastado o pleito de indenização por <em>danos</em> <em>morais</em>.
+IV. Dispositivo e tese
+5. Preliminar rejeitada. Apelo parcialmente provido.
+____________ 
+Dispositivos relevantes citados: sem citação.
+Jurisprudência relevante citada:
+TJGO, AC: 5619062-78.2021.8.09.0146, Relator Des. Sérgio Mendonça de Araújo, 7ª Câmara Cível, Data do Julgamento: 16/3/2023; Data de Publicação: 16/3/2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>25&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503680" cdForo="0" >
+										0700802-40.2025.8.01.0013
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503680" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503680);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503680" style="display: none;" >
+	<div id="textAreaDados_2503680" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE CONTRATUAL. FRAUDE BANC&Aacute;RIA. EMPR&Eacute;STIMO. RECONHECIMENTO DE RESPONSABILIDADE DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. IMPOSSIBILIDADE. A RESPONSABILIDADE OBJETIVA DOS BANCOS N&Atilde;O &Eacute; ABSOLUTA. TRANSA&Ccedil;&Atilde;O REALIZADA MEDIANTE USO DE APLICATIVO COM SENHA PESSOAL. CULPA EXCLUSIVA DA V&Iacute;TIMA. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso em face de senten&ccedil;a que julgou improcedentes os pedidos iniciais e declarou extinto o processo com resolu&ccedil;&atilde;o de m&eacute;rito, nos termos do art. 485, inciso I, do C&oacute;digo de Processo Civil.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se &eacute; poss&iacute;vel reconhecer a responsabilidade da institui&ccedil;&atilde;o financeira, para declarar nulo o empr&eacute;stimo, condenando-a &agrave; devolu&ccedil;&atilde;o em dobro e indeniza&ccedil;&atilde;o por danos morais.
+III. Raz&otilde;es de decidir
+3. Inexistindo prova de invas&atilde;o de sistema ou defeito na seguran&ccedil;a banc&aacute;ria, e demonstrado que a transa&ccedil;&atilde;o fora realizada com uso de senha pessoal, n&atilde;o h&aacute; que falar em responsabilidade da institui&ccedil;&atilde;o financeira por rompimento do nexo causal.
+IV. Dispositivo e tese
+4. Recurso desprovido.
+________
+Dispositivos relevantes citados: art. 14 do C&oacute;digo de Defesa do Consumidor; S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a.
+Jurisprud&ecirc;ncia relevante citada:
+STJ, Esp: 2046026 RJ 2022/0216413-5, Relator Ministra NANCY ANDRIGHI, Data de Julgamento: 13/6/2023, T3 - TERCEIRA TURMA, Data de Publica&ccedil;&atilde;o: 27/6/2023;
+TJAC, N&uacute;mero do Processo: 0700627-04.2024.8.01.0006, Relator Des. Lois Arruda, &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel, Data do julgamento: 11/2/2026, Data de registro: 11/2/2026. &nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Feij&oacute;;N&uacute;mero do Processo:0700802-40.2025.8.01.0013;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Feijó
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE NULIDADE CONTRATUAL. FRAUDE BANCÁRIA. EMPRÉSTIMO. RECONHECIMENTO DE RESPONSABILIDADE DA INSTITUIÇÃO FINANCEIRA. IMPOSSIBILIDADE. A RESPONSABILIDADE OBJETIVA DOS BANCOS NÃO É ABSOLUTA. TRANSAÇÃO REALIZADA MEDIANTE USO DE APLICATIVO COM SENHA PESSOAL. CULPA EXCLUSIVA DA VÍTIMA. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE NULIDADE CONTRATUAL. FRAUDE BANCÁRIA. EMPRÉSTIMO. RECONHECIMENTO DE RESPONSABILIDADE DA INSTITUIÇÃO FINANCEIRA. IMPOSSIBILIDADE. A RESPONSABILIDADE OBJETIVA DOS BANCOS NÃO É ABSOLUTA. TRANSAÇÃO REALIZADA MEDIANTE USO DE APLICATIVO COM SENHA PESSOAL. CULPA EXCLUSIVA DA VÍTIMA. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso em face de sentença que julgou improcedentes os pedidos iniciais e declarou extinto o processo com resolução de mérito, nos termos do art. 485, inciso I, do Código de Processo Civil.
+II. Questão em discussão
+2. A questão em discussão consiste em saber se é possível reconhecer a responsabilidade da instituição financeira, para declarar nulo o empréstimo, condenando-a à devolução em dobro e indenização por <em>danos</em> <em>morais</em>.
+III. Razões de decidir
+3. Inexistindo prova de invasão de sistema ou defeito na segurança bancária, e demonstrado que a transação fora realizada com uso de senha pessoal, não há que falar em responsabilidade da instituição financeira por rompimento do nexo causal.
+IV. Dispositivo e tese
+4. Recurso desprovido.
+________
+Dispositivos relevantes citados: art. 14 do Código de Defesa do Consumidor; Súmula 479 do Superior Tribunal de Justiça.
+Jurisprudência relevante citada:
+STJ, Esp: 2046026 RJ 2022/0216413-5, Relator Ministra NANCY ANDRIGHI, Data de Julgamento: 13/6/2023, T3 - TERCEIRA TURMA, Data de Publicação: 27/6/2023;
+TJAC, Número do Processo: 0700627-04.2024.8.01.0006, Relator Des. Lois Arruda, Órgão julgador: Primeira Câmara Cível, Data do julgamento: 11/2/2026, Data de registro: 11/2/2026.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>26&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503665" cdForo="0" >
+										0712857-93.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503665" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503665);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503665" style="display: none;" >
+	<div id="textAreaDados_2503665" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. DIREITO ADMINISTRATIVO. APELA&Ccedil;&Atilde;O C&Iacute;VEL. CONCURSO P&Uacute;BLICO. CADASTRO DE RESERVA. PRETENS&Atilde;O DE NOMEA&Ccedil;&Atilde;O e INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. DESPROVIMENTO.
+I. Caso em exame
+1.  Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedentes os pedidos de candidata aprovada fora do n&uacute;mero de vagas em concurso p&uacute;blico para o cargo de Escriv&atilde; de Pol&iacute;cia Civil, que pleiteia nomea&ccedil;&atilde;o em raz&atilde;o de alegada vac&acirc;ncia superveniente, necessidade de pessoal e preteri&ccedil;&atilde;o indevida, bem como indeniza&ccedil;&atilde;o por danos morais.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o, a saber: (i) se a aus&ecirc;ncia de intima&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico enseja nulidade processual; e (ii) se a candidata aprovada em cadastro de reserva possui direito subjetivo &agrave; nomea&ccedil;&atilde;o em raz&atilde;o de vac&acirc;ncia decorrente de desist&ecirc;ncia, convoca&ccedil;&otilde;es al&eacute;m do edital e alegada preteri&ccedil;&atilde;o.
+III. Raz&otilde;es de decidir
+3. A interven&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico somente &eacute; obrigat&oacute;ria nas hip&oacute;teses previstas no art. 178 do C&oacute;digo de Processo Civil, n&atilde;o sendo suficiente a alega&ccedil;&atilde;o de interesse p&uacute;blico reflexo, sobretudo, em demanda de natureza individual, inexistindo nulidade.
+4. A aprova&ccedil;&atilde;o em concurso p&uacute;blico fora do n&uacute;mero de vagas previstas no edital confere mera expectativa de direito, n&atilde;o gerando direito subjetivo &agrave; nomea&ccedil;&atilde;o sem comprova&ccedil;&atilde;o de preteri&ccedil;&atilde;o arbitr&aacute;ria e imotivada. A aus&ecirc;ncia de ilegalidade afasta o dever de indenizar.
+IV. Dispositivo e tese
+5. Agravo de Instrumento desprovido.
+_________
+Dispositivo relevante citado: art. 37, inciso IV, da Constitui&ccedil;&atilde;o Federal.
+Jurisprud&ecirc;ncia relevante citada:
+STJ, RMS: 30881 CE 2009/0219672-7, Relator.: Ministro OG FERNANDES, Data de Julgamento: 20/04/2010, T6 - SEXTA TURMA, Data de Publica&ccedil;&atilde;o: DJe 10/05/2010.
+TJAC, N&uacute;mero do Processo: 1000364-24.2018.8.01.0000, Relator Des. Francisco Djalma, &Oacute;rg&atilde;o julgador: Tribunal Pleno Jurisdicional, Data do julgamento: 11/7/2018, Data de registro: 13/7/2018. &nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Rio Branco;N&uacute;mero do Processo:0712857-93.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara da Fazenda P&uacute;blica&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Classificação e/ou Preterição
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO ADMINISTRATIVO. APELAÇÃO CÍVEL. CONCURSO PÚBLICO. CADASTRO DE RESERVA. PRETENSÃO DE NOMEAÇÃO e INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. DESPROVIMENTO.
+I. Caso em exame
+1.  Apelação cível interposta contra sentença que julgou improcedentes os pedidos de candidata aprovada fora do número de vagas em concurso público para o cargo de Escrivã de Polícia Civil, que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO ADMINISTRATIVO. APELAÇÃO CÍVEL. CONCURSO PÚBLICO. CADASTRO DE RESERVA. PRETENSÃO DE NOMEAÇÃO e INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. DESPROVIMENTO.
+I. Caso em exame
+1.  Apelação cível interposta contra sentença que julgou improcedentes os pedidos de candidata aprovada fora do número de vagas em concurso público para o cargo de Escrivã de Polícia Civil, que pleiteia nomeação em razão de alegada vacância superveniente, necessidade de pessoal e preterição indevida, bem como indenização por <em>danos</em> <em>morais</em>.
+II. Questão em discussão
+2. Há duas questões em discussão, a saber: (i) se a ausência de intimação do Ministério Público enseja nulidade processual; e (ii) se a candidata aprovada em cadastro de reserva possui direito subjetivo à nomeação em razão de vacância decorrente de desistência, convocações além do edital e alegada preterição.
+III. Razões de decidir
+3. A intervenção do Ministério Público somente é obrigatória nas hipóteses previstas no art. 178 do Código de Processo Civil, não sendo suficiente a alegação de interesse público reflexo, sobretudo, em demanda de natureza individual, inexistindo nulidade.
+4. A aprovação em concurso público fora do número de vagas previstas no edital confere mera expectativa de direito, não gerando direito subjetivo à nomeação sem comprovação de preterição arbitrária e imotivada. A ausência de ilegalidade afasta o dever de indenizar.
+IV. Dispositivo e tese
+5. Agravo de Instrumento desprovido.
+_________
+Dispositivo relevante citado: art. 37, inciso IV, da Constituição Federal.
+Jurisprudência relevante citada:
+STJ, RMS: 30881 CE 2009/0219672-7, Relator.: Ministro OG FERNANDES, Data de Julgamento: 20/04/2010, T6 - SEXTA TURMA, Data de Publicação: DJe 10/05/2010.
+TJAC, Número do Processo: 1000364-24.2018.8.01.0000, Relator Des. Francisco Djalma, Órgão julgador: Tribunal Pleno Jurisdicional, Data do julgamento: 11/7/2018, Data de registro: 13/7/2018.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>27&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503679" cdForo="0" >
+										0713274-12.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503679" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503679);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503679" style="display: none;" >
+	<div id="textAreaDados_2503679" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. EMPR&Eacute;STIMO BANC&Aacute;RIO. GOLPE. BENEFICI&Aacute;RIO DESCONHECIDO. AUS&Ecirc;NCIA DE CAUTELAS M&Iacute;NIMAS. CULPA EXCLUSIVA DO CONSUMIDOR. AUS&Ecirc;NCIA DE RESPONSABILIDADE CIVIL DA INSTITUI&Ccedil;&Atilde;O BANC&Aacute;RIA. DESPROVIMENTO.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedentes os pedidos de danos decorrentes de fraude banc&aacute;ria e nulidade do contrato.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em definir se a institui&ccedil;&atilde;o financeira deve ser responsabilizada pelo preju&iacute;zo sofrido pela parte consumidora, em raz&atilde;o de empr&eacute;stimo levado a efeito mediante a&ccedil;&atilde;o de terceiro fraudador.
+III. Raz&otilde;es de decidir:
+3. O fornecedor de servi&ccedil;os financeiros n&atilde;o responde por danos decorrentes de empr&eacute;stimo banc&aacute;rio e repasse do valor a terceiro fraudador, quando comprovada a culpa exclusiva da v&iacute;tima, negligente.
+IV. Dispositivo e tese
+4. Recurso desprovido.
+________________
+Dispositivo relevante citado:  art. 14, &sect; 3&ordm;, II,  do C&oacute;digo de Defesa do Consumidor.
+Jurisprud&ecirc;ncia relevante citada:
+TJAC, N&uacute;mero do Processo 0703721-72.2024.8.01.0001; Relator Des. Laudivon Nogueira; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 26/02/2025; Data de registro: 26/02/2025; e
+N&uacute;mero do Processo: 0700739-50.2022.8.01.0003; Relator Des. J&uacute;nior Alberto; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 29/11/2024; Data de registro: 29/11/2024. &nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Rio Branco;N&uacute;mero do Processo:0713274-12.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(17 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Moral
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. EMPRÉSTIMO BANCÁRIO. GOLPE. BENEFICIÁRIO DESCONHECIDO. AUSÊNCIA DE CAUTELAS MÍNIMAS. CULPA EXCLUSIVA DO CONSUMIDOR. AUSÊNCIA DE RESPONSABILIDADE CIVIL DA INSTITUIÇÃO BANCÁRIA. DESPROVIMENTO.
+I. Caso em exame
+1. Apelação cível interposta contra sentença que julgou improcedentes os pedidos de <em>danos</em> decorrentes de fraude bancária e nulidade do contrato.
+II.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. EMPRÉSTIMO BANCÁRIO. GOLPE. BENEFICIÁRIO DESCONHECIDO. AUSÊNCIA DE CAUTELAS MÍNIMAS. CULPA EXCLUSIVA DO CONSUMIDOR. AUSÊNCIA DE RESPONSABILIDADE CIVIL DA INSTITUIÇÃO BANCÁRIA. DESPROVIMENTO.
+I. Caso em exame
+1. Apelação cível interposta contra sentença que julgou improcedentes os pedidos de <em>danos</em> decorrentes de fraude bancária e nulidade do contrato.
+II. Questão em discussão
+2. A questão em discussão consiste em definir se a instituição financeira deve ser responsabilizada pelo prejuízo sofrido pela parte consumidora, em razão de empréstimo levado a efeito mediante ação de terceiro fraudador.
+III. Razões de decidir:
+3. O fornecedor de serviços financeiros não responde por <em>danos</em> decorrentes de empréstimo bancário e repasse do valor a terceiro fraudador, quando comprovada a culpa exclusiva da vítima, negligente.
+IV. Dispositivo e tese
+4. Recurso desprovido.
+________________
+Dispositivo relevante citado:  art. 14, § 3º, II,  do Código de Defesa do Consumidor.
+Jurisprudência relevante citada:
+TJAC, Número do Processo 0703721-72.2024.8.01.0001; Relator Des. Laudivon Nogueira; Órgão julgador: Primeira Câmara Cível; Data do julgamento: 26/02/2025; Data de registro: 26/02/2025; e
+Número do Processo: 0700739-50.2022.8.01.0003; Relator Des. Júnior Alberto; Órgão julgador: Segunda Câmara Cível; Data do julgamento: 29/11/2024; Data de registro: 29/11/2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>28&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503662" cdForo="0" >
+										0722099-76.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503662" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503662);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503662" style="display: none;" >
+	<div id="textAreaDados_2503662" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. INSCRI&Ccedil;&Atilde;O DO CONSUMIDOR NO SERVI&Ccedil;O DE PROTE&Ccedil;&Atilde;O AO CR&Eacute;DITO. LICITUDE DO APONTAMENTO &quot;VENCIDO&quot;. DANOS MORAIS N&Atilde;O CONFIGURADOS. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso em face de senten&ccedil;a que julgou improcedentes os pedidos autorais.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se est&atilde;o presentes os requisitos para reformar a senten&ccedil;a de origem.
+III. Raz&otilde;es de decidir
+3. Constando d&iacute;vida vencida no momento do ajuizamento da a&ccedil;&atilde;o, inexiste ato il&iacute;cito na inclus&atilde;o do nome da autora nos &Oacute;rg&atilde;os de Prote&ccedil;&atilde;o ao Cr&eacute;dito, bem como imposs&iacute;vel reconhecer o dano moral e o direito de indenizar.
+IV. Dispositivo e tese
+4. Recurso desprovido.
+________
+Dispositivo relevante citado: art. 14 da Lei n&ordm; 8.078/90.
+Jurisprud&ecirc;ncia relevante citada:
+TJAC, N&uacute;mero do Processo: 0701086-31.2023.8.01.0009; Relator: Des. Roberto Barros; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 27/2/2025; Data de registro: 27/2/2025;
+N&uacute;mero do Processo: 0712395-73.2023.8.01.0001; Relator: Des. Lois Arruda; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 21/2/2025; Data de registro: 21/2/2025;
+N&uacute;mero do Processo: 0701429-17.2024.8.01.0001; Relator: Des. J&uacute;nior Alberto; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 18/2/2025; Data de registro: 18/2/2025; e
+N&uacute;mero do Processo: 0703449-78.2024.8.01.0001; Relatora: Des&ordf;. Waldirene Cordeiro;  &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 24/11/2024; Data de registro: 24/11/2024.
+TJMG, AC: 10000230121881001 MG, Relator: Habib Felippe Jabour, Data de Julgamento: 28/2/2023, C&acirc;maras C&iacute;veis/18&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 1/3/2023.
+TJAM, AC: 06961760620208040001, Relator: Yedo Sim&otilde;es de Oliveira, Data de Julgamento: 14/2/2023, Segunda C&acirc;mara C&iacute;vel, Data de Publica&ccedil;&atilde;o: 14/2/2023.
+TJRO, AC: 70333928220218220001, Relator: Des. Kiyochi Mori, Data de Julgamento: 14/12/2022, 2&ordf; C&acirc;mara C&iacute;vel, Data de Publica&ccedil;&atilde;o: 14/12/2022.
+TJBA, APL: 80227296520208050001, Relator: HELOISA PINTO DE FREITAS VIEIRA GRADDI, Data de Julgamento: 21/11/2022, QUARTA CAMARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 2/12/2022.
+TJGO, 5190793-62.2019.8.09.0050, Relator: OSCAR DE OLIVEIRA S&Aacute; NETO, Data de Julgamento: 10/3/2021, 2&ordf; Turma Recursal dos Juizados Especiais, Data de Publica&ccedil;&atilde;o: 10/3/2021. &nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Rio Branco;N&uacute;mero do Processo:0722099-76.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;5&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(56 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE NULIDADE DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. INSCRIÇÃO DO CONSUMIDOR NO SERVIÇO DE PROTEÇÃO AO CRÉDITO. LICITUDE DO APONTAMENTO "VENCIDO". <em>DANOS</em> <em>MORAIS</em> NÃO CONFIGURADOS. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso em face de sentença que julgou improcedentes os pedidos
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE NULIDADE DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. INSCRIÇÃO DO CONSUMIDOR NO SERVIÇO DE PROTEÇÃO AO CRÉDITO. LICITUDE DO APONTAMENTO "VENCIDO". <em>DANOS</em> <em>MORAIS</em> NÃO CONFIGURADOS. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso em face de sentença que julgou improcedentes os pedidos autorais.
+II. Questão em discussão
+2. A questão em discussão consiste em saber se estão presentes os requisitos para reformar a sentença de origem.
+III. Razões de decidir
+3. Constando dívida vencida no momento do ajuizamento da ação, inexiste ato ilícito na inclusão do nome da autora nos Órgãos de Proteção ao Crédito, bem como impossível reconhecer o <em>dano</em> <em>moral</em> e o direito de indenizar.
+IV. Dispositivo e tese
+4. Recurso desprovido.
+________
+Dispositivo relevante citado: art. 14 da Lei nº 8.078/90.
+Jurisprudência relevante citada:
+TJAC, Número do Processo: 0701086-31.2023.8.01.0009; Relator: Des. Roberto Barros; Órgão julgador: Primeira Câmara Cível; Data do julgamento: 27/2/2025; Data de registro: 27/2/2025;
+Número do Processo: 0712395-73.2023.8.01.0001; Relator: Des. Lois Arruda; Órgão julgador: Primeira Câmara Cível; Data do julgamento: 21/2/2025; Data de registro: 21/2/2025;
+Número do Processo: 0701429-17.2024.8.01.0001; Relator: Des. Júnior Alberto; Órgão julgador: Segunda Câmara Cível; Data do julgamento: 18/2/2025; Data de registro: 18/2/2025; e
+Número do Processo: 0703449-78.2024.8.01.0001; Relatora: Desª. Waldirene Cordeiro;  Órgão julgador: Segunda Câmara Cível; Data do julgamento: 24/11/2024; Data de registro: 24/11/2024.
+TJMG, AC: 10000230121881001 MG, Relator: Habib Felippe Jabour, Data de Julgamento: 28/2/2023, Câmaras Cíveis/18ª CÂMARA CÍVEL, Data de Publicação: 1/3/2023.
+TJAM, AC: 06961760620208040001, Relator: Yedo Simões de Oliveira, Data de Julgamento: 14/2/2023, Segunda Câmara Cível, Data de Publicação: 14/2/2023.
+TJRO, AC: 70333928220218220001, Relator: Des. Kiyochi Mori, Data de Julgamento: 14/12/2022, 2ª Câmara Cível, Data de Publicação: 14/12/2022.
+TJBA, APL: 80227296520208050001, Relator: HELOISA PINTO DE FREITAS VIEIRA GRADDI, Data de Julgamento: 21/11/2022, QUARTA CAMARA CÍVEL, Data de Publicação: 2/12/2022.
+TJGO, 5190793-62.2019.8.09.0050, Relator: OSCAR DE OLIVEIRA SÁ NETO, Data de Julgamento: 10/3/2021, 2ª Turma Recursal dos Juizados Especiais, Data de Publicação: 10/3/2021.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>29&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503670" cdForo="0" >
+										0707120-75.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503670" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503670);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503670" style="display: none;" >
+	<div id="textAreaDados_2503670" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA C/C OBRIGA&Ccedil;&Atilde;O DE FAZER E INDENIZA&Ccedil;&Atilde;O POR DANO MORAL. ENERGIA EL&Eacute;TRICA. TRANSFER&Ecirc;NCIA DE TITULARIDADE. INFORME TARDIO, EMBORA DEMONSTRADA A VENDA DO IM&Oacute;VEL H&Aacute; MAIS DE 15 (QUINZE) ANOS. D&Eacute;BITO POR IRREGULARIDADE N&Atilde;O ATRIBU&Iacute;VEL AO ALIENANTE. DANO MORAL AFASTADO POR AUS&Ecirc;NCIA DO DEVER DE MITIGAR O PR&Oacute;PRIO PREJU&Iacute;ZO E FALTA DE PROVA DE COBRAN&Ccedil;A INSISTENTE. SENTEN&Ccedil;A MANTIDA. RECURSOS DESPROVIDOS.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o destinada a reformar senten&ccedil;a que julgou parcialmente procedentes os pedidos iniciais.
+II. Quest&atilde;o em discuss&atilde;o
+2. As quest&otilde;es postas em discuss&atilde;o pela concession&aacute;ria 2&ordf; Apelante s&atilde;o: (i) se h&aacute; legalidade da cobran&ccedil;a, v&iacute;nculo contratual v&aacute;lido entre as partes e exerc&iacute;cio regular do direito de inscrever o d&eacute;bito em &oacute;rg&atilde;o de prote&ccedil;&atilde;o ao cr&eacute;dito; e pelo 1&ordm; Apelante (ii) se h&aacute; dano moral pass&iacute;vel de indeniza&ccedil;&atilde;o.
+III. Raz&otilde;es de decidir
+3. Escorreita a senten&ccedil;a que elidiu rela&ccedil;&atilde;o contratual entre as partes face a prova de aliena&ccedil;&atilde;o do im&oacute;vel h&aacute; anos, n&atilde;o havendo que falar no regular exerc&iacute;cio do direito de cobrar pelo suposto cr&eacute;dito e/ou possibilidade de inscrever o nome do devedor em &oacute;rg&atilde;os de prote&ccedil;&atilde;o ao cr&eacute;dito quanto ao d&eacute;bito apurado ap&oacute;s a transfer&ecirc;ncia do im&oacute;vel.
+4. O consumidor que n&atilde;o diligencia perante a concession&aacute;ria de servi&ccedil;o p&uacute;blico para alterar a titularidade da&nbsp;unidade consumidora, contribui para a efetiva&ccedil;&atilde;o de protesto em seu nome, inexistindo prova de cobran&ccedil;a abusiva atrav&eacute;s de liga&ccedil;&otilde;es e mensagens insistentes.
+IV. Dispositivo e Tese
+5. Apelos desprovidos.
+____________
+Dispositivo relevante citado: sem cita&ccedil;&atilde;o.
+Jurisprud&ecirc;ncia relevante citada:
+TJMG, Apela&ccedil;&atilde;o C&iacute;vel 1.0338.16.005996-4/001, Relator Des. Newton Teixeira Carvalho, 13&ordf; C&acirc;mara C&iacute;vel, julgamento em 5/12/2019, publica&ccedil;&atilde;o da s&uacute;mula em 13/12/2019.&nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Rio Branco;N&uacute;mero do Processo:0707120-75.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(18 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Fornecimento de Energia Elétrica
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA C/C OBRIGAÇÃO DE FAZER E INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em>. ENERGIA ELÉTRICA. TRANSFERÊNCIA DE TITULARIDADE. INFORME TARDIO, EMBORA DEMONSTRADA A VENDA DO IMÓVEL HÁ MAIS DE 15 (QUINZE) ANOS. DÉBITO POR IRREGULARIDADE NÃO ATRIBUÍVEL AO ALIENANTE. <em>DANO</em> <em>MORAL</em> AFASTADO POR AUSÊNCIA DO DEVER DE MITIGAR O PRÓPRIO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA C/C OBRIGAÇÃO DE FAZER E INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em>. ENERGIA ELÉTRICA. TRANSFERÊNCIA DE TITULARIDADE. INFORME TARDIO, EMBORA DEMONSTRADA A VENDA DO IMÓVEL HÁ MAIS DE 15 (QUINZE) ANOS. DÉBITO POR IRREGULARIDADE NÃO ATRIBUÍVEL AO ALIENANTE. <em>DANO</em> <em>MORAL</em> AFASTADO POR AUSÊNCIA DO DEVER DE MITIGAR O PRÓPRIO PREJUÍZO E FALTA DE PROVA DE COBRANÇA INSISTENTE. SENTENÇA MANTIDA. RECURSOS DESPROVIDOS.
+I. Caso em exame
+1. Apelação destinada a reformar sentença que julgou parcialmente procedentes os pedidos iniciais.
+II. Questão em discussão
+2. As questões postas em discussão pela concessionária 2ª Apelante são: (i) se há legalidade da cobrança, vínculo contratual válido entre as partes e exercício regular do direito de inscrever o débito em órgão de proteção ao crédito; e pelo 1º Apelante (ii) se há <em>dano</em> <em>moral</em> passível de indenização.
+III. Razões de decidir
+3. Escorreita a sentença que elidiu relação contratual entre as partes face a prova de alienação do imóvel há anos, não havendo que falar no regular exercício do direito de cobrar pelo suposto crédito e/ou possibilidade de inscrever o nome do devedor em órgãos de proteção ao crédito quanto ao débito apurado após a transferência do imóvel.
+4. O consumidor que não diligencia perante a concessionária de serviço público para alterar a titularidade da unidade consumidora, contribui para a efetivação de protesto em seu nome, inexistindo prova de cobrança abusiva através de ligações e mensagens insistentes.
+IV. Dispositivo e Tese
+5. Apelos desprovidos.
+____________
+Dispositivo relevante citado: sem citação.
+Jurisprudência relevante citada:
+TJMG, Apelação Cível 1.0338.16.005996-4/001, Relator Des. Newton Teixeira Carvalho, 13ª Câmara Cível, julgamento em 5/12/2019, publicação da súmula em 13/12/2019.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>30&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503649" cdForo="0" >
+										0700624-34.2024.8.01.0011
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503649" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503649);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503649" style="display: none;" >
+	<div id="textAreaDados_2503649" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O. CONTRADI&Ccedil;&Atilde;O. FALTA. FUNDAMENTA&Ccedil;&Atilde;O DO JULGADO. ADEQUA&Ccedil;&Atilde;O. N&Atilde;O ACOLHIMENTO.
+I. Caso em exame
+1. Embargos de Declara&ccedil;&atilde;o alegando contradi&ccedil;&atilde;o no ac&oacute;rd&atilde;o recorrido.
+II. Quest&atilde;o em discuss&atilde;o
+2. Analisar se o ac&oacute;rd&atilde;o embargado apresenta contradi&ccedil;&atilde;o apta a justificar o acolhimento dos Embargos de Declara&ccedil;&atilde;o.
+III. Raz&otilde;es de decidir
+3. N&atilde;o resulta da motiva&ccedil;&atilde;o do ac&oacute;rd&atilde;o hostilizado &#150;  sem qualquer viola&ccedil;&atilde;o a dispositivos legais &#150;  aventada hip&oacute;tese de contradi&ccedil;&atilde;o, equivalendo o arrazoado deste recurso a mero inconformismo.
+IV. Dispositivo e Tese
+4. Embargos de Declara&ccedil;&atilde;o n&atilde;o acolhidos.
+____________
+Dispositivo relevante citado: art. 1.022 do C&oacute;digo de Processo Civil.
+Jurisprud&ecirc;ncia relevante citada:
+STF, RE 1497892 AgR-ED, Relator Edson Fachin, Segunda Turma, julgado em 12/3/2025, publicado em 25/3/2025.
+STJ, AgInt no AREsp n&ordm; 2.706.055/DF, relator Ministro Francisco Falc&atilde;o, Segunda Turma, julgado em 26/2/2025, publicado em 5/3/2025; e
+REsp n&ordm; 1.652.347/SC, relator Ministro Francisco Falc&atilde;o, Segunda Turma, julgado em 13/8/2024, publicado em 22/10/2024.
+TJAC, N&uacute;mero do Processo 0701257-56.2021.8.01.0009; Relator Des. Laudivon Nogueira; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 26/2/2025; Data de registro: 26/2/2025; e
+N&uacute;mero do Processo 0101742-30.2024.8.01.0000; Relator Des. Lois Arruda; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 27/2/2025; Data de registro: 27/2/2025.     &nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Sena Madureira;N&uacute;mero do Processo:0700624-34.2024.8.01.0011;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sena Madureira
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO. CONTRADIÇÃO. FALTA. FUNDAMENTAÇÃO DO JULGADO. ADEQUAÇÃO. NÃO ACOLHIMENTO.
+I. Caso em exame
+1. Embargos de Declaração alegando contradição no acórdão recorrido.
+II. Questão em discussão
+2. Analisar se o acórdão embargado apresenta contradição apta a justificar o acolhimento dos Embargos de Declaração.
+III. Razões de decidir
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO. CONTRADIÇÃO. FALTA. FUNDAMENTAÇÃO DO JULGADO. ADEQUAÇÃO. NÃO ACOLHIMENTO.
+I. Caso em exame
+1. Embargos de Declaração alegando contradição no acórdão recorrido.
+II. Questão em discussão
+2. Analisar se o acórdão embargado apresenta contradição apta a justificar o acolhimento dos Embargos de Declaração.
+III. Razões de decidir
+3. Não resulta da motivação do acórdão hostilizado   sem qualquer violação a dispositivos legais   aventada hipótese de contradição, equivalendo o arrazoado deste recurso a mero inconformismo.
+IV. Dispositivo e Tese
+4. Embargos de Declaração não acolhidos.
+____________
+Dispositivo relevante citado: art. 1.022 do Código de Processo Civil.
+Jurisprudência relevante citada:
+STF, RE 1497892 AgR-ED, Relator Edson Fachin, Segunda Turma, julgado em 12/3/2025, publicado em 25/3/2025.
+STJ, AgInt no AREsp nº 2.706.055/DF, relator Ministro Francisco Falcão, Segunda Turma, julgado em 26/2/2025, publicado em 5/3/2025; e
+REsp nº 1.652.347/SC, relator Ministro Francisco Falcão, Segunda Turma, julgado em 13/8/2024, publicado em 22/10/2024.
+TJAC, Número do Processo 0701257-56.2021.8.01.0009; Relator Des. Laudivon Nogueira; Órgão julgador: Primeira Câmara Cível; Data do julgamento: 26/2/2025; Data de registro: 26/2/2025; e
+Número do Processo 0101742-30.2024.8.01.0000; Relator Des. Lois Arruda; Órgão julgador: Primeira Câmara Cível; Data do julgamento: 27/2/2025; Data de registro: 27/2/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>31&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503690" cdForo="0" >
+										0700274-33.2025.8.01.0004
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503690" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503690);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503690" style="display: none;" >
+	<div id="textAreaDados_2503690" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. NEGATIVA&Ccedil;&Atilde;O NOS CADASTROS DE INADIMPLENTES. ATIVOS S/A. CESS&Atilde;O DE CR&Eacute;DITOS. AUS&Ecirc;NCIA DOS REQUISITOS LEGAIS. OCORR&Ecirc;NCIA. N&Atilde;O COMPROVA&Ccedil;&Atilde;O DO V&Iacute;NCULO CONTRATUAL E LEGITIMIDADE DO D&Eacute;BITO. CONDENA&Ccedil;&Atilde;O EM DANOS MORAIS. NECESSIDADE. DANO IN RE IPSA. LESIVIDADE &Agrave; DIGNIDADE HUMANA. PROVIMENTO.
+I. Caso em exame
+1. Recurso em face de senten&ccedil;a que julgou improcedente o pedido em face da Ativos S/A Securitizadora de Cr&eacute;ditos Financeiros, com fulcro no art. 487, inciso I, do C&oacute;digo de Processo Civil.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o, a saber: (i) se &eacute; poss&iacute;vel declarar a inexist&ecirc;ncia do d&eacute;bito; e (ii) se &eacute; poss&iacute;vel condenar a empresa em danos morais.
+III. Raz&otilde;es de decidir
+3. Nas a&ccedil;&otilde;es declarat&oacute;rias de inexist&ecirc;ncia de d&eacute;bito fundadas em negativa&ccedil;&atilde;o oriunda de cess&atilde;o de cr&eacute;dito, compete ao cession&aacute;rio demonstrar a exist&ecirc;ncia do v&iacute;nculo contratual e a legitimidade do d&eacute;bito.
+4. A inscri&ccedil;&atilde;o indevida em cadastros de inadimplentes mostra-se lesiva &agrave; dignidade da pessoa humana, tanto em sua dimens&atilde;o individual quanto em sua proje&ccedil;&atilde;o social, configurado o dano moral in re ipsa, gerando o dever de indenizar.
+IV. Dispositivo e tese
+5. Recurso provido.
+________
+Dispositivos relevantes citados: arts. 186, 288, 290 e 927 do C&oacute;digo Civil; art. 373, inciso II, do C&oacute;digo de Processo Civil.
+Jurisprud&ecirc;ncia relevante citada:
+TJAC, N&uacute;mero do Processo: 0702481-45.2024.8.01.0002, Relatora Desa. Waldirene Cordeiro, &Oacute;rg&atilde;o Julgador: Segunda C&acirc;mara C&iacute;vel; Data do Julgamento: 23/03/2026; Data da Publica&ccedil;&atilde;o: 06/04/2026.
+TJSP, Apela&ccedil;&atilde;o C&iacute;vel: 10607324520238260576 S&atilde;o Jos&eacute; do Rio Preto, Relator.: Achile Alesina, Data de Julgamento: 11/10/2024, 15&ordf; C&acirc;mara de Direito Privado, Data de Publica&ccedil;&atilde;o: 11/10/2024;
+TJMT, RECURSO INOMINADO: 1061544-20.2022.8.11.0001, Relator Des. VALMIR ALAERCIO DOS SANTOS, Data de Julgamento: 14/04/2023, Turma Recursal &Uacute;nica, Data de Publica&ccedil;&atilde;o: 17/04/2023;
+TJMG, AI: 10000220472856001 MG, Relator Des. Moacyr Lobato, Data de Julgamento: 29/06/2022, C&acirc;maras Especializadas C&iacute;veis/21&ordf; C&acirc;mara C&iacute;vel Especializada, Data de Publica&ccedil;&atilde;o: 05/07/2022.&nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Epitaciol&acirc;ndia;N&uacute;mero do Processo:0700274-33.2025.8.01.0004;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;Vara &Uacute;nica - C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(85 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Epitaciolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. NEGATIVAÇÃO NOS CADASTROS DE INADIMPLENTES. ATIVOS S/A. CESSÃO DE CRÉDITOS. AUSÊNCIA DOS REQUISITOS LEGAIS. OCORRÊNCIA. NÃO COMPROVAÇÃO DO VÍNCULO CONTRATUAL E LEGITIMIDADE DO DÉBITO. CONDENAÇÃO EM <em>DANOS</em> <em>MORAIS</em>. NECESSIDADE.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. NEGATIVAÇÃO NOS CADASTROS DE INADIMPLENTES. ATIVOS S/A. CESSÃO DE CRÉDITOS. AUSÊNCIA DOS REQUISITOS LEGAIS. OCORRÊNCIA. NÃO COMPROVAÇÃO DO VÍNCULO CONTRATUAL E LEGITIMIDADE DO DÉBITO. CONDENAÇÃO EM <em>DANOS</em> <em>MORAIS</em>. NECESSIDADE. <em>DANO</em> IN RE IPSA. LESIVIDADE À DIGNIDADE HUMANA. PROVIMENTO.
+I. Caso em exame
+1. Recurso em face de sentença que julgou improcedente o pedido em face da Ativos S/A Securitizadora de Créditos Financeiros, com fulcro no art. 487, inciso I, do Código de Processo Civil.
+II. Questão em discussão
+2. Há duas questões em discussão, a saber: (i) se é possível declarar a inexistência do débito; e (ii) se é possível condenar a empresa em <em>danos</em> <em>morais</em>.
+III. Razões de decidir
+3. Nas ações declaratórias de inexistência de débito fundadas em negativação oriunda de cessão de crédito, compete ao cessionário demonstrar a existência do vínculo contratual e a legitimidade do débito.
+4. A inscrição indevida em cadastros de inadimplentes mostra-se lesiva à dignidade da pessoa humana, tanto em sua dimensão individual quanto em sua projeção social, configurado o <em>dano</em> <em>moral</em> in re ipsa, gerando o dever de indenizar.
+IV. Dispositivo e tese
+5. Recurso provido.
+________
+Dispositivos relevantes citados: arts. 186, 288, 290 e 927 do Código Civil; art. 373, inciso II, do Código de Processo Civil.
+Jurisprudência relevante citada:
+TJAC, Número do Processo: 0702481-45.2024.8.01.0002, Relatora Desa. Waldirene Cordeiro, Órgão Julgador: Segunda Câmara Cível; Data do Julgamento: 23/03/2026; Data da Publicação: 06/04/2026.
+TJSP, Apelação Cível: 10607324520238260576 São José do Rio Preto, Relator.: Achile Alesina, Data de Julgamento: 11/10/2024, 15ª Câmara de Direito Privado, Data de Publicação: 11/10/2024;
+TJMT, RECURSO INOMINADO: 1061544-20.2022.8.11.0001, Relator Des. VALMIR ALAERCIO DOS SANTOS, Data de Julgamento: 14/04/2023, Turma Recursal Única, Data de Publicação: 17/04/2023;
+TJMG, AI: 10000220472856001 MG, Relator Des. Moacyr Lobato, Data de Julgamento: 29/06/2022, Câmaras Especializadas Cíveis/21ª Câmara Cível Especializada, Data de Publicação: 05/07/2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>32&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503644" cdForo="0" >
+										0700201-67.2025.8.01.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503644" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503644);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503644" style="display: none;" >
+	<div id="textAreaDados_2503644" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANO MORAL. CONTRATA&Ccedil;&Atilde;O DE LINHA TELEF&Ocirc;NICA. PRELIMINAR. IMPUGNA&Ccedil;&Atilde;O &Agrave; JUSTI&Ccedil;A GRATUITA. MANUTEN&Ccedil;&Atilde;O DA GRATUIDADE JUDICI&Aacute;RIA. REQUISITOS ATENDIDOS. REJEI&Ccedil;&Atilde;O. M&Eacute;RITO. V&Iacute;CIO NA CONTRATA&Ccedil;&Atilde;O DOS SERVI&Ccedil;OS. INOCORR&Ecirc;NCIA. PROVAS ROBUSTAS DA CONTRATA&Ccedil;&Atilde;O. UTILIZA&Ccedil;&Atilde;O DA LINHA TELEF&Ocirc;NICA PELA AUTORA. CHAMADAS REALIZADAS E SMS ENVIADOS E RECEBIDOS. DANOS MORAIS N&Atilde;O CONFIGURADOS. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso contra senten&ccedil;a que julgou improcedente o pedido de indeniza&ccedil;&atilde;o por danos morais em face de Telef&ocirc;nica Brasil S/A.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o, a saber: (i) se &eacute; poss&iacute;vel cassar a gratuita judici&aacute;ria concedida &agrave; Apelante; e (ii) se &eacute; poss&iacute;vel declarar a inexist&ecirc;ncia de contrata&ccedil;&atilde;o do servi&ccedil;o, e se est&atilde;o presentes os requisitos para condenar a empresa em danos morais.
+III. Raz&otilde;es de decidir
+3. Para a concess&atilde;o da gratuidade judici&aacute;ria, a legisla&ccedil;&atilde;o n&atilde;o exige que o autor comprove estado de miserabilidade absoluta, sendo bastante a demonstra&ccedil;&atilde;o de insufici&ecirc;ncia de recursos para arcar com as custas processuais, despesas do processo e honor&aacute;rios advocat&iacute;cios sem preju&iacute;zo de seu sustento.
+4. Imposs&iacute;vel reconhecer o dano moral e o dever de indenizar em virtude da negativa&ccedil;&atilde;o pelo inadimplemento, pois restou demonstrado que a parte contratou o servi&ccedil;o de telefonia, inclusive pagando faturas anteriores, comprovando a rela&ccedil;&atilde;o jur&iacute;dica entre as partes.
+IV. Dispositivo e tese
+5. Recurso desprovido.
+________
+Dispositivos relevantes citados: art. 5&ordm;, inciso LXXIV, da Constitui&ccedil;&atilde;o Federal; art. 99 do C&oacute;digo de Processo Civil; art. 6&ordm;, incisos III, IV, V e VI, do C&oacute;digo de Defesa do Consumidor.
+Jurisprud&ecirc;ncia relevante citada:
+TJAC, N&uacute;mero do Processo: 1000817-72.2025.8.01.0000, Relator Des. Lu&iacute;s Camolez, &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel, Data do julgamento: 03/06/2025, Data de registro: 03/06/2025;
+N&uacute;mero do Processo: 1000660-02.2025.8.01.0000, Relator Des. J&uacute;nior Alberto, &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel, Data do julgamento: 16/05/2025, Data de registro: 16/05/2025;
+N&uacute;mero do Processo: 0710877-48.2023.8.01.0001; Relator Des. Roberto Barros; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 8/5/2025; Data de registro: 9/5/2025;
+N&uacute;mero do Processo: 0716389-12.2023.8.01.0001; Relator Des. Lois Arruda; Comarca: Rio Branco; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 27/3/2025; Data de registro: 27/3/2025.&nbsp;<br>(Relator (a): Des. Elcio Mendes; Comarca: Cruzeiro do Sul;N&uacute;mero do Processo:0700201-67.2025.8.01.0002;&Oacute;rg&atilde;o julgador:  Primeira C&acirc;mara C&iacute;vel;Data do julgamento: 16/04/2026; Data de registro: 16/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(47 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Elcio Mendes
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cruzeiro do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em>. CONTRATAÇÃO DE LINHA TELEFÔNICA. PRELIMINAR. IMPUGNAÇÃO À JUSTIÇA GRATUITA. MANUTENÇÃO DA GRATUIDADE JUDICIÁRIA. REQUISITOS ATENDIDOS. REJEIÇÃO. MÉRITO. VÍCIO NA CONTRATAÇÃO DOS SERVIÇOS. INOCORRÊNCIA. PROVAS ROBUSTAS DA CONTRATAÇÃO. UTILIZAÇÃO DA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em>. CONTRATAÇÃO DE LINHA TELEFÔNICA. PRELIMINAR. IMPUGNAÇÃO À JUSTIÇA GRATUITA. MANUTENÇÃO DA GRATUIDADE JUDICIÁRIA. REQUISITOS ATENDIDOS. REJEIÇÃO. MÉRITO. VÍCIO NA CONTRATAÇÃO DOS SERVIÇOS. INOCORRÊNCIA. PROVAS ROBUSTAS DA CONTRATAÇÃO. UTILIZAÇÃO DA LINHA TELEFÔNICA PELA AUTORA. CHAMADAS REALIZADAS E SMS ENVIADOS E RECEBIDOS. <em>DANOS</em> <em>MORAIS</em> NÃO CONFIGURADOS. DESPROVIMENTO.
+I. Caso em exame
+1. Recurso contra sentença que julgou improcedente o pedido de indenização por <em>danos</em> <em>morais</em> em face de Telefônica Brasil S/A.
+II. Questão em discussão
+2. Há duas questões em discussão, a saber: (i) se é possível cassar a gratuita judiciária concedida à Apelante; e (ii) se é possível declarar a inexistência de contratação do serviço, e se estão presentes os requisitos para condenar a empresa em <em>danos</em> <em>morais</em>.
+III. Razões de decidir
+3. Para a concessão da gratuidade judiciária, a legislação não exige que o autor comprove estado de miserabilidade absoluta, sendo bastante a demonstração de insuficiência de recursos para arcar com as custas processuais, despesas do processo e honorários advocatícios sem prejuízo de seu sustento.
+4. Impossível reconhecer o <em>dano</em> <em>moral</em> e o dever de indenizar em virtude da negativação pelo inadimplemento, pois restou demonstrado que a parte contratou o serviço de telefonia, inclusive pagando faturas anteriores, comprovando a relação jurídica entre as partes.
+IV. Dispositivo e tese
+5. Recurso desprovido.
+________
+Dispositivos relevantes citados: art. 5º, inciso LXXIV, da Constituição Federal; art. 99 do Código de Processo Civil; art. 6º, incisos III, IV, V e VI, do Código de Defesa do Consumidor.
+Jurisprudência relevante citada:
+TJAC, Número do Processo: 1000817-72.2025.8.01.0000, Relator Des. Luís Camolez, Órgão julgador: Segunda Câmara Cível, Data do julgamento: 03/06/2025, Data de registro: 03/06/2025;
+Número do Processo: 1000660-02.2025.8.01.0000, Relator Des. Júnior Alberto, Órgão julgador: Segunda Câmara Cível, Data do julgamento: 16/05/2025, Data de registro: 16/05/2025;
+Número do Processo: 0710877-48.2023.8.01.0001; Relator Des. Roberto Barros; Órgão julgador: Primeira Câmara Cível; Data do julgamento: 8/5/2025; Data de registro: 9/5/2025;
+Número do Processo: 0716389-12.2023.8.01.0001; Relator Des. Lois Arruda; Comarca: Rio Branco; Órgão julgador: Primeira Câmara Cível; Data do julgamento: 27/3/2025; Data de registro: 27/3/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>33&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503500" cdForo="0" >
+										0700051-74.2025.8.01.0006
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503500" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503500);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503500" style="display: none;" >
+	<div id="textAreaDados_2503500" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. FORMA&Ccedil;&Atilde;O DO CONTRATO EM AMBIENTE VIRTUAL. BIOMETRIA FACIAL. ELEMENTOS QUE DENOTAM A IRREGULARIDADE DA CONTRATA&Ccedil;&Atilde;O. AUS&Ecirc;NCIA DE GEOLOCALIZA&Ccedil;&Atilde;O, ASSINATURA NO CONTRATO OU COMPROVANTE DE TRANSFER&Ecirc;NCIA DE VALORES. DANO MORAL DEVIDO.
+1. As C&acirc;maras C&iacute;veis desta Corte t&ecirc;m entendido ser v&aacute;lida a contrata&ccedil;&atilde;o via ambiente virtual. Todavia, h&aacute; situa&ccedil;&otilde;es em que a institui&ccedil;&atilde;o financeira junta aos autos a mera captura de imagem do consumidor, deixando de trazer outros elementos necess&aacute;rios &agrave; comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o, tais como geolocaliza&ccedil;&atilde;o ou transfer&ecirc;ncia de valores, sendo necess&aacute;rio analisar caso a caso.
+2. Havendo falha na presta&ccedil;&atilde;o dos servi&ccedil;os pela institui&ccedil;&atilde;o banc&aacute;ria, configura-se a responsabilidade objetiva do r&eacute;u pelos danos sofridos pelo cliente, impondo o dever de indenizar moralmente a parte autora.
+3. Apela&ccedil;&atilde;o desprovida.&nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Acrel&acirc;ndia;N&uacute;mero do Processo:0700051-74.2025.8.01.0006;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;Vara &Uacute;nica - C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(31 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Acrelândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FORMAÇÃO DO CONTRATO EM AMBIENTE VIRTUAL. BIOMETRIA FACIAL. ELEMENTOS QUE DENOTAM A IRREGULARIDADE DA CONTRATAÇÃO. AUSÊNCIA DE GEOLOCALIZAÇÃO, ASSINATURA NO CONTRATO OU COMPROVANTE DE TRANSFERÊNCIA DE VALORES. <em>DANO</em> <em>MORAL</em> DEVIDO.
+1. As Câmaras Cíveis desta Corte têm
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. FORMAÇÃO DO CONTRATO EM AMBIENTE VIRTUAL. BIOMETRIA FACIAL. ELEMENTOS QUE DENOTAM A IRREGULARIDADE DA CONTRATAÇÃO. AUSÊNCIA DE GEOLOCALIZAÇÃO, ASSINATURA NO CONTRATO OU COMPROVANTE DE TRANSFERÊNCIA DE VALORES. <em>DANO</em> <em>MORAL</em> DEVIDO.
+1. As Câmaras Cíveis desta Corte têm entendido ser válida a contratação via ambiente virtual. Todavia, há situações em que a instituição financeira junta aos autos a mera captura de imagem do consumidor, deixando de trazer outros elementos necessários à comprovação da contratação, tais como geolocalização ou transferência de valores, sendo necessário analisar caso a caso.
+2. Havendo falha na prestação dos serviços pela instituição bancária, configura-se a responsabilidade objetiva do réu pelos <em>danos</em> sofridos pelo cliente, impondo o dever de indenizar <em>moralmente</em> a parte autora.
+3. Apelação desprovida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>34&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503479" cdForo="0" >
+										0708849-39.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503479" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503479);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503479" style="display: none;" >
+	<div id="textAreaDados_2503479" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O. A&Ccedil;&Atilde;O DE BUSCA E APREENS&Atilde;O EM ALIENA&Ccedil;&Atilde;O FIDUCI&Aacute;RIA. DECRETO-LEI N&ordm; 911/69. INADIMPLEMENTO CONTRATUAL. MORA REGULARMENTE CONSTITU&Iacute;DA. AUS&Ecirc;NCIA DE PURGA DA MORA. NECESSIDADE DE PAGAMENTO INTEGRAL DO D&Eacute;BITO. IRRELEV&Acirc;NCIA DO PAGAMENTO PARCIAL DAS PARCELAS VENCIDAS. ALEGA&Ccedil;&Atilde;O DE NECESSIDADE DO VE&Iacute;CULO PARA TRABALHO. INEXIST&Ecirc;NCIA DE &Oacute;BICE &Agrave; MEDIDA. NOTIFICA&Ccedil;&Atilde;O EXTRAJUDICIAL COMPROVADA. DANOS MORAIS N&Atilde;O CONFIGURADOS. SENTEN&Ccedil;A MANTIDA.
+1. Nos termos do art. 3&ordm; do Decreto-Lei n&ordm; 911/69, a mora do devedor fiduciante autoriza o ajuizamento da a&ccedil;&atilde;o de busca e apreens&atilde;o do bem alienado fiduciariamente.
+2. A purga da mora exige o pagamento integral da d&iacute;vida, abrangendo parcelas vencidas e vincendas, al&eacute;m dos encargos contratuais.
+3. O pagamento parcial das parcelas vencidas n&atilde;o tem o cond&atilde;o de afastar a mora nem impedir a consolida&ccedil;&atilde;o da propriedade em favor do credor fiduci&aacute;rio.
+4. A alega&ccedil;&atilde;o de que o bem &eacute; utilizado para atividade laboral n&atilde;o afasta a incid&ecirc;ncia da legisla&ccedil;&atilde;o espec&iacute;fica nem o exerc&iacute;cio regular do direito do credor.
+5. Comprovada a notifica&ccedil;&atilde;o extrajudicial enviada ao endere&ccedil;o do contrato, resta caracterizada a constitui&ccedil;&atilde;o em mora do devedor.
+6. Inexistindo irregularidade no procedimento de busca e apreens&atilde;o, tampouco se configura dano moral indeniz&aacute;vel.
+7. Recurso de apela&ccedil;&atilde;o desprovido.&nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Rio Branco;N&uacute;mero do Processo:0708849-39.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Alienação Fiduciária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO. AÇÃO DE BUSCA E APREENSÃO EM ALIENAÇÃO FIDUCIÁRIA. DECRETO-LEI Nº 911/69. INADIMPLEMENTO CONTRATUAL. MORA REGULARMENTE CONSTITUÍDA. AUSÊNCIA DE PURGA DA MORA. NECESSIDADE DE PAGAMENTO INTEGRAL DO DÉBITO. IRRELEVÂNCIA DO PAGAMENTO PARCIAL DAS PARCELAS VENCIDAS. ALEGAÇÃO DE NECESSIDADE DO VEÍCULO PARA TRABALHO. INEXISTÊNCIA DE ÓBICE À MEDIDA. NOTIFICAÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO. AÇÃO DE BUSCA E APREENSÃO EM ALIENAÇÃO FIDUCIÁRIA. DECRETO-LEI Nº 911/69. INADIMPLEMENTO CONTRATUAL. MORA REGULARMENTE CONSTITUÍDA. AUSÊNCIA DE PURGA DA MORA. NECESSIDADE DE PAGAMENTO INTEGRAL DO DÉBITO. IRRELEVÂNCIA DO PAGAMENTO PARCIAL DAS PARCELAS VENCIDAS. ALEGAÇÃO DE NECESSIDADE DO VEÍCULO PARA TRABALHO. INEXISTÊNCIA DE ÓBICE À MEDIDA. NOTIFICAÇÃO EXTRAJUDICIAL COMPROVADA. <em>DANOS</em> <em>MORAIS</em> NÃO CONFIGURADOS. SENTENÇA MANTIDA.
+1. Nos termos do art. 3º do Decreto-Lei nº 911/69, a mora do devedor fiduciante autoriza o ajuizamento da ação de busca e apreensão do bem alienado fiduciariamente.
+2. A purga da mora exige o pagamento integral da dívida, abrangendo parcelas vencidas e vincendas, além dos encargos contratuais.
+3. O pagamento parcial das parcelas vencidas não tem o condão de afastar a mora nem impedir a consolidação da propriedade em favor do credor fiduciário.
+4. A alegação de que o bem é utilizado para atividade laboral não afasta a incidência da legislação específica nem o exercício regular do direito do credor.
+5. Comprovada a notificação extrajudicial enviada ao endereço do contrato, resta caracterizada a constituição em mora do devedor.
+6. Inexistindo irregularidade no procedimento de busca e apreensão, tampouco se configura <em>dano</em> <em>moral</em> indenizável.
+7. Recurso de apelação desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>35&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503487" cdForo="0" >
+										0723634-40.2024.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503487" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503487);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503487" style="display: none;" >
+	<div id="textAreaDados_2503487" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. PRELIMINAR DE VIOLA&Ccedil;&Atilde;O AO PRINC&Iacute;PIO DA DIALETICIDADE. IMPUGNA&Ccedil;&Atilde;O ESPEC&Iacute;FICA DA SENTEN&Ccedil;A. PRELIMINAR DE NULIDADE DA SENTEN&Ccedil;A POR AUS&Ecirc;NCIA DE FUNDAMENTA&Ccedil;&Atilde;O. EXAME SATISFAT&Oacute;RIO DAS ALEGA&Ccedil;&Otilde;ES DAS PARTES. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE RESCIS&Atilde;O CONTRATUAL. PROMESSA DE COMPRA E VENDA DE IM&Oacute;VEL. REGIME DE MULTIPROPRIEDADE. LEGALIDADE DA CL&Aacute;USULA PENAL DE RETEN&Ccedil;&Atilde;O DE 50% DOS VALORES PAGOS PELA ADQUIRENTE. RESTITUI&Ccedil;&Atilde;O FIXADA EM CONFORMIDADE COM OS VALORES EFETIVAMENTE PAGOS.
+1. Mesmo se as raz&otilde;es recursais fossem uma mera compila&ccedil;&atilde;o dos argumentos da pe&ccedil;a de defesa, a jurisprud&ecirc;ncia pac&iacute;fica do Superior Tribunal de Justi&ccedil;a orienta que a reprodu&ccedil;&atilde;o, na Apela&ccedil;&atilde;o, dos argumentos contidos na peti&ccedil;&atilde;o inicial ou na contesta&ccedil;&atilde;o n&atilde;o impede, por si s&oacute;, o conhecimento do recurso, bastando para o Apelo ser admitido a possibilidade de ser extra&iacute;da da fundamenta&ccedil;&atilde;o recursal o verdadeiro descontentamento das Apelantes com a Senten&ccedil;a recorrida.
+2. N&atilde;o h&aacute; ofensa ao art. 93, inciso IX, da CF/1988, e/ou ao art. 489, &sect; 1&ordm;, inciso IV, do CPC, porque a Senten&ccedil;a examinou a mat&eacute;ria de forma satisfat&oacute;ria, comparando as alega&ccedil;&otilde;es das partes com os elementos de convencimento dos autos para sustentar as respectivas conclus&otilde;es do Julgador.
+3. A legisla&ccedil;&atilde;o aplic&aacute;vel ao caso autoriza a fixa&ccedil;&atilde;o da pena de reten&ccedil;&atilde;o em percentual de at&eacute; 50%, conforme previsto no art. 67-A, &sect; 5&ordm;, da Lei n. 4.591/1964, n&atilde;o havendo que se falar em ilegalidade da cobran&ccedil;a na hip&oacute;tese de haver submiss&atilde;o do contrato ao regime de hip&oacute;tese do patrim&ocirc;nio de afeta&ccedil;&atilde;o. Ademais, registre-se que a incid&ecirc;ncia do C&oacute;digo de Defesa do Consumidor n&atilde;o implica, automaticamente, na invalida&ccedil;&atilde;o das cl&aacute;usulas contratuais, quando livremente pactuadas entre as partes e submetidos aos par&acirc;metros da legisla&ccedil;&atilde;o de reg&ecirc;ncia.
+4. A base de c&aacute;lculo da restitui&ccedil;&atilde;o devido &agrave; adquirente deve ser readequada ao valor efetivamente pago em raz&atilde;o da aquisi&ccedil;&atilde;o das cotas de unidade residencial em modalidade de multipropriedade.
+5. Apela&ccedil;&atilde;o parcialmente provida. &nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Rio Branco;N&uacute;mero do Processo:0723634-40.2024.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Rescisão do contrato e devolução do dinheiro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. PRELIMINAR DE VIOLAÇÃO AO PRINCÍPIO DA DIALETICIDADE. IMPUGNAÇÃO ESPECÍFICA DA SENTENÇA. PRELIMINAR DE NULIDADE DA SENTENÇA POR AUSÊNCIA DE FUNDAMENTAÇÃO. EXAME SATISFATÓRIO DAS ALEGAÇÕES DAS PARTES. APELAÇÃO CÍVEL. AÇÃO DE RESCISÃO CONTRATUAL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. REGIME DE MULTIPROPRIEDADE. LEGALIDADE DA CLÁUSULA PENAL DE RETENÇÃO DE 50% DOS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. PRELIMINAR DE VIOLAÇÃO AO PRINCÍPIO DA DIALETICIDADE. IMPUGNAÇÃO ESPECÍFICA DA SENTENÇA. PRELIMINAR DE NULIDADE DA SENTENÇA POR AUSÊNCIA DE FUNDAMENTAÇÃO. EXAME SATISFATÓRIO DAS ALEGAÇÕES DAS PARTES. APELAÇÃO CÍVEL. AÇÃO DE RESCISÃO CONTRATUAL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. REGIME DE MULTIPROPRIEDADE. LEGALIDADE DA CLÁUSULA PENAL DE RETENÇÃO DE 50% DOS VALORES PAGOS PELA ADQUIRENTE. RESTITUIÇÃO FIXADA EM CONFORMIDADE COM OS VALORES EFETIVAMENTE PAGOS.
+1. Mesmo se as razões recursais fossem uma mera compilação dos argumentos da peça de defesa, a jurisprudência pacífica do Superior Tribunal de Justiça orienta que a reprodução, na Apelação, dos argumentos contidos na petição inicial ou na contestação não impede, por si só, o conhecimento do recurso, bastando para o Apelo ser admitido a possibilidade de ser extraída da fundamentação recursal o verdadeiro descontentamento das Apelantes com a Sentença recorrida.
+2. Não há ofensa ao art. 93, inciso IX, da CF/1988, e/ou ao art. 489, § 1º, inciso IV, do CPC, porque a Sentença examinou a matéria de forma satisfatória, comparando as alegações das partes com os elementos de convencimento dos autos para sustentar as respectivas conclusões do Julgador.
+3. A legislação aplicável ao caso autoriza a fixação da pena de retenção em percentual de até 50%, conforme previsto no art. 67-A, § 5º, da Lei n. 4.591/1964, não havendo que se falar em ilegalidade da cobrança na hipótese de haver submissão do contrato ao regime de hipótese do patrimônio de afetação. Ademais, registre-se que a incidência do Código de Defesa do Consumidor não implica, automaticamente, na invalidação das cláusulas contratuais, quando livremente pactuadas entre as partes e submetidos aos parâmetros da legislação de regência.
+4. A base de cálculo da restituição devido à adquirente deve ser readequada ao valor efetivamente pago em razão da aquisição das cotas de unidade residencial em modalidade de multipropriedade.
+5. Apelação parcialmente provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>36&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503503" cdForo="0" >
+										0710150-21.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503503" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503503);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503503" style="display: none;" >
+	<div id="textAreaDados_2503503" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O REVISIONAL. CART&Atilde;O DE CR&Eacute;DITO ADIANTAMENTO SALARIAL. INFORMA&Ccedil;&Otilde;ES DO CONTRATO BANC&Aacute;RIO. REGULARIDADE DA CONTRATA&Ccedil;&Atilde;O. OBSERV&Acirc;NCIA DOS PRINC&Iacute;PIOS DA TRANSPAR&Ecirc;NCIA E DA INFORMA&Ccedil;&Atilde;O. LITIG&Acirc;NCIA DE M&Aacute;-F&Eacute; N&Atilde;O CARACTERIZADA.
+1. N&atilde;o existe qualquer abusividade nos descontos efetuados, tendo em vista que o Apelante obteve todas as informa&ccedil;&otilde;es sobre a modalidade de cr&eacute;dito ofertada. Por consequ&ecirc;ncia, ocorreu a plena observ&acirc;ncia aos princ&iacute;pios da transpar&ecirc;ncia e informa&ccedil;&atilde;o, previstos nos arts. 6&ordm;, inciso III, 46 e 52, todos do CDC, n&atilde;o tendo proced&ecirc;ncia o pedido de revis&atilde;o judicial do contrato.
+2. De acordo com jurisprud&ecirc;ncia do TJAC, &quot;a assinatura eletr&ocirc;nica acompanhada de selfie, somada &agrave; expressa identifica&ccedil;&atilde;o do contrato como&nbsp;cart&atilde;o&nbsp;de&nbsp;cr&eacute;dito&nbsp;consignado&nbsp;e apresenta&ccedil;&atilde;o de termo de consentimento esclarecido com compara&ccedil;&atilde;o entre modalidades de&nbsp;cr&eacute;dito, al&eacute;m da utiliza&ccedil;&atilde;o do&nbsp;cart&atilde;o&nbsp;para compras na fun&ccedil;&atilde;o&nbsp;cr&eacute;dito&nbsp;afastam a alega&ccedil;&atilde;o de v&iacute;cio de consentimento, comprova o dever de informa&ccedil;&atilde;o e confirma o conhecimento e aceita&ccedil;&atilde;o do produto contratado&quot;. Precedente: Apela&ccedil;&atilde;o n. 0712485-13.2025.8.01.0001.
+3. De acordo com os autos, n&atilde;o existem elementos suficientes para caracterizar uma conduta temer&aacute;ria do Apelante (altera&ccedil;&atilde;o da verdade dos fatos), considerando que a interposi&ccedil;&atilde;o do recurso &eacute; vista como uma forma leg&iacute;tima da parte questionar a Senten&ccedil;a do primeiro grau, n&atilde;o ultrapassando os padr&otilde;es &eacute;ticos-processuais ao se limitar ao exerc&iacute;cio do direito constitucional de contradit&oacute;rio e ampla defesa.
+4. Apela&ccedil;&atilde;o desprovida. &nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Rio Branco;N&uacute;mero do Processo:0710150-21.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO REVISIONAL. CARTÃO DE CRÉDITO ADIANTAMENTO SALARIAL. INFORMAÇÕES DO CONTRATO BANCÁRIO. REGULARIDADE DA CONTRATAÇÃO. OBSERVÂNCIA DOS PRINCÍPIOS DA TRANSPARÊNCIA E DA INFORMAÇÃO. LITIGÂNCIA DE MÁ-FÉ NÃO CARACTERIZADA.
+1. Não existe qualquer abusividade nos descontos efetuados, tendo em vista que o Apelante obteve todas as informações sobre a modalidade
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO REVISIONAL. CARTÃO DE CRÉDITO ADIANTAMENTO SALARIAL. INFORMAÇÕES DO CONTRATO BANCÁRIO. REGULARIDADE DA CONTRATAÇÃO. OBSERVÂNCIA DOS PRINCÍPIOS DA TRANSPARÊNCIA E DA INFORMAÇÃO. LITIGÂNCIA DE MÁ-FÉ NÃO CARACTERIZADA.
+1. Não existe qualquer abusividade nos descontos efetuados, tendo em vista que o Apelante obteve todas as informações sobre a modalidade de crédito ofertada. Por consequência, ocorreu a plena observância aos princípios da transparência e informação, previstos nos arts. 6º, inciso III, 46 e 52, todos do CDC, não tendo procedência o pedido de revisão judicial do contrato.
+2. De acordo com jurisprudência do TJAC, "a assinatura eletrônica acompanhada de selfie, somada à expressa identificação do contrato como cartão de crédito consignado e apresentação de termo de consentimento esclarecido com comparação entre modalidades de crédito, além da utilização do cartão para compras na função crédito afastam a alegação de vício de consentimento, comprova o dever de informação e confirma o conhecimento e aceitação do produto contratado". Precedente: Apelação n. 0712485-13.2025.8.01.0001.
+3. De acordo com os autos, não existem elementos suficientes para caracterizar uma conduta temerária do Apelante (alteração da verdade dos fatos), considerando que a interposição do recurso é vista como uma forma legítima da parte questionar a Sentença do primeiro grau, não ultrapassando os padrões éticos-processuais ao se limitar ao exercício do direito constitucional de contraditório e ampla defesa.
+4. Apelação desprovida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>37&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503501" cdForo="0" >
+										0716153-89.2025.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503501" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503501);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503501" style="display: none;" >
+	<div id="textAreaDados_2503501" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DO NEG&Oacute;CIO JUR&Iacute;DICO E INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. INVERS&Atilde;O DO &Ocirc;NUS DA PROVA. DOCUMENTOS APRESENTADOS PELO BANCO QUE COMPROVAM A CONTRATA&Ccedil;&Atilde;O E UTILIZA&Ccedil;&Atilde;O DO CART&Atilde;O DE CR&Eacute;DITO.
+1. Tratando-se de rela&ccedil;&atilde;o de consumo, aplica-se o C&oacute;digo de Defesa do Consumidor, cabendo &agrave; institui&ccedil;&atilde;o financeira demonstrar a regularidade da contrata&ccedil;&atilde;o quando a autora nega a exist&ecirc;ncia do d&eacute;bito.
+2. O banco apresentou contrato firmado com a autora, al&eacute;m de extratos de faturas que evidenciam a efetiva utiliza&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito.
+3. Prints de tela, embora unilateralmente produzidos, quando confirmados por outros elementos de prova, s&atilde;o aptos a demonstrar a regularidade da contrata&ccedil;&atilde;o. Precedentes desta Corte de Justi&ccedil;a.
+4. Considerando que os descontos efetuados na conta da apelante constitu&iacute;ram-se em exerc&iacute;cio regular de direito da parte apelada, inexiste ato il&iacute;cito a ensejar repara&ccedil;&atilde;o por danos morais, de rigor a manuten&ccedil;&atilde;o da senten&ccedil;a recorrida.
+5. Apela&ccedil;&atilde;o desprovida.&nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Rio Branco;N&uacute;mero do Processo:0716153-89.2025.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE NULIDADE DO NEGÓCIO JURÍDICO E INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. INVERSÃO DO ÔNUS DA PROVA. DOCUMENTOS APRESENTADOS PELO BANCO QUE COMPROVAM A CONTRATAÇÃO E UTILIZAÇÃO DO CARTÃO DE CRÉDITO.
+1. Tratando-se de relação de consumo, aplica-se o Código de Defesa do Consumidor, cabendo à instituição
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE NULIDADE DO NEGÓCIO JURÍDICO E INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. INVERSÃO DO ÔNUS DA PROVA. DOCUMENTOS APRESENTADOS PELO BANCO QUE COMPROVAM A CONTRATAÇÃO E UTILIZAÇÃO DO CARTÃO DE CRÉDITO.
+1. Tratando-se de relação de consumo, aplica-se o Código de Defesa do Consumidor, cabendo à instituição financeira demonstrar a regularidade da contratação quando a autora nega a existência do débito.
+2. O banco apresentou contrato firmado com a autora, além de extratos de faturas que evidenciam a efetiva utilização do cartão de crédito.
+3. Prints de tela, embora unilateralmente produzidos, quando confirmados por outros elementos de prova, são aptos a demonstrar a regularidade da contratação. Precedentes desta Corte de Justiça.
+4. Considerando que os descontos efetuados na conta da apelante constituíram-se em exercício regular de direito da parte apelada, inexiste ato ilícito a ensejar reparação por <em>danos</em> <em>morais</em>, de rigor a manutenção da sentença recorrida.
+5. Apelação desprovida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>38&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503495" cdForo="0" >
+										0700744-89.2024.8.01.0007
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503495" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503495);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503495" style="display: none;" >
+	<div id="textAreaDados_2503495" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Iacute;VIDA C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. PROVA DA AQUISI&Ccedil;&Atilde;O DE MERCADORIAS. LICITUDE DA INSCRI&Ccedil;&Atilde;O EM &Oacute;RG&Atilde;OS DE PROTE&Ccedil;&Atilde;O AO CR&Eacute;DITO. EXERC&Iacute;CIO REGULAR DE DIREITO. DANO MORAL N&Atilde;O CONFIGURADO.
+1. Nos termos do art. 14, &sect; 3&ordm;, incisos I e II, do CDC, a responsabilidade do fornecedor de servi&ccedil;os somente poder&aacute; ser exclu&iacute;da se demonstrada uma das seguintes causas excludentes: defeito inexistente e culpa exclusiva do consumidor ou de terceiro. Havendo prova v&aacute;lida da contrata&ccedil;&atilde;o questionada na presente demanda, n&atilde;o existe falha no servi&ccedil;o a fundamentar a repara&ccedil;&atilde;o por danos morais.
+2. Sendo a inscri&ccedil;&atilde;o nos cadastros de inadimplentes um exerc&iacute;cio regular de direito, nos termos do art. 188, inciso I, do CC/2002, c/c o art. 43, &sect; 2&ordm;, do CDC, n&atilde;o h&aacute; ato il&iacute;cito a ensejar indeniza&ccedil;&atilde;o por danos morais, sendo imposs&iacute;vel imputar falha na presta&ccedil;&atilde;o de servi&ccedil;os.
+3. Apela&ccedil;&atilde;o desprovida.&nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Xapuri;N&uacute;mero do Processo:0700744-89.2024.8.01.0007;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;Vara &Uacute;nica - C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Xapuri
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. PROVA DA AQUISIÇÃO DE MERCADORIAS. LICITUDE DA INSCRIÇÃO EM ÓRGÃOS DE PROTEÇÃO AO CRÉDITO. EXERCÍCIO REGULAR DE DIREITO. <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO.
+1. Nos termos do art. 14, § 3º, incisos I e II, do CDC, a responsabilidade do fornecedor de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. PROVA DA AQUISIÇÃO DE MERCADORIAS. LICITUDE DA INSCRIÇÃO EM ÓRGÃOS DE PROTEÇÃO AO CRÉDITO. EXERCÍCIO REGULAR DE DIREITO. <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO.
+1. Nos termos do art. 14, § 3º, incisos I e II, do CDC, a responsabilidade do fornecedor de serviços somente poderá ser excluída se demonstrada uma das seguintes causas excludentes: defeito inexistente e culpa exclusiva do consumidor ou de terceiro. Havendo prova válida da contratação questionada na presente demanda, não existe falha no serviço a fundamentar a reparação por <em>danos</em> <em>morais</em>.
+2. Sendo a inscrição nos cadastros de inadimplentes um exercício regular de direito, nos termos do art. 188, inciso I, do CC/2002, c/c o art. 43, § 2º, do CDC, não há ato ilícito a ensejar indenização por <em>danos</em> <em>morais</em>, sendo impossível imputar falha na prestação de serviços.
+3. Apelação desprovida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>39&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503491" cdForo="0" >
+										0701148-71.2023.8.01.0009
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503491" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503491);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503491" style="display: none;" >
+	<div id="textAreaDados_2503491" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. PRELIMINAR DE CERCEAMENTO DE DEFESA. PRECLUS&Atilde;O CONSUMATIVA DO DIREITO DE REQUERER A PRODU&Ccedil;&Atilde;O DE PROVA PERICIAL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA. CART&Atilde;O DE CR&Eacute;DITO ADIANTAMENTO SALARIAL. INFORMA&Ccedil;&Otilde;ES DO CONTRATO BANC&Aacute;RIO. REGULARIDADE DA CONTRATA&Ccedil;&Atilde;O. OBSERV&Acirc;NCIA DOS PRINC&Iacute;PIOS DA TRANSPAR&Ecirc;NCIA E DA INFORMA&Ccedil;&Atilde;O. LITIG&Acirc;NCIA DE M&Aacute;-F&Eacute;. N&Atilde;O CARACTERIZA&Ccedil;&Atilde;O DE LIDE TEMER&Aacute;RIA.
+1. Nos termos do art. 507, do CPC, houve a preclus&atilde;o consumativa do direito de requerer a produ&ccedil;&atilde;o de prova pericial, &agrave; medida que, no momento processual adequado, o Apelante externou a certeza de que o ato processual n&atilde;o seria necess&aacute;rio.
+2. N&atilde;o existe qualquer abusividade nos descontos efetuados, tendo em vista que o Apelante obteve todas as informa&ccedil;&otilde;es sobre a modalidade de cr&eacute;dito ofertada. Por consequ&ecirc;ncia, ocorreu a plena observ&acirc;ncia aos princ&iacute;pios da transpar&ecirc;ncia e informa&ccedil;&atilde;o, previstos nos arts. 6&ordm;, inciso III, 46 e 52, todos do CDC, n&atilde;o tendo proced&ecirc;ncia o pedido de revis&atilde;o judicial do contrato.
+3. De acordo com jurisprud&ecirc;ncia do TJAC, &quot;a assinatura eletr&ocirc;nica acompanhada de selfie, somada &agrave; expressa identifica&ccedil;&atilde;o do contrato como&nbsp;cart&atilde;o&nbsp;de&nbsp;cr&eacute;dito&nbsp;consignado&nbsp;e apresenta&ccedil;&atilde;o de termo de consentimento esclarecido com compara&ccedil;&atilde;o entre modalidades de&nbsp;cr&eacute;dito, al&eacute;m da utiliza&ccedil;&atilde;o do&nbsp;cart&atilde;o&nbsp;para compras na fun&ccedil;&atilde;o&nbsp;cr&eacute;dito&nbsp;afastam a alega&ccedil;&atilde;o de v&iacute;cio de consentimento, comprova o dever de informa&ccedil;&atilde;o e confirma o conhecimento e aceita&ccedil;&atilde;o do produto contratado&quot;. Precedente: Apela&ccedil;&atilde;o n. 0712485-13.2025.8.01.0001.
+4. De acordo com os autos, n&atilde;o existem elementos suficientes para caracterizar o ajuizamento de uma lide temer&aacute;ria, considerando que a mera propositura da a&ccedil;&atilde;o declarat&oacute;ria &eacute; vista como uma forma leg&iacute;tima da consumidora questionar a validade da cobran&ccedil;a da d&iacute;vida, n&atilde;o ultrapassando os padr&otilde;es &eacute;ticos-processuais ao se limitar ao exerc&iacute;cio do direito constitucional de a&ccedil;&atilde;o
+5. Apela&ccedil;&atilde;o parcialmente provida. &nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Senador Guiomard;N&uacute;mero do Processo:0701148-71.2023.8.01.0009;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Senador Guiomard
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. PRELIMINAR DE CERCEAMENTO DE DEFESA. PRECLUSÃO CONSUMATIVA DO DIREITO DE REQUERER A PRODUÇÃO DE PROVA PERICIAL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA. CARTÃO DE CRÉDITO ADIANTAMENTO SALARIAL. INFORMAÇÕES DO CONTRATO BANCÁRIO. REGULARIDADE DA CONTRATAÇÃO. OBSERVÂNCIA DOS PRINCÍPIOS DA TRANSPARÊNCIA E DA INFORMAÇÃO. LITIGÂNCIA DE MÁ-FÉ. NÃO CARACTERIZAÇÃO DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. PRELIMINAR DE CERCEAMENTO DE DEFESA. PRECLUSÃO CONSUMATIVA DO DIREITO DE REQUERER A PRODUÇÃO DE PROVA PERICIAL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA. CARTÃO DE CRÉDITO ADIANTAMENTO SALARIAL. INFORMAÇÕES DO CONTRATO BANCÁRIO. REGULARIDADE DA CONTRATAÇÃO. OBSERVÂNCIA DOS PRINCÍPIOS DA TRANSPARÊNCIA E DA INFORMAÇÃO. LITIGÂNCIA DE MÁ-FÉ. NÃO CARACTERIZAÇÃO DE LIDE TEMERÁRIA.
+1. Nos termos do art. 507, do CPC, houve a preclusão consumativa do direito de requerer a produção de prova pericial, à medida que, no momento processual adequado, o Apelante externou a certeza de que o ato processual não seria necessário.
+2. Não existe qualquer abusividade nos descontos efetuados, tendo em vista que o Apelante obteve todas as informações sobre a modalidade de crédito ofertada. Por consequência, ocorreu a plena observância aos princípios da transparência e informação, previstos nos arts. 6º, inciso III, 46 e 52, todos do CDC, não tendo procedência o pedido de revisão judicial do contrato.
+3. De acordo com jurisprudência do TJAC, "a assinatura eletrônica acompanhada de selfie, somada à expressa identificação do contrato como cartão de crédito consignado e apresentação de termo de consentimento esclarecido com comparação entre modalidades de crédito, além da utilização do cartão para compras na função crédito afastam a alegação de vício de consentimento, comprova o dever de informação e confirma o conhecimento e aceitação do produto contratado". Precedente: Apelação n. 0712485-13.2025.8.01.0001.
+4. De acordo com os autos, não existem elementos suficientes para caracterizar o ajuizamento de uma lide temerária, considerando que a mera propositura da ação declaratória é vista como uma forma legítima da consumidora questionar a validade da cobrança da dívida, não ultrapassando os padrões éticos-processuais ao se limitar ao exercício do direito constitucional de ação
+5. Apelação parcialmente provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>40&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2503494" cdForo="0" >
+										0711272-74.2022.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2503494" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2503494);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2503494" style="display: none;" >
+	<div id="textAreaDados_2503494" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSO CIVIL. APELA&Ccedil;&Atilde;O. EMPR&Eacute;STIMO CONSIGNADO. CONTRATA&Ccedil;&Atilde;O FRAUDULENTA. PER&Iacute;CIA GRAFOT&Eacute;CNICA. INEXIST&Ecirc;NCIA DO NEG&Oacute;CIO JUR&Iacute;DICO. RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO. MODULA&Ccedil;&Atilde;O DO STJ. COMPENSA&Ccedil;&Atilde;O DOS VALORES CREDITADOS. DANO MORAL CONFIGURADO. MANUTEN&Ccedil;&Atilde;O DO VALOR INDENIZAT&Oacute;RIO. SENTEN&Ccedil;A MANTIDA.
+1. As institui&ccedil;&otilde;es financeiras respondem objetivamente pelos danos decorrentes de fraudes praticadas por terceiros no &acirc;mbito de opera&ccedil;&otilde;es banc&aacute;rias (S&uacute;mula 479 do STJ).
+2. Laudo pericial grafot&eacute;cnico que atesta a falsifica&ccedil;&atilde;o da assinatura aposta em contrato banc&aacute;rio afasta a exist&ecirc;ncia de manifesta&ccedil;&atilde;o v&aacute;lida de vontade e imp&otilde;e o reconhecimento da inexist&ecirc;ncia da contrata&ccedil;&atilde;o.
+3. Nos termos da modula&ccedil;&atilde;o fixada pelo STJ no julgamento do EAREsp 676.608/RS, a repeti&ccedil;&atilde;o do ind&eacute;bito deve ocorrer de forma simples em rela&ccedil;&atilde;o &agrave;s cobran&ccedil;as anteriores a 30/03/2021 e em dobro quanto &agrave;s posteriores.
+4. &Eacute; cab&iacute;vel a compensa&ccedil;&atilde;o entre o valor creditado ao consumidor e os valores indevidamente descontados, a fim de evitar enriquecimento sem causa.
+5. A contrata&ccedil;&atilde;o fraudulenta de empr&eacute;stimo consignado, com descontos incidentes sobre benef&iacute;cio previdenci&aacute;rio de pessoa idosa por aproximadamente um ano, configura dano moral indeniz&aacute;vel. Mant&eacute;m-se a indeniza&ccedil;&atilde;o fixada pelo Ju&iacute;zo de origem, diante das circunst&acirc;ncias do caso concreto, observando-se o m&eacute;todo bif&aacute;sico. Jurisprud&ecirc;ncia deste Tribunal.
+6. Juros de mora desde o evento danoso (S&uacute;mula 54 do STJ) e corre&ccedil;&atilde;o monet&aacute;ria desde o arbitramento (S&uacute;mula 362 do STJ).
+7. Apela&ccedil;&atilde;o parcialmente provida.&nbsp;<br>(Relator (a): Des. Lu&iacute;s Camolez; Comarca: Rio Branco;N&uacute;mero do Processo:0711272-74.2022.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br> C&iacute;vel &nbsp;4&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luís Camolez
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSO CIVIL. APELAÇÃO. EMPRÉSTIMO CONSIGNADO. CONTRATAÇÃO FRAUDULENTA. PERÍCIA GRAFOTÉCNICA. INEXISTÊNCIA DO NEGÓCIO JURÍDICO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. REPETIÇÃO DO INDÉBITO. MODULAÇÃO DO STJ. COMPENSAÇÃO DOS VALORES CREDITADOS. <em>DANO</em> <em>MORAL</em> CONFIGURADO. MANUTENÇÃO DO VALOR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSO CIVIL. APELAÇÃO. EMPRÉSTIMO CONSIGNADO. CONTRATAÇÃO FRAUDULENTA. PERÍCIA GRAFOTÉCNICA. INEXISTÊNCIA DO NEGÓCIO JURÍDICO. RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. REPETIÇÃO DO INDÉBITO. MODULAÇÃO DO STJ. COMPENSAÇÃO DOS VALORES CREDITADOS. <em>DANO</em> <em>MORAL</em> CONFIGURADO. MANUTENÇÃO DO VALOR INDENIZATÓRIO. SENTENÇA MANTIDA.
+1. As instituições financeiras respondem objetivamente pelos <em>danos</em> decorrentes de fraudes praticadas por terceiros no âmbito de operações bancárias (Súmula 479 do STJ).
+2. Laudo pericial grafotécnico que atesta a falsificação da assinatura aposta em contrato bancário afasta a existência de manifestação válida de vontade e impõe o reconhecimento da inexistência da contratação.
+3. Nos termos da modulação fixada pelo STJ no julgamento do EAREsp 676.608/RS, a repetição do indébito deve ocorrer de forma simples em relação às cobranças anteriores a 30/03/2021 e em dobro quanto às posteriores.
+4. É cabível a compensação entre o valor creditado ao consumidor e os valores indevidamente descontados, a fim de evitar enriquecimento sem causa.
+5. A contratação fraudulenta de empréstimo consignado, com descontos incidentes sobre benefício previdenciário de pessoa idosa por aproximadamente um ano, configura <em>dano</em> <em>moral</em> indenizável. Mantém-se a indenização fixada pelo Juízo de origem, diante das circunstâncias do caso concreto, observando-se o método bifásico. Jurisprudência deste Tribunal.
+6. Juros de mora desde o evento danoso (Súmula 54 do STJ) e correção monetária desde o arbitramento (Súmula 362 do STJ).
+7. Apelação parcialmente provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="APELAÇÃO">
+									<label for="ckTermo1">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="CIVIL">
+									<label for="ckTermo2">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="DIREITO">
+									<label for="ckTermo3">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="RECURSO">
+									<label for="ckTermo4">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="CÍVEL">
+									<label for="ckTermo5">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="Recurso">
+									<label for="ckTermo6">
+										Recurso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="parte">
+									<label for="ckTermo7">
+										parte
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="danos">
+									<label for="ckTermo8">
+										danos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="AÇÃO">
+									<label for="ckTermo9">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="desprovido">
+									<label for="ckTermo10">
+										desprovido
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="autos">
+									<label for="ckTermo11">
+										autos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="caso">
+									<label for="ckTermo12">
+										caso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="Código">
+									<label for="ckTermo13">
+										Código
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="Apelação">
+									<label for="ckTermo14">
+										Apelação
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="sentença">
+									<label for="ckTermo15">
+										sentença
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				21 a 40
+			</strong>
+			de 13929
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+			<a name="A1" title="Página anterior">
+				&lt;
+			</a>
+
+
+
+
+
+
+
+
+
+
+
+					<a name="A1" style="padding-left:4px" >
+						1
+					</a>
+
+
+
+
+
+					<span class="paginaAtual" >
+						2
+					</span>
+
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A3" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjac/samples/cjsg/single_page.html
+++ b/tests/tjac/samples/cjsg/single_page.html
@@ -1,0 +1,730 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(3)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="3" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="2472811" cdForo="0" >
+										0713800-23.2018.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="2472811" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(2472811);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_2472811" style="display: none;" >
+	<div id="textAreaDados_2472811" class="mensagemSemFormatacao" >
+		V.V.APELA&Ccedil;&Atilde;O C&Iacute;VEL. USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIO. JUNTADA DE DOCUMENTOS NOVOS EM SEDE RECURSAL. N&Atilde;O CONHECIMENTO. M&Eacute;RITO. REQUISITOS DO ART. 1.238 DO C&Oacute;DIGO CIVIL PREENCHIDOS. APELO PROVIDO.
+1. Nos termos do art. 435 do CPC, n&atilde;o se pode admitir a juntada de documentos ou novas alega&ccedil;&otilde;es, em fase recursal, salvo quando se trata de fato novo posterior &agrave; senten&ccedil;a ou documentos que a parte n&atilde;o tinha conhecimento ou condi&ccedil;&otilde;es de produzir.
+2. No m&eacute;rito, deve ser prestigiado o princ&iacute;pio da&nbsp;seguran&ccedil;a&nbsp;jur&iacute;dica&nbsp;quando verificado que j&aacute; houve o reconhecimento &#150;  ainda que de forma indireta &#150;  da aquisi&ccedil;&atilde;o da propriedade pelo exerc&iacute;cio da posse pela autora em outros autos, sob pena de se estar julgando de forma contradit&oacute;ria a um feito que j&aacute; teve seu tr&acirc;nsito em julgado.
+3. Ademais, n&atilde;o se revela adequada a conclus&atilde;o exarada na senten&ccedil;a no sentido de que a autora e o r&eacute;u mantiveram o conv&iacute;vio marital, mesmo porque resta demonstrado nos autos que o casal estava separado h&aacute; muitos anos e viviam em Estados da Federa&ccedil;&atilde;o distintos (ela no Acre e ele em Goi&aacute;s), de modo que os reencontros ocorridos ap&oacute;s a separa&ccedil;&atilde;o se deram t&atilde;o somente pelo bom conv&iacute;vio com os filhos do casal advindos da uni&atilde;o.
+4. A a&ccedil;&atilde;o que visa usucapir com base no art. 1.238 do CC, usucapi&atilde;o extraordin&aacute;rio, tem por requisito prova da posse de im&oacute;vel por quinze anos ininterruptos, sem oposi&ccedil;&atilde;o, independentemente de t&iacute;tulo e boa-f&eacute;. Na hip&oacute;tese do possuidor estabelecer no im&oacute;vel a sua moradia habitual ou ter realizado obras ou servi&ccedil;os de car&aacute;ter produtivo o prazo &eacute; reduzido para 10 anos, respeitada a regra de transi&ccedil;&atilde;o disposta no art. 2.209 do CC. Circunst&acirc;ncia dos autos em que se imp&otilde;e julgar procedente a a&ccedil;&atilde;o
+5. Apelo conhecido, em parte, e, na parte conhecida, provido.
+
+V.v.APELA&Ccedil;&Atilde;O C&Iacute;VEL. USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIO. REJEI&Ccedil;&Atilde;O. AUS&Ecirc;NCIA DE POSSE &quot;AD USUCAPIONEM&quot;. COMPOSSE DAS PARTES DEMONSTRADA. SENTEN&Ccedil;A MANTIDA. RECURSO PARCIALMENTE CONHECIDO. N&Atilde;O PROVIDO.
+1. A insurg&ecirc;ncia em face da r. Senten&ccedil;a que deu por improcedente a demanda. Alega&ccedil;&otilde;es de cumprimento do lapso temporal na posse, que era exclusiva, assim como cumprimento dos demais requisitos elencados no art. 1.238 do CC, ao deferimento do pedido de usucapi&atilde;o extraordin&aacute;rio.
+2. Exist&ecirc;ncia de posse prec&aacute;ria em raz&atilde;o de composse do companheiro. Aus&ecirc;ncia de animus domini.
+3. Aus&ecirc;ncia de elementos que consubstanciem as alega&ccedil;&otilde;es da apelante. Posse ad usucapionem n&atilde;o demonstrada.
+4. Nos termos do art. 435 do CPC, n&atilde;o se pode admitir a juntada de documentos ou novas alega&ccedil;&otilde;es, em fase recursal, salvo quando se trata de fato novo posterior &agrave; senten&ccedil;a ou documentos que a parte n&atilde;o tinha conhecimento ou condi&ccedil;&otilde;es de produzir.
+5. Recurso parcialmente conhecido e n&atilde;o provido. &nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0713800-23.2018.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 12/09/2024; Data de registro: 20/09/2024)<br> C&iacute;vel &nbsp;2&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(66 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Extraordinária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/09/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									20/09/2024
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>V.V.APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIO</em>. JUNTADA DE DOCUMENTOS NOVOS EM SEDE RECURSAL. NÃO CONHECIMENTO. MÉRITO. REQUISITOS DO ART. 1.238 DO CÓDIGO CIVIL PREENCHIDOS. APELO PROVIDO.
+1. Nos termos do art. 435 do CPC, não se pode admitir a juntada de documentos ou novas alegações, em fase recursal, salvo quando se trata de fato novo posterior à sentença ou documentos que a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>V.V.APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIO</em>. JUNTADA DE DOCUMENTOS NOVOS EM SEDE RECURSAL. NÃO CONHECIMENTO. MÉRITO. REQUISITOS DO ART. 1.238 DO CÓDIGO CIVIL PREENCHIDOS. APELO PROVIDO.
+1. Nos termos do art. 435 do CPC, não se pode admitir a juntada de documentos ou novas alegações, em fase recursal, salvo quando se trata de fato novo posterior à sentença ou documentos que a parte não tinha conhecimento ou condições de produzir.
+2. No mérito, deve ser prestigiado o princípio da segurança jurídica quando verificado que já houve o reconhecimento   ainda que de forma indireta   da aquisição da propriedade pelo exercício da posse pela autora em outros autos, sob pena de se estar julgando de forma contraditória a um feito que já teve seu trânsito em julgado.
+3. Ademais, não se revela adequada a conclusão exarada na sentença no sentido de que a autora e o réu mantiveram o convívio marital, mesmo porque resta demonstrado nos autos que o casal estava separado há muitos anos e viviam em Estados da Federação distintos (ela no Acre e ele em Goiás), de modo que os reencontros ocorridos após a separação se deram tão somente pelo bom convívio com os filhos do casal advindos da união.
+4. A ação que visa usucapir com base no art. 1.238 do CC, <em>usucapião</em> <em>extraordinário</em>, tem por requisito prova da posse de imóvel por quinze anos ininterruptos, sem oposição, independentemente de título e boa-fé. Na hipótese do possuidor estabelecer no imóvel a sua moradia habitual ou ter realizado obras ou serviços de caráter produtivo o prazo é reduzido para 10 anos, respeitada a regra de transição disposta no art. 2.209 do CC. Circunstância dos autos em que se impõe julgar procedente a ação
+5. Apelo conhecido, em parte, e, na parte conhecida, provido.
+
+V.v.APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIO</em>. REJEIÇÃO. AUSÊNCIA DE POSSE "AD USUCAPIONEM". COMPOSSE DAS PARTES DEMONSTRADA. SENTENÇA MANTIDA. RECURSO PARCIALMENTE CONHECIDO. NÃO PROVIDO.
+1. A insurgência em face da r. Sentença que deu por improcedente a demanda. Alegações de cumprimento do lapso temporal na posse, que era exclusiva, assim como cumprimento dos demais requisitos elencados no art. 1.238 do CC, ao deferimento do pedido de <em>usucapião</em> <em>extraordinário</em>.
+2. Existência de posse precária em razão de composse do companheiro. Ausência de animus domini.
+3. Ausência de elementos que consubstanciem as alegações da apelante. Posse ad usucapionem não demonstrada.
+4. Nos termos do art. 435 do CPC, não se pode admitir a juntada de documentos ou novas alegações, em fase recursal, salvo quando se trata de fato novo posterior à sentença ou documentos que a parte não tinha conhecimento ou condições de produzir.
+5. Recurso parcialmente conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="108821" cdForo="0" >
+										0700115-73.2014.8.01.0005
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="108821" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(108821);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_108821" style="display: none;" >
+	<div id="textAreaDados_108821" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. APELA&Ccedil;&Atilde;O. REIVINDICAT&Oacute;RIA. SOBREPOSI&Ccedil;&Atilde;O DE &Aacute;REAS. IM&Oacute;VEL RURAL. DUPLICIDADE DE REGISTRO IMOBILI&Aacute;RIO.  COMPROVA&Ccedil;&Atilde;O DA POSSE E DO DOM&Iacute;NIO DOS REQUERIDOS/APELADOS.
+1. Diante da exist&ecirc;ncia de t&iacute;tulos de registro em favor de ambas as partes, decorrente da sobreposi&ccedil;&atilde;o de &aacute;reas nos assentamentos registrais e verificado que os Requeridos/Apelados exercem a posse direta do bem, justa, pac&iacute;fica e de boa-f&eacute; porque possuem t&iacute;tulo justo, cuja inscri&ccedil;&atilde;o nos Registros P&uacute;blicos &eacute; anterior ao registro do t&iacute;tulo apresentado pelo Autor/Apelante, tem-se por escorreita a senten&ccedil;a que julga improcedente o pedido autoral e reconhece o direito dos Requeridos/Apelados sob a &aacute;rea objeto da lide.
+2. Constatado que a cadeia dominial constante nas certid&otilde;es imobili&aacute;rias apresentadas pelos Requeridos/Apelados &eacute; mais antiga que aquela constante na matr&iacute;cula que indica o Apelante como propriet&aacute;rio e, ainda, havendo evid&ecirc;ncias nos autos de que os Apelados det&eacute;m a posse da coisa reivindicada, imperioso a manuten&ccedil;&atilde;o da realidade possess&oacute;ria e o reconhecimento do dom&iacute;nio das partes demandadas na a&ccedil;&atilde;o reivindicat&oacute;ria.
+4. Recurso conhecido e desprovido.&nbsp;<br>(Relator (a): Des&ordf;. Waldirene Cordeiro; Comarca: Capixaba;N&uacute;mero do Processo:0700115-73.2014.8.01.0005;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 26/05/2020; Data de registro: 31/05/2020)<br> C&iacute;vel &nbsp;Vara &Uacute;nica - C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Esbulho / Turbação / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Desª. Waldirene Cordeiro
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Capixaba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									31/05/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO. REIVINDICATÓRIA. SOBREPOSIÇÃO DE ÁREAS. IMÓVEL <em>RURAL</em>. DUPLICIDADE DE REGISTRO IMOBILIÁRIO.  COMPROVAÇÃO DA POSSE E DO DOMÍNIO DOS REQUERIDOS/APELADOS.
+1. Diante da existência de títulos de registro em favor de ambas as partes, decorrente da sobreposição de áreas nos assentamentos registrais e verificado que os Requeridos/Apelados exercem a posse direta do bem,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO. REIVINDICATÓRIA. SOBREPOSIÇÃO DE ÁREAS. IMÓVEL <em>RURAL</em>. DUPLICIDADE DE REGISTRO IMOBILIÁRIO.  COMPROVAÇÃO DA POSSE E DO DOMÍNIO DOS REQUERIDOS/APELADOS.
+1. Diante da existência de títulos de registro em favor de ambas as partes, decorrente da sobreposição de áreas nos assentamentos registrais e verificado que os Requeridos/Apelados exercem a posse direta do bem, justa, pacífica e de boa-fé porque possuem título justo, cuja inscrição nos Registros Públicos é anterior ao registro do título apresentado pelo Autor/Apelante, tem-se por escorreita a sentença que julga improcedente o pedido autoral e reconhece o direito dos Requeridos/Apelados sob a área objeto da lide.
+2. Constatado que a cadeia dominial constante nas certidões imobiliárias apresentadas pelos Requeridos/Apelados é mais antiga que aquela constante na matrícula que indica o Apelante como proprietário e, ainda, havendo evidências nos autos de que os Apelados detém a posse da coisa reivindicada, imperioso a manutenção da realidade possessória e o reconhecimento do domínio das partes demandadas na ação reivindicatória.
+4. Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="71554" cdForo="0" >
+										0710401-88.2015.8.01.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="71554" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(71554);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_71554" style="display: none;" >
+	<div id="textAreaDados_71554" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O REIVINDICAT&Oacute;RIA. PRELIMINAR DE NULIDADE DA SENTEN&Ccedil;A POR AUS&Ecirc;NCIA DE INTERVEN&Ccedil;&Atilde;O DO MINIST&Eacute;RIO P&Uacute;BLICO. AFASTADA. COMODATO FIRMADO ENTRE A PROPRIET&Aacute;RIA DA TERRA E SEU FUNCION&Aacute;RIO. &Aacute;REA DE TERRA CEDIDA PARA EFEITOS DE MORADIA E PLANTA&Ccedil;&Atilde;O. LOTEAMENTO E VENDA POR PARTE DOS HERDEIROS DO COMODAT&Aacute;RIO. NOTIFICA&Ccedil;&Atilde;O. ALEGA&Ccedil;&Atilde;O DE USUCAPI&Atilde;O EM DEFESA. POSSE AD USUCAPIONEM N&Atilde;O COMPROVADA. PRECARIEDADE. ESBULHO. OCORR&Ecirc;NCIA. SENTEN&Ccedil;A MANTIDA.
+1. A interven&ccedil;&atilde;o ministerial n&atilde;o &eacute; obrigat&oacute;ria quando ausente interesse p&uacute;blico, social ou individual indispon&iacute;vel a ser tutelado e, ainda,  o direito &agrave; usucapi&atilde;o &eacute; alegado simplesmente como mat&eacute;ria de defesa.
+2. Resistindo o comodat&aacute;rio &agrave; desocupa&ccedil;&atilde;o do im&oacute;vel, a posse que outrora era l&iacute;cita passa a ser prec&aacute;ria e injusta, pois desamparada de qualquer neg&oacute;cio jur&iacute;dico e exercida contra a vontade do  propriet&aacute;rio, sendo a a&ccedil;&atilde;o reivindicat&oacute;ria o meio adequado para reaver o im&oacute;vel havido em comodato.
+2. Decerto houve posse mansa e pac&iacute;fica, notadamente porque a posse direta exercida atualmente pela apelante foi concedida espontaneamente pela titular dominial da terra, por&eacute;m, o &ecirc;xito da a&ccedil;&atilde;o de&nbsp;usucapi&atilde;o, al&eacute;m da demonstra&ccedil;&atilde;o da posse mansa, pac&iacute;fica e ininterrupta&nbsp;depende de competente prova dos requisitos relativos ao 'animus domini', sem os quais o pedido respectivo revela-se improcedente.
+3. A precariedade da posse e o seu exerc&iacute;cio mediante mera permiss&atilde;o ou toler&acirc;ncia afasta a posse ad usucapionem, essencial ao reconhecimento da prescri&ccedil;&atilde;o aquisitiva da usucapi&atilde;o.
+4. Prejudicial de m&eacute;rito afastada. Apela&ccedil;&atilde;o conhecida e, no m&eacute;rito, desprovida.&nbsp;<br>(Relator (a): Des. J&uacute;nior Alberto; Comarca: Rio Branco;N&uacute;mero do Processo:0710401-88.2015.8.01.0001;&Oacute;rg&atilde;o julgador:  Segunda C&acirc;mara C&iacute;vel;Data do julgamento: 23/06/2017; Data de registro: 30/06/2017)<br> C&iacute;vel &nbsp;1&ordf; Vara C&iacute;vel&nbsp;
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(34 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Esbulho / Turbação / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Júnior Alberto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Branco
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									23/06/2017
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									30/06/2017
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO REIVINDICATÓRIA. PRELIMINAR DE NULIDADE DA SENTENÇA POR AUSÊNCIA DE INTERVENÇÃO DO MINISTÉRIO PÚBLICO. AFASTADA. COMODATO FIRMADO ENTRE A PROPRIETÁRIA DA TERRA E SEU FUNCIONÁRIO. ÁREA DE TERRA CEDIDA PARA EFEITOS DE MORADIA E PLANTAÇÃO. LOTEAMENTO E VENDA POR PARTE DOS HERDEIROS DO COMODATÁRIO. NOTIFICAÇÃO. ALEGAÇÃO DE <em>USUCAPIÃO</em> EM DEFESA. POSSE AD USUCAPIONEM NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO REIVINDICATÓRIA. PRELIMINAR DE NULIDADE DA SENTENÇA POR AUSÊNCIA DE INTERVENÇÃO DO MINISTÉRIO PÚBLICO. AFASTADA. COMODATO FIRMADO ENTRE A PROPRIETÁRIA DA TERRA E SEU FUNCIONÁRIO. ÁREA DE TERRA CEDIDA PARA EFEITOS DE MORADIA E PLANTAÇÃO. LOTEAMENTO E VENDA POR PARTE DOS HERDEIROS DO COMODATÁRIO. NOTIFICAÇÃO. ALEGAÇÃO DE <em>USUCAPIÃO</em> EM DEFESA. POSSE AD USUCAPIONEM NÃO COMPROVADA. PRECARIEDADE. ESBULHO. OCORRÊNCIA. SENTENÇA MANTIDA.
+1. A intervenção ministerial não é obrigatória quando ausente interesse público, social ou individual indisponível a ser tutelado e, ainda,  o direito à <em>usucapião</em> é alegado simplesmente como matéria de defesa.
+2. Resistindo o comodatário à desocupação do imóvel, a posse que outrora era lícita passa a ser precária e injusta, pois desamparada de qualquer negócio jurídico e exercida contra a vontade do  proprietário, sendo a ação reivindicatória o meio adequado para reaver o imóvel havido em comodato.
+2. Decerto houve posse mansa e pacífica, notadamente porque a posse direta exercida atualmente pela apelante foi concedida espontaneamente pela titular dominial da terra, porém, o êxito da ação de <em>usucapião</em>, além da demonstração da posse mansa, pacífica e ininterrupta depende de competente prova dos requisitos relativos ao 'animus domini', sem os quais o pedido respectivo revela-se improcedente.
+3. A precariedade da posse e o seu exercício mediante mera permissão ou tolerância afasta a posse ad usucapionem, essencial ao reconhecimento da prescrição aquisitiva da <em>usucapião</em>.
+4. Prejudicial de mérito afastada. Apelação conhecida e, no mérito, desprovida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="POSSE">
+									<label for="ckTermo1">
+										POSSE
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="ainda">
+									<label for="ckTermo2">
+										ainda
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="ação">
+									<label for="ckTermo3">
+										ação
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="improcedente">
+									<label for="ckTermo4">
+										improcedente
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="pedido">
+									<label for="ckTermo5">
+										pedido
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="porque">
+									<label for="ckTermo6">
+										porque
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="posse">
+									<label for="ckTermo7">
+										posse
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="reconhecimento">
+									<label for="ckTermo8">
+										reconhecimento
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="APELAÇÃO">
+									<label for="ckTermo9">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="AUSÊNCIA">
+									<label for="ckTermo10">
+										AUSÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="CIVIL">
+									<label for="ckTermo11">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="CÍVEL">
+									<label for="ckTermo12">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="MANTIDA">
+									<label for="ckTermo13">
+										MANTIDA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="REIVINDICATÓRIA">
+									<label for="ckTermo14">
+										REIVINDICATÓRIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="Recurso">
+									<label for="ckTermo15">
+										Recurso
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 3
+			</strong>
+			de 3
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjac/test_cjsg_contract.py
+++ b/tests/tjac/test_cjsg_contract.py
@@ -1,0 +1,86 @@
+"""Offline contract tests for TJAC cjsg.
+
+Mocks ``resultadoCompleta.do`` + ``trocaDePagina.do`` with captured samples
+(see ``tests/fixtures/capture/tjac.py``) and asserts the public DataFrame
+contract. Covers typical multi-page, single-page, and zero-result scenarios.
+"""
+import pandas as pd
+import responses
+from responses.matchers import query_param_matcher, urlencoded_params_matcher
+
+import juscraper as jus
+from tests._helpers import load_sample_bytes
+from tests.fixtures.capture._util import make_esaj_body
+
+BASE = "https://esaj.tjac.jus.br/cjsg"
+CJSG_MIN_COLUMNS = {"processo", "cd_acordao", "cd_foro", "ementa"}
+
+
+def _add_post(pesquisa: str) -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjac", "cjsg/post_initial.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(make_esaj_body(pesquisa), allow_blank=True)],
+    )
+
+
+def _add_get(pagina: int, sample_path: str) -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjac", sample_path),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": str(pagina)})],
+    )
+
+
+@responses.activate
+def test_cjsg_typical_com_paginacao(tmp_path, mocker):
+    """Typical multi-page query returns a DataFrame with the minimum schema."""
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+    _add_get(2, "cjsg/results_normal_page_02.html")
+
+    df = jus.scraper("tjac", download_path=str(tmp_path)).cjsg(
+        "dano moral", paginas=range(1, 3)
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_single_page(tmp_path, mocker):
+    """Query whose hits fit in one page skips the per-page loop."""
+    mocker.patch("time.sleep")
+    _add_post("usucapiao extraordinario predio rural familia")
+    _add_get(1, "cjsg/single_page.html")
+
+    df = jus.scraper("tjac", download_path=str(tmp_path)).cjsg(
+        "usucapiao extraordinario predio rural familia", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_no_results(tmp_path, mocker):
+    """Zero-result query returns an empty DataFrame instead of raising."""
+    mocker.patch("time.sleep")
+    _add_post("juscraper_probe_zero_hits_xyzqwe")
+    _add_get(1, "cjsg/no_results.html")
+
+    df = jus.scraper("tjac", download_path=str(tmp_path)).cjsg(
+        "juscraper_probe_zero_hits_xyzqwe", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty

--- a/tests/tjal/samples/cjsg/no_results.html
+++ b/tests/tjal/samples/cjsg/no_results.html
@@ -1,0 +1,18 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(0)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="0" />
+
+
+
+			<div align="center" class="ementaClass" style="padding: 80px;">
+				<strong>
+					Não foi encontrado nenhum resultado correspondente à busca realizada.
+				</strong>
+			</div>

--- a/tests/tjal/samples/cjsg/post_initial.html
+++ b/tests/tjal/samples/cjsg/post_initial.html
@@ -1,0 +1,8389 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Nodo 7 -->
+
+<html>
+	<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+
+
+
+
+
+
+
+
+
+
+
+	<script language="javascript" type="text/JavaScript" src="https://www2.tjal.jus.br/sajcas/verificarLogin.js?script=1776718193980"></script>
+
+	<script language="javascript">
+		if(window.sajcas && window.sajcas.usuarioLogadoNoCasServer) {
+			var urlRetornoSistema = 'https://www2.tjal.jus.br/cjsg/consultaCompleta.do';
+			if(urlRetornoSistema === '') {
+				urlRetornoSistema = window.location.href;
+			}
+
+			if(urlRetornoSistema.lastIndexOf('?') != -1) {
+				urlRetornoSistema += '&';
+			} else {
+				urlRetornoSistema += '?';
+			}
+			urlRetornoSistema+= 'gateway=true';
+			window.location.href = urlRetornoSistema;
+		}
+	</script>
+
+
+
+
+
+
+
+
+
+
+	<title>Consulta de Jurisprudência do Segundo Grau</title>
+	<script>
+		window.saj = window.saj || {};
+		window.saj.env = window.saj.env || {};
+		window.saj.env.root = '/cjsg';
+		window.saj.env.css = '/cjsg/css';
+		window.saj.env.js = '/cjsg/js';
+		window.saj.env.imagens = '/cjsg/imagens';
+		window.saj.env.cliente = 'AL';
+	</script>
+ 	<script src="/cjsg/js/jquery/jquery.min.js?n=b5d78a2c-2a08-468c-99ae-3769404dce38"></script>
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/saj/saj-web-2.2.41-4.js?n=6951c1f3-a82b-4673-9bb6-d52002a59308"></script>
+
+
+ 	<script>var localeJS = "pt_BR"; </script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMsg.js"></script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMap_pt.js"></script>
+	<script src="/cjsg/js/jquery/jquery.browser.min.js?n=74a8f43c-7969-44ab-8fbf-ca28740913d2"></script>
+ 	<script src="/cjsg/js/spw/spwConcatenado.js?n=27c52ebe-9241-4c43-a21b-3ddbc0b7d1df"></script>
+ 	<link href="/cjsg/css/spw/spwConcatenado.css" rel="stylesheet" type="text/css" />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+<meta http-equiv="pragma" content="no-cache"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<meta http-equiv="expires" content="0"/>
+
+<link href="https://www2.tjal.jus.br/esaj-layout/tema/padrao/css/esajComum.css" rel="stylesheet" type="text/css" />
+<link href="https://www2.tjal.jus.br/esaj-layout/tema/padrao/css/esajLayout.css" rel="stylesheet" type="text/css" />
+<link href="https://www2.tjal.jus.br/esaj-layout/tema/padrao/clientes/AL/css/esajLayoutAL.css" rel="stylesheet" type="text/css" />
+
+<style type="text/css">
+<!--
+/* botao default means o mais claro, que seria o "botï¿½o principal" */
+.spwBotaoDefault, .spwBotaoDefault-o {
+	background-image: url(https://www2.tjal.jus.br/esaj-layout/tema/padrao/clientes/AL/imagens/layout/fundoBotaoDefault.gif);
+}
+/* o botao secundario, menos provavel de ser clicado, mais escuro */
+.spwBotao, .spwBotao-o {
+	background-image: url(https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/fundoBotao.gif);
+}
+-->
+</style>
+
+
+<script language="javascript" type="text/JavaScript" src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/js/menu.js?n=2553626853"></script>
+
+<link rel="shortcut icon" href="https://www2.tjal.jus.br/esaj-layout/tema/padrao/clientes/AL/imagens/favicon.ico" type="image/x-icon" />
+
+
+
+
+<script>
+    var dict = {
+        'certificado.tituloCertificadoDigital': 'Certificado digital',
+        'certificado.msgCarregandoCertificado': 'Carregando certificados...',
+        'certificado.msgNenhumCertificadoEncontrado': 'Nenhum certificado encontrado',
+        'certificado.msgErroCarregarCertificado': 'Erro ao carregar certificados',
+        'certificado.msgCertificadoExpirado': '[Expirado]',
+        'certificado.msgCertificadoNaoValido': '[Ainda não válido]',
+        'certificado.msgCertificadoNaoIcpBrasil': '[Não ICP-Brasil]',
+        'certificado.tituloProblemasAoAssinar': 'Falha de comunicação com o dispositivo de assinatura digital',
+
+        'label.contato': 'Contato',
+        'label.identificarSe': 'Identificar-se ',
+
+        'mensagem.aguarde': 'Por favor, aguarde.',
+        'mensagem.paginaNaoCarregada': 'Não foi possível carregar a página.',
+        'mensagem.marcarLido': 'Marcar como lido',
+        'mensagem.registrosSelecionados': 'Registros selecionados',
+        'mensagem.registroJaSelecionado': 'Este registro já está selecionado',
+
+        'mensagem.data.invalida': 'A data digitada é inválida.',
+        'mensagem.data.anoInvalido': 'O ano informado deve ser maior que',
+        'mensagem.data.mesInvalido': 'O mês não pode ser maior que 12.',
+        'mensagem.data.mes': 'O mês',
+        'mensagem.data.mesMaior29dias': 'não pode ter mais que 29 dias.',
+        'mensagem.data.mesMaior28dias': 'não pode ter mais que 28 dias.',
+        'mensagem.data.mesMaior31dias': 'não pode ter mais que 31 dias.',
+        'mensagem.data.mesMaior30dias': 'não pode ter mais que 30 dias.',
+
+        'mensagem.email.invalido': 'O formato do endereço de e-mail não é válido. Verifique se ele tem o formato "usuario@dominio".',
+        'mensagem.email.caracteresInvalidos': 'O endereço de e-mail possui caracteres inválidos',
+        'mensagem.email.usuarioInvalido': 'O formato do usuário informado no endereço de e-mail não é válido.',
+        'mensagem.email.ipInvalido': 'O endereço IP informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioInvalido': 'O formato do domínio informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioIncompleto': 'O domínio informado no endereço de e-mail deve possuir pelo menos duas partes. Por exemplo: "usuario@empresa.com.br".',
+
+        'mensagem.texto.tamanhoInvalido': 'O tamanho do texto digitado é maior do que o tamanho permitido. Tamanho permitido:',
+        'mensagem.texto.caracter': 'O caracter',
+        'mensagem.texto.caracterPosicaoInvalida': 'não está permitido na posição',
+
+        'mensagem.numero.numeroInvalido': 'O valor digitado não é um número válido.',
+        'mensagem.numero.numeroNaoPodeCasasDecimais': 'O número não pode conter casas decimais',
+        'mensagem.numero.numeroCasaDecimaisInvalidas': 'O número de casas decimais é inválido. O número pode conter apenas',
+        'mensagem.numero.casaDecimais': 'casas decimais',
+        'mensagem.numero.numeroInteiroInvalido': 'O número de dígitos inteiros é inválido. O número pode conter apenas',
+        'mensagem.numero.digitosInteiros': 'dígitos inteiros',
+        'mensagem.numero.numeroTamanhoInvalido': 'O número digitado não pode ser maior que',
+        'mensagem.numero.numeroZeroInvalido': 'O número digitado deve ser diferente de zero.'
+    }
+</script>
+
+
+
+
+
+
+
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/cjsg-2.2.5-0.js?n=260410155"></script>
+ 	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/AL/cjsg.css" />
+	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/AL/link.css" />
+
+
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/spw/spwTab.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-popup-modal.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-tree.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/cjsg.css" />
+
+
+		<script type="text/JavaScript" src="/cjsg/js/jquery/jquery.blockUI.min.js?n=c5ffc7ba-4326-4414-b73c-417e0a6d4191"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tooltip.js?n=df275a5c-c641-4c60-a60c-034d4d36a519"></script>
+		<script type="text/JavaScript" src="/cjsg/js/spw/spwTab.js?n=2803951349"></script>
+		<script type="text/javascript" src="/cjsg/js/saj/saj-popup-modal-1.0.0-1.js?n=ad7b132a-be56-48a3-a7dc-68ed4400000d"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-popup.js?n=2538966893"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tree-2.5.1-1.js?n=13698285-becd-4e70-9ec7-27800642f308"></script>
+
+		<!-- remover valor da versao na proxima versao do sistema -->
+		<script type="text/JavaScript" src="/cjsg/js/filtrosLaterais.js?n=2874483102?c=123"></script>
+		<script type="text/JavaScript" src="/cjsg/jsp/completa/consultaCompleta.js?n=769933514"></script>
+	</head>
+
+	<body style="margin: 0px;">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoCliente" summary=" " role="presentation">
+	<tr>
+		<td><a href="http://www.tjal.jus.br"><img src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/clientes/AL/imagens/layout/cabecalhoLogo.jpg" width="433" height="58" alt="Tribunal de Justi&ccedil;a de Alagoas" /></a></td>
+		<td align="right" valign="top"><img src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/clientes/AL/imagens/layout/cabecalhoImagem.jpg" alt=" " width="353" height="58" /></td>
+	</tr>
+</table>
+<script language="javascript" type="text/JavaScript" src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/js/libras.js?n=369456521"></script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- cabecalho e-Saj -->
+<table width="100%" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoServico" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaCabecalhoServicoLogo">
+
+
+
+
+<a href="https://www2.tjal.jus.br/esaj-layout/redirecionarNovoEsaj.do"><img src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServico.gif" title="Voltar para página inicial do e-SAJ" alt="Voltar para página inicial do e-SAJ" width="255" height="53" border="0" /></a><img src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServicoInf.gif" alt=" " width="255" height="28" border="0" />
+</td>
+		<td class="esajCelulaCabecalhoServicoMenu">
+		    <table width="100%" border="0" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+				<tr>
+					<td align="right">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Devido ao alinhamento inline das imagens, elas nÃ£o podem ter nenhum tipo de espaÃ§amento entre elas, portanto Ã© necessÃ¡rio finalizar a linha iniciando um comentÃ¡rio e fechar o comentÃ¡rio imediatamente antes da abertura da nova tag-->
+<img height="24" width="47" alt=" " src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/inicioMenuSup.jpg"/><a href="https://www2.tjal.jus.br/caixapostal"><!--
+
+    --><img height="24" width="83" border="0" alt="Caixa Postal" src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/caixaPostal.gif"/></a><!--
+    --><img height="24" width="4" alt=" " src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a href="https://www2.tjal.jus.br/esaj/cadastro.do"><!--
+
+--><img src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/cadastro.gif" alt="Cadastro" width="81" height="24" border="0" /></a><!--
+
+
+    --><img height="24" width="4" alt=" " src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a target="blank" href="https://www2.tjal.jus.br/WebHelp/"><!--
+    --><img height="24" width="61" border="0" alt="Ajuda do e-Saj" src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/ajuda.gif"/></a><!--
+
+
+-->
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaIdentificacaoServico" >
+
+
+
+
+<style>
+
+    td.esajCelulaIdentificacao, td.esajCelulaIdentificacaoServico {
+        position: relative;
+    }
+
+    button.escolhaBeta {
+        border: 0;
+        background: #0078D7;
+        color: #fff;
+        margin-right: 5px;
+        font-family: verdana;
+        font-size: 12px;
+        height: 27px;
+        line-height: 14px;
+        border-radius: 0;
+        text-shadow: 1px 1px 1px #797979;
+        position: absolute;
+        top: 30px;
+        right: 3px;
+        padding: 7px 12px;
+        cursor: pointer;
+    }
+
+    button.escolhaBeta:hover {
+        background-color: #0b5c9c;
+    }
+</style>
+
+<span id="identificacao"></span>
+
+<button style="display: none" class="escolhaBeta"></button>
+
+
+
+
+
+
+        <script language="javascript" type="text/JavaScript" src="https://www2.tjal.jus.br/sajcas/conteudoIdentificacao?script=1776670620755"></script>
+
+
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaCabecalhoServicoCaminho" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<a href="" class="esajCaminhoLink"></a>
+
+ &gt;
+
+
+<a href="https://www2.tjal.jus.br/esaj?servico=740000" class="esajCaminhoLink">Bem-vindo</a>
+
+ &gt;
+
+
+<a href="https://www2.tjal.jus.br/esaj?servico=780000" class="esajCaminhoLink">Consultas de Jurisprudência</a>
+
+ &gt;
+
+
+
+Consulta Completa
+</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+<!-- CONTEUDO -->
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaTitulo" role="presentation">
+	<tr>
+		<td class="esajCelulaMenuSuspenso">
+		<a href="#" onclick="return showMenuSuspenso()"><img src="https://www2.tjal.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSuspenso.gif" alt="Menu de servi&ccedil;os" width="243" height="21" style="display:block" /></a>
+		<div id="layerMenu" style="display:none">
+
+
+<!-- MENU -->
+<ul id="esajMenuArea">
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Consultas</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/cpopg/open.do">Processos de 1º Grau</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Ordem de Processos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoPg.do">Julgamento do 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/cop/abrirConsultaDeOrdemDeAtoPg.do">Publicação e Cumprimento de Atos de 1º Grau</a></li>
+</ul>
+  </li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/cposg5/open.do">Processos de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/pauta-julgamento-virtual">Pauta de Julgamento Virtual do Segundo Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Recolhimento de Custas</a>
+<ul>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas de 1º Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/abrirConsultaCustas.do">Consulta de Custas de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=20&flTipoCusta=0&cdServicoCalculoCusta=690003">Custas Iniciais de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=26&flTipoCusta=5&cdServicoCalculoCusta=690004">Atos Avulsos de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=21&flTipoCusta=1&cdServicoCalculoCusta=690005">Custas de Preparo de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=24&flTipoCusta=0&cdServicoCalculoCusta=690006">Custas Juizado Especial - Recurso Inominado</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=28&flTipoCusta=1&cdServicoCalculoCusta=690009">Custas Intermediárias de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=29&flTipoCusta=1&cdServicoCalculoCusta=690010">Custas Intermediárias de 1º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas de 2º Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/abrirConsultaCustasSg.do">Consulta de Custas de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdServicoCalculoCusta=690205&flTipoCusta=0&cdTipoCusta=19">Custas iniciais de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdServicoCalculoCusta=690206&flTipoCusta=5&cdTipoCusta=20">Custas iniciais de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdServicoCalculoCusta=690207&flTipoCusta=1&cdTipoCusta=21">Custas iniciais de 2º Grau</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Jurisprudência</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/cjsg/consultaSimples.do">Simples</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/cjsg/consultaCompleta.do">Completa</a></li>
+</ul>
+  </li>
+  <li class="esajMenuFechado"><a href="https://www2.tjal.jus.br/cdje">Diário da Justiça Eletrônico</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Push</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/pushpg">1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/pushsg5">2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Pauta de Julgamento</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/pauta-julgamento/consulta">Consulta da Pauta de Julgamento</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Certidões</a>
+<ul>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Certidões de 1º grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/sco/abrirCadastro.do">Pedido de Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/sco/abrirConferencia.do">Conferência de Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/sco/abrirDownload.do">Baixar Certidão de 1º Grau</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Conferência de Documentos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/pastadigital/pg/abrirConferenciaDocumento.do">Documento Digital do 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/pastadigital/sg/abrirConferenciaDocumento.do">Documento Digital do 2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Intimação e Citação Eletrônica</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/intimacoesweb/abrirConsultaAtosRecebidos.do">Consulta de Recebidas</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/intimacoesweb/abrirConsultaAtosNaoRecebidos.do">Recebimento</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico</a>
+<ul>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico de 1º Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petpg/abrirNovaPeticaoInicial.do?instancia=PG">Peticionamento Inicial de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petpg/abrirNovaPeticaoIntermediaria.do?instancia=PG">Peticionamento Intermediário de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petpg/abrirConsultaPeticoes.do">Consulta de Petições de 1º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico de 2º Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petsg/abrirNovaPeticaoInicial.do?instancia=SG">Peticionamento Inicial de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petsg/abrirNovaPeticaoIntermediaria.do?instancia=SG">Peticionamento Intermediário de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petsg/abrirConsultaPeticoes.do">Consulta de Petições de 2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico de Turmas Recursais / Plantão (2º Grau)/ Precatórios</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petcr/abrirNovaPeticaoInicial.do?instancia=CR">Peticionamento Inicial - TR/ Plantão TJ/ Precat.</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petcr/abrirNovaPeticaoIntermediaria.do?instancia=CR">Peticionamento Intermediário - TR/ Plantão TJ/ Precat.</a></li>
+  <li class="esajMenuItem"><a href="https://www2.tjal.jus.br/petcr/abrirConsultaPeticoes.do">Consulta de Petições - TR/ Plantão TJ/ Precat.</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+</ul>
+
+		</div>
+		</td>
+		<td class="esajCelulaTituloServico"><h1 class="esajTituloPagina">Consulta Completa</h1></td>
+	</tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaConteudoServico" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <span class="esajTituloOrientacoes">Orientações</span>
+
+
+
+
+            <ul class="esajUlOrientacoes" id="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<li>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Para detalhes sobre cada campo de busca, selecione o campo específico.
+
+
+
+	</li>
+
+
+
+
+            </ul>
+
+
+
+
+    <br>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<form name="consultaCompletaForm" method="post" action="/cjsg/resultadoCompleta.do;jsessionid=F40EBCD4345D247D04383EDADFCDB451.cjsg1" autocomplete="off" enctype="" onsubmit="return applySubmit(this, eval('function spwSubmit(t, e){decodificaInputMulSelOnSubmit();if (!IS_enableSubmit) return false; return BENV_isCamposValidos(t); } spwSubmit(this, event);'));" id="" target="">
+	<input type="hidden" name="conversationId" value="">
+
+
+
+
+
+<div style="display: none;">
+
+	<div id="inteiroTeor">
+		<b>"Pesquisa Livre"</b> <br />Busca acórdãos que contenham as <br /> palavras/expressões desejadas no seu inteiro teor.
+	</div>
+
+	<div id="ementa">
+		<b>"Ementa"</b><br>Busca acórdaos que contenham as palavras/express&otilde;es<br />desejadas na ementa do acórdão.
+	</div>
+
+	<div id="classesTooltip">
+		<b>"Classe"</b><br />Busca decisões que sejam de uma determinada classe processual.<br> Exemplo: Ação Penal.
+	</div>
+
+	<div id="assuntosTooltip">
+		<b>"Assuntos"</b><br />Busca acórdãos que sejam de um determinado assunto.
+	</div>
+
+	<div id="secoesTooltip">
+		<b>"Orgão julgadores"</b><br /> Busca acórdãos que sejam de uma determinado orgão julgador.
+	</div>
+
+	<div id="dtJulgamentoInicioTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtJulgamentoFimTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoInicioTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoFimTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroInicioTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroFimTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="orgaoJulgador">
+		<b>"Órgão Julgador"</b><br />Busca acórdãos que sejam de um determinado órgão julgador.<br />Exemplo: 10ª Câmara de Direito Público.
+	</div>
+
+	<div id="comarcaTooltip">
+		<b>"Comarca"</b><br>Busca acórdãos que sejam de uma determinada comarca de origem.<br> Exemplo: São Paulo.
+	</div>
+
+	<div id="agenteTooltip">
+		<b>"Relator"</b><br>Busca acórdãos que sejam de um determinado relator.
+	</div>
+
+	<div id="juizProlatorTooltip">
+		<b>"Juiz prolator"</b><br>Busca acórdãos para o juiz prolator selecionado.<br />
+	</div>
+
+	<div id="nuRegistro">
+		<b>&quot;N&uacute;mero do Registro&quot;</b><br>Busca acórdãos que tenham sido registrados<br />com o número informado.
+	</div>
+
+	<div id="nuProcOrigem">
+		<b>"Número do recurso"</b><br/>Busca acórdãos que se referem ao<br/>número de recurso informado.
+	</div>
+
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Consulta Completa
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaInteiroTeor';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="top">
+
+
+
+
+				<label for="iddados.buscaInteiroTeor" class="" style="float:left;font-weight:bold;margin-top:3px;">Pesquisa livre</label><div style="text-align:right;font-weight:bold;margin-top:3px;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="top">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaInteiroTeor" size="100" value="dano moral" formatType="TEXT" formato="120" obrigatorio="" rotulo="Pesquisa livre" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaInteiroTeor" title="" alt="">
+
+
+
+
+
+
+
+						<div class="botoesOperadores" style="margin-top: 3px;">
+							<input type="button" value=" E " name="E" />
+							<input type="button" value=" OU " name="OU" />
+							<input type="button" value=" N&Atilde;O " name="NAO" />
+							<input type="button" value='"&nbsp;&nbsp;"' name="ASP" />
+							<a style="font-size: 11px; font-weight: bold; padding-left: 10px; padding-right: 2px;" href="https://www2.tjal.jus.br/WebHelp//#id_operadores_logicos.htm" target="_blank">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="">
+
+
+
+	<span id="">Como utilizar os filtros</span>
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+							</a>
+							<input type="checkbox" name="dados.pesquisarComSinonimos" value="S" checked="checked" uncheckedValue="N"  onclick="CH_updateHiddenValue(this);" style="width: 10px" id="checkBoxSinonimos"><input type="hidden" value="S" name="dados.pesquisarComSinonimos" inputCheckBox="true">
+							<label for="checkBoxSinonimos" >
+								Pesquisar por sinônimos
+							</label>
+							&nbsp;&nbsp;&nbsp;
+						</div>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Pesquisa por campos específicos
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaEmenta';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.buscaEmenta" class="" style="float:left;font-weight:bold;">Ementa</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaEmenta" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Ementa" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaEmenta" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuProcOrigem';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.nuProcOrigem" class="" style="float:left;font-weight:bold;">Número do recurso</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuProcOrigem" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do recurso" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuProcOrigem" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuRegistro';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.relator" class="" style="float:left;font-weight:bold;">Relator(a)</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var agenteNomeCamposArray = new Array();
+ agenteNomeCamposArray[0] = 'codigoCr';
+ agenteNomeCamposArray[1] = 'codigoTr';
+ agenteNomeCamposArray[2] = 'nmAgente';
+ var codigoCrNomeCamposArray = agenteNomeCamposArray;
+ var codigoTrNomeCamposArray = agenteNomeCamposArray;
+ var nmAgenteNomeCamposArray = agenteNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="agente" idPai="null" filtroPai="null" url="jsp/search/searchAgente.jsp" input-select="agente" property="dados.agentes" name="codigoCr" title="Relatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="agenteSelectedEntitiesList"  value="" id="agenteSelectedEntitiesList" />
+<input type="hidden" name="contadoragente"  value="0" id="contadoragente" />
+<input type="hidden" name="contadorMaioragente"  value="0" id="contadorMaioragente" />
+    <tr>
+								<td >
+            <input type="text" name="codigoCr" id="codigoCr" bindingReference="codigoCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoTr" id="codigoTr" bindingReference="codigoTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoTr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="nmAgente" id="nmAgente" bindingReference="nmAgente" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'nmAgente', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="agente" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr','','/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('agente');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="agenteLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.juizProlator" class="" style="float:left;font-weight:bold;">Magistrado prolator</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var juizProlatorNomeCamposArray = new Array();
+ juizProlatorNomeCamposArray[0] = 'codigoJuizCr';
+ juizProlatorNomeCamposArray[1] = 'codigoJuizTr';
+ juizProlatorNomeCamposArray[2] = 'nmJuiz';
+ var codigoJuizCrNomeCamposArray = juizProlatorNomeCamposArray;
+ var codigoJuizTrNomeCamposArray = juizProlatorNomeCamposArray;
+ var nmJuizNomeCamposArray = juizProlatorNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="juizProlator" idPai="null" filtroPai="null" url="jsp/search/searchJuizProlator.jsp" input-select="juizProlator" property="dados.juizesProlatores" name="codigoJuizCr" title="Juizes prolatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="juizProlatorSelectedEntitiesList"  value="" id="juizProlatorSelectedEntitiesList" />
+<input type="hidden" name="contadorjuizProlator"  value="0" id="contadorjuizProlator" />
+<input type="hidden" name="contadorMaiorjuizProlator"  value="0" id="contadorMaiorjuizProlator" />
+    <tr>
+								<td >
+            <input type="text" name="codigoJuizCr" id="codigoJuizCr" bindingReference="codigoJuizCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoJuizTr" id="codigoJuizTr" bindingReference="codigoJuizTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizTr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="nmJuiz" id="nmJuiz" bindingReference="nmJuiz" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'nmJuiz', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="juizProlator" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr','','/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('juizProlator');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="juizLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="classes_selectionText" class="" style="float:left;font-weight:bold;">Classe</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="classesId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="classesTreeSelection.values" value="" id="classes">
+						<span id="classes_action" value="/cjsg/classesTreeSelect.do" />
+
+						<input type="text" name="classesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'classes',
+								treeSelectId: 'classesId',
+								url: '/cjsg/classesTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="classes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_classes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_classes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'classes',
+				treeSelectId: 'classesId',
+				url: '/cjsg/classesTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_classes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_classes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="assuntos_selectionText" class="" style="float:left;font-weight:bold;">Assunto</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="assuntosId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="assuntosTreeSelection.values" value="" id="assuntos">
+						<span id="assuntos_action" value="/cjsg/assuntosTreeSelect.do" />
+
+						<input type="text" name="assuntosTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'assuntos',
+								treeSelectId: 'assuntosId',
+								url: '/cjsg/assuntosTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="assuntos_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_assuntos"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_assuntos"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'assuntos',
+				treeSelectId: 'assuntosId',
+				url: '/cjsg/assuntosTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_assuntos').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_assuntos').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="secoes_selectionText" class="" style="float:left;font-weight:bold;">Órgão julgador</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="secaoId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="secoesTreeSelection.values" value="" id="secoes">
+						<span id="secoes_action" value="/cjsg/secaoTreeSelect.do" />
+
+						<input type="text" name="secoesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'secoes',
+								treeSelectId: 'secaoId',
+								url: '/cjsg/secaoTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="secoes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_secoes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_secoes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'secoes',
+				treeSelectId: 'secaoId',
+				url: '/cjsg/secaoTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_secoes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_secoes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtJulgamento" class="" style="float:left;font-weight:bold;">Data do julgamento</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoInicio">
+
+
+
+	<input type="text" name="dados.dtJulgamentoInicio" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoFim">
+
+
+
+	<input type="text" name="dados.dtJulgamentoFim" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							<span id="dtJulgamentoFormato">
+								(dd/mm/aaaa)
+							</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtPublicacao" class="" style="float:left;font-weight:bold;">Data de publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoInicio">
+
+
+
+	<input type="text" name="dados.dtPublicacaoInicio" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoFim">
+
+
+
+	<input type="text" name="dados.dtPublicacaoFim" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						<span id="dtPublicacaoFormato">
+							(dd/mm/aaaa)
+						</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.origem" class="" style="float:left;font-weight:bold;">Origem</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<input type="checkbox" name="dados.origensSelecionadas" value="T" checked="checked" id="origem2grau">
+						<label for="origem2grau">
+							2° grau
+						</label>
+						<input type="checkbox" name="dados.origensSelecionadas" value="R" id="origemRecursal">
+						<label for="origemRecursal">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Colégios Recursais
+
+
+						</label>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.tpDecisao" class="" style="float:left;font-weight:bold;">Tipo de Publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<div id="linhaTipoDecisao">
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="A" checked="checked" id="Acheckbox">
+								<label for="Acheckbox">
+									Acórdãos
+								</label>
+
+						</div>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.ordenar" class="" style="float:left;font-weight:bold;">Ordenar por</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenardtPublicacao">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenardtPublicacao" value="dtPublicacao" style="vertical-align:middle;" onclick="" class="" title=""  checked/>
+			Data de publicação
+		</label>
+
+	</span>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenarRelevancia">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenarRelevancia" value="relevancia" style="vertical-align:middle;" onclick="" class="" title=""  />
+			Relevância
+		</label>
+
+	</span>
+
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<table id="" class="secaoBotoesBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+		<tr>
+
+ 				<td width="150">&nbsp;</td>
+
+			<td align="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="submit" name="pbSubmit" value="Pesquisar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotaoDefault " id="pbSubmit">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="button" name="pbLimpar" value="Limpar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotao " id="pbLimpar">
+
+
+
+			</td>
+		</tr>
+	</table>
+
+
+
+
+
+
+</form>
+
+
+
+
+			<!-- Resultado consulta -->
+
+				<!-- Tabs -->
+				<div id="tabs">
+					<ul>
+
+							<li tipo="A" >
+								<a href="A">
+									<span  id="nomeAba-A" >Acórdãos(136804)</span>
+									<input id="totalResultadoAba-A" type="hidden" value="136804" />
+								</a>
+							</li>
+
+					</ul>
+
+						<div id="tabs-A">
+
+
+
+
+
+
+
+
+
+
+<div id="paginacaoSuperior-A" style="padding-bottom: 15px;" >
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 20
+			</strong>
+			de 136804
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr>
+		<td height="1" valign="top" id="tdResultados" width="*" >
+			<div id="divDadosResultado-A" >
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812970" cdForo="0" >
+										0709767-89.2020.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812970" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812970);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812970" style="display: none;" >
+	<div id="textAreaDados_812970" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. CRIMES CONTRA A HONRA. CAL&Uacute;NIA E DIFAMA&Ccedil;&Atilde;O. IMPUTA&Ccedil;&Atilde;O DE CRIMES A MAGISTRADO EM V&Iacute;DEO DIVULGADO EM REDE SOCIAL. ABUSO DO DIREITO &Agrave; LIBERDADE DE EXPRESS&Atilde;O. DOLO ESPEC&Iacute;FICO CONFIGURADO. DOSIMETRIA DA PENA. REGULARIDADE. FIXA&Ccedil;&Atilde;O DE VALOR M&Iacute;NIMO DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. ART. 387, IV, DO CPP. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A CONDENAT&Oacute;RIA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a que condenou a apelante pela pr&aacute;tica dos crimes de cal&uacute;nia e difama&ccedil;&atilde;o (arts. 138 e 139 do C&oacute;digo Penal), com incid&ecirc;ncia das causas de aumento previstas no art. 141, incisos II e III e &sect;2&ordm;, do mesmo diploma legal, em concurso formal (art. 70 do C&oacute;digo Penal), em raz&atilde;o da divulga&ccedil;&atilde;o de v&iacute;deo em rede social no qual imputou a Desembargador do Tribunal de Justi&ccedil;a de Alagoas a pr&aacute;tica de condutas criminosas relacionadas ao suposto acobertamento de homic&iacute;dio e manipula&ccedil;&atilde;o de processo judicial. A pena foi fixada em 03 anos, 07 meses e 27 dias de deten&ccedil;&atilde;o, em regime inicial aberto, substitu&iacute;da por penas restritivas de direitos, al&eacute;m de 63 dias-multa e fixa&ccedil;&atilde;o de valor m&iacute;nimo de R$ 7.545,00 a t&iacute;tulo de repara&ccedil;&atilde;o por danos morais. A defesa pleiteia a absolvi&ccedil;&atilde;o por atipicidade da conduta e aus&ecirc;ncia de dolo espec&iacute;fico, invocando a liberdade de express&atilde;o. Subsidiariamente, requer a revis&atilde;o da dosimetria da pena, a exclus&atilde;o ou redu&ccedil;&atilde;o do valor fixado a t&iacute;tulo de repara&ccedil;&atilde;o civil e a concess&atilde;o dos benef&iacute;cios da justi&ccedil;a gratuita.
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se as declara&ccedil;&otilde;es divulgadas pela apelante em rede social configuram exerc&iacute;cio leg&iacute;timo da liberdade de express&atilde;o ou se caracterizam os crimes de cal&uacute;nia e difama&ccedil;&atilde;o; (ii) estabelecer se houve irregularidade ou despropor&ccedil;&atilde;o na dosimetria da pena aplicada; e (iii) determinar se deve ser afastada ou reduzida a indeniza&ccedil;&atilde;o por danos morais fixada na senten&ccedil;a, bem como se &eacute; cab&iacute;vel a concess&atilde;o imediata da gratuidade da justi&ccedil;a.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A materialidade e a autoria delitivas encontram-se comprovadas pelo conte&uacute;do das manifesta&ccedil;&otilde;es divulgadas em rede social, nas quais a apelante imputou diretamente ao querelante a pr&aacute;tica de crimes graves, sem qualquer suporte probat&oacute;rio m&iacute;nimo.
+4. As declara&ccedil;&otilde;es extrapolam os limites do direito de cr&iacute;tica ou de narrativa de fatos de interesse p&uacute;blico, pois consistem em imputa&ccedil;&otilde;es categ&oacute;ricas de condutas criminosas dirigidas &agrave; v&iacute;tima, o que caracteriza os delitos de cal&uacute;nia e difama&ccedil;&atilde;o.
+5. O dolo espec&iacute;fico dos crimes contra a honra pode ser inferido das circunst&acirc;ncias f&aacute;ticas da conduta, especialmente do teor das afirma&ccedil;&otilde;es, do contexto em que foram proferidas e da ampla divulga&ccedil;&atilde;o em ambiente virtual.
+6. A liberdade de express&atilde;o n&atilde;o possui car&aacute;ter absoluto e encontra limites na prote&ccedil;&atilde;o &agrave; honra, &agrave; imagem e &agrave; dignidade das pessoas, n&atilde;o podendo ser invocada para justificar a imputa&ccedil;&atilde;o irrespons&aacute;vel de fatos criminosos a terceiros.
+7. A ampla divulga&ccedil;&atilde;o das ofensas em plataformas digitais potencializa o alcance das imputa&ccedil;&otilde;es e intensifica a les&atilde;o &agrave; honra e &agrave; reputa&ccedil;&atilde;o da v&iacute;tima, especialmente em raz&atilde;o de sua condi&ccedil;&atilde;o institucional de magistrado.
+8. A dosimetria da pena foi realizada de forma fundamentada e em conson&acirc;ncia com os crit&eacute;rios previstos nos arts. 59 e 68 do C&oacute;digo Penal, inexistindo ilegalidade ou despropor&ccedil;&atilde;o que justifique interven&ccedil;&atilde;o da inst&acirc;ncia revisora.
+9. A fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos morais encontra amparo no art. 387, IV, do C&oacute;digo de Processo Penal, sendo compat&iacute;vel com a gravidade das imputa&ccedil;&otilde;es, a ampla divulga&ccedil;&atilde;o das ofensas e a intensidade do dano causado &agrave; honra do ofendido.
+10. A an&aacute;lise acerca da eventual impossibilidade de pagamento das custas processuais pode ser realizada oportunamente na fase de execu&ccedil;&atilde;o, quando ser&aacute; poss&iacute;vel aferir concretamente a condi&ccedil;&atilde;o econ&ocirc;mica da condenada.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e n&atilde;o provido.
+Tese de julgamento: A imputa&ccedil;&atilde;o p&uacute;blica de fatos definidos como crime, sem suporte probat&oacute;rio m&iacute;nimo, configura os delitos de cal&uacute;nia e difama&ccedil;&atilde;o, ainda que veiculada sob o argumento de exerc&iacute;cio da liberdade de express&atilde;o. A liberdade de express&atilde;o n&atilde;o autoriza acusa&ccedil;&otilde;es criminosas infundadas que atinjam a honra e a reputa&ccedil;&atilde;o de terceiros. A divulga&ccedil;&atilde;o de ofensas em redes sociais, com amplo alcance, evidencia o dolo espec&iacute;fico e agrava a lesividade dos crimes contra a honra. &Eacute; leg&iacute;tima a fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos morais na senten&ccedil;a penal condenat&oacute;ria, nos termos do art. 387, IV, do C&oacute;digo de Processo Penal.
+_________
+Dispositivos relevantes citados: C&oacute;digo Penal, arts. 70, 138, 139 e 141; C&oacute;digo de Processo Penal, art. 387, IV; Constitui&ccedil;&atilde;o Federal, art. 5&ordm;, IV e IX.
+Jurisprud&ecirc;ncia relevante citada: TJAL, Apela&ccedil;&atilde;o Criminal n&ordm; 0500872-21.2023.8.02.0001, rel. Des. F&aacute;bio Costa de Almeida Ferrario, j. 29.11.2023. <br><br>(N&uacute;mero do Processo: 0709767-89.2020.8.02.0001; Relator (a):&nbsp;Des. M&aacute;rcio Roberto Ten&oacute;rio de Albuquerque; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 08/04/2026; Data de registro: 16/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Desclassificação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Márcio Roberto Tenório de Albuquerque
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. CRIMES CONTRA A HONRA. CALÚNIA E DIFAMAÇÃO. IMPUTAÇÃO DE CRIMES A MAGISTRADO EM VÍDEO DIVULGADO EM REDE SOCIAL. ABUSO DO DIREITO À LIBERDADE DE EXPRESSÃO. DOLO ESPECÍFICO CONFIGURADO. DOSIMETRIA DA PENA. REGULARIDADE. FIXAÇÃO DE VALOR MÍNIMO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. ART. 387, IV, DO CPP. MANUTENÇÃO DA SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. CRIMES CONTRA A HONRA. CALÚNIA E DIFAMAÇÃO. IMPUTAÇÃO DE CRIMES A MAGISTRADO EM VÍDEO DIVULGADO EM REDE SOCIAL. ABUSO DO DIREITO À LIBERDADE DE EXPRESSÃO. DOLO ESPECÍFICO CONFIGURADO. DOSIMETRIA DA PENA. REGULARIDADE. FIXAÇÃO DE VALOR MÍNIMO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. ART. 387, IV, DO CPP. MANUTENÇÃO DA SENTENÇA CONDENATÓRIA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação criminal interposta contra sentença que condenou a apelante pela prática dos crimes de calúnia e difamação (arts. 138 e 139 do Código Penal), com incidência das causas de aumento previstas no art. 141, incisos II e III e §2º, do mesmo diploma legal, em concurso formal (art. 70 do Código Penal), em razão da divulgação de vídeo em rede social no qual imputou a Desembargador do Tribunal de Justiça de Alagoas a prática de condutas criminosas relacionadas ao suposto acobertamento de homicídio e manipulação de processo judicial. A pena foi fixada em 03 anos, 07 meses e 27 dias de detenção, em regime inicial aberto, substituída por penas restritivas de direitos, além de 63 dias-multa e fixação de valor mínimo de R$ 7.545,00 a título de reparação por <em>danos</em> <em>morais</em>. A defesa pleiteia a absolvição por atipicidade da conduta e ausência de dolo específico, invocando a liberdade de expressão. Subsidiariamente, requer a revisão da dosimetria da pena, a exclusão ou redução do valor fixado a título de reparação civil e a concessão dos benefícios da justiça gratuita.
+2. Há três questões em discussão: (i) definir se as declarações divulgadas pela apelante em rede social configuram exercício legítimo da liberdade de expressão ou se caracterizam os crimes de calúnia e difamação; (ii) estabelecer se houve irregularidade ou desproporção na dosimetria da pena aplicada; e (iii) determinar se deve ser afastada ou reduzida a indenização por <em>danos</em> <em>morais</em> fixada na sentença, bem como se é cabível a concessão imediata da gratuidade da justiça.
+III. RAZÕES DE DECIDIR
+3. A materialidade e a autoria delitivas encontram-se comprovadas pelo conteúdo das manifestações divulgadas em rede social, nas quais a apelante imputou diretamente ao querelante a prática de crimes graves, sem qualquer suporte probatório mínimo.
+4. As declarações extrapolam os limites do direito de crítica ou de narrativa de fatos de interesse público, pois consistem em imputações categóricas de condutas criminosas dirigidas à vítima, o que caracteriza os delitos de calúnia e difamação.
+5. O dolo específico dos crimes contra a honra pode ser inferido das circunstâncias fáticas da conduta, especialmente do teor das afirmações, do contexto em que foram proferidas e da ampla divulgação em ambiente virtual.
+6. A liberdade de expressão não possui caráter absoluto e encontra limites na proteção à honra, à imagem e à dignidade das pessoas, não podendo ser invocada para justificar a imputação irresponsável de fatos criminosos a terceiros.
+7. A ampla divulgação das ofensas em plataformas digitais potencializa o alcance das imputações e intensifica a lesão à honra e à reputação da vítima, especialmente em razão de sua condição institucional de magistrado.
+8. A dosimetria da pena foi realizada de forma fundamentada e em consonância com os critérios previstos nos arts. 59 e 68 do Código Penal, inexistindo ilegalidade ou desproporção que justifique intervenção da instância revisora.
+9. A fixação de valor mínimo para reparação dos <em>danos</em> <em>morais</em> encontra amparo no art. 387, IV, do Código de Processo Penal, sendo compatível com a gravidade das imputações, a ampla divulgação das ofensas e a intensidade do <em>dano</em> causado à honra do ofendido.
+10. A análise acerca da eventual impossibilidade de pagamento das custas processuais pode ser realizada oportunamente na fase de execução, quando será possível aferir concretamente a condição econômica da condenada.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e não provido.
+Tese de julgamento: A imputação pública de fatos definidos como crime, sem suporte probatório mínimo, configura os delitos de calúnia e difamação, ainda que veiculada sob o argumento de exercício da liberdade de expressão. A liberdade de expressão não autoriza acusações criminosas infundadas que atinjam a honra e a reputação de terceiros. A divulgação de ofensas em redes sociais, com amplo alcance, evidencia o dolo específico e agrava a lesividade dos crimes contra a honra. É legítima a fixação de valor mínimo para reparação dos <em>danos</em> <em>morais</em> na sentença penal condenatória, nos termos do art. 387, IV, do Código de Processo Penal.
+_________
+Dispositivos relevantes citados: Código Penal, arts. 70, 138, 139 e 141; Código de Processo Penal, art. 387, IV; Constituição Federal, art. 5º, IV e IX.
+Jurisprudência relevante citada: TJAL, Apelação Criminal nº 0500872-21.2023.8.02.0001, rel. Des. Fábio Costa de Almeida Ferrario, j. 29.11.2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="813031" cdForo="0" >
+										0731106-12.2017.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="813031" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(813031);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_813031" style="display: none;" >
+	<div id="textAreaDados_813031" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. PETI&Ccedil;&Atilde;O INCIDENTAL. MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA. PRESCRI&Ccedil;&Atilde;O DA PRETENS&Atilde;O PUNITIVA RETROATIVA. R&Eacute;U MENOR DE 21 ANOS &Agrave; &Eacute;POCA DOS FATOS. REDU&Ccedil;&Atilde;O DO PRAZO PRESCRICIONAL. TRANSCURSO SUPERIOR AO PRAZO ENTRE MARCOS INTERRUPTIVOS. EXTIN&Ccedil;&Atilde;O DA PUNIBILIDADE. DECLARA&Ccedil;&Atilde;O.
+I. CASO EM EXAME
+Peti&ccedil;&atilde;o criminal apresentada pela defesa no curso de apela&ccedil;&atilde;o, na qual se suscita mat&eacute;ria de ordem p&uacute;blica consistente no reconhecimento da prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa, ap&oacute;s a redu&ccedil;&atilde;o da pena para 3 anos, 11 meses e 15 dias de reclus&atilde;o para os crimes de homic&iacute;dio tentado e roubo, totalizando 7 anos, 11 meses e 15 dias, alegando que o r&eacute;u era menor de 21 anos &agrave; &eacute;poca dos fatos e que transcorreu lapso superior ao prazo prescricional entre a decis&atilde;o de pron&uacute;ncia e a senten&ccedil;a.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em definir se ocorreu a prescri&ccedil;&atilde;o da pretens&atilde;o punitiva estatal, na modalidade retroativa, considerada a pena aplicada em concreto, a redu&ccedil;&atilde;o do prazo prescricional pela menoridade relativa e o lapso temporal entre os marcos interruptivos.
+III. RAZ&Otilde;ES DE DECIDIR
+A prescri&ccedil;&atilde;o, ap&oacute;s o tr&acirc;nsito em julgado para a acusa&ccedil;&atilde;o, regula-se pela pena aplicada em concreto, nos termos do art. 110, &sect; 1&ordm;, do C&oacute;digo Penal.
+Para penas superiores a 2 anos e n&atilde;o superiores a 4 anos, o prazo prescricional &eacute; de 8 anos, conforme o art. 109, IV, do C&oacute;digo Penal.
+O prazo prescricional deve ser reduzido pela metade quando o agente era menor de 21 anos &agrave; &eacute;poca dos fatos, nos termos do art. 115 do C&oacute;digo Penal.
+No caso, o r&eacute;u possu&iacute;a menos de 21 anos ao tempo do crime, reduzindo-se o prazo prescricional para 4 anos.
+Transcorreu lapso temporal superior a 4 anos entre a decis&atilde;o de pron&uacute;ncia e a senten&ccedil;a condenat&oacute;ria, sem causas interruptivas ou suspensivas aptas a afastar a prescri&ccedil;&atilde;o.
+A ocorr&ecirc;ncia da prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa imp&otilde;e o reconhecimento da extin&ccedil;&atilde;o da punibilidade, por se tratar de mat&eacute;ria de ordem p&uacute;blica cognosc&iacute;vel a qualquer tempo.
+IV. DISPOSITIVO E TESE
+Punibilidade extinta.
+Tese de julgamento: 1. A prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa regula-se pela pena aplicada em concreto ap&oacute;s o tr&acirc;nsito em julgado para a acusa&ccedil;&atilde;o. 2. O prazo prescricional &eacute; reduzido pela metade quando o agente era menor de 21 anos &agrave; &eacute;poca dos fatos. 3. O transcurso de prazo superior ao prescricional entre marcos interruptivos imp&otilde;e o reconhecimento da extin&ccedil;&atilde;o da punibilidade.
+Dispositivos relevantes citados: CP, arts. 109, IV; 110, &sect; 1&ordm;; 115.
+Jurisprud&ecirc;ncia relevante citada: TJAL, Apela&ccedil;&atilde;o Criminal n&ordm; 0708028-81.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 05.02.2025; TJAL, Apela&ccedil;&atilde;o Criminal n&ordm; 0720858-79.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 02.10.2024.  <br><br>(N&uacute;mero do Processo: 0731106-12.2017.8.02.0001; Relator (a):&nbsp;Des. Tutm&eacute;s Airan de Albuquerque Melo; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Tutmés Airan de Albuquerque Melo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. PETIÇÃO INCIDENTAL. MATÉRIA DE ORDEM PÚBLICA. PRESCRIÇÃO DA PRETENSÃO PUNITIVA RETROATIVA. RÉU MENOR DE 21 ANOS À ÉPOCA DOS FATOS. REDUÇÃO DO PRAZO PRESCRICIONAL. TRANSCURSO SUPERIOR AO PRAZO ENTRE MARCOS INTERRUPTIVOS. EXTINÇÃO DA PUNIBILIDADE. DECLARAÇÃO.
+I. CASO EM EXAME
+Petição criminal apresentada pela defesa no curso de apelação, na
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. PETIÇÃO INCIDENTAL. MATÉRIA DE ORDEM PÚBLICA. PRESCRIÇÃO DA PRETENSÃO PUNITIVA RETROATIVA. RÉU MENOR DE 21 ANOS À ÉPOCA DOS FATOS. REDUÇÃO DO PRAZO PRESCRICIONAL. TRANSCURSO SUPERIOR AO PRAZO ENTRE MARCOS INTERRUPTIVOS. EXTINÇÃO DA PUNIBILIDADE. DECLARAÇÃO.
+I. CASO EM EXAME
+Petição criminal apresentada pela defesa no curso de apelação, na qual se suscita matéria de ordem pública consistente no reconhecimento da prescrição da pretensão punitiva retroativa, após a redução da pena para 3 anos, 11 meses e 15 dias de reclusão para os crimes de homicídio tentado e roubo, totalizando 7 anos, 11 meses e 15 dias, alegando que o réu era menor de 21 anos à época dos fatos e que transcorreu lapso superior ao prazo prescricional entre a decisão de pronúncia e a sentença.
+II. QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em definir se ocorreu a prescrição da pretensão punitiva estatal, na modalidade retroativa, considerada a pena aplicada em concreto, a redução do prazo prescricional pela menoridade relativa e o lapso temporal entre os marcos interruptivos.
+III. RAZÕES DE DECIDIR
+A prescrição, após o trânsito em julgado para a acusação, regula-se pela pena aplicada em concreto, nos termos do art. 110, § 1º, do Código Penal.
+Para penas superiores a 2 anos e não superiores a 4 anos, o prazo prescricional é de 8 anos, conforme o art. 109, IV, do Código Penal.
+O prazo prescricional deve ser reduzido pela metade quando o agente era menor de 21 anos à época dos fatos, nos termos do art. 115 do Código Penal.
+No caso, o réu possuía menos de 21 anos ao tempo do crime, reduzindo-se o prazo prescricional para 4 anos.
+Transcorreu lapso temporal superior a 4 anos entre a decisão de pronúncia e a sentença condenatória, sem causas interruptivas ou suspensivas aptas a afastar a prescrição.
+A ocorrência da prescrição da pretensão punitiva retroativa impõe o reconhecimento da extinção da punibilidade, por se tratar de matéria de ordem pública cognoscível a qualquer tempo.
+IV. DISPOSITIVO E TESE
+Punibilidade extinta.
+Tese de julgamento: 1. A prescrição da pretensão punitiva retroativa regula-se pela pena aplicada em concreto após o trânsito em julgado para a acusação. 2. O prazo prescricional é reduzido pela metade quando o agente era menor de 21 anos à época dos fatos. 3. O transcurso de prazo superior ao prescricional entre marcos interruptivos impõe o reconhecimento da extinção da punibilidade.
+Dispositivos relevantes citados: CP, arts. 109, IV; 110, § 1º; 115.
+Jurisprudência relevante citada: TJAL, Apelação Criminal nº 0708028-81.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 05.02.2025; TJAL, Apelação Criminal nº 0720858-79.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 02.10.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812972" cdForo="0" >
+										0700457-96.2017.8.02.0055
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812972" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812972);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812972" style="display: none;" >
+	<div id="textAreaDados_812972" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. FURTO QUALIFICADO PELO CONCURSO DE AGENTES. SUBTRA&Ccedil;&Atilde;O DE SEMOVENTES EM PROPRIEDADE RURAL. PARTICIPA&Ccedil;&Atilde;O DE ADOLESCENTES. CORRUP&Ccedil;&Atilde;O DE MENORES. CRIME FORMAL. S&Uacute;MULA 500 DO STJ. CONCURSO FORMAL COM RESULTADOS AUT&Ocirc;NOMOS EM RELA&Ccedil;&Atilde;O A CADA MENOR. DOSIMETRIA DA PENA. VALORA&Ccedil;&Atilde;O NEGATIVA DA CULPABILIDADE E DAS CIRCUNST&Acirc;NCIAS DO CRIME. PR&Aacute;TICA NO PER&Iacute;ODO NOTURNO E SUBTRA&Ccedil;&Atilde;O DE ANIMAIS DOMESTIC&Aacute;VEIS DE PRODU&Ccedil;&Atilde;O. METODOLOGIA DO INTERVALO ENTRE PENAS M&Iacute;NIMA E M&Aacute;XIMA. PROPORCIONALIDADE. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta pela Defensoria P&uacute;blica do Estado de Alagoas contra senten&ccedil;a da 3&ordf; Vara Criminal da Comarca de Santana do Ipanema/AL que condenou o r&eacute;u pela pr&aacute;tica do crime de furto qualificado pelo concurso de agentes (art. 155, &sect;4&ordm;, IV, do CP) e corrup&ccedil;&atilde;o de menores (art. 244-B do ECA, por tr&ecirc;s vezes), em concurso formal, &agrave; pena de 4 anos, 4 meses e 15 dias de reclus&atilde;o e 97 dias-multa. Os fatos ocorreram em 28/05/2017, quando o apelante, em companhia de tr&ecirc;s adolescentes, subtraiu quatro ovelhas de propriedade rural da v&iacute;tima. A defesa pleiteia absolvi&ccedil;&atilde;o por insufici&ecirc;ncia probat&oacute;ria, absolvi&ccedil;&atilde;o quanto ao delito de corrup&ccedil;&atilde;o de menores por exigir prova da efetiva corrup&ccedil;&atilde;o, e, subsidiariamente, a revis&atilde;o da dosimetria da pena.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se o conjunto probat&oacute;rio &eacute; suficiente para comprovar a autoria do furto qualificado imputado ao r&eacute;u; (ii) estabelecer se o crime de corrup&ccedil;&atilde;o de menores previsto no art. 244-B do ECA exige prova da efetiva corrup&ccedil;&atilde;o do adolescente; (iii) determinar se houve ilegalidade na valora&ccedil;&atilde;o das circunst&acirc;ncias judiciais e no crit&eacute;rio adotado para a fixa&ccedil;&atilde;o da pena-base.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O conjunto probat&oacute;rio &eacute; consistente e suficiente para comprovar a autoria do furto qualificado, pois depoimentos de adolescentes participantes do fato, colhidos sob contradit&oacute;rio, confirmam a participa&ccedil;&atilde;o ativa do r&eacute;u na subtra&ccedil;&atilde;o das ovelhas, sendo corroborados por prova material consistente na apreens&atilde;o e restitui&ccedil;&atilde;o dos animais.
+4. A aus&ecirc;ncia de oitiva da v&iacute;tima em ju&iacute;zo n&atilde;o gera d&uacute;vida probat&oacute;ria apta a ensejar absolvi&ccedil;&atilde;o quando a pr&oacute;pria defesa anuiu expressamente &agrave; sua dispensa na audi&ecirc;ncia de instru&ccedil;&atilde;o, n&atilde;o podendo posteriormente invocar tal circunst&acirc;ncia como fundamento recursal.
+5. O crime de corrup&ccedil;&atilde;o de menores previsto no art. 244-B do ECA possui natureza formal, consumando-se com a pr&aacute;tica da infra&ccedil;&atilde;o penal em companhia de adolescente, independentemente de prova da efetiva corrup&ccedil;&atilde;o do menor, conforme entendimento consolidado na S&uacute;mula 500 do STJ.
+6. A participa&ccedil;&atilde;o do r&eacute;u em infra&ccedil;&atilde;o penal juntamente com tr&ecirc;s adolescentes caracteriza tr&ecirc;s crimes aut&ocirc;nomos de corrup&ccedil;&atilde;o de menores, admitindo-se o reconhecimento de concurso formal quando uma &uacute;nica a&ccedil;&atilde;o do agente adulto produz resultados independentes em rela&ccedil;&atilde;o a cada menor.
+7. A valora&ccedil;&atilde;o negativa da culpabilidade &eacute; leg&iacute;tima quando fundamentada na pr&aacute;tica do crime durante o per&iacute;odo noturno, circunst&acirc;ncia que demonstra maior intensidade do dolo e aproveitamento do repouso das v&iacute;timas para facilitar a empreitada criminosa.
+8. A valora&ccedil;&atilde;o negativa das circunst&acirc;ncias do crime &eacute; v&aacute;lida quando fundamentada na subtra&ccedil;&atilde;o de animais semoventes domestic&aacute;veis de produ&ccedil;&atilde;o, situa&ccedil;&atilde;o que revela maior gravidade concreta da conduta, sem configurar bis in idem quando a qualificadora aplicada &eacute; o concurso de agentes.
+9. A fixa&ccedil;&atilde;o da pena-base mediante aplica&ccedil;&atilde;o da fra&ccedil;&atilde;o de 1/8 para cada circunst&acirc;ncia judicial negativa sobre o intervalo entre as penas m&iacute;nima e m&aacute;xima do tipo penal constitui metodologia admitida pela jurisprud&ecirc;ncia do STJ e revela-se proporcional &agrave; gravidade concreta do fato.
+10. A aplica&ccedil;&atilde;o do concurso formal entre o furto qualificado e os tr&ecirc;s crimes de corrup&ccedil;&atilde;o de menores, com aumento de 1/4 sobre a pena mais grave, observa os par&acirc;metros do art. 70 do C&oacute;digo Penal e encontra respaldo na jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento:
+1. O crime de corrup&ccedil;&atilde;o de menores previsto no art. 244-B do ECA possui natureza formal e se consuma com a pr&aacute;tica de infra&ccedil;&atilde;o penal em companhia de adolescente, sendo desnecess&aacute;ria a prova da efetiva corrup&ccedil;&atilde;o do menor.
+2. A participa&ccedil;&atilde;o de agente adulto em infra&ccedil;&atilde;o penal praticada com m&uacute;ltiplos adolescentes configura crimes aut&ocirc;nomos de corrup&ccedil;&atilde;o de menores, admitindo-se concurso formal quando uma &uacute;nica conduta produz resultados independentes em rela&ccedil;&atilde;o a cada menor.
+3. A pr&aacute;tica do crime no per&iacute;odo noturno e a subtra&ccedil;&atilde;o de animais semoventes domestic&aacute;veis de produ&ccedil;&atilde;o podem justificar a valora&ccedil;&atilde;o negativa das circunst&acirc;ncias judiciais da culpabilidade e das circunst&acirc;ncias do crime, desde que n&atilde;o coincidam com qualificadoras aplicadas.
+4. A fixa&ccedil;&atilde;o da pena-base com utiliza&ccedil;&atilde;o do crit&eacute;rio do intervalo entre as penas m&iacute;nima e m&aacute;xima do tipo penal, mediante fra&ccedil;&atilde;o proporcional &agrave;s circunst&acirc;ncias judiciais desfavor&aacute;veis, &eacute; metodologia leg&iacute;tima no sistema de individualiza&ccedil;&atilde;o da pena.
+Dispositivos relevantes citados: CP, arts. 33, &sect;2&ordm;, &quot;b&quot; e &quot;c&quot;, 59, 70 e 155, &sect;4&ordm;, IV; ECA, art. 244-B; CPP, art. 593, I; LEP, art. 112, I; LC 80/1990, art. 128, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula 500; STJ, REsp 1.680.114/GO, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, j. 10.10.2017, DJe 16.10.2017; STJ, REsp 1.719.489/GO, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, j. 23.08.2018, DJe 04.09.2018; STJ, REsp 1.890.981/SP, Rel. Min. Jo&atilde;o Ot&aacute;vio de Noronha, Terceira Se&ccedil;&atilde;o, Tema 1087, j. 25.05.2022; STJ, AgRg no AREsp 1.799.289/DF.  <br><br>(N&uacute;mero do Processo: 0700457-96.2017.8.02.0055; Relator (a):&nbsp;Des. Tutm&eacute;s Airan de Albuquerque Melo; Comarca:&nbsp;Foro de Santana do Ipanema; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Roubo qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Tutmés Airan de Albuquerque Melo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Santana do Ipanema
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO PELO CONCURSO DE AGENTES. SUBTRAÇÃO DE SEMOVENTES EM PROPRIEDADE RURAL. PARTICIPAÇÃO DE ADOLESCENTES. CORRUPÇÃO DE MENORES. CRIME FORMAL. SÚMULA 500 DO STJ. CONCURSO FORMAL COM RESULTADOS AUTÔNOMOS EM RELAÇÃO A CADA MENOR. DOSIMETRIA DA PENA. VALORAÇÃO NEGATIVA DA CULPABILIDADE E DAS CIRCUNSTÂNCIAS DO CRIME. PRÁTICA NO PERÍODO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO PELO CONCURSO DE AGENTES. SUBTRAÇÃO DE SEMOVENTES EM PROPRIEDADE RURAL. PARTICIPAÇÃO DE ADOLESCENTES. CORRUPÇÃO DE MENORES. CRIME FORMAL. SÚMULA 500 DO STJ. CONCURSO FORMAL COM RESULTADOS AUTÔNOMOS EM RELAÇÃO A CADA MENOR. DOSIMETRIA DA PENA. VALORAÇÃO NEGATIVA DA CULPABILIDADE E DAS CIRCUNSTÂNCIAS DO CRIME. PRÁTICA NO PERÍODO NOTURNO E SUBTRAÇÃO DE ANIMAIS DOMESTICÁVEIS DE PRODUÇÃO. METODOLOGIA DO INTERVALO ENTRE PENAS MÍNIMA E MÁXIMA. PROPORCIONALIDADE. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta pela Defensoria Pública do Estado de Alagoas contra sentença da 3ª Vara Criminal da Comarca de Santana do Ipanema/AL que condenou o réu pela prática do crime de furto qualificado pelo concurso de agentes (art. 155, §4º, IV, do CP) e corrupção de menores (art. 244-B do ECA, por três vezes), em concurso formal, à pena de 4 anos, 4 meses e 15 dias de reclusão e 97 dias-multa. Os fatos ocorreram em 28/05/2017, quando o apelante, em companhia de três adolescentes, subtraiu quatro ovelhas de propriedade rural da vítima. A defesa pleiteia absolvição por insuficiência probatória, absolvição quanto ao delito de corrupção de menores por exigir prova da efetiva corrupção, e, subsidiariamente, a revisão da dosimetria da pena.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se o conjunto probatório é suficiente para comprovar a autoria do furto qualificado imputado ao réu; (ii) estabelecer se o crime de corrupção de menores previsto no art. 244-B do ECA exige prova da efetiva corrupção do adolescente; (iii) determinar se houve ilegalidade na valoração das circunstâncias judiciais e no critério adotado para a fixação da pena-base.
+III. RAZÕES DE DECIDIR
+3. O conjunto probatório é consistente e suficiente para comprovar a autoria do furto qualificado, pois depoimentos de adolescentes participantes do fato, colhidos sob contraditório, confirmam a participação ativa do réu na subtração das ovelhas, sendo corroborados por prova material consistente na apreensão e restituição dos animais.
+4. A ausência de oitiva da vítima em juízo não gera dúvida probatória apta a ensejar absolvição quando a própria defesa anuiu expressamente à sua dispensa na audiência de instrução, não podendo posteriormente invocar tal circunstância como fundamento recursal.
+5. O crime de corrupção de menores previsto no art. 244-B do ECA possui natureza formal, consumando-se com a prática da infração penal em companhia de adolescente, independentemente de prova da efetiva corrupção do menor, conforme entendimento consolidado na Súmula 500 do STJ.
+6. A participação do réu em infração penal juntamente com três adolescentes caracteriza três crimes autônomos de corrupção de menores, admitindo-se o reconhecimento de concurso formal quando uma única ação do agente adulto produz resultados independentes em relação a cada menor.
+7. A valoração negativa da culpabilidade é legítima quando fundamentada na prática do crime durante o período noturno, circunstância que demonstra maior intensidade do dolo e aproveitamento do repouso das vítimas para facilitar a empreitada criminosa.
+8. A valoração negativa das circunstâncias do crime é válida quando fundamentada na subtração de animais semoventes domesticáveis de produção, situação que revela maior gravidade concreta da conduta, sem configurar bis in idem quando a qualificadora aplicada é o concurso de agentes.
+9. A fixação da pena-base mediante aplicação da fração de 1/8 para cada circunstância judicial negativa sobre o intervalo entre as penas mínima e máxima do tipo penal constitui metodologia admitida pela jurisprudência do STJ e revela-se proporcional à gravidade concreta do fato.
+10. A aplicação do concurso formal entre o furto qualificado e os três crimes de corrupção de menores, com aumento de 1/4 sobre a pena mais grave, observa os parâmetros do art. 70 do Código Penal e encontra respaldo na jurisprudência do Superior Tribunal de Justiça.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento:
+1. O crime de corrupção de menores previsto no art. 244-B do ECA possui natureza formal e se consuma com a prática de infração penal em companhia de adolescente, sendo desnecessária a prova da efetiva corrupção do menor.
+2. A participação de agente adulto em infração penal praticada com múltiplos adolescentes configura crimes autônomos de corrupção de menores, admitindo-se concurso formal quando uma única conduta produz resultados independentes em relação a cada menor.
+3. A prática do crime no período noturno e a subtração de animais semoventes domesticáveis de produção podem justificar a valoração negativa das circunstâncias judiciais da culpabilidade e das circunstâncias do crime, desde que não coincidam com qualificadoras aplicadas.
+4. A fixação da pena-base com utilização do critério do intervalo entre as penas mínima e máxima do tipo penal, mediante fração proporcional às circunstâncias judiciais desfavoráveis, é metodologia legítima no sistema de individualização da pena.
+Dispositivos relevantes citados: CP, arts. 33, §2º, "b" e "c", 59, 70 e 155, §4º, IV; ECA, art. 244-B; CPP, art. 593, I; LEP, art. 112, I; LC 80/1990, art. 128, I.
+Jurisprudência relevante citada: STJ, Súmula 500; STJ, REsp 1.680.114/GO, Rel. Min. Sebastião Reis Júnior, Sexta Turma, j. 10.10.2017, DJe 16.10.2017; STJ, REsp 1.719.489/GO, Rel. Min. Sebastião Reis Júnior, Sexta Turma, j. 23.08.2018, DJe 04.09.2018; STJ, REsp 1.890.981/SP, Rel. Min. João Otávio de Noronha, Terceira Seção, Tema 1087, j. 25.05.2022; STJ, AgRg no AREsp 1.799.289/DF.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812477" cdForo="0" >
+										0500036-12.2026.8.02.9000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812477" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812477);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812477" style="display: none;" >
+	<div id="textAreaDados_812477" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL PENAL. CONFLITO NEGATIVO DE COMPET&Ecirc;NCIA. VIOL&Ecirc;NCIA DOM&Eacute;STICA E FAMILIAR CONTRA A MULHER. AMEA&Ccedil;A DE FILHA CONTRA M&Atilde;E. INCID&Ecirc;NCIA DA LEI MARIA DA PENHA. INAPLICABILIDADE DA LEI DOS JUIZADOS ESPECIAIS CRIMINAIS. COMPET&Ecirc;NCIA DO JUIZADO DE VIOL&Ecirc;NCIA DOM&Eacute;STICA.
+I. CASO EM EXAME
+Conflito de jurisdi&ccedil;&atilde;o suscitado pelo Juizado Especial Criminal e do Torcedor da Capital em face do Ju&iacute;zo da 6&ordf; Vara Criminal da Capital, visando definir a compet&ecirc;ncia para processar e julgar a&ccedil;&atilde;o penal decorrente de amea&ccedil;a proferida por filha contra sua genitora no &acirc;mbito dom&eacute;stico e familiar, tendo ambos os ju&iacute;zos declinado da compet&ecirc;ncia, enquanto o Juizado de Viol&ecirc;ncia Dom&eacute;stica afastou sua atua&ccedil;&atilde;o por aus&ecirc;ncia de quest&atilde;o de g&ecirc;nero.
+H&aacute; 2 quest&otilde;es em discuss&atilde;o: (i) definir se a amea&ccedil;a praticada por filha contra m&atilde;e, no contexto dom&eacute;stico, atrai a incid&ecirc;ncia da Lei n&ordm; 11.340/2006; (ii) estabelecer se, nessa hip&oacute;tese, &eacute; competente o Juizado de Viol&ecirc;ncia Dom&eacute;stica e Familiar contra a Mulher ou o Juizado Especial Criminal.
+A conduta de amea&ccedil;a praticada no &acirc;mbito da unidade familiar configura viol&ecirc;ncia dom&eacute;stica e familiar contra a mulher, nos termos do art. 5&ordm;, II, da Lei n&ordm; 11.340/2006, ao envolver agress&atilde;o psicol&oacute;gica contra a v&iacute;tima.
+A incid&ecirc;ncia da Lei Maria da Penha n&atilde;o exige demonstra&ccedil;&atilde;o de motiva&ccedil;&atilde;o de g&ecirc;nero espec&iacute;fica, bastando que a viol&ecirc;ncia ocorra em contexto dom&eacute;stico ou familiar, no qual a vulnerabilidade da mulher &eacute; juridicamente presumida.
+O art. 40-A da Lei n&ordm; 11.340/2006 amplia a prote&ccedil;&atilde;o legal ao estabelecer sua aplica&ccedil;&atilde;o independentemente da condi&ccedil;&atilde;o do ofensor, desde que presente o contexto de viol&ecirc;ncia dom&eacute;stica.
+A jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a admite a aplica&ccedil;&atilde;o da Lei Maria da Penha mesmo quando a agressora &eacute; mulher, desde que caracterizada a viol&ecirc;ncia dom&eacute;stica (HC 277.561/AL).
+O art. 41 da Lei n&ordm; 11.340/2006 afasta a incid&ecirc;ncia dos institutos despenalizadores da Lei n&ordm; 9.099/1995, excluindo a compet&ecirc;ncia do Juizado Especial Criminal.
+A tramita&ccedil;&atilde;o do feito fora da vara especializada compromete a finalidade protetiva da Lei Maria da Penha, voltada &agrave; repress&atilde;o e preven&ccedil;&atilde;o da viol&ecirc;ncia no ambiente dom&eacute;stico.
+Conflito procedente.
+Jurisprud&ecirc;ncia relevante citada: STJ, HC 277.561/AL, Rel. Min. Jorge Mussi, 5&ordf; Turma, j. 06.11.2014.  <br><br>(N&uacute;mero do Processo: 0500036-12.2026.8.02.9000; Relator (a):&nbsp;Des. Jo&atilde;o Luiz Azevedo Lessa; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Conflito de Jurisdição / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. João Luiz Azevedo Lessa
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. CONFLITO NEGATIVO DE COMPETÊNCIA. VIOLÊNCIA DOMÉSTICA E FAMILIAR CONTRA A MULHER. AMEAÇA DE FILHA CONTRA MÃE. INCIDÊNCIA DA LEI MARIA DA PENHA. INAPLICABILIDADE DA LEI DOS JUIZADOS ESPECIAIS CRIMINAIS. COMPETÊNCIA DO JUIZADO DE VIOLÊNCIA DOMÉSTICA.
+I. CASO EM EXAME
+Conflito de jurisdição suscitado pelo Juizado Especial Criminal e do Torcedor da Capital em face do Juízo
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. CONFLITO NEGATIVO DE COMPETÊNCIA. VIOLÊNCIA DOMÉSTICA E FAMILIAR CONTRA A MULHER. AMEAÇA DE FILHA CONTRA MÃE. INCIDÊNCIA DA LEI MARIA DA PENHA. INAPLICABILIDADE DA LEI DOS JUIZADOS ESPECIAIS CRIMINAIS. COMPETÊNCIA DO JUIZADO DE VIOLÊNCIA DOMÉSTICA.
+I. CASO EM EXAME
+Conflito de jurisdição suscitado pelo Juizado Especial Criminal e do Torcedor da Capital em face do Juízo da 6ª Vara Criminal da Capital, visando definir a competência para processar e julgar ação penal decorrente de ameaça proferida por filha contra sua genitora no âmbito doméstico e familiar, tendo ambos os juízos declinado da competência, enquanto o Juizado de Violência Doméstica afastou sua atuação por ausência de questão de gênero.
+Há 2 questões em discussão: (i) definir se a ameaça praticada por filha contra mãe, no contexto doméstico, atrai a incidência da Lei nº 11.340/2006; (ii) estabelecer se, nessa hipótese, é competente o Juizado de Violência Doméstica e Familiar contra a Mulher ou o Juizado Especial Criminal.
+A conduta de ameaça praticada no âmbito da unidade familiar configura violência doméstica e familiar contra a mulher, nos termos do art. 5º, II, da Lei nº 11.340/2006, ao envolver agressão psicológica contra a vítima.
+A incidência da Lei Maria da Penha não exige demonstração de motivação de gênero específica, bastando que a violência ocorra em contexto doméstico ou familiar, no qual a vulnerabilidade da mulher é juridicamente presumida.
+O art. 40-A da Lei nº 11.340/2006 amplia a proteção legal ao estabelecer sua aplicação independentemente da condição do ofensor, desde que presente o contexto de violência doméstica.
+A jurisprudência do Superior Tribunal de Justiça admite a aplicação da Lei Maria da Penha mesmo quando a agressora é mulher, desde que caracterizada a violência doméstica (HC 277.561/AL).
+O art. 41 da Lei nº 11.340/2006 afasta a incidência dos institutos despenalizadores da Lei nº 9.099/1995, excluindo a competência do Juizado Especial Criminal.
+A tramitação do feito fora da vara especializada compromete a finalidade protetiva da Lei Maria da Penha, voltada à repressão e prevenção da violência no ambiente doméstico.
+Conflito procedente.
+Jurisprudência relevante citada: STJ, HC 277.561/AL, Rel. Min. Jorge Mussi, 5ª Turma, j. 06.11.2014.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812660" cdForo="0" >
+										0000015-95.2025.8.02.0022
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812660" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812660);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812660" style="display: none;" >
+	<div id="textAreaDados_812660" class="mensagemSemFormatacao" >
+		Direito penal. Apela&ccedil;&atilde;o criminal. Vias de fato e amea&ccedil;a em contexto de viol&ecirc;ncia dom&eacute;stica. Senten&ccedil;a condenat&oacute;ria. Recurso conhecido e parcialmente provido.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o criminal de senten&ccedil;a que condenou o r&eacute;u pelas infra&ccedil;&otilde;es penais de vias de fato e amea&ccedil;a, em contexto de viol&ecirc;ncia dom&eacute;stica, fixando-lhe pena de 3 (tr&ecirc;s) meses de deten&ccedil;&atilde;o, em regime inicial aberto, e 3 (tr&ecirc;s) meses de pris&atilde;o simples.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se o conjunto probat&oacute;rio autoriza a manuten&ccedil;&atilde;o da condena&ccedil;&atilde;o pelo crime de amea&ccedil;a; (ii) estabelecer se &eacute; id&ocirc;nea a fundamenta&ccedil;&atilde;o para a negativa&ccedil;&atilde;o da culpabilidade e das circunst&acirc;ncias do delito na dosimetria da contraven&ccedil;&atilde;o de vias de fato; (iii) determinar se deve incidir a atenuante da confiss&atilde;o espont&acirc;nea; (iv) verificar se a majorante prevista no art. 21, &sect;2&ordm;, da Lei de Contraven&ccedil;&otilde;es Penais foi corretamente aplicada.
+III. Raz&otilde;es de decidir
+3. O crime de amea&ccedil;a &eacute; formal e consuma-se com a idoneidade intimidativa da conduta, sendo irrelevante a efetiva concretiza&ccedil;&atilde;o do mal anunciado ou a dura&ccedil;&atilde;o do temor experimentado pela v&iacute;tima. A amea&ccedil;a pode ser praticada por palavras, de forma direta ou indireta, ainda que condicional, sendo suficiente que a conduta seja apta a intimidar o sujeito passivo.
+4. O relato da v&iacute;tima, quando corroborado pelos demais elementos de prova constante nos autos, possui relev&acirc;ncia destacada para fins probat&oacute;rios, sendo suficiente, inclusive, para sustentar o &eacute;dito condenat&oacute;rio, na linha da jurisprud&ecirc;ncia do STJ.
+5. No caso, a palavra da ofendida mostrou-se harm&ocirc;nica e consistente desde a fase inquisitorial at&eacute; a instru&ccedil;&atilde;o judicial, encontrando respaldo na prova oral colhida,no sentido de que seu ex-companheiro a amea&ccedil;ou de morte, afirmando que &quot;daquele dia ela n&atilde;o passaria&quot; e que ele iria mat&aacute;-la. O conjunto probat&oacute;rio &eacute; suficiente para a manuten&ccedil;&atilde;o da condena&ccedil;&atilde;o.
+6. O fato de as amea&ccedil;as terem ocorrido em contexto de discuss&atilde;o ou exalta&ccedil;&atilde;o de &acirc;nimos n&atilde;o afasta a tipicidade do crime de amea&ccedil;a, conforme jurisprud&ecirc;ncia do STJ.
+7. A pr&aacute;tica da infra&ccedil;&atilde;o na presen&ccedil;a dos filhos do casal evidencia maior reprovabilidade da conduta, justificando a negativa&ccedil;&atilde;o da culpabilidade.
+8. A confiss&atilde;o do r&eacute;u, ainda que acompanhada de alega&ccedil;&atilde;o de leg&iacute;tima defesa, configura confiss&atilde;o qualificada e autoriza a incid&ecirc;ncia da atenuante prevista no art. 65, III, &quot;d&quot;, do CP, por&eacute;m em patamar inferior, conforme  Tema Repetitivo 1.194 do STJ.
+9. A causa de aumento prevista no art. 21, &sect;2&ordm;, da Lei de Contraven&ccedil;&otilde;es Penais determina a aplica&ccedil;&atilde;o da pena em triplo quando a infra&ccedil;&atilde;o &eacute; praticada contra a mulher por raz&otilde;es da condi&ccedil;&atilde;o do sexo feminino, inexistindo o erro material alegado.
+IV. Dispositivo
+10. Recurso conhecido e parcialmente provido.
+_________
+Dispositivos relevantes citados: CP, arts. 59 e 65, III, &quot;d&quot;; Lei n&ordm; 3.688/41, art. 21, &sect;2&ordm;; Lei n&ordm; 14.994/2024.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no AREsp n&ordm; 2.974.992/DF, Rel. Min. Joel Ilan Paciornik, Quinta Turma, j. 17.12.2025; STJ, AgRg no RHC n&ordm; 162.389/DF, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, j. 13.9.2022; STJ, AgRg no AREsp n&ordm; 2.650.606/RR, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 5.11.2024; STJ, AgRg no AREsp n&ordm; 2.916.517/AL, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, j. 17.6.2025; STJ, Tema Repetitivo 1.194; STJ, AgRg no AREsp n. 1.964.508/MS, Rel. Ministro Ribeiro Dantas, Quinta Turma, j. 29/3/2022; STJ, AgRg no AREsp n. 2.595.604/SC, Rel. Ministro Messod Azulay Neto, Quinta Turma, j. 2/9/2025  <br><br>(N&uacute;mero do Processo: 0000015-95.2025.8.02.0022; Relator (a):&nbsp;Des. Ivan Vasconcelos Brito J&uacute;nior; Comarca:&nbsp;Foro de Mata Grande; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Ivan Vasconcelos Brito Júnior
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mata Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito penal. Apelação criminal. Vias de fato e ameaça em contexto de violência doméstica. Sentença condenatória. Recurso conhecido e parcialmente provido.
+I. Caso em exame
+1. Apelação criminal de sentença que condenou o réu pelas infrações penais de vias de fato e ameaça, em contexto de violência doméstica, fixando-lhe pena de 3 (três) meses de detenção, em regime inicial aberto, e 3 (três)
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito penal. Apelação criminal. Vias de fato e ameaça em contexto de violência doméstica. Sentença condenatória. Recurso conhecido e parcialmente provido.
+I. Caso em exame
+1. Apelação criminal de sentença que condenou o réu pelas infrações penais de vias de fato e ameaça, em contexto de violência doméstica, fixando-lhe pena de 3 (três) meses de detenção, em regime inicial aberto, e 3 (três) meses de prisão simples.
+II. Questão em discussão
+2. Há quatro questões em discussão: (i) definir se o conjunto probatório autoriza a manutenção da condenação pelo crime de ameaça; (ii) estabelecer se é idônea a fundamentação para a negativação da culpabilidade e das circunstâncias do delito na dosimetria da contravenção de vias de fato; (iii) determinar se deve incidir a atenuante da confissão espontânea; (iv) verificar se a majorante prevista no art. 21, §2º, da Lei de Contravenções Penais foi corretamente aplicada.
+III. Razões de decidir
+3. O crime de ameaça é formal e consuma-se com a idoneidade intimidativa da conduta, sendo irrelevante a efetiva concretização do mal anunciado ou a duração do temor experimentado pela vítima. A ameaça pode ser praticada por palavras, de forma direta ou indireta, ainda que condicional, sendo suficiente que a conduta seja apta a intimidar o sujeito passivo.
+4. O relato da vítima, quando corroborado pelos demais elementos de prova constante nos autos, possui relevância destacada para fins probatórios, sendo suficiente, inclusive, para sustentar o édito condenatório, na linha da jurisprudência do STJ.
+5. No caso, a palavra da ofendida mostrou-se harmônica e consistente desde a fase inquisitorial até a instrução judicial, encontrando respaldo na prova oral colhida,no sentido de que seu ex-companheiro a ameaçou de morte, afirmando que "daquele dia ela não passaria" e que ele iria matá-la. O conjunto probatório é suficiente para a manutenção da condenação.
+6. O fato de as ameaças terem ocorrido em contexto de discussão ou exaltação de ânimos não afasta a tipicidade do crime de ameaça, conforme jurisprudência do STJ.
+7. A prática da infração na presença dos filhos do casal evidencia maior reprovabilidade da conduta, justificando a negativação da culpabilidade.
+8. A confissão do réu, ainda que acompanhada de alegação de legítima defesa, configura confissão qualificada e autoriza a incidência da atenuante prevista no art. 65, III, "d", do CP, porém em patamar inferior, conforme  Tema Repetitivo 1.194 do STJ.
+9. A causa de aumento prevista no art. 21, §2º, da Lei de Contravenções Penais determina a aplicação da pena em triplo quando a infração é praticada contra a mulher por razões da condição do sexo feminino, inexistindo o erro material alegado.
+IV. Dispositivo
+10. Recurso conhecido e parcialmente provido.
+_________
+Dispositivos relevantes citados: CP, arts. 59 e 65, III, "d"; Lei nº 3.688/41, art. 21, §2º; Lei nº 14.994/2024.
+Jurisprudência relevante citada: STJ, AgRg no AREsp nº 2.974.992/DF, Rel. Min. Joel Ilan Paciornik, Quinta Turma, j. 17.12.2025; STJ, AgRg no RHC nº 162.389/DF, Rel. Min. Sebastião Reis Júnior, Sexta Turma, j. 13.9.2022; STJ, AgRg no AREsp nº 2.650.606/RR, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 5.11.2024; STJ, AgRg no AREsp nº 2.916.517/AL, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, j. 17.6.2025; STJ, Tema Repetitivo 1.194; STJ, AgRg no AREsp n. 1.964.508/MS, Rel. Ministro Ribeiro Dantas, Quinta Turma, j. 29/3/2022; STJ, AgRg no AREsp n. 2.595.604/SC, Rel. Ministro Messod Azulay Neto, Quinta Turma, j. 2/9/2025
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812588" cdForo="0" >
+										0809933-59.2025.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812588" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812588);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812588" style="display: none;" >
+	<div id="textAreaDados_812588" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL E PROCESSUAL CIVIL. MANDADO DE SEGURAN&Ccedil;A. MULTA POR LITIG&Acirc;NCIA DE M&Aacute;-F&Eacute; IMPOSTA AO ADVOGADO. IMPOSSIBILIDADE. NECESSIDADE DE APURA&Ccedil;&Atilde;O EM A&Ccedil;&Atilde;O PR&Oacute;PRIA. AUS&Ecirc;NCIA DE DOLO. MERO ERRO MATERIAL CORRIGIDO. VIOLA&Ccedil;&Atilde;O AO CONTRADIT&Oacute;RIO E &Agrave; AMPLA DEFESA. SEGURAN&Ccedil;A CONCEDIDA.
+I. CASO EM EXAME
+1. O recurso
+Mandado de seguran&ccedil;a impetrado contra ato judicial que aplicou multa por litig&acirc;ncia de m&aacute;-f&eacute; diretamente ao advogado subscritor da peti&ccedil;&atilde;o, no percentual de 1% sobre o valor da causa.
+2. O fato relevante
+A multa foi aplicada em raz&atilde;o de equ&iacute;voco material na cita&ccedil;&atilde;o de dispositivo legal (art. 115 do CPC), posteriormente reconhecido e corrigido espontaneamente pelo advogado, sem preju&iacute;zo ao andamento processual e sem demonstra&ccedil;&atilde;o de dolo.
+3. A decis&atilde;o recorrida
+Decis&atilde;o que condenou o advogado por litig&acirc;ncia de m&aacute;-f&eacute;, nos pr&oacute;prios autos, com fundamento nos arts. 80 e 81 do CPC. Em sede inicial do mandado de seguran&ccedil;a, reconheceu-se a ilegitimidade de litisconsortes e deferiu-se liminar para suspender a exigibilidade da multa.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+Saber se &eacute; legal a imposi&ccedil;&atilde;o direta de multa por litig&acirc;ncia de m&aacute;-f&eacute; ao advogado, nos autos da causa origin&aacute;ria, sem pr&eacute;via instaura&ccedil;&atilde;o de procedimento pr&oacute;prio e sem comprova&ccedil;&atilde;o de dolo ou abuso.
+III. RAZ&Otilde;ES DE DECIDIR
+As penalidades por litig&acirc;ncia de m&aacute;-f&eacute; previstas nos arts. 79 e 80 do CPC s&atilde;o destinadas &agrave;s partes, n&atilde;o se estendendo ao advogado, cuja eventual responsabiliza&ccedil;&atilde;o deve ocorrer em a&ccedil;&atilde;o pr&oacute;pria, nos termos do art. 32 da Lei n&ordm; 8.906/1994.
+A jurisprud&ecirc;ncia consolidada do STJ admite, de forma excepcional, o mandado de seguran&ccedil;a contra ato judicial manifestamente ilegal, como na hip&oacute;tese de imposi&ccedil;&atilde;o de multa diretamente ao advogado.
+No caso concreto, o erro na indica&ccedil;&atilde;o do dispositivo legal foi meramente material, corrigido de forma espont&acirc;nea e sem causar preju&iacute;zo ao processo, inexistindo demonstra&ccedil;&atilde;o do elemento subjetivo indispens&aacute;vel &agrave; caracteriza&ccedil;&atilde;o da litig&acirc;ncia de m&aacute;-f&eacute;.
+IV. DISPOSITIVO
+Concede-se a seguran&ccedil;a para afastar a multa por litig&acirc;ncia de m&aacute;-f&eacute; imposta ao advogado impetrante.
+Atos normativos citados:
+CF/1988, art. 5&ordm;, LXIX;
+Lei n&ordm; 12.016/2009, arts. 1&ordm;, 23 e 25;
+CPC, arts. 79, 80 e 81;
+Lei n&ordm; 8.906/1994 (Estatuto da Advocacia), art. 32.
+Jurisprud&ecirc;ncia citada:
+STJ, AgInt no AREsp 1.722.332/MT, Quarta Turma, j. 13/06/2022;
+STJ, RMS 59.322/MG, Quarta Turma, j. 05/02/2019;
+STJ, RMS 71.836/MT, Quarta Turma, j. 26/09/2023;
+TJ/AL, Mandado de Seguran&ccedil;a n&ordm; 0803211-19.2019.8.02.0000, Se&ccedil;&atilde;o Especializada C&iacute;vel, j. 13/03/2020.  <br><br>(N&uacute;mero do Processo: 0809933-59.2025.8.02.0000; Relator (a):&nbsp;Des. Klever R&ecirc;go Loureiro; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: Se&ccedil;&atilde;o Especializada C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Mandado de Segurança Cível / Litisconsórcio
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Klever Rêgo Loureiro
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Especializada Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E PROCESSUAL CIVIL. MANDADO DE SEGURANÇA. MULTA POR LITIGÂNCIA DE MÁ-FÉ IMPOSTA AO ADVOGADO. IMPOSSIBILIDADE. NECESSIDADE DE APURAÇÃO EM AÇÃO PRÓPRIA. AUSÊNCIA DE DOLO. MERO ERRO MATERIAL CORRIGIDO. VIOLAÇÃO AO CONTRADITÓRIO E À AMPLA DEFESA. SEGURANÇA CONCEDIDA.
+I. CASO EM EXAME
+1. O recurso
+Mandado de segurança impetrado contra ato judicial que aplicou multa por
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E PROCESSUAL CIVIL. MANDADO DE SEGURANÇA. MULTA POR LITIGÂNCIA DE MÁ-FÉ IMPOSTA AO ADVOGADO. IMPOSSIBILIDADE. NECESSIDADE DE APURAÇÃO EM AÇÃO PRÓPRIA. AUSÊNCIA DE DOLO. MERO ERRO MATERIAL CORRIGIDO. VIOLAÇÃO AO CONTRADITÓRIO E À AMPLA DEFESA. SEGURANÇA CONCEDIDA.
+I. CASO EM EXAME
+1. O recurso
+Mandado de segurança impetrado contra ato judicial que aplicou multa por litigância de má-fé diretamente ao advogado subscritor da petição, no percentual de 1% sobre o valor da causa.
+2. O fato relevante
+A multa foi aplicada em razão de equívoco material na citação de dispositivo legal (art. 115 do CPC), posteriormente reconhecido e corrigido espontaneamente pelo advogado, sem prejuízo ao andamento processual e sem demonstração de dolo.
+3. A decisão recorrida
+Decisão que condenou o advogado por litigância de má-fé, nos próprios autos, com fundamento nos arts. 80 e 81 do CPC. Em sede inicial do mandado de segurança, reconheceu-se a ilegitimidade de litisconsortes e deferiu-se liminar para suspender a exigibilidade da multa.
+II. QUESTÃO EM DISCUSSÃO
+Saber se é legal a imposição direta de multa por litigância de má-fé ao advogado, nos autos da causa originária, sem prévia instauração de procedimento próprio e sem comprovação de dolo ou abuso.
+III. RAZÕES DE DECIDIR
+As penalidades por litigância de má-fé previstas nos arts. 79 e 80 do CPC são destinadas às partes, não se estendendo ao advogado, cuja eventual responsabilização deve ocorrer em ação própria, nos termos do art. 32 da Lei nº 8.906/1994.
+A jurisprudência consolidada do STJ admite, de forma excepcional, o mandado de segurança contra ato judicial manifestamente ilegal, como na hipótese de imposição de multa diretamente ao advogado.
+No caso concreto, o erro na indicação do dispositivo legal foi meramente material, corrigido de forma espontânea e sem causar prejuízo ao processo, inexistindo demonstração do elemento subjetivo indispensável à caracterização da litigância de má-fé.
+IV. DISPOSITIVO
+Concede-se a segurança para afastar a multa por litigância de má-fé imposta ao advogado impetrante.
+Atos normativos citados:
+CF/1988, art. 5º, LXIX;
+Lei nº 12.016/2009, arts. 1º, 23 e 25;
+CPC, arts. 79, 80 e 81;
+Lei nº 8.906/1994 (Estatuto da Advocacia), art. 32.
+Jurisprudência citada:
+STJ, AgInt no AREsp 1.722.332/MT, Quarta Turma, j. 13/06/2022;
+STJ, RMS 59.322/MG, Quarta Turma, j. 05/02/2019;
+STJ, RMS 71.836/MT, Quarta Turma, j. 26/09/2023;
+TJ/AL, Mandado de Segurança nº 0803211-19.2019.8.02.0000, Seção Especializada Cível, j. 13/03/2020.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812578" cdForo="0" >
+										0804189-83.2025.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812578" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812578);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812578" style="display: none;" >
+	<div id="textAreaDados_812578" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL E DIREITO CIVIL. RECLAMA&Ccedil;&Atilde;O. ATRASO NA ENTREGA DE IM&Oacute;VEL NA PLANTA. CL&Aacute;USULA PENAL MORAT&Oacute;RIA. LUCROS CESSANTES. POSSIBILIDADE DE CUMULA&Ccedil;&Atilde;O. TEMA 970 DO STJ. VIOLA&Ccedil;&Atilde;O A PRECEDENTE OBRIGAT&Oacute;RIO. PROCED&Ecirc;NCIA.
+I. CASO EM EXAME
+1. Reclama&ccedil;&atilde;o ajuizada contra ac&oacute;rd&atilde;o da Turma Recursal de Alagoas que, em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por atraso na entrega de im&oacute;vel adquirido na planta, reconheceu o inadimplemento contratual, mas afastou a cumula&ccedil;&atilde;o entre cl&aacute;usula penal morat&oacute;ria e lucros cessantes, sob o fundamento de veda&ccedil;&atilde;o ao bis in idem.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; cab&iacute;vel reclama&ccedil;&atilde;o para garantir a observ&acirc;ncia de tese firmada em recurso especial repetitivo; (ii) estabelecer se &eacute; poss&iacute;vel a cumula&ccedil;&atilde;o entre cl&aacute;usula penal morat&oacute;ria fixada em percentual &uacute;nico e lucros cessantes em caso de atraso na entrega de im&oacute;vel.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O art. 234, IV, do RITJAL admite expressamente a reclama&ccedil;&atilde;o para dirimir diverg&ecirc;ncia entre ac&oacute;rd&atilde;o de Turma Recursal e tese firmada em recurso repetitivo do STJ.
+4. O CPC/2015 imp&otilde;e a observ&acirc;ncia obrigat&oacute;ria dos precedentes qualificados, sendo a reclama&ccedil;&atilde;o instrumento adequado para assegurar a uniformidade e coer&ecirc;ncia da jurisprud&ecirc;ncia (art. 927, III).
+5. O Tema 970 do STJ estabelece que a cl&aacute;usula penal morat&oacute;ria, quando equivalente ao valor locativo, afasta a cumula&ccedil;&atilde;o com lucros cessantes, para evitar bis in idem.
+6. A veda&ccedil;&atilde;o &agrave; cumula&ccedil;&atilde;o n&atilde;o &eacute; absoluta, pois depende da equival&ecirc;ncia entre a multa contratual e o valor locativo do im&oacute;vel.
+7. Cl&aacute;usula penal fixada em percentual &uacute;nico sobre o valor do contrato, sem vincula&ccedil;&atilde;o &agrave; dura&ccedil;&atilde;o da mora, n&atilde;o possui natureza compensat&oacute;ria suficiente para recompor o preju&iacute;zo do adquirente.
+8. A insufici&ecirc;ncia da cl&aacute;usula penal autoriza a cumula&ccedil;&atilde;o com lucros cessantes para assegurar a repara&ccedil;&atilde;o integral do dano.
+9. A previs&atilde;o contratual expressa de cumula&ccedil;&atilde;o entre multa e perdas e danos refor&ccedil;a a inexist&ecirc;ncia de car&aacute;ter substitutivo da cl&aacute;usula penal.
+10. O ac&oacute;rd&atilde;o reclamado diverge do Tema 970 ao afastar automaticamente a cumula&ccedil;&atilde;o sem analisar a equival&ecirc;ncia ao locativo, violando precedente obrigat&oacute;rio.
+IV. DISPOSITIVO
+11. Reclama&ccedil;&atilde;o julgada procedente.
+_______________
+Dispositivos relevantes citados: CPC/2015, arts. 85, &sect;&sect; 2&ordm; e 8&ordm;, 927, III, e 988; CC, art. 424; RITJAL, art. 234, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, Tema Repetitivo n&ordm; 970. <br><br>(N&uacute;mero do Processo: 0804189-83.2025.8.02.0000; Relator (a):&nbsp;Ju&iacute;za Conv. Adriana Carla Feitosa Martins; Comarca:&nbsp;1&ordm; Juizado Especial C&iacute;vel da Capital; &Oacute;rg&atilde;o julgador: Tribunal Pleno; Data do julgamento: 14/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Reclamação / Vícios de Construção
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Conv. Adriana Carla Feitosa Martins
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Tribunal Pleno
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO CIVIL. RECLAMAÇÃO. ATRASO NA ENTREGA DE IMÓVEL NA PLANTA. CLÁUSULA PENAL MORATÓRIA. LUCROS CESSANTES. POSSIBILIDADE DE CUMULAÇÃO. TEMA 970 DO STJ. VIOLAÇÃO A PRECEDENTE OBRIGATÓRIO. PROCEDÊNCIA.
+I. CASO EM EXAME
+1. Reclamação ajuizada contra acórdão da Turma Recursal de Alagoas que, em ação de indenização por atraso na entrega de imóvel adquirido na planta,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO CIVIL. RECLAMAÇÃO. ATRASO NA ENTREGA DE IMÓVEL NA PLANTA. CLÁUSULA PENAL MORATÓRIA. LUCROS CESSANTES. POSSIBILIDADE DE CUMULAÇÃO. TEMA 970 DO STJ. VIOLAÇÃO A PRECEDENTE OBRIGATÓRIO. PROCEDÊNCIA.
+I. CASO EM EXAME
+1. Reclamação ajuizada contra acórdão da Turma Recursal de Alagoas que, em ação de indenização por atraso na entrega de imóvel adquirido na planta, reconheceu o inadimplemento contratual, mas afastou a cumulação entre cláusula penal moratória e lucros cessantes, sob o fundamento de vedação ao bis in idem.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se é cabível reclamação para garantir a observância de tese firmada em recurso especial repetitivo; (ii) estabelecer se é possível a cumulação entre cláusula penal moratória fixada em percentual único e lucros cessantes em caso de atraso na entrega de imóvel.
+III. RAZÕES DE DECIDIR
+3. O art. 234, IV, do RITJAL admite expressamente a reclamação para dirimir divergência entre acórdão de Turma Recursal e tese firmada em recurso repetitivo do STJ.
+4. O CPC/2015 impõe a observância obrigatória dos precedentes qualificados, sendo a reclamação instrumento adequado para assegurar a uniformidade e coerência da jurisprudência (art. 927, III).
+5. O Tema 970 do STJ estabelece que a cláusula penal moratória, quando equivalente ao valor locativo, afasta a cumulação com lucros cessantes, para evitar bis in idem.
+6. A vedação à cumulação não é absoluta, pois depende da equivalência entre a multa contratual e o valor locativo do imóvel.
+7. Cláusula penal fixada em percentual único sobre o valor do contrato, sem vinculação à duração da mora, não possui natureza compensatória suficiente para recompor o prejuízo do adquirente.
+8. A insuficiência da cláusula penal autoriza a cumulação com lucros cessantes para assegurar a reparação integral do <em>dano</em>.
+9. A previsão contratual expressa de cumulação entre multa e perdas e <em>danos</em> reforça a inexistência de caráter substitutivo da cláusula penal.
+10. O acórdão reclamado diverge do Tema 970 ao afastar automaticamente a cumulação sem analisar a equivalência ao locativo, violando precedente obrigatório.
+IV. DISPOSITIVO
+11. Reclamação julgada procedente.
+_______________
+Dispositivos relevantes citados: CPC/2015, arts. 85, §§ 2º e 8º, 927, III, e 988; CC, art. 424; RITJAL, art. 234, IV.
+Jurisprudência relevante citada: STJ, Tema Repetitivo nº 970.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812572" cdForo="0" >
+										0728669-56.2021.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812572" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812572);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812572" style="display: none;" >
+	<div id="textAreaDados_812572" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM AGRAVO INTERNO EM RECURSO ESPECIAL. AC&Oacute;RD&Atilde;O QUE CONHECEU E NEGOU PROVIMENTO AO AGRAVO INTERNO MANEJADO CONTRA DECIS&Atilde;O QUE SUSPENDEU O RECURSO ESPECIAL EM RAZ&Atilde;O DA INCID&Ecirc;NCIA DO TEMA 929 DO STJ. OBSCURIDADE CONSTATADA. AUS&Ecirc;NCIA DE ADER&Ecirc;NCIA ESTRITA. ACOLHIMENTO DOS ACLARAT&Oacute;RIOS COM EFEITOS INFRINGENTES.
+I. Caso em exame
+Embargos de declara&ccedil;&atilde;o em face de ac&oacute;rd&atilde;o que negou provimento ao agravo interno.
+II. Quest&atilde;o em discuss&atilde;o
+2. Verificar a exist&ecirc;ncia de omiss&atilde;o e obscuridade quanto &agrave;s mat&eacute;rias suscitadas nas raz&otilde;es do agravo interno.
+3. Verificados os v&iacute;cios de omiss&atilde;o e obscuridade alegados, uma vez que o agravo interno contemplava quest&otilde;es que demonstravam a exist&ecirc;ncia de mat&eacute;rias debatidas no recurso especial que n&atilde;o atrairiam a incid&ecirc;ncia do precedente vinculante que ensejou a suspens&atilde;o.
+4. O Tema 929 dos recursos repetitivos visa definir se a repeti&ccedil;&atilde;o em dobro prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC necessita ou n&atilde;o da comprova&ccedil;&atilde;o da m&aacute;-f&eacute; do prestador de servi&ccedil;os.
+5. Se o &oacute;rg&atilde;o fracion&aacute;rio sequer reconheceu a ocorr&ecirc;ncia da falha na presta&ccedil;&atilde;o de servi&ccedil;os que ensejaria a repeti&ccedil;&atilde;o do ind&eacute;bito, imp&otilde;e-se reconhecer a aus&ecirc;ncia de ader&ecirc;ncia estrita entre a mat&eacute;ria debatida no recurso especial e a quest&atilde;o afetada ao precedente vinculante.
+6. Afastada a incid&ecirc;ncia do tema que ensejou a suspens&atilde;o do feito, deve ser promovido o ju&iacute;zo de admissibilidade do ju&iacute;zo especial.
+IV. Dispositivo
+7. Embargos de declara&ccedil;&atilde;o conhecidos e acolhidos com efeitos infringentes. Decis&atilde;o un&acirc;nime.
+______________________
+Dispositivos relevantes citados: CPC, art. 1.022; CDC, arts. 14 e 42, par&aacute;grafo &uacute;nico.
+Jurisprud&ecirc;ncia relevante: ProAfR no REsp 1.823.218/AC .  <br><br>(N&uacute;mero do Processo: 0728669-56.2021.8.02.0001; Relator (a):&nbsp;Presidente do Tribunal de Justi&ccedil;a de Alagoas; Comarca:&nbsp;Foro de Arapiraca; &Oacute;rg&atilde;o julgador: Tribunal Pleno; Data do julgamento: 14/04/2026; Data de registro: 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Presidente do Tribunal de Justiça de Alagoas
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Arapiraca
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Tribunal Pleno
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									728669562021802000150002
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO INTERNO EM RECURSO ESPECIAL. ACÓRDÃO QUE CONHECEU E NEGOU PROVIMENTO AO AGRAVO INTERNO MANEJADO CONTRA DECISÃO QUE SUSPENDEU O RECURSO ESPECIAL EM RAZÃO DA INCIDÊNCIA DO TEMA 929 DO STJ. OBSCURIDADE CONSTATADA. AUSÊNCIA DE ADERÊNCIA ESTRITA. ACOLHIMENTO DOS ACLARATÓRIOS COM EFEITOS INFRINGENTES.
+I. Caso em exame
+Embargos de declaração em face de acórdão que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO INTERNO EM RECURSO ESPECIAL. ACÓRDÃO QUE CONHECEU E NEGOU PROVIMENTO AO AGRAVO INTERNO MANEJADO CONTRA DECISÃO QUE SUSPENDEU O RECURSO ESPECIAL EM RAZÃO DA INCIDÊNCIA DO TEMA 929 DO STJ. OBSCURIDADE CONSTATADA. AUSÊNCIA DE ADERÊNCIA ESTRITA. ACOLHIMENTO DOS ACLARATÓRIOS COM EFEITOS INFRINGENTES.
+I. Caso em exame
+Embargos de declaração em face de acórdão que negou provimento ao agravo interno.
+II. Questão em discussão
+2. Verificar a existência de omissão e obscuridade quanto às matérias suscitadas nas razões do agravo interno.
+3. Verificados os vícios de omissão e obscuridade alegados, uma vez que o agravo interno contemplava questões que demonstravam a existência de matérias debatidas no recurso especial que não atrairiam a incidência do precedente vinculante que ensejou a suspensão.
+4. O Tema 929 dos recursos repetitivos visa definir se a repetição em dobro prevista no art. 42, parágrafo único, do CDC necessita ou não da comprovação da má-fé do prestador de serviços.
+5. Se o órgão fracionário sequer reconheceu a ocorrência da falha na prestação de serviços que ensejaria a repetição do indébito, impõe-se reconhecer a ausência de aderência estrita entre a matéria debatida no recurso especial e a questão afetada ao precedente vinculante.
+6. Afastada a incidência do tema que ensejou a suspensão do feito, deve ser promovido o juízo de admissibilidade do juízo especial.
+IV. Dispositivo
+7. Embargos de declaração conhecidos e acolhidos com efeitos infringentes. Decisão unânime.
+______________________
+Dispositivos relevantes citados: CPC, art. 1.022; CDC, arts. 14 e 42, parágrafo único.
+Jurisprudência relevante: ProAfR no REsp 1.823.218/AC .
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811845" cdForo="0" >
+										0801684-22.2025.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811845" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811845);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811845" style="display: none;" >
+	<div id="textAreaDados_811845" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL E DIREITO ADMINISTRATIVO. A&Ccedil;&Atilde;O RESCIS&Oacute;RIA. RESPONSABILIDADE CIVIL DO ESTADO. PRIS&Atilde;O PREVENTIVA. POSTERIOR ABSOLVI&Ccedil;&Atilde;O POR INSUFICI&Ecirc;NCIA DE PROVAS. AUS&Ecirc;NCIA DE ERRO DE FATO E DE VIOLA&Ccedil;&Atilde;O MANIFESTA A NORMA JUR&Iacute;DICA. UTILIZA&Ccedil;&Atilde;O DA RESCIS&Oacute;RIA COMO SUCED&Acirc;NEO RECURSAL. IMPROCED&Ecirc;NCIA.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o rescis&oacute;ria proposta por particular em face do Estado de Alagoas, com fundamento no art. 966, incisos IV, V e VIII, do CPC, visando &agrave; desconstitui&ccedil;&atilde;o de senten&ccedil;a que julgou improcedente pedido de indeniza&ccedil;&atilde;o por danos morais decorrentes de pris&atilde;o preventiva posteriormente seguida de absolvi&ccedil;&atilde;o pelo Tribunal do J&uacute;ri por insufici&ecirc;ncia de provas.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se a senten&ccedil;a rescindenda incorreu em erro de fato, nos termos do art. 966, &sect; 1&ordm;, do CPC, ao afastar o dever de indenizar mesmo diante de absolvi&ccedil;&atilde;o criminal; e (ii) estabelecer se houve viola&ccedil;&atilde;o manifesta a norma jur&iacute;dica apta a ensejar a rescis&atilde;o do julgado.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A a&ccedil;&atilde;o rescis&oacute;ria possui natureza excepcional e cogni&ccedil;&atilde;o restrita, limitando-se &agrave;s hip&oacute;teses taxativas do art. 966 do CPC, n&atilde;o se prestando ao reexame de mat&eacute;ria f&aacute;tica ou &agrave; rediscuss&atilde;o da justi&ccedil;a da decis&atilde;o rescindenda.
+4. Configura erro de fato apenas a admiss&atilde;o de fato inexistente ou a desconsidera&ccedil;&atilde;o de fato efetivamente ocorrido, desde que n&atilde;o tenha havido controv&eacute;rsia ou pronunciamento judicial sobre ele, conforme entendimento consolidado do STJ.
+5. A senten&ccedil;a rescindenda reconhece expressamente a absolvi&ccedil;&atilde;o do autor, mas conclui que tal circunst&acirc;ncia, por si s&oacute;, n&atilde;o caracteriza erro judici&aacute;rio nem responsabilidade civil do Estado, ausente demonstra&ccedil;&atilde;o de ilegalidade na decreta&ccedil;&atilde;o e manuten&ccedil;&atilde;o da pris&atilde;o preventiva.
+6. A pretens&atilde;o autoral busca rediscutir a valora&ccedil;&atilde;o jur&iacute;dica conferida aos fatos j&aacute; examinados na a&ccedil;&atilde;o origin&aacute;ria, o que revela indevida utiliza&ccedil;&atilde;o da a&ccedil;&atilde;o rescis&oacute;ria como suced&acirc;neo recursal.
+7. A absolvi&ccedil;&atilde;o por insufici&ecirc;ncia de provas n&atilde;o gera, automaticamente, dever de indenizar quando a pris&atilde;o preventiva foi decretada com fundamento nos requisitos legais e em decis&otilde;es devidamente motivadas.
+8. A responsabilidade civil do Estado por atos jurisdicionais &eacute; excepcional, restringindo-se &agrave;s hip&oacute;teses do art. 5&ordm;, LXXV, da Constitui&ccedil;&atilde;o Federal &ndash; erro judici&aacute;rio ou pris&atilde;o al&eacute;m do tempo fixado na senten&ccedil;a &ndash; ou &agrave; demonstra&ccedil;&atilde;o de ilegalidade manifesta, n&atilde;o verificada no caso.
+IV. DISPOSITIVO
+9. A&ccedil;&atilde;o rescis&oacute;ria julgada improcedente.
+__________
+Dispositivos relevantes citados: CF/1988, arts. 5&ordm;, V, X e LXXV, e 37, &sect; 6&ordm;; CPC, art. 966, incisos IV, V, VIII e &sect; 1&ordm;, e art. 975; CC, arts. 186 e 927.
+
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no AREsp 1958417/ES, Rel. Min. Raul Ara&uacute;jo, T4, j. 20.05.2024, DJe 04.06.2024; STJ, AR 5.254/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, Segunda Se&ccedil;&atilde;o, DJe 30.05.2022; STJ, AgInt na AR 6.562/DF, Rel. Min. Antonio Carlos Ferreira, Segunda Se&ccedil;&atilde;o, DJe 16.12.2019; STJ, AgInt na AR 6.991/BA, Rel. Min. Nancy Andrighi, Segunda Se&ccedil;&atilde;o, DJe 07.03.2024; STJ, AR 5.223/SP, Rel. Min. Gurgel de Faria, Primeira Se&ccedil;&atilde;o, DJe 25.08.2022; STJ, AR 6.052/SP, Rel. Min. Marco Aur&eacute;lio Bellizze, Segunda Se&ccedil;&atilde;o, DJe 14.02.2023; TJAL, Apela&ccedil;&atilde;o n&ordm; 0735401-82.2023.8.02.0001, Rel. Des. Fernando Tourinho de Omena Souza, 3&ordf; C&acirc;mara C&iacute;vel, j. 06.05.2025. <br><br>(N&uacute;mero do Processo: 0801684-22.2025.8.02.0000; Relator (a):&nbsp;Ju&iacute;za Conv. Adriana Carla Feitosa Martins; Comarca:&nbsp;Foro de Traipu; &Oacute;rg&atilde;o julgador: Se&ccedil;&atilde;o Especializada C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Ação Rescisória / Rescisão / Resolução
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Conv. Adriana Carla Feitosa Martins
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Traipu
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Especializada Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO ADMINISTRATIVO. AÇÃO RESCISÓRIA. RESPONSABILIDADE CIVIL DO ESTADO. PRISÃO PREVENTIVA. POSTERIOR ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. AUSÊNCIA DE ERRO DE FATO E DE VIOLAÇÃO MANIFESTA A NORMA JURÍDICA. UTILIZAÇÃO DA RESCISÓRIA COMO SUCEDÂNEO RECURSAL. IMPROCEDÊNCIA.
+I. CASO EM EXAME
+1. Ação rescisória proposta por particular em face do Estado de Alagoas, com
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO ADMINISTRATIVO. AÇÃO RESCISÓRIA. RESPONSABILIDADE CIVIL DO ESTADO. PRISÃO PREVENTIVA. POSTERIOR ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. AUSÊNCIA DE ERRO DE FATO E DE VIOLAÇÃO MANIFESTA A NORMA JURÍDICA. UTILIZAÇÃO DA RESCISÓRIA COMO SUCEDÂNEO RECURSAL. IMPROCEDÊNCIA.
+I. CASO EM EXAME
+1. Ação rescisória proposta por particular em face do Estado de Alagoas, com fundamento no art. 966, incisos IV, V e VIII, do CPC, visando à desconstituição de sentença que julgou improcedente pedido de indenização por <em>danos</em> <em>morais</em> decorrentes de prisão preventiva posteriormente seguida de absolvição pelo Tribunal do Júri por insuficiência de provas.
+II. QUESTÕES EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se a sentença rescindenda incorreu em erro de fato, nos termos do art. 966, § 1º, do CPC, ao afastar o dever de indenizar mesmo diante de absolvição criminal; e (ii) estabelecer se houve violação manifesta a norma jurídica apta a ensejar a rescisão do julgado.
+III. RAZÕES DE DECIDIR
+3. A ação rescisória possui natureza excepcional e cognição restrita, limitando-se às hipóteses taxativas do art. 966 do CPC, não se prestando ao reexame de matéria fática ou à rediscussão da justiça da decisão rescindenda.
+4. Configura erro de fato apenas a admissão de fato inexistente ou a desconsideração de fato efetivamente ocorrido, desde que não tenha havido controvérsia ou pronunciamento judicial sobre ele, conforme entendimento consolidado do STJ.
+5. A sentença rescindenda reconhece expressamente a absolvição do autor, mas conclui que tal circunstância, por si só, não caracteriza erro judiciário nem responsabilidade civil do Estado, ausente demonstração de ilegalidade na decretação e manutenção da prisão preventiva.
+6. A pretensão autoral busca rediscutir a valoração jurídica conferida aos fatos já examinados na ação originária, o que revela indevida utilização da ação rescisória como sucedâneo recursal.
+7. A absolvição por insuficiência de provas não gera, automaticamente, dever de indenizar quando a prisão preventiva foi decretada com fundamento nos requisitos legais e em decisões devidamente motivadas.
+8. A responsabilidade civil do Estado por atos jurisdicionais é excepcional, restringindo-se às hipóteses do art. 5º, LXXV, da Constituição Federal – erro judiciário ou prisão além do tempo fixado na sentença – ou à demonstração de ilegalidade manifesta, não verificada no caso.
+IV. DISPOSITIVO
+9. Ação rescisória julgada improcedente.
+__________
+Dispositivos relevantes citados: CF/1988, arts. 5º, V, X e LXXV, e 37, § 6º; CPC, art. 966, incisos IV, V, VIII e § 1º, e art. 975; CC, arts. 186 e 927.
+
+Jurisprudência relevante citada: STJ, AgInt no AREsp 1958417/ES, Rel. Min. Raul Araújo, T4, j. 20.05.2024, DJe 04.06.2024; STJ, AR 5.254/SP, Rel. Min. Ricardo Villas Bôas Cueva, Segunda Seção, DJe 30.05.2022; STJ, AgInt na AR 6.562/DF, Rel. Min. Antonio Carlos Ferreira, Segunda Seção, DJe 16.12.2019; STJ, AgInt na AR 6.991/BA, Rel. Min. Nancy Andrighi, Segunda Seção, DJe 07.03.2024; STJ, AR 5.223/SP, Rel. Min. Gurgel de Faria, Primeira Seção, DJe 25.08.2022; STJ, AR 6.052/SP, Rel. Min. Marco Aurélio Bellizze, Segunda Seção, DJe 14.02.2023; TJAL, Apelação nº 0735401-82.2023.8.02.0001, Rel. Des. Fernando Tourinho de Omena Souza, 3ª Câmara Cível, j. 06.05.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811835" cdForo="0" >
+										0724834-31.2019.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811835" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811835);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811835" style="display: none;" >
+	<div id="textAreaDados_811835" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. PLANO DE SA&Uacute;DE. DEVER DE COBERTURA DE PROCEDIMENTO. PREVIS&Atilde;O NO ROL DA ANS. REEMBOLSO LIMITADO AO VALOR DE TABELA. DANO MORAL CONFIGURADO. RECURSO CONHECIDO E PROVIDO EM PARTE.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pela Unimed Macei&oacute; em face de senten&ccedil;a que julgou parcialmente procedente a pretens&atilde;o autoral, no sentido de no sentido de: (i) confirmar a tutela de urg&ecirc;ncia, que determinou que a parte demandada autorizasse e custeasse a cirurgia de les&atilde;o por radiofrequ&ecirc;ncia de nervos espl&acirc;ncnicos bilaterais; (ii) condenar o r&eacute;u ao reembolso integral das despesas relativas ao procedimento de bloqueio anest&eacute;sico de plexo cel&iacute;aco; e (iii) condenar a operadora de sa&uacute;de ao pagamento de indeniza&ccedil;&atilde;o por danos morais no importe de R$ 10.000,00 (dez mil reais).
+II. Quest&atilde;o em discuss&atilde;o
+2. O cerne da controv&eacute;rsia em sede recursal consiste em verificar: (i) se houve negativa de cobertura em rela&ccedil;&atilde;o ao procedimento de bloqueio anest&eacute;sico de plexo cel&iacute;aco; (ii) se o reembolso das despesas realizadas pelo autor em rede particular deve ser integral ou limitado ao valor de tabela do plano; (iii) se a operadora de sa&uacute;de tem a obriga&ccedil;&atilde;o de custear a cirurgia de les&atilde;o por radiofrequ&ecirc;ncia de nervos espl&acirc;ncnicos bilaterais; e (iv) se foi configurado abalo moral.
+III. Raz&otilde;es de decidir
+3. O reembolso das despesas realizadas pela paciente em rede particular deve ser limitado ao valor da tabela do plano, quando demonstrada a exist&ecirc;ncia de rede credenciada apta e n&atilde;o restar configurada a urg&ecirc;ncia. 3.1. No presente caso, n&atilde;o h&aacute; nos autos prova da negativa do plano em realizar a cobertura do procedimento de bloqueio anest&eacute;sico de plexo cel&iacute;aco, somando-se a isso o fato de ter sido demonstrada a exist&ecirc;ncia de rede credenciada e n&atilde;o haver prova da urg&ecirc;ncia alegada, restando evidente que a autora optou por espont&acirc;nea vontade realizar procedimento com profissional n&atilde;o credenciado, de modo que o reembolso deve ser limitado ao valor de tabela do plano.
+4. O STF, em recente julgamento da ADI 7265, adotou novo entendimento no sentido de que a aus&ecirc;ncia de inclus&atilde;o do procedimento ou tratamento no rol da ANS impede, como regra geral, a sua concess&atilde;o judicial, salvo quando preenchidos determinados crit&eacute;rios cumulativos estabelecidos pela Corte Suprema. 4.1. No presente caso, o procedimento de bloqueio neurol&iacute;tico plexo cel&iacute;aco est&aacute; previsto no rol da ANS, sendo, portanto, de cobertura obrigat&oacute;ria.
+5. A Resolu&ccedil;&atilde;o Normativa n. 465/2021 da ANS estabelece que os procedimentos por radiofrequ&ecirc;ncia ser&atilde;o de cobertura obrigat&oacute;ria quando o procedimento pleiteado estiver previsto no rol da ANS.
+6 Os julgados mais recentes do STJ s&atilde;o no sentido de que os danos morais decorrentes de negativa de cobertura pelo plano de sa&uacute;de n&atilde;o se configuram in re ipsa. 6.1. Caso concreto em que restou demonstrada a viola&ccedil;&atilde;o aos direitos da personalidade da autora, diante do agravamento da dor e preju&iacute;zos &agrave; sa&uacute;de da paciente.  6.2. Quantum indenizat&oacute;rio fixado no primeiro grau est&aacute; de acordo com o valor arbitrado por esta C&acirc;mara C&iacute;vel, devendo, portanto, ser mantido.
+IV. Dispositivo
+7. Dispositivo: recurso conhecido e provido em parte.
+__________
+Dispositivos relevantes citados:
+Jurisprud&ecirc;ncia relevante citada: STF, ADI 7265, Rel. Ministro Lu&iacute;s Roberto Barroso, Plen&aacute;rio, Data de julgamento: 18/09/2025; STJ, S&uacute;mula 608; STJ, REsp: 1760955 SP 2018/0144917-1, Rel. Ministro Marco Aur&eacute;lio Bellizze,  Terceira Turma, Data de Julgamento: 11/06/2019; STJ, REsp: 1882584 DF 2020/0163550-9, Rel. Ministro Humberto Martins, Terceira Turma, Data de Julgamento: 28/04/2025; STJ, AgInt no AREsp: 2433593 SE 2023/0287822-2, Rel. Ministro Jo&atilde;o Ot&aacute;vio de Noronha, Quarta Turma, Data de Julgamento: 13/05/2024; TJAL, AI 0809231-50.2024.8.02.0000, Rel. Des. F&aacute;bio Jos&eacute; Bittencourt Ara&uacute;jo, 3&ordf; C&acirc;mara C&iacute;vel, Data do julgamento: 10/10/2024; TJAL, AC  0726157-03.2021.8.02.0001, Rel. Des. Alcides Gusm&atilde;o da Silva, 3&ordf; C&acirc;mara C&iacute;vel, Data do julgamento: 17/07/2024. <br><br>(N&uacute;mero do Processo: 0724834-31.2019.8.02.0001; Relator (a):&nbsp;Des. Paulo Zacarias da Silva; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 3&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 06/04/2026; Data de registro: 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(44 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Zacarias da Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									06/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PLANO DE SAÚDE. DEVER DE COBERTURA DE PROCEDIMENTO. PREVISÃO NO ROL DA ANS. REEMBOLSO LIMITADO AO VALOR DE TABELA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO CONHECIDO E PROVIDO EM PARTE.
+I. Caso em exame
+1. Apelação cível interposta pela Unimed Maceió em face de sentença que julgou parcialmente procedente a pretensão autoral, no sentido de no
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PLANO DE SAÚDE. DEVER DE COBERTURA DE PROCEDIMENTO. PREVISÃO NO ROL DA ANS. REEMBOLSO LIMITADO AO VALOR DE TABELA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO CONHECIDO E PROVIDO EM PARTE.
+I. Caso em exame
+1. Apelação cível interposta pela Unimed Maceió em face de sentença que julgou parcialmente procedente a pretensão autoral, no sentido de no sentido de: (i) confirmar a tutela de urgência, que determinou que a parte demandada autorizasse e custeasse a cirurgia de lesão por radiofrequência de nervos esplâncnicos bilaterais; (ii) condenar o réu ao reembolso integral das despesas relativas ao procedimento de bloqueio anestésico de plexo celíaco; e (iii) condenar a operadora de saúde ao pagamento de indenização por <em>danos</em> <em>morais</em> no importe de R$ 10.000,00 (dez mil reais).
+II. Questão em discussão
+2. O cerne da controvérsia em sede recursal consiste em verificar: (i) se houve negativa de cobertura em relação ao procedimento de bloqueio anestésico de plexo celíaco; (ii) se o reembolso das despesas realizadas pelo autor em rede particular deve ser integral ou limitado ao valor de tabela do plano; (iii) se a operadora de saúde tem a obrigação de custear a cirurgia de lesão por radiofrequência de nervos esplâncnicos bilaterais; e (iv) se foi configurado abalo <em>moral</em>.
+III. Razões de decidir
+3. O reembolso das despesas realizadas pela paciente em rede particular deve ser limitado ao valor da tabela do plano, quando demonstrada a existência de rede credenciada apta e não restar configurada a urgência. 3.1. No presente caso, não há nos autos prova da negativa do plano em realizar a cobertura do procedimento de bloqueio anestésico de plexo celíaco, somando-se a isso o fato de ter sido demonstrada a existência de rede credenciada e não haver prova da urgência alegada, restando evidente que a autora optou por espontânea vontade realizar procedimento com profissional não credenciado, de modo que o reembolso deve ser limitado ao valor de tabela do plano.
+4. O STF, em recente julgamento da ADI 7265, adotou novo entendimento no sentido de que a ausência de inclusão do procedimento ou tratamento no rol da ANS impede, como regra geral, a sua concessão judicial, salvo quando preenchidos determinados critérios cumulativos estabelecidos pela Corte Suprema. 4.1. No presente caso, o procedimento de bloqueio neurolítico plexo celíaco está previsto no rol da ANS, sendo, portanto, de cobertura obrigatória.
+5. A Resolução Normativa n. 465/2021 da ANS estabelece que os procedimentos por radiofrequência serão de cobertura obrigatória quando o procedimento pleiteado estiver previsto no rol da ANS.
+6 Os julgados mais recentes do STJ são no sentido de que os <em>danos</em> <em>morais</em> decorrentes de negativa de cobertura pelo plano de saúde não se configuram in re ipsa. 6.1. Caso concreto em que restou demonstrada a violação aos direitos da personalidade da autora, diante do agravamento da dor e prejuízos à saúde da paciente.  6.2. Quantum indenizatório fixado no primeiro grau está de acordo com o valor arbitrado por esta Câmara Cível, devendo, portanto, ser mantido.
+IV. Dispositivo
+7. Dispositivo: recurso conhecido e provido em parte.
+__________
+Dispositivos relevantes citados:
+Jurisprudência relevante citada: STF, ADI 7265, Rel. Ministro Luís Roberto Barroso, Plenário, Data de julgamento: 18/09/2025; STJ, Súmula 608; STJ, REsp: 1760955 SP 2018/0144917-1, Rel. Ministro Marco Aurélio Bellizze,  Terceira Turma, Data de Julgamento: 11/06/2019; STJ, REsp: 1882584 DF 2020/0163550-9, Rel. Ministro Humberto Martins, Terceira Turma, Data de Julgamento: 28/04/2025; STJ, AgInt no AREsp: 2433593 SE 2023/0287822-2, Rel. Ministro João Otávio de Noronha, Quarta Turma, Data de Julgamento: 13/05/2024; TJAL, AI 0809231-50.2024.8.02.0000, Rel. Des. Fábio José Bittencourt Araújo, 3ª Câmara Cível, Data do julgamento: 10/10/2024; TJAL, AC  0726157-03.2021.8.02.0001, Rel. Des. Alcides Gusmão da Silva, 3ª Câmara Cível, Data do julgamento: 17/07/2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811848" cdForo="0" >
+										0720874-96.2021.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811848" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811848);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811848" style="display: none;" >
+	<div id="textAreaDados_811848" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO CIVIL. ACIDENTE DE TR&Acirc;NSITO ENTRE PARTICULARES. COLIS&Atilde;O. A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA POR DANOS MORAIS E MATERIAIS (LUCROS CESSANTES). SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. COLIS&Atilde;O TRASEIRA.  ART.&nbsp;29&nbsp;,&nbsp;II&nbsp;,&nbsp;CTB. N&Atilde;O COMPROVADO. PRESUN&Ccedil;&Atilde;O AFASTADA. RESPONSABILIDADE CIVIL N&Atilde;O CONFIGURADA. PARTE AUTORA QUE N&Atilde;O SE DESINCUMBIU DO SEU &Ocirc;NUS PROBAT&Oacute;RIO. ART. 373, I, DO CPC/15. SENTEN&Ccedil;A MANTIDA. MAJORA&Ccedil;&Atilde;O DE HONOR&Aacute;RIOS. RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedente a&ccedil;&atilde;o indenizat&oacute;ria por danos materiais, a t&iacute;tulo de lucros cessantes, e danos morais, decorrentes de acidente de tr&acirc;nsito envolvendo colis&atilde;o traseira entre ve&iacute;culos particulares.
+2. A parte autora sustentou que o r&eacute;u teria agido com culpa ao colidir na traseira de seu ve&iacute;culo. A senten&ccedil;a concluiu pela aus&ecirc;ncia de comprova&ccedil;&atilde;o suficiente da din&acirc;mica do acidente e da culpa do demandado, afastando a responsabilidade civil.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+3. A quest&atilde;o em discuss&atilde;o consiste em saber se (i) a colis&atilde;o traseira gera presun&ccedil;&atilde;o absoluta de culpa do condutor que colide; e (ii) se est&atilde;o presentes os requisitos da responsabilidade civil aptos a ensejar indeniza&ccedil;&atilde;o por danos materiais e morais.
+III. RAZ&Otilde;ES DE DECIDIR
+4. A regra do art. 29, II, do C&oacute;digo de Tr&acirc;nsito Brasileiro imp&otilde;e ao condutor o dever de guardar dist&acirc;ncia de seguran&ccedil;a, sendo certo que a colis&atilde;o traseira enseja presun&ccedil;&atilde;o relativa de culpa.
+5. Referida presun&ccedil;&atilde;o admite prova em contr&aacute;rio, cabendo &agrave; parte autora demonstrar os fatos constitutivos de seu direito, nos termos do art. 373, I, do CPC.
+6. Ausente comprova&ccedil;&atilde;o segura acerca da din&acirc;mica do acidente e da conduta culposa do r&eacute;u, n&atilde;o se evidenciam os pressupostos da responsabilidade civil, especialmente o nexo causal e a culpa, inviabilizando a indeniza&ccedil;&atilde;o pretendida.
+7. Mantida a senten&ccedil;a de improced&ecirc;ncia, imp&otilde;e-se a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios, nos termos do art. 85, &sect;11, do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e n&atilde;o provido.
+    Dispositivos relevantes citados: CTB, art. 29, II; CPC, arts. 373, I, e 85, &sect;11.
+Jurisprud&ecirc;ncia relevante citada: TJ-MG - AC: 18518738920148130024 Belo Horizonte, Relator.: Des.(a) Evangelina Castilho Duarte, Data de Julgamento: 03/08/2023, 14&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 03/08/2023; AP 1.0433.05.145675-7/001 - Rel. Des. Alberto Alu&iacute;zio Pacheco de Andrade - j. 15.05.2007, DJ 25.05.2007; TJ-MG - AC: 10000222796807001 MG, Relator.: M&ocirc;nica Lib&acirc;nio, Data de Julgamento: 15/02/2023, C&acirc;maras C&iacute;veis / 11&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 15/02/2023; TJ-MG - AC: 10000220275721001 MG, Relator.: Habib Felippe Jabour, Data de Julgamento: 26/04/2022, C&acirc;maras C&iacute;veis / 18&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 26/04/2022. <br><br>(N&uacute;mero do Processo: 0720874-96.2021.8.02.0001; Relator (a):&nbsp;Des. Paulo Barros da Silva Lima; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 1&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 08/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Barros da Silva Lima
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. ACIDENTE DE TRÂNSITO ENTRE PARTICULARES. COLISÃO. AÇÃO INDENIZATÓRIA POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS (LUCROS CESSANTES). SENTENÇA DE IMPROCEDÊNCIA. COLISÃO TRASEIRA.  ART. 29 , II , CTB. NÃO COMPROVADO. PRESUNÇÃO AFASTADA. RESPONSABILIDADE CIVIL NÃO CONFIGURADA. PARTE AUTORA QUE NÃO SE DESINCUMBIU DO SEU ÔNUS PROBATÓRIO. ART. 373, I, DO CPC/15.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. ACIDENTE DE TRÂNSITO ENTRE PARTICULARES. COLISÃO. AÇÃO INDENIZATÓRIA POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS (LUCROS CESSANTES). SENTENÇA DE IMPROCEDÊNCIA. COLISÃO TRASEIRA.  ART. 29 , II , CTB. NÃO COMPROVADO. PRESUNÇÃO AFASTADA. RESPONSABILIDADE CIVIL NÃO CONFIGURADA. PARTE AUTORA QUE NÃO SE DESINCUMBIU DO SEU ÔNUS PROBATÓRIO. ART. 373, I, DO CPC/15. SENTENÇA MANTIDA. MAJORAÇÃO DE HONORÁRIOS. RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que julgou improcedente ação indenizatória por <em>danos</em> materiais, a título de lucros cessantes, e <em>danos</em> <em>morais</em>, decorrentes de acidente de trânsito envolvendo colisão traseira entre veículos particulares.
+2. A parte autora sustentou que o réu teria agido com culpa ao colidir na traseira de seu veículo. A sentença concluiu pela ausência de comprovação suficiente da dinâmica do acidente e da culpa do demandado, afastando a responsabilidade civil.
+II. QUESTÃO EM DISCUSSÃO
+3. A questão em discussão consiste em saber se (i) a colisão traseira gera presunção absoluta de culpa do condutor que colide; e (ii) se estão presentes os requisitos da responsabilidade civil aptos a ensejar indenização por <em>danos</em> materiais e <em>morais</em>.
+III. RAZÕES DE DECIDIR
+4. A regra do art. 29, II, do Código de Trânsito Brasileiro impõe ao condutor o dever de guardar distância de segurança, sendo certo que a colisão traseira enseja presunção relativa de culpa.
+5. Referida presunção admite prova em contrário, cabendo à parte autora demonstrar os fatos constitutivos de seu direito, nos termos do art. 373, I, do CPC.
+6. Ausente comprovação segura acerca da dinâmica do acidente e da conduta culposa do réu, não se evidenciam os pressupostos da responsabilidade civil, especialmente o nexo causal e a culpa, inviabilizando a indenização pretendida.
+7. Mantida a sentença de improcedência, impõe-se a majoração dos honorários advocatícios, nos termos do art. 85, §11, do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e não provido.
+    Dispositivos relevantes citados: CTB, art. 29, II; CPC, arts. 373, I, e 85, §11.
+Jurisprudência relevante citada: TJ-MG - AC: 18518738920148130024 Belo Horizonte, Relator.: Des.(a) Evangelina Castilho Duarte, Data de Julgamento: 03/08/2023, 14ª CÂMARA CÍVEL, Data de Publicação: 03/08/2023; AP 1.0433.05.145675-7/001 - Rel. Des. Alberto Aluízio Pacheco de Andrade - j. 15.05.2007, DJ 25.05.2007; TJ-MG - AC: 10000222796807001 MG, Relator.: Mônica Libânio, Data de Julgamento: 15/02/2023, Câmaras Cíveis / 11ª CÂMARA CÍVEL, Data de Publicação: 15/02/2023; TJ-MG - AC: 10000220275721001 MG, Relator.: Habib Felippe Jabour, Data de Julgamento: 26/04/2022, Câmaras Cíveis / 18ª CÂMARA CÍVEL, Data de Publicação: 26/04/2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811840" cdForo="0" >
+										0746851-22.2023.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811840" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811840);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811840" style="display: none;" >
+	<div id="textAreaDados_811840" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E CIVIL. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. PLANO DE SA&Uacute;DE. TRANSTORNO DO ESPECTRO AUTISTA. TRATAMENTO MULTIDISCIPLINAR. COBERTURA ASSISTENCIAL. EXCLUS&Atilde;O DO ASSISTENTE TERAP&Ecirc;UTICO EM AMBIENTE DOMICILIAR E ESCOLAR. REDE CREDENCIADA E REEMBOLSO. DANO MORAL. MAJORA&Ccedil;&Atilde;O. HONOR&Aacute;RIOS SUCUMBENCIAIS. RECURSO DA OPERADORA PROVIDO. RECURSO DA AUTORA PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&otilde;es C&iacute;veis interpostas contra senten&ccedil;a que julgou parcialmente procedente a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer cumulada com indeniza&ccedil;&atilde;o por danos morais, determinando o custeio de tratamento multidisciplinar para paciente diagnosticada com Transtorno do Espectro Autista, bem como condenando a r&eacute; ao pagamento de indeniza&ccedil;&atilde;o por dano moral no valor de R$ 3.000,00.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; obrigat&oacute;ria a cobertura, pelo plano de sa&uacute;de, do servi&ccedil;o de Assistente Terap&ecirc;utico em ambiente domiciliar ou escolar; (ii) estabelecer as condi&ccedil;&otilde;es de custeio ou reembolso do tratamento multidisciplinar realizado fora da rede credenciada; (iii) determinar a configura&ccedil;&atilde;o e o quantum indenizat&oacute;rio do dano moral decorrente da negativa de cobertura; (iv) examinar a corre&ccedil;&atilde;o da base de c&aacute;lculo e do percentual dos honor&aacute;rios advocat&iacute;cios sucumbenciais.
+III. RAZ&Otilde;ES DE DECIDIR
+1. A rela&ccedil;&atilde;o entre as partes &eacute; de consumo, submetida ao C&oacute;digo de Defesa do Consumidor, aplicando-se a interpreta&ccedil;&atilde;o mais favor&aacute;vel ao consumidor e a veda&ccedil;&atilde;o de cl&aacute;usulas abusivas.
+2. O direito fundamental &agrave; sa&uacute;de, aliado aos princ&iacute;pios da dignidade da pessoa humana e da inafastabilidade da jurisdi&ccedil;&atilde;o, imp&otilde;e a cobertura do tratamento prescrito por m&eacute;dico assistente para paciente com TEA.
+3. A Resolu&ccedil;&atilde;o Normativa ANS n&ordm; 539/2022 ampliou a cobertura assistencial para benefici&aacute;rios com transtornos globais do desenvolvimento, tornando obrigat&oacute;ria a cobertura dos m&eacute;todos e t&eacute;cnicas indicados pelo m&eacute;dico assistente, desde que executados por profissionais de sa&uacute;de habilitados.
+4. A imposi&ccedil;&atilde;o de custeio de Assistente Terap&ecirc;utico em ambiente natural do paciente extrapola o objeto do contrato de plano de sa&uacute;de e implica risco de desequil&iacute;brio da equa&ccedil;&atilde;o contratual, inexistindo obriga&ccedil;&atilde;o legal ou contratual de cobertura.
+5. A operadora deve fornecer o tratamento multidisciplinar indicado, na carga hor&aacute;ria prescrita, por meio de profissionais ou cl&iacute;nicas credenciadas tecnicamente habilitadas.
+6. Comprovada a inexist&ecirc;ncia ou indisponibilidade de prestadores aptos na rede credenciada, imp&otilde;e-se o custeio ou reembolso integral das despesas realizadas com profissionais n&atilde;o credenciados. Existindo rede credenciada dispon&iacute;vel e optando o benefici&aacute;rio por atendimento particular, o reembolso deve observar os limites da tabela contratual.
+7. A negativa indevida de cobertura de tratamento essencial configura dano moral in re ipsa, dispensando prova do preju&iacute;zo extrapatrimonial. O valor da indeniza&ccedil;&atilde;o por dano moral deve ser majorado para atender aos princ&iacute;pios da razoabilidade e proporcionalidade, considerando a gravidade da conduta, a condi&ccedil;&atilde;o das partes e o car&aacute;ter pedag&oacute;gico da condena&ccedil;&atilde;o.
+8. Os honor&aacute;rios advocat&iacute;cios sucumbenciais foram corretamente fixados no percentual m&iacute;nimo legal sobre o valor da condena&ccedil;&atilde;o, nos termos do art. 85, &sect; 2&ordm;, do CPC e da jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a.
+IV. DISPOSITIVO E TESE
+Recurso da operadora provido. Recurso da autora parcialmente provido.
+Dispositivos relevantes citados: CF/1988, arts. 1&ordm;, III; 5&ordm;, XXXV; 6&ordm;; 196; CDC, arts. 14, 47, 51; CC/2002, arts. 186 e 927; CPC/2015, art. 85, &sect; 2&ordm;; Lei n&ordm; 9.656/98, art. 10, &sect;&sect; 12 e 13; Resolu&ccedil;&atilde;o Normativa ANS n&ordm; 539/2022.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no AREsp n&ordm; 2.153.601/MA, Rel. Min. Moura Ribeiro, 3&ordf; Turma, j. 24.10.2022; STJ, REsp n&ordm; 2.064.964/SP, Rel. Min. Nancy Andrighi, 3&ordf; Turma, j. 20.02.2024; STJ, EAREsp n&ordm; 1.459.849/ES, Rel. Min. Marco Aur&eacute;lio Bellizze, 2&ordf; Se&ccedil;&atilde;o, j. 14.10.2020; TJAL, AI n&ordm; 0805789-13.2023.8.02.0000, Rel. Des. Ivan Vasconcelos Brito J&uacute;nior, 4&ordf; C&acirc;mara C&iacute;vel, j. 13.09.2023. <br><br>(N&uacute;mero do Processo: 0746851-22.2023.8.02.0001; Relator (a):&nbsp;Des. Paulo Barros da Silva Lima; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 1&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(69 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento da Própria Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Barros da Silva Lima
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÕES CÍVEIS. PLANO DE SAÚDE. TRANSTORNO DO ESPECTRO AUTISTA. TRATAMENTO MULTIDISCIPLINAR. COBERTURA ASSISTENCIAL. EXCLUSÃO DO ASSISTENTE TERAPÊUTICO EM AMBIENTE DOMICILIAR E ESCOLAR. REDE CREDENCIADA E REEMBOLSO. <em>DANO</em> <em>MORAL</em>. MAJORAÇÃO. HONORÁRIOS SUCUMBENCIAIS. RECURSO DA OPERADORA PROVIDO. RECURSO DA AUTORA PARCIALMENTE PROVIDO.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÕES CÍVEIS. PLANO DE SAÚDE. TRANSTORNO DO ESPECTRO AUTISTA. TRATAMENTO MULTIDISCIPLINAR. COBERTURA ASSISTENCIAL. EXCLUSÃO DO ASSISTENTE TERAPÊUTICO EM AMBIENTE DOMICILIAR E ESCOLAR. REDE CREDENCIADA E REEMBOLSO. <em>DANO</em> <em>MORAL</em>. MAJORAÇÃO. HONORÁRIOS SUCUMBENCIAIS. RECURSO DA OPERADORA PROVIDO. RECURSO DA AUTORA PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apelações Cíveis interpostas contra sentença que julgou parcialmente procedente ação de obrigação de fazer cumulada com indenização por <em>danos</em> <em>morais</em>, determinando o custeio de tratamento multidisciplinar para paciente diagnosticada com Transtorno do Espectro Autista, bem como condenando a ré ao pagamento de indenização por <em>dano</em> <em>moral</em> no valor de R$ 3.000,00.
+II. QUESTÃO EM DISCUSSÃO
+Há quatro questões em discussão: (i) definir se é obrigatória a cobertura, pelo plano de saúde, do serviço de Assistente Terapêutico em ambiente domiciliar ou escolar; (ii) estabelecer as condições de custeio ou reembolso do tratamento multidisciplinar realizado fora da rede credenciada; (iii) determinar a configuração e o quantum indenizatório do <em>dano</em> <em>moral</em> decorrente da negativa de cobertura; (iv) examinar a correção da base de cálculo e do percentual dos honorários advocatícios sucumbenciais.
+III. RAZÕES DE DECIDIR
+1. A relação entre as partes é de consumo, submetida ao Código de Defesa do Consumidor, aplicando-se a interpretação mais favorável ao consumidor e a vedação de cláusulas abusivas.
+2. O direito fundamental à saúde, aliado aos princípios da dignidade da pessoa humana e da inafastabilidade da jurisdição, impõe a cobertura do tratamento prescrito por médico assistente para paciente com TEA.
+3. A Resolução Normativa ANS nº 539/2022 ampliou a cobertura assistencial para beneficiários com transtornos globais do desenvolvimento, tornando obrigatória a cobertura dos métodos e técnicas indicados pelo médico assistente, desde que executados por profissionais de saúde habilitados.
+4. A imposição de custeio de Assistente Terapêutico em ambiente natural do paciente extrapola o objeto do contrato de plano de saúde e implica risco de desequilíbrio da equação contratual, inexistindo obrigação legal ou contratual de cobertura.
+5. A operadora deve fornecer o tratamento multidisciplinar indicado, na carga horária prescrita, por meio de profissionais ou clínicas credenciadas tecnicamente habilitadas.
+6. Comprovada a inexistência ou indisponibilidade de prestadores aptos na rede credenciada, impõe-se o custeio ou reembolso integral das despesas realizadas com profissionais não credenciados. Existindo rede credenciada disponível e optando o beneficiário por atendimento particular, o reembolso deve observar os limites da tabela contratual.
+7. A negativa indevida de cobertura de tratamento essencial configura <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo extrapatrimonial. O valor da indenização por <em>dano</em> <em>moral</em> deve ser majorado para atender aos princípios da razoabilidade e proporcionalidade, considerando a gravidade da conduta, a condição das partes e o caráter pedagógico da condenação.
+8. Os honorários advocatícios sucumbenciais foram corretamente fixados no percentual mínimo legal sobre o valor da condenação, nos termos do art. 85, § 2º, do CPC e da jurisprudência do Superior Tribunal de Justiça.
+IV. DISPOSITIVO E TESE
+Recurso da operadora provido. Recurso da autora parcialmente provido.
+Dispositivos relevantes citados: CF/1988, arts. 1º, III; 5º, XXXV; 6º; 196; CDC, arts. 14, 47, 51; CC/2002, arts. 186 e 927; CPC/2015, art. 85, § 2º; Lei nº 9.656/98, art. 10, §§ 12 e 13; Resolução Normativa ANS nº 539/2022.
+Jurisprudência relevante citada: STJ, AgInt no AREsp nº 2.153.601/MA, Rel. Min. Moura Ribeiro, 3ª Turma, j. 24.10.2022; STJ, REsp nº 2.064.964/SP, Rel. Min. Nancy Andrighi, 3ª Turma, j. 20.02.2024; STJ, EAREsp nº 1.459.849/ES, Rel. Min. Marco Aurélio Bellizze, 2ª Seção, j. 14.10.2020; TJAL, AI nº 0805789-13.2023.8.02.0000, Rel. Des. Ivan Vasconcelos Brito Júnior, 4ª Câmara Cível, j. 13.09.2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811921" cdForo="0" >
+										0745115-95.2025.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811921" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811921);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811921" style="display: none;" >
+	<div id="textAreaDados_811921" class="mensagemSemFormatacao" >
+		DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E &Agrave; SA&Uacute;DE. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS. REAJUSTE DE MENSALIDADE DE PLANO DE SA&Uacute;DE COLETIVO COM MENOS DE TRINTA USU&Aacute;RIOS. &quot;FALSO COLETIVO&quot;. PRESCRI&Ccedil;&Atilde;O TRIENAL. POSSIBILIDADE DE APLICA&Ccedil;&Atilde;O APENAS DOS REAJUSTES POR FAIXA ET&Aacute;RIA E DOS REAJUSTES ANUAIS SEGUNDO OS &Iacute;NDICES DA ANS. PROVIMENTO.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta caontra senten&ccedil;a que julgou parcialmente procedentes os pedidos na inicial, reconhecendo a abusividade do reajuste superior ao &iacute;ndice aplicado pela ANS para planos individuais e familiares, com a determina&ccedil;&atilde;o da restitui&ccedil;&atilde;o, na forma simples, do que foi pago a maior, limitado ao quinqu&ecirc;nio anterior ao ajuizamento da demanda.
+ii. Quest&atilde;o em discuss&atilde;o
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) apreciar se houve cerceamento de defesa ao indeferir a prova atuarial; (ii) apreciar a incid&ecirc;ncia da prescri&ccedil;&atilde;o; (iii) verificar a regularidade dos reajustes aplicados sobre a mensalidade do plano de sa&uacute;de da parte autora.
+iii. raz&otilde;es de decidir
+3. Cerceamento de defesa n&atilde;o configurado. Prova manifestamente desnecess&aacute;ria para o deslinde da controv&eacute;rsia.
+4. Incid&ecirc;ncia do prazo prescricional de tr&ecirc;s anos, aplic&aacute;vel para o ressarcimento decorrente do enriquecimento sem causa.
+5. Em casos de contratos considerados &quot;falsos coletivos&quot;, quando o plano coletivo &eacute;, na pr&aacute;tica, similar a um plano individual ou familiar, o Superior Tribunal de Justi&ccedil;a tem decidido que esses contratos podem ser equiparados a planos individuais ou familiares.&nbsp;Permite-se, por consequ&ecirc;ncia, que lhe sejam aplicados apenas os reajustes por faixa et&aacute;ria e os reajustes anuais segundo os &iacute;ndices da ANS, tendo em vista a hipossufici&ecirc;ncia da empresa contratante perante as operadoras de plano de sa&uacute;de em tais hip&oacute;teses.
+6. O c&aacute;lculo dos valores devidos deve ser realizado com base nos &iacute;ndices de reajuste estabelecidos pela ANS.
+iv. Dispositivo e tese
+7. Recurso conhecido e parcialmente provido, apenas para reconhecer a incid&ecirc;ncia da prescri&ccedil;&atilde;o trienal.
+_________
+Dispositivos relevantes citados: CDC, art. 2&ordm;, art. 3&ordm;; Resolu&ccedil;&atilde;o Normativa n&ordm; 309/2012 ANS, art. 9&ordm;; CC , art. 206, &sect; 3&ordm;, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no REsp 1568244 RJ 2015/0297278-0, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 2&ordf;Se&ccedil;&atilde;o, j. 22.02.2018; STJ, AgRg nos EDcl no AREsp 235.553/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 3&ordf; Turma, j. 02.06.2015; STJ, AgInt no AREsp: 2366300 SP 2023/0175392-1, Rel. Min. Antonio Carlos Ferreira, 4&ordf; Turma, j. 30.10.2023; STJ, AgInt no AREsp 2285008 SP 2023/0020654-2, Rel. Min. Humberto Martins, 3&ordf; Turma, j. 08.04.2024; STJ, REM 56.333/BA, Rel. Min. Mauro Campbell Marques, 2&ordf; Turma, j. 01.03.2018; STJ, AgInt no AREsp 1170544/MG, Rel. Min. Luis Felipe Salom&atilde;o, 4&ordf; Turma, j. 06.02.2018. <br><br>(N&uacute;mero do Processo: 0745115-95.2025.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANOS</em> MATERIAIS. REAJUSTE DE MENSALIDADE DE PLANO DE SAÚDE COLETIVO COM MENOS DE TRINTA USUÁRIOS. "FALSO COLETIVO". PRESCRIÇÃO TRIENAL. POSSIBILIDADE DE APLICAÇÃO APENAS DOS REAJUSTES POR FAIXA ETÁRIA E DOS REAJUSTES ANUAIS SEGUNDO OS ÍNDICES DA ANS. PROVIMENTO.
+I.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANOS</em> MATERIAIS. REAJUSTE DE MENSALIDADE DE PLANO DE SAÚDE COLETIVO COM MENOS DE TRINTA USUÁRIOS. "FALSO COLETIVO". PRESCRIÇÃO TRIENAL. POSSIBILIDADE DE APLICAÇÃO APENAS DOS REAJUSTES POR FAIXA ETÁRIA E DOS REAJUSTES ANUAIS SEGUNDO OS ÍNDICES DA ANS. PROVIMENTO.
+I. Caso em exame
+1. Apelação cível interposta caontra sentença que julgou parcialmente procedentes os pedidos na inicial, reconhecendo a abusividade do reajuste superior ao índice aplicado pela ANS para planos individuais e familiares, com a determinação da restituição, na forma simples, do que foi pago a maior, limitado ao quinquênio anterior ao ajuizamento da demanda.
+ii. Questão em discussão
+2. As questões em discussão consistem em: (i) apreciar se houve cerceamento de defesa ao indeferir a prova atuarial; (ii) apreciar a incidência da prescrição; (iii) verificar a regularidade dos reajustes aplicados sobre a mensalidade do plano de saúde da parte autora.
+iii. razões de decidir
+3. Cerceamento de defesa não configurado. Prova manifestamente desnecessária para o deslinde da controvérsia.
+4. Incidência do prazo prescricional de três anos, aplicável para o ressarcimento decorrente do enriquecimento sem causa.
+5. Em casos de contratos considerados "falsos coletivos", quando o plano coletivo é, na prática, similar a um plano individual ou familiar, o Superior Tribunal de Justiça tem decidido que esses contratos podem ser equiparados a planos individuais ou familiares. Permite-se, por consequência, que lhe sejam aplicados apenas os reajustes por faixa etária e os reajustes anuais segundo os índices da ANS, tendo em vista a hipossuficiência da empresa contratante perante as operadoras de plano de saúde em tais hipóteses.
+6. O cálculo dos valores devidos deve ser realizado com base nos índices de reajuste estabelecidos pela ANS.
+iv. Dispositivo e tese
+7. Recurso conhecido e parcialmente provido, apenas para reconhecer a incidência da prescrição trienal.
+_________
+Dispositivos relevantes citados: CDC, art. 2º, art. 3º; Resolução Normativa nº 309/2012 ANS, art. 9º; CC , art. 206, § 3º, IV.
+Jurisprudência relevante citada: STJ, EDcl no REsp 1568244 RJ 2015/0297278-0, Rel. Min. Ricardo Villas Bôas Cueva, 2ªSeção, j. 22.02.2018; STJ, AgRg nos EDcl no AREsp 235.553/SP, Rel. Min. Ricardo Villas Bôas Cueva, 3ª Turma, j. 02.06.2015; STJ, AgInt no AREsp: 2366300 SP 2023/0175392-1, Rel. Min. Antonio Carlos Ferreira, 4ª Turma, j. 30.10.2023; STJ, AgInt no AREsp 2285008 SP 2023/0020654-2, Rel. Min. Humberto Martins, 3ª Turma, j. 08.04.2024; STJ, REM 56.333/BA, Rel. Min. Mauro Campbell Marques, 2ª Turma, j. 01.03.2018; STJ, AgInt no AREsp 1170544/MG, Rel. Min. Luis Felipe Salomão, 4ª Turma, j. 06.02.2018.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811915" cdForo="0" >
+										0802158-56.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811915" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811915);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811915" style="display: none;" >
+	<div id="textAreaDados_811915" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. EXTIN&Ccedil;&Atilde;O DO PROCESSO DE ORIGEM EM RELA&Ccedil;&Atilde;O &Agrave;S PARTES AGRAVANTES. REALIZA&Ccedil;&Atilde;O DE ACORDO COM A EMPRESA RECORRIDA NOS AUTOS DO CUMPRIMENTO DE SENTEN&Ccedil;A QUE TRAMITA NA 3&ordf; VARA FEDERAL DE ALAGOAS, QUE ENGLOBA O OBJETO DA DEMANDA. POSSIBILIDADE DE REQUERIMENTO DE FIXA&Ccedil;&Atilde;O E RETEN&Ccedil;&Atilde;O DE HONOR&Aacute;RIOS EM FAVOR DO PATRONO DAS PARTES AGRAVANTES, DESDE QUE PERANTE AO JU&Iacute;ZO QUE PROCEDEU &Agrave; HOMOLOGA&Ccedil;&Atilde;O DO ACORDO. INCOMPET&Ecirc;NCIA DA JUSTI&Ccedil;A ESTADUAL. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa &agrave; reforma da decis&atilde;o de primeiro grau, que indeferiu os pedidos de produ&ccedil;&atilde;o de prova oral e de invers&atilde;o do &ocirc;nus da prova, assim como extinguiu parcialmente o feito, sem resolu&ccedil;&atilde;o de m&eacute;rito, em rela&ccedil;&atilde;o a 4 (quatro) partes autoras, uma vez que estas teriam optado pela ades&atilde;o ao Programa de Compensa&ccedil;&atilde;o Financeira, ao celebrar acordo nos autos dos cumprimentos de senten&ccedil;as vinculados &agrave; A&ccedil;&atilde;o Civil P&uacute;blica n&ordm; 0803836-61.2019.4.05.8000, em tr&acirc;mite perante a 3&ordf; Vara Federal de Alagoas.
+ii. Quest&atilde;o em discuss&atilde;o
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) saber se as partes agravantes fazem jus &agrave; concess&atilde;o dos benef&iacute;cios da justi&ccedil;a gratuita; (ii) verificar o cabimento da insurg&ecirc;ncia recursal relativa ao indeferimento da produ&ccedil;&atilde;o de prova oral; (iii) analisar se os pedidos de desmembramento do feito em rela&ccedil;&atilde;o &agrave;s partes que n&atilde;o fizeram acordo na Justi&ccedil;a Federal e de sobrestamento do processo at&eacute; o julgamento definitivo da a&ccedil;&atilde;o civil p&uacute;blica n. 0807343-54.2024.4.05.8000, observam o princ&iacute;pio da dialeticidade; (iv) saber se os acordos firmados entre as partes agravantes, os quais foram submetidos &agrave; homologa&ccedil;&atilde;o do Ju&iacute;zo Federal da 3&ordf; Vara Federal em Macei&oacute;, nos autos dos cumprimentos de senten&ccedil;a vinculados &agrave; a&ccedil;&atilde;o civil p&uacute;blica n. 0803836-61.2019.4.05.8000, ensejam a perda superveniente do interesse de agir dos recorrentes quanto ao pedido de indeniza&ccedil;&atilde;o por danos morais; (v) aferir a suposta abusividade do acordo, tendo em vista que conteria cl&aacute;usulas leoninas; (vi) analisar o pedido subsidi&aacute;rio de resguardo dos direitos do patrono das partes agravantes, em raz&atilde;o da suposta viola&ccedil;&atilde;o do contrato de presta&ccedil;&atilde;o de servi&ccedil;o outrora firmado; e (vii) averiguar se a conduta das partes recorrentes configura&nbsp;litig&acirc;ncia&nbsp;de&nbsp;m&aacute;-f&eacute;.
+iii. raz&otilde;es de decidir
+3. N&atilde;o conhecimento do recurso, por&nbsp;aus&ecirc;ncia&nbsp;de&nbsp;interesse&nbsp;recursal, no ponto em que pleiteia a concess&atilde;o do benef&iacute;cio&nbsp;de&nbsp;justi&ccedil;a&nbsp;gratuita, tendo em vista que a gratuidade&nbsp;de&nbsp;justi&ccedil;a&nbsp;j&aacute; havia sido deferida na origem.&nbsp;
+4. Na esp&eacute;cie, o depoimento pessoal das partes e a oitiva de testemunhas se destinariam a comprovar que os agravantes s&atilde;o moradores inseridos na &aacute;rea de risco e nos bairros afetados pelo desastre socioambiental. Aus&ecirc;ncia de risco de perecimento do objeto da prova neste caso. Inexist&ecirc;ncia de inutilidade da aprecia&ccedil;&atilde;o do indeferimento da prova oral em sede de apela&ccedil;&atilde;o. N&atilde;o conhecimento desse ponto.
+5. Alega&ccedil;&atilde;o de necessidade de desmembramento e&nbsp;sobrestamento&nbsp;do feito que n&atilde;o dialoga com os fundamentos do decisum recorrido. Viola&ccedil;&atilde;o ao princ&iacute;pio da&nbsp;dialeticidade&nbsp;verificada.&nbsp;N&atilde;o conhecimento dessa parcela da insurg&ecirc;ncia recursal.
+6. Inexist&ecirc;ncia de interesse de agir dos agravantes, tendo em vista que suas pretens&otilde;es j&aacute; foram abarcadas pelos acordos firmados no Programa de Compensa&ccedil;&atilde;o Financeira - PCF, homologados perante a Justi&ccedil;a Federal, que contemplam os danos materiais e morais, direta ou indiretamente relacionados &agrave; desocupa&ccedil;&atilde;o de im&oacute;vel, em raz&atilde;o do fen&ocirc;meno geol&oacute;gico. Exist&ecirc;ncia de ren&uacute;ncia expressa dos referidos demandantes a quaisquer direitos remanescentes decorrentes da desocupa&ccedil;&atilde;o.
+7. O presente recurso n&atilde;o &eacute; a via adequada para questionar a regularidade dos acordos firmados pelos recorrentes, cabendo a eles, primeiramente, impugnar a aven&ccedil;a junto &agrave; Justi&ccedil;a Federal, visto que o acordo foi homologado pelo Ju&iacute;zo da 3&ordf; Vara Federal, para s&oacute; ent&atilde;o pleitear o direito que entendem devido perante a Justi&ccedil;a Estadual.
+8. Cabimento do pedido de preserva&ccedil;&atilde;o do direito de honor&aacute;rios, em benef&iacute;cio do patrono das partes recorrentes, tendo em vista que a realiza&ccedil;&atilde;o de acordo extrajudicial, posteriormente homologado judicialmente, n&atilde;o implica ren&uacute;ncia autom&aacute;tica &agrave; verba honor&aacute;ria. No entanto, considerando que os acordos firmados tiveram sua homologa&ccedil;&atilde;o firmada perante a Justi&ccedil;a Federal, este &eacute; competente para a an&aacute;lise do direito do patrono das partes agravantes ao recebimento dos seus respectivos honor&aacute;rios.
+9. O art. 80 do CPC exige a presen&ccedil;a inequ&iacute;voca de m&aacute;-f&eacute; na&nbsp;litig&acirc;ncia&nbsp;para a aplica&ccedil;&atilde;o da multa, sendo essa requisito indispens&aacute;vel, sem o qual n&atilde;o se autoriza a aplica&ccedil;&atilde;o da penalidade prevista.&nbsp;Litig&acirc;ncia&nbsp;de m&aacute;-f&eacute; n&atilde;o caracterizada.
+iv. Dispositivo e tese
+10. Recurso parcialmente conhecido e, nesta parte, desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 80, art. 81, e art. 85, &sect;14; CC, art. 844; Lei n. 8.906/1994, art. 24, &sect;4&ordm;, &sect;5&ordm; e &sect;6&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, 1.613..672/RJ, Rel. Min. Marco Aur&eacute;lio Bellizze, Terceira Turma, j. 14.02.2017; STJ, AgInt no AREsp n. 1.636.268/RJ, Rel. Min. Luis Felipe Salom&atilde;o, Rel. para ac&oacute;rd&atilde;o Min. Raul Ara&uacute;jo, Quarta Turma, j. 24.08.2021. <br><br>(N&uacute;mero do Processo: 0802158-56.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Litisconsórcio
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. EXTINÇÃO DO PROCESSO DE ORIGEM EM RELAÇÃO ÀS PARTES AGRAVANTES. REALIZAÇÃO DE ACORDO COM A EMPRESA RECORRIDA NOS AUTOS DO CUMPRIMENTO DE SENTENÇA QUE TRAMITA NA 3ª VARA FEDERAL DE ALAGOAS, QUE ENGLOBA O OBJETO DA DEMANDA. POSSIBILIDADE DE REQUERIMENTO DE FIXAÇÃO E RETENÇÃO DE HONORÁRIOS EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. EXTINÇÃO DO PROCESSO DE ORIGEM EM RELAÇÃO ÀS PARTES AGRAVANTES. REALIZAÇÃO DE ACORDO COM A EMPRESA RECORRIDA NOS AUTOS DO CUMPRIMENTO DE SENTENÇA QUE TRAMITA NA 3ª VARA FEDERAL DE ALAGOAS, QUE ENGLOBA O OBJETO DA DEMANDA. POSSIBILIDADE DE REQUERIMENTO DE FIXAÇÃO E RETENÇÃO DE HONORÁRIOS EM FAVOR DO PATRONO DAS PARTES AGRAVANTES, DESDE QUE PERANTE AO JUÍZO QUE PROCEDEU À HOMOLOGAÇÃO DO ACORDO. INCOMPETÊNCIA DA JUSTIÇA ESTADUAL. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa à reforma da decisão de primeiro grau, que indeferiu os pedidos de produção de prova oral e de inversão do ônus da prova, assim como extinguiu parcialmente o feito, sem resolução de mérito, em relação a 4 (quatro) partes autoras, uma vez que estas teriam optado pela adesão ao Programa de Compensação Financeira, ao celebrar acordo nos autos dos cumprimentos de sentenças vinculados à Ação Civil Pública nº 0803836-61.2019.4.05.8000, em trâmite perante a 3ª Vara Federal de Alagoas.
+ii. Questão em discussão
+2. As questões em discussão consistem em: (i) saber se as partes agravantes fazem jus à concessão dos benefícios da justiça gratuita; (ii) verificar o cabimento da insurgência recursal relativa ao indeferimento da produção de prova oral; (iii) analisar se os pedidos de desmembramento do feito em relação às partes que não fizeram acordo na Justiça Federal e de sobrestamento do processo até o julgamento definitivo da ação civil pública n. 0807343-54.2024.4.05.8000, observam o princípio da dialeticidade; (iv) saber se os acordos firmados entre as partes agravantes, os quais foram submetidos à homologação do Juízo Federal da 3ª Vara Federal em Maceió, nos autos dos cumprimentos de sentença vinculados à ação civil pública n. 0803836-61.2019.4.05.8000, ensejam a perda superveniente do interesse de agir dos recorrentes quanto ao pedido de indenização por <em>danos</em> <em>morais</em>; (v) aferir a suposta abusividade do acordo, tendo em vista que conteria cláusulas leoninas; (vi) analisar o pedido subsidiário de resguardo dos direitos do patrono das partes agravantes, em razão da suposta violação do contrato de prestação de serviço outrora firmado; e (vii) averiguar se a conduta das partes recorrentes configura litigância de má-fé.
+iii. razões de decidir
+3. Não conhecimento do recurso, por ausência de interesse recursal, no ponto em que pleiteia a concessão do benefício de justiça gratuita, tendo em vista que a gratuidade de justiça já havia sido deferida na origem. 
+4. Na espécie, o depoimento pessoal das partes e a oitiva de testemunhas se destinariam a comprovar que os agravantes são moradores inseridos na área de risco e nos bairros afetados pelo desastre socioambiental. Ausência de risco de perecimento do objeto da prova neste caso. Inexistência de inutilidade da apreciação do indeferimento da prova oral em sede de apelação. Não conhecimento desse ponto.
+5. Alegação de necessidade de desmembramento e sobrestamento do feito que não dialoga com os fundamentos do decisum recorrido. Violação ao princípio da dialeticidade verificada. Não conhecimento dessa parcela da insurgência recursal.
+6. Inexistência de interesse de agir dos agravantes, tendo em vista que suas pretensões já foram abarcadas pelos acordos firmados no Programa de Compensação Financeira - PCF, homologados perante a Justiça Federal, que contemplam os <em>danos</em> materiais e <em>morais</em>, direta ou indiretamente relacionados à desocupação de imóvel, em razão do fenômeno geológico. Existência de renúncia expressa dos referidos demandantes a quaisquer direitos remanescentes decorrentes da desocupação.
+7. O presente recurso não é a via adequada para questionar a regularidade dos acordos firmados pelos recorrentes, cabendo a eles, primeiramente, impugnar a avença junto à Justiça Federal, visto que o acordo foi homologado pelo Juízo da 3ª Vara Federal, para só então pleitear o direito que entendem devido perante a Justiça Estadual.
+8. Cabimento do pedido de preservação do direito de honorários, em benefício do patrono das partes recorrentes, tendo em vista que a realização de acordo extrajudicial, posteriormente homologado judicialmente, não implica renúncia automática à verba honorária. No entanto, considerando que os acordos firmados tiveram sua homologação firmada perante a Justiça Federal, este é competente para a análise do direito do patrono das partes agravantes ao recebimento dos seus respectivos honorários.
+9. O art. 80 do CPC exige a presença inequívoca de má-fé na litigância para a aplicação da multa, sendo essa requisito indispensável, sem o qual não se autoriza a aplicação da penalidade prevista. Litigância de má-fé não caracterizada.
+iv. Dispositivo e tese
+10. Recurso parcialmente conhecido e, nesta parte, desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 80, art. 81, e art. 85, §14; CC, art. 844; Lei n. 8.906/1994, art. 24, §4º, §5º e §6º.
+Jurisprudência relevante citada: STJ, 1.613..672/RJ, Rel. Min. Marco Aurélio Bellizze, Terceira Turma, j. 14.02.2017; STJ, AgInt no AREsp n. 1.636.268/RJ, Rel. Min. Luis Felipe Salomão, Rel. para acórdão Min. Raul Araújo, Quarta Turma, j. 24.08.2021.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811894" cdForo="0" >
+										0802122-14.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811894" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811894);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811894" style="display: none;" >
+	<div id="textAreaDados_811894" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C REPARA&Ccedil;&Atilde;O DE DANOS MATERIAIS E MORAIS.  OCORR&Ecirc;NCIA DO SINISTRO DECORRENTE DA ATIVIDADE MINERADORA EXERCIDA PELA AGRAVADA. DEGRADA&Ccedil;&Atilde;O AMBIENTAL. FATO NOT&Oacute;RIO E INCONTROVERSO. DESNECESSIDADE DE INVERS&Atilde;O DO &Ocirc;NUS DA PROVA. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa &agrave; reforma da decis&atilde;o de primeiro grau que  rejeitou  o pedido de invers&atilde;o do &ocirc;nus da prova, ao passo em que deferiu o pedido de produ&ccedil;&atilde;o de prova pericial formulado pela parte autora.
+ii. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se &eacute; devida a invers&atilde;o do &ocirc;nus da prova.
+iii. raz&otilde;es de decidir
+3. N&atilde;o cabimento da invers&atilde;o do &ocirc;nus probat&oacute;rio nos moldes pretendidos pela parte recorrente, em raz&atilde;o de ser fato p&uacute;blico e not&oacute;rio &ndash; e incontroverso &ndash; que a atividade mineradora exercida pela empresa Braskem em alguns bairros da capital trouxe consequ&ecirc;ncias urban&iacute;sticas e ambientais, motivo pelo qual a aplica&ccedil;&atilde;o do instituto seria desnecess&aacute;ria para demonstrar que n&atilde;o causou o evento apontado pela parte agravante.
+4. Possibilidade de o perito nomeado pelo ju&iacute;zo a quo solicitar outros documentos que estejam em poder da empresa demandada, se necess&aacute;rios ao esclarecimento do objeto da per&iacute;cia, nos moldes do art. 473, &sect;3&ordm;, do CPC.
+iv. Dispositivo e tese
+5. Recurso conhecido e desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 374, I, art. 473, &sect;3&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n. 802.832/MG, Rel. Min. Paulo de Tarso Sanseverino, Segunda Se&ccedil;&atilde;o, j. 13.04.2011; S&uacute;mula n. 618/STJ; STJ, AgInt no AREsp 663.184/TO, Rel. Min. Marco Buzzi, Quarta Turma, j. 15.05.2018. <br><br>(N&uacute;mero do Processo: 0802122-14.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(31 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Dano Ambiental
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE <em>DANOS</em> MATERIAIS E <em>MORAIS</em>.  OCORRÊNCIA DO SINISTRO DECORRENTE DA ATIVIDADE MINERADORA EXERCIDA PELA AGRAVADA. DEGRADAÇÃO AMBIENTAL. FATO NOTÓRIO E INCONTROVERSO. DESNECESSIDADE DE INVERSÃO DO ÔNUS DA PROVA. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa à reforma da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE <em>DANOS</em> MATERIAIS E <em>MORAIS</em>.  OCORRÊNCIA DO SINISTRO DECORRENTE DA ATIVIDADE MINERADORA EXERCIDA PELA AGRAVADA. DEGRADAÇÃO AMBIENTAL. FATO NOTÓRIO E INCONTROVERSO. DESNECESSIDADE DE INVERSÃO DO ÔNUS DA PROVA. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa à reforma da decisão de primeiro grau que  rejeitou  o pedido de inversão do ônus da prova, ao passo em que deferiu o pedido de produção de prova pericial formulado pela parte autora.
+ii. Questão em discussão
+2. A questão em discussão consiste em saber se é devida a inversão do ônus da prova.
+iii. razões de decidir
+3. Não cabimento da inversão do ônus probatório nos moldes pretendidos pela parte recorrente, em razão de ser fato público e notório – e incontroverso – que a atividade mineradora exercida pela empresa Braskem em alguns bairros da capital trouxe consequências urbanísticas e ambientais, motivo pelo qual a aplicação do instituto seria desnecessária para demonstrar que não causou o evento apontado pela parte agravante.
+4. Possibilidade de o perito nomeado pelo juízo a quo solicitar outros documentos que estejam em poder da empresa demandada, se necessários ao esclarecimento do objeto da perícia, nos moldes do art. 473, §3º, do CPC.
+iv. Dispositivo e tese
+5. Recurso conhecido e desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 374, I, art. 473, §3º.
+Jurisprudência relevante citada: STJ, REsp n. 802.832/MG, Rel. Min. Paulo de Tarso Sanseverino, Segunda Seção, j. 13.04.2011; Súmula n. 618/STJ; STJ, AgInt no AREsp 663.184/TO, Rel. Min. Marco Buzzi, Quarta Turma, j. 15.05.2018.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811868" cdForo="0" >
+										0700737-38.2024.8.02.0050
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811868" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811868);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811868" style="display: none;" >
+	<div id="textAreaDados_811868" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. DIREITO CIVIL. JU&Iacute;ZO DE RETRATA&Ccedil;&Atilde;O EM EMBARGOS DE DECLARA&Ccedil;&Atilde;O DE APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE COBRAN&Ccedil;A C/C DANOS MORAIS. DESFALQUES EM PASEP. TEMA 1.387/STJ PUBLICADO AP&Oacute;S O JULGAMENTO PRINCIPAL E ANTES DO JULGAMENTO DOS EMBARGOS DECLARAT&Oacute;RIOS. ERRO DE PROCEDIMENTO. NECESSIDADE DE OBSERV&Acirc;NCIA AO TEMA VINCULANTE. REALIZA&Ccedil;&Atilde;O DA RETRATA&Ccedil;&Atilde;O. EMBARGOS PARCIALMENTE ACOLHIDOS.
+I. CASO EM EXAME
+1. Trata-se de poss&iacute;vel ju&iacute;zo de retrata&ccedil;&atilde;o previsto no art. 1.030, II, do CPC, ante a aparente diverg&ecirc;ncia entre o ac&oacute;rd&atilde;o proferido por esta C&acirc;mara e o entendimento firmado pela Superior Tribunal de Justi&ccedil;a no Tema n.&ordm; 1.387.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em analisar a necessidade de observar o julgamento do Tema n.&ordm; 1.387/STJ, apesar de sua publica&ccedil;&atilde;o ter ocorrido ap&oacute;s o julgamento do ac&oacute;rd&atilde;o principal da presente demanda e antes do julgamento dos embargos de declara&ccedil;&atilde;o opostos contra o ac&oacute;rd&atilde;o.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os embargos de declara&ccedil;&atilde;o t&ecirc;m efeito integrativo do ac&oacute;rd&atilde;o recorrido, que se completa apenas ap&oacute;s o fim do julgamento dos aclarat&oacute;rios.
+4. O Tema n.&ordm; 1.387/STJ foi publicado apenas ap&oacute;s o ac&oacute;rd&atilde;o embargado, mas antes do julgamento dos embargos de declara&ccedil;&atilde;o, que deveria ter observado o entendimento vinculante.
+5. Retrata&ccedil;&atilde;o do entendimento anterior desta C&acirc;mara, para adotar o saque integral como termo inicial da prescri&ccedil;&atilde;o, em aten&ccedil;&atilde;o ao Tema n&ordm; 1.387/STJ.
+6. Necessidade de acolher parcialmente os embargos de declara&ccedil;&atilde;o para, anulando a senten&ccedil;a recorrida, determinar o retorno dos autos ao primeiro grau de jurisdi&ccedil;&atilde;o para possibilitar que a instru&ccedil;&atilde;o probat&oacute;ria observe os Temas n.&ordm; 1.387/STJ e n.&ordm; 1.300/STJ.
+IV. DISPOSITIVO
+7. Ju&iacute;zo de retrata&ccedil;&atilde;o exercido. Recurso conhecido e parcialmente acolhido.
+_________________
+Dispositivos relevantes citados: CPC, art. 1.030, II.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp 2174291/PR, Rel. Min. Nancy Andrighi, Terceira Turma, j. 10.6.2025; STJ, REsp 2088734/RS, Rel. Min. Ricardo Villas B&ocirc;as Cueva, Terceira Turma, j. 10.6.2025; STJ, REsp 00000000000002214879/PE, Rel. Min. Maria Thereza de Assis Moura, Primeira Se&ccedil;&atilde;o, j. 10.12.2025;  STJ, EDcl no AgInt no REsp 2196026/SC, Rel. Min. Benedito Gon&ccedil;alves, Primeira Turma, j. 9.2.2026; STJ, REsp 1858227/PR, Rel. Min. Herman Benjamin, Segunda Turma, j. 5.3.2020. <br><br>(N&uacute;mero do Processo: 0700737-38.2024.8.02.0050; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Porto Calvo; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / PASEP
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Porto Calvo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. DIREITO CIVIL. JUÍZO DE RETRATAÇÃO EM EMBARGOS DE DECLARAÇÃO DE APELAÇÃO CÍVEL. AÇÃO DE COBRANÇA C/C <em>DANOS</em> <em>MORAIS</em>. DESFALQUES EM PASEP. TEMA 1.387/STJ PUBLICADO APÓS O JULGAMENTO PRINCIPAL E ANTES DO JULGAMENTO DOS EMBARGOS DECLARATÓRIOS. ERRO DE PROCEDIMENTO. NECESSIDADE DE OBSERVÂNCIA AO TEMA VINCULANTE. REALIZAÇÃO DA RETRATAÇÃO. EMBARGOS PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. DIREITO CIVIL. JUÍZO DE RETRATAÇÃO EM EMBARGOS DE DECLARAÇÃO DE APELAÇÃO CÍVEL. AÇÃO DE COBRANÇA C/C <em>DANOS</em> <em>MORAIS</em>. DESFALQUES EM PASEP. TEMA 1.387/STJ PUBLICADO APÓS O JULGAMENTO PRINCIPAL E ANTES DO JULGAMENTO DOS EMBARGOS DECLARATÓRIOS. ERRO DE PROCEDIMENTO. NECESSIDADE DE OBSERVÂNCIA AO TEMA VINCULANTE. REALIZAÇÃO DA RETRATAÇÃO. EMBARGOS PARCIALMENTE ACOLHIDOS.
+I. CASO EM EXAME
+1. Trata-se de possível juízo de retratação previsto no art. 1.030, II, do CPC, ante a aparente divergência entre o acórdão proferido por esta Câmara e o entendimento firmado pela Superior Tribunal de Justiça no Tema n.º 1.387.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em analisar a necessidade de observar o julgamento do Tema n.º 1.387/STJ, apesar de sua publicação ter ocorrido após o julgamento do acórdão principal da presente demanda e antes do julgamento dos embargos de declaração opostos contra o acórdão.
+III. RAZÕES DE DECIDIR
+3. Os embargos de declaração têm efeito integrativo do acórdão recorrido, que se completa apenas após o fim do julgamento dos aclaratórios.
+4. O Tema n.º 1.387/STJ foi publicado apenas após o acórdão embargado, mas antes do julgamento dos embargos de declaração, que deveria ter observado o entendimento vinculante.
+5. Retratação do entendimento anterior desta Câmara, para adotar o saque integral como termo inicial da prescrição, em atenção ao Tema nº 1.387/STJ.
+6. Necessidade de acolher parcialmente os embargos de declaração para, anulando a sentença recorrida, determinar o retorno dos autos ao primeiro grau de jurisdição para possibilitar que a instrução probatória observe os Temas n.º 1.387/STJ e n.º 1.300/STJ.
+IV. DISPOSITIVO
+7. Juízo de retratação exercido. Recurso conhecido e parcialmente acolhido.
+_________________
+Dispositivos relevantes citados: CPC, art. 1.030, II.
+Jurisprudência relevante citada: STJ, REsp 2174291/PR, Rel. Min. Nancy Andrighi, Terceira Turma, j. 10.6.2025; STJ, REsp 2088734/RS, Rel. Min. Ricardo Villas Bôas Cueva, Terceira Turma, j. 10.6.2025; STJ, REsp 00000000000002214879/PE, Rel. Min. Maria Thereza de Assis Moura, Primeira Seção, j. 10.12.2025;  STJ, EDcl no AgInt no REsp 2196026/SC, Rel. Min. Benedito Gonçalves, Primeira Turma, j. 9.2.2026; STJ, REsp 1858227/PR, Rel. Min. Herman Benjamin, Segunda Turma, j. 5.3.2020.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812008" cdForo="0" >
+										0700659-21.2024.8.02.0090
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812008" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812008);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812008" style="display: none;" >
+	<div id="textAreaDados_812008" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL. DIREITO &Agrave; SA&Uacute;DE. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. PARTE DIAGNOSTICADA COM TRANSTORNO DO ESPECTRO AUTISTA. PRETENS&Atilde;O DE FORNECIMENTO DO TRATAMENTO COM A APLICA&Ccedil;&Atilde;O DOS M&Eacute;TODOS ABA E INTEGRA&Ccedil;&Atilde;O SENSORIAL, TERAPIA OCUPACIONAL &ndash; AVDS, AL&Eacute;M DA CARGA HOR&Aacute;RIA PRESCRITA. PROVIMENTO EM PARTE. ANULA&Ccedil;&Atilde;O, EM PARTE, DA SENTEN&Ccedil;A NO PONTO EM QUE INDEFERIU A TERAPIA OCUPACIONAL &ndash; AVDS.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pelo Estado de Alagoas em face da senten&ccedil;a que  julgou parcialmente procedente a a&ccedil;&atilde;o, determinando o fornecimento, em favor da parte autora, na rede p&uacute;blica de sa&uacute;de, por tempo indeterminado, sujeito a posterior reavalia&ccedil;&atilde;o, de tratamento com os seguintes profissionais multidisciplinares: psic&oacute;logo, fonoaudi&oacute;logo e terapeuta ocupacional, permitindo, desde j&aacute;, que a carga hor&aacute;ria seja definida de acordo com a forma de disponibiliza&ccedil;&atilde;o na rede de sa&uacute;de p&uacute;blica estadual, desde que todas as terapias sejam ofertadas durante a semana. Tamb&eacute;m condenou o ente p&uacute;blico em honor&aacute;rios no valor de R$ 750,00 (setecentos e cinquenta reais).
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o cinge-se a aferir o direito do autor, menor de idade, diagnosticado com Transtorno do Espectro Autista (TEA), a receber do ente p&uacute;blico demandado tratamento multidisciplinar nos termos prescritos pelo profissional da sa&uacute;de que o acompanha.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Nas diretrizes estabelecidas pela Portaria Conjunta n&ordm; 07 de abril de 2022 do Minist&eacute;rio da Sa&uacute;de foi aprovado o Protocolo Cl&iacute;nico e Diretrizes Terap&ecirc;uticas do Comportamento Agressivo no Transtorno do Espectro do Autismo, em que h&aacute; previs&atilde;o expressa do m&eacute;todo An&aacute;lise do Comportamento Aplicada (ABA) como forma de tratamento. Ainda, a Lei Estadual de n&ordm; 8.996/23 autorizou a implementa&ccedil;&atilde;o da metodologia ABA nas escolas p&uacute;blicas de Alagoas.
+4. Quanto ao m&eacute;todo de integra&ccedil;&atilde;o sensorial, h&aacute; previs&atilde;o na Linha de Cuidado para a Aten&ccedil;&atilde;o &agrave;s pessoas com Transtornos do Espectro do Autismo e suas Fam&iacute;lias na rede de Aten&ccedil;&atilde;o Psicossocial do Sistema &Uacute;nico de Sa&uacute;de. O terapeuta ocupacional faz uso da terapia de integra&ccedil;&atilde;o sensorial buscando: (a) a diminui&ccedil;&atilde;o dos n&iacute;veis elevados de atividade; (b) o incremento do repert&oacute;rio de respostas adaptativas, dos jogos com prop&oacute;sitos e do compromisso social; e (c) a melhoria da capacidade de sustenta&ccedil;&atilde;o da aten&ccedil;&atilde;o e o equil&iacute;brio do n&iacute;vel de atividade, bem como a diminui&ccedil;&atilde;o na emiss&atilde;o de comportamentos de autoagress&atilde;o ou autoestimula&ccedil;&atilde;o e a facilita&ccedil;&atilde;o de comportamentos de imita&ccedil;&atilde;o e antecipa&ccedil;&atilde;o, al&eacute;m da diminui&ccedil;&atilde;o de problemas de coordena&ccedil;&atilde;o e planejamento motor.
+5. No que se refere &agrave; terapia ocupacional com treinamento das atividades b&aacute;sicas da vida di&aacute;ria (T.O. com AVD), o seu fornecimento est&aacute; inserido na fun&ccedil;&atilde;o do profissional. Ocorre que a Resolu&ccedil;&atilde;o n&ordm; 316/2006 do Conselho Federal de Fisioterapia e Terapia Ocupacional disp&otilde;e sobre a pr&aacute;tica de Atividades de Vida Di&aacute;ria, de Atividades Instrumentais da Vida Di&aacute;ria e Tecnologia Assistiva pelo Terapeuta ocupacional e prev&ecirc; a este profissional, no &acirc;mbito da sua atua&ccedil;&atilde;o, a compet&ecirc;ncia para praticar a interven&ccedil;&atilde;o denominada AVD, cujo objetivo busca o desenvolvimento ocupacional, motor, sensorial, percepto-cognitivo, mental, emocional, comportamental, funcional, cultural, social e econ&ocirc;mico dos pacientes.
+6. Considerando a idade da crian&ccedil;a, o quantitativo de horas apresentado (Psicoterapia comportamental - 12 horas semanais, Fonoaudiologia - 4h semanais, al&eacute;m de Terapia ocupacional para integra&ccedil;&atilde;o sensorial e treino de AVDs - 4h semanais), tem-se que, por estarem em conson&acirc;ncia com o entendimento jurisprudencial e por totalizarem um quantitativo de horas adequado, quando avaliado o per&iacute;odo prescrito pelo m&eacute;dico do paciente, a carga hor&aacute;ria pode ser adotada.
+7. A continuidade do fornecimento do tratamento ficar&aacute; condicionada &agrave; apresenta&ccedil;&atilde;o, a cada 12 (doze) meses, junto ao &oacute;rg&atilde;o administrativo competente, de laudo m&eacute;dico atualizado que ateste a imprescindibilidade das medidas m&eacute;dicas, e para que especifique as necessidades do paciente, demonstrando se elas permanecem as mesmas. Dever&aacute; o apelado viabilizar o tratamento, no todo ou em parte, preferencialmente no Sistema &Uacute;nico de Sa&uacute;de e, somente em caso de sua inexist&ecirc;ncia, buscar alternativas privadas. N&atilde;o &eacute; poss&iacute;vel condicionar a realiza&ccedil;&atilde;o do tratamento &agrave; disponibiliza&ccedil;&atilde;o na rede municipal ou estadual. Trata-se de restri&ccedil;&atilde;o incompat&iacute;vel com a patologia discutida e com os dispositivos constitucionais e legais pertinentes.
+8. Em que pese a demonstra&ccedil;&atilde;o da adequa&ccedil;&atilde;o e imprescindibilidade cl&iacute;nica do tratamento com terapia ocupacional - AVDs, a negativa administrativa n&atilde;o restou comprovada, o que impossibilita o seu fornecimento, em aten&ccedil;&atilde;o aos enunciados do FONAJUS.
+9. A fase instrut&oacute;ria se fazia imprescind&iacute;vel no caso dos autos, j&aacute; que os pontos cruciais para o acolhimento ou n&atilde;o da pretens&atilde;o autoral demandam comprova&ccedil;&atilde;o pela parte autora, que deve ter oportunidade de se manifestar previamente e de produzir as provas tidas como essenciais, sob pena de viola&ccedil;&atilde;o ao princ&iacute;pio da veda&ccedil;&atilde;o &agrave; decis&atilde;o surpresa, previsto nos artigos 9&ordm; e 10 do C&oacute;digo de Processo Civil.
+IV. DISPOSITIVO
+10. Recurso conhecido e parcialmente provido, a fim de que o ente p&uacute;blico forne&ccedil;a ao autor tratamento com psicoterapia comportamental (12 horas semanais), fonoaudi&oacute;logo (4h semanais) e terapeuta ocupacional para integra&ccedil;&atilde;o sensorial (4h semanais). De of&iacute;cio, por for&ccedil;a do efeito devolutivo e translativo, anular, em parte, a senten&ccedil;a recorrida, no que atine &agrave; improced&ecirc;ncia do pleito de fornecimento de terapeuta ocupacional &ndash; AVDs, determinando o retorno dos autos &agrave; vara de origem para o regular processamento, com a deflagra&ccedil;&atilde;o da fase de instru&ccedil;&atilde;o processual.
+________
+Dispositivos relevantes citados: CF, arts. 6&ordm; e 196; Portaria Conjunta n&ordm; 07 de abril de 2022 do Minist&eacute;rio da Sa&uacute;de; Lei Estadual n&ordm; 8.996/23, arts. 1&ordm; e 3&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STF, Temas 06 e 1234, ARE 685230 AgR, Rel. Celso de Mello, Segunda Turma, j. 05/03/2013; STJ, AgRg no AREsp n. 807.820/PR, Rel. Min. Humberto Martins, Segunda Turma, j. 17/12/2015, AgRg no AREsp n. 36.394/RJ, Rel. Min. Herman Benjamin, Segunda Turma, j. 28/2/2012, REsp n. 2.064.964/SP, Rel. Min. Nancy Andrighi, Terceira Turma, j. 20/2/2024, AgInt no AgInt no REsp: 1991503 SP 2022/0076305-7, Rel. Min. Jo&atilde;o Ot&aacute;vio De Noronha, j. 07/10/2024, T4 - Quarta Turma, AgInt no REsp n. 2.049.402/RS, Rel. Min. Humberto Martins, Terceira Turma, j. 26/2/2024, AgRg no AREsp n&ordm; 740.150/SP, 3&ordf; Turma,&nbsp;Rel. Min. Marco Aur&eacute;lio Bellizze, DJe de 16/11/2015.  <br><br>(N&uacute;mero do Processo: 0700659-21.2024.8.02.0090; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;28&ordf; Vara Inf&acirc;ncia e Juventude da Capital; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento da Própria Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL. DIREITO À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER. PARTE DIAGNOSTICADA COM TRANSTORNO DO ESPECTRO AUTISTA. PRETENSÃO DE FORNECIMENTO DO TRATAMENTO COM A APLICAÇÃO DOS MÉTODOS ABA E INTEGRAÇÃO SENSORIAL, TERAPIA OCUPACIONAL – AVDS, ALÉM DA CARGA HORÁRIA PRESCRITA. PROVIMENTO EM PARTE. ANULAÇÃO, EM PARTE, DA SENTENÇA NO PONTO EM QUE INDEFERIU A TERAPIA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL. DIREITO À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER. PARTE DIAGNOSTICADA COM TRANSTORNO DO ESPECTRO AUTISTA. PRETENSÃO DE FORNECIMENTO DO TRATAMENTO COM A APLICAÇÃO DOS MÉTODOS ABA E INTEGRAÇÃO SENSORIAL, TERAPIA OCUPACIONAL – AVDS, ALÉM DA CARGA HORÁRIA PRESCRITA. PROVIMENTO EM PARTE. ANULAÇÃO, EM PARTE, DA SENTENÇA NO PONTO EM QUE INDEFERIU A TERAPIA OCUPACIONAL – AVDS.
+I. CASO EM EXAME
+1. Apelação cível interposta pelo Estado de Alagoas em face da sentença que  julgou parcialmente procedente a ação, determinando o fornecimento, em favor da parte autora, na rede pública de saúde, por tempo indeterminado, sujeito a posterior reavaliação, de tratamento com os seguintes profissionais multidisciplinares: psicólogo, fonoaudiólogo e terapeuta ocupacional, permitindo, desde já, que a carga horária seja definida de acordo com a forma de disponibilização na rede de saúde pública estadual, desde que todas as terapias sejam ofertadas durante a semana. Também condenou o ente público em honorários no valor de R$ 750,00 (setecentos e cinquenta reais).
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão cinge-se a aferir o direito do autor, menor de idade, diagnosticado com Transtorno do Espectro Autista (TEA), a receber do ente público demandado tratamento multidisciplinar nos termos prescritos pelo profissional da saúde que o acompanha.
+III. RAZÕES DE DECIDIR
+3. Nas diretrizes estabelecidas pela Portaria Conjunta nº 07 de abril de 2022 do Ministério da Saúde foi aprovado o Protocolo Clínico e Diretrizes Terapêuticas do Comportamento Agressivo no Transtorno do Espectro do Autismo, em que há previsão expressa do método Análise do Comportamento Aplicada (ABA) como forma de tratamento. Ainda, a Lei Estadual de nº 8.996/23 autorizou a implementação da metodologia ABA nas escolas públicas de Alagoas.
+4. Quanto ao método de integração sensorial, há previsão na Linha de Cuidado para a Atenção às pessoas com Transtornos do Espectro do Autismo e suas Famílias na rede de Atenção Psicossocial do Sistema Único de Saúde. O terapeuta ocupacional faz uso da terapia de integração sensorial buscando: (a) a diminuição dos níveis elevados de atividade; (b) o incremento do repertório de respostas adaptativas, dos jogos com propósitos e do compromisso social; e (c) a melhoria da capacidade de sustentação da atenção e o equilíbrio do nível de atividade, bem como a diminuição na emissão de comportamentos de autoagressão ou autoestimulação e a facilitação de comportamentos de imitação e antecipação, além da diminuição de problemas de coordenação e planejamento motor.
+5. No que se refere à terapia ocupacional com treinamento das atividades básicas da vida diária (T.O. com AVD), o seu fornecimento está inserido na função do profissional. Ocorre que a Resolução nº 316/2006 do Conselho Federal de Fisioterapia e Terapia Ocupacional dispõe sobre a prática de Atividades de Vida Diária, de Atividades Instrumentais da Vida Diária e Tecnologia Assistiva pelo Terapeuta ocupacional e prevê a este profissional, no âmbito da sua atuação, a competência para praticar a intervenção denominada AVD, cujo objetivo busca o desenvolvimento ocupacional, motor, sensorial, percepto-cognitivo, mental, emocional, comportamental, funcional, cultural, social e econômico dos pacientes.
+6. Considerando a idade da criança, o quantitativo de horas apresentado (Psicoterapia comportamental - 12 horas semanais, Fonoaudiologia - 4h semanais, além de Terapia ocupacional para integração sensorial e treino de AVDs - 4h semanais), tem-se que, por estarem em consonância com o entendimento jurisprudencial e por totalizarem um quantitativo de horas adequado, quando avaliado o período prescrito pelo médico do paciente, a carga horária pode ser adotada.
+7. A continuidade do fornecimento do tratamento ficará condicionada à apresentação, a cada 12 (doze) meses, junto ao órgão administrativo competente, de laudo médico atualizado que ateste a imprescindibilidade das medidas médicas, e para que especifique as necessidades do paciente, demonstrando se elas permanecem as mesmas. Deverá o apelado viabilizar o tratamento, no todo ou em parte, preferencialmente no Sistema Único de Saúde e, somente em caso de sua inexistência, buscar alternativas privadas. Não é possível condicionar a realização do tratamento à disponibilização na rede municipal ou estadual. Trata-se de restrição incompatível com a patologia discutida e com os dispositivos constitucionais e legais pertinentes.
+8. Em que pese a demonstração da adequação e imprescindibilidade clínica do tratamento com terapia ocupacional - AVDs, a negativa administrativa não restou comprovada, o que impossibilita o seu fornecimento, em atenção aos enunciados do FONAJUS.
+9. A fase instrutória se fazia imprescindível no caso dos autos, já que os pontos cruciais para o acolhimento ou não da pretensão autoral demandam comprovação pela parte autora, que deve ter oportunidade de se manifestar previamente e de produzir as provas tidas como essenciais, sob pena de violação ao princípio da vedação à decisão surpresa, previsto nos artigos 9º e 10 do Código de Processo Civil.
+IV. DISPOSITIVO
+10. Recurso conhecido e parcialmente provido, a fim de que o ente público forneça ao autor tratamento com psicoterapia comportamental (12 horas semanais), fonoaudiólogo (4h semanais) e terapeuta ocupacional para integração sensorial (4h semanais). De ofício, por força do efeito devolutivo e translativo, anular, em parte, a sentença recorrida, no que atine à improcedência do pleito de fornecimento de terapeuta ocupacional – AVDs, determinando o retorno dos autos à vara de origem para o regular processamento, com a deflagração da fase de instrução processual.
+________
+Dispositivos relevantes citados: CF, arts. 6º e 196; Portaria Conjunta nº 07 de abril de 2022 do Ministério da Saúde; Lei Estadual nº 8.996/23, arts. 1º e 3º.
+Jurisprudência relevante citada: STF, Temas 06 e 1234, ARE 685230 AgR, Rel. Celso de Mello, Segunda Turma, j. 05/03/2013; STJ, AgRg no AREsp n. 807.820/PR, Rel. Min. Humberto Martins, Segunda Turma, j. 17/12/2015, AgRg no AREsp n. 36.394/RJ, Rel. Min. Herman Benjamin, Segunda Turma, j. 28/2/2012, REsp n. 2.064.964/SP, Rel. Min. Nancy Andrighi, Terceira Turma, j. 20/2/2024, AgInt no AgInt no REsp: 1991503 SP 2022/0076305-7, Rel. Min. João Otávio De Noronha, j. 07/10/2024, T4 - Quarta Turma, AgInt no REsp n. 2.049.402/RS, Rel. Min. Humberto Martins, Terceira Turma, j. 26/2/2024, AgRg no AREsp nº 740.150/SP, 3ª Turma, Rel. Min. Marco Aurélio Bellizze, DJe de 16/11/2015.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811976" cdForo="0" >
+										0717500-67.2024.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811976" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811976);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811976" style="display: none;" >
+	<div id="textAreaDados_811976" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. ALEGA&Ccedil;&Atilde;O DE OMISS&Atilde;O E ERRO DE PREMISSA F&Aacute;TICA. AUS&Ecirc;NCIA DE V&Iacute;CIOS. RECURSO N&Atilde;O ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declara&ccedil;&atilde;o opostos com o objetivo de suprir supostos v&iacute;cios no ac&oacute;rd&atilde;o proferido por esta 4&ordf; C&acirc;mara C&iacute;vel, que conheceu do recurso de apela&ccedil;&atilde;o interposto pelo Plano de Sa&uacute;de para, no m&eacute;rito, dar-lhe parcial provimento, a fim de excluir o fornecimento de interven&ccedil;&atilde;o baseada em an&aacute;lise comportamental aplicada (ABA) com supervis&atilde;o de analista do comportamento e a compensa&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; omiss&atilde;o e erro de premissa f&aacute;tica no julgado, por supostamente desconsiderar provas no sentido de que a interven&ccedil;&atilde;o baseada em an&aacute;lise comportamental aplicada (ABA) com supervis&atilde;o de analista do comportamento era realizada em ambiente cl&iacute;nico.
+III. RAZ&Otilde;ES DE DECIDIR
+3. As provas juntadas pela parte autora ora caminham no sentido de que a interven&ccedil;&atilde;o baseada em an&aacute;lise comportamental aplicada (ABA) com supervis&atilde;o de analista do comportamento seria realizada ora em ambiente escolar ora em domic&iacute;lio. Contudo, tanto em um como noutro caso, n&atilde;o h&aacute; obrigatoriedade de custeio pelo plano de sa&uacute;de, conforme assentado no ac&oacute;rd&atilde;o vergastado.
+4. O ac&oacute;rd&atilde;o embargado analisou de forma clara e expressa sobre a mat&eacute;ria posta &agrave; aprecia&ccedil;&atilde;o, apresentando os fundamentos que sustentam de forma suficiente a conclus&atilde;o alcan&ccedil;ada.
+5. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o de mat&eacute;ria de m&eacute;rito ou &agrave; rean&aacute;lise de fatos e provas, sendo cab&iacute;veis apenas para sanar obscuridade, omiss&atilde;o, contradi&ccedil;&atilde;o ou erro material, conforme o art. 1.022 do CPC.
+IV. Dispositivo e tese
+6. Embargos de declara&ccedil;&atilde;o conhecidos e n&atilde;o acolhidos.
+__________
+Dispositivos relevantes citados: CPC/2015, arts. 1.022 e 1.026, &sect; 2&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017. <br><br>(N&uacute;mero do Processo: 0717500-67.2024.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									717500672024802000150000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. ALEGAÇÃO DE OMISSÃO E ERRO DE PREMISSA FÁTICA. AUSÊNCIA DE VÍCIOS. RECURSO NÃO ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos com o objetivo de suprir supostos vícios no acórdão proferido por esta 4ª Câmara Cível, que conheceu do recurso de apelação interposto pelo Plano de Saúde para, no mérito, dar-lhe parcial
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. ALEGAÇÃO DE OMISSÃO E ERRO DE PREMISSA FÁTICA. AUSÊNCIA DE VÍCIOS. RECURSO NÃO ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos com o objetivo de suprir supostos vícios no acórdão proferido por esta 4ª Câmara Cível, que conheceu do recurso de apelação interposto pelo Plano de Saúde para, no mérito, dar-lhe parcial provimento, a fim de excluir o fornecimento de intervenção baseada em análise comportamental aplicada (ABA) com supervisão de analista do comportamento e a compensação por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em saber se há omissão e erro de premissa fática no julgado, por supostamente desconsiderar provas no sentido de que a intervenção baseada em análise comportamental aplicada (ABA) com supervisão de analista do comportamento era realizada em ambiente clínico.
+III. RAZÕES DE DECIDIR
+3. As provas juntadas pela parte autora ora caminham no sentido de que a intervenção baseada em análise comportamental aplicada (ABA) com supervisão de analista do comportamento seria realizada ora em ambiente escolar ora em domicílio. Contudo, tanto em um como noutro caso, não há obrigatoriedade de custeio pelo plano de saúde, conforme assentado no acórdão vergastado.
+4. O acórdão embargado analisou de forma clara e expressa sobre a matéria posta à apreciação, apresentando os fundamentos que sustentam de forma suficiente a conclusão alcançada.
+5. Os embargos de declaração não se prestam à rediscussão de matéria de mérito ou à reanálise de fatos e provas, sendo cabíveis apenas para sanar obscuridade, omissão, contradição ou erro material, conforme o art. 1.022 do CPC.
+IV. Dispositivo e tese
+6. Embargos de declaração conhecidos e não acolhidos.
+__________
+Dispositivos relevantes citados: CPC/2015, arts. 1.022 e 1.026, § 2º.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Seção, j. 08.11.2017.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811898" cdForo="0" >
+										0803207-35.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811898" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811898);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811898" style="display: none;" >
+	<div id="textAreaDados_811898" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O ORDIN&Aacute;RIA DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C TUTELA DE URG&Ecirc;NCIA DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS.  IMPOSSIBILIDADE DE INTERRUP&Ccedil;&Atilde;O DO FORNECIMENTO DE ENERGIA EL&Eacute;TRICA.. UTILIZA&Ccedil;&Atilde;O DO SERVI&Ccedil;O DE&nbsp;HOME&nbsp;CARE. OBRIGA&Ccedil;&Atilde;O DE CUSTEIO, PELO ENTE P&Uacute;BLICO, DO CONSUMO DE ENERGIA EL&Eacute;TRICA REFERENTE AO TRATAMENTO DOMICILIAR. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela concession&aacute;ria de energia el&eacute;trica contra decis&atilde;o interlocut&oacute;ria que deferiu a tutela de urg&ecirc;ncia, para determinar que a Equatorial se abstenha de suspender os servi&ccedil;os de energia el&eacute;trica no im&oacute;vel da parte autora, bem como instale nova unidade consumidora para medi&ccedil;&atilde;o exclusiva do consumo dos equipamentos e demais aparelhos vinculados ao home care. Determinou, ainda, que a Equatorial proceda &agrave; cobran&ccedil;a com base na m&eacute;dia de consumo das &uacute;ltimas faturas antes da aferi&ccedil;&atilde;o do consumo de energia de todos os aparelhos do servi&ccedil;o de home care, enquanto n&atilde;o seja instalado o novo medidor.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) analisar o interesse recursal quanto ao reconhecimento do &ocirc;nus exclusivo do ente p&uacute;blico de arcar com as contrapresta&ccedil;&otilde;es financeiras necess&aacute;rias &agrave; manuten&ccedil;&atilde;o da sa&uacute;de da parte agravada; (ii) examinar a proibi&ccedil;&atilde;o de suspens&atilde;o do servi&ccedil;o de energia el&eacute;trica na unidade consumidora do agravado; (iii) avaliar a responsabilidade do ente p&uacute;blico estadual e municipal pela obriga&ccedil;&atilde;o de custeio financeiro das despesas relativas &agrave; adequa&ccedil;&atilde;o do padr&atilde;o interno da unidade consumidora.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Aus&ecirc;ncia de interesse recursal da concession&aacute;ria agravante quanto &agrave; pretens&atilde;o de reconhecer a responsabilidade do Estado de Alagoas, notadamente porque a decis&atilde;o agravada imp&ocirc;s expressamente ao ente p&uacute;blico estadual e municipal a obriga&ccedil;&atilde;o de custeio financeiro do incremento do valor cobrado de energia el&eacute;trica da resid&ecirc;ncia da parte agravada, oriundo da instala&ccedil;&atilde;o dos equipamentos necess&aacute;rios &agrave; garantia do direito &agrave; sa&uacute;de e &agrave; vida do esposo da agravado. O valor remanescente continua sendo imput&aacute;vel &agrave; agravada, n&atilde;o havendo que se falar em fornecimento gratuito do servi&ccedil;o essencial.
+4. A interna&ccedil;&atilde;o domiciliar representa a continua&ccedil;&atilde;o do tratamento m&eacute;dico, de modo que recusar seu fornecimento significa interromper o processo terap&ecirc;utico, com o agravamento das sequelas e limita&ccedil;&otilde;es da autora. O funcionamento dos equipamentos hospitalares e demais aparelhos necess&aacute;rios ao atendimento da paciente depende da utiliza&ccedil;&atilde;o de energia el&eacute;trica, tendo restado demonstrada a insufici&ecirc;ncia econ&ocirc;mica da parte para arcar com tais despesas.
+5. Ainda n&atilde;o foi cumprida a determina&ccedil;&atilde;o para que seja instalada uma nova unidade consumidora para medi&ccedil;&atilde;o exclusivamente do consumo de energia el&eacute;trica dos equipamentos vinculados ao sistema de home care, n&atilde;o podendo haver a interrup&ccedil;&atilde;o do fornecimento do servi&ccedil;o, uma vez que tal conduta afetaria diretamente a benefici&aacute;ria do tratamento domiciliar. Desse modo, privilegia-se o direito &agrave; sa&uacute;de e &agrave; pr&oacute;pria vida, em detrimento de valores financeiros.
+6. O &ocirc;nus financeiro da adequa&ccedil;&atilde;o interna adequada para implementa&ccedil;&atilde;o e instala&ccedil;&atilde;o do novo ponto de energia para medi&ccedil;&atilde;o exclusiva do home care dever&aacute; ser imputado aos entes p&uacute;blicos.
+IV. DISPOSITIVO
+7. Recurso parcialmente conhecido e, na parte conhecida, parcialmente provido.
+_____________
+Dispositivos relevantes citados: CF, arts. 6&ordm; e 196; Dec-Lei n&deg; 4.657/42, art. 20; Res. n&ordm; 1.000/2021 da ANEEL, art. 2&ordm;  XLIV, c, art. 40;
+Jurisprud&ecirc;ncia relevante citada: n/a.  <br><br>(N&uacute;mero do Processo: 0803207-35.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Fato Atípico
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM AÇÃO ORDINÁRIA DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>.  IMPOSSIBILIDADE DE INTERRUPÇÃO DO FORNECIMENTO DE ENERGIA ELÉTRICA.. UTILIZAÇÃO DO SERVIÇO DE HOME CARE. OBRIGAÇÃO DE CUSTEIO, PELO ENTE PÚBLICO, DO CONSUMO DE ENERGIA ELÉTRICA REFERENTE AO TRATAMENTO DOMICILIAR. PARCIAL PROVIMENTO.
+I.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM AÇÃO ORDINÁRIA DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>.  IMPOSSIBILIDADE DE INTERRUPÇÃO DO FORNECIMENTO DE ENERGIA ELÉTRICA.. UTILIZAÇÃO DO SERVIÇO DE HOME CARE. OBRIGAÇÃO DE CUSTEIO, PELO ENTE PÚBLICO, DO CONSUMO DE ENERGIA ELÉTRICA REFERENTE AO TRATAMENTO DOMICILIAR. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela concessionária de energia elétrica contra decisão interlocutória que deferiu a tutela de urgência, para determinar que a Equatorial se abstenha de suspender os serviços de energia elétrica no imóvel da parte autora, bem como instale nova unidade consumidora para medição exclusiva do consumo dos equipamentos e demais aparelhos vinculados ao home care. Determinou, ainda, que a Equatorial proceda à cobrança com base na média de consumo das últimas faturas antes da aferição do consumo de energia de todos os aparelhos do serviço de home care, enquanto não seja instalado o novo medidor.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) analisar o interesse recursal quanto ao reconhecimento do ônus exclusivo do ente público de arcar com as contraprestações financeiras necessárias à manutenção da saúde da parte agravada; (ii) examinar a proibição de suspensão do serviço de energia elétrica na unidade consumidora do agravado; (iii) avaliar a responsabilidade do ente público estadual e municipal pela obrigação de custeio financeiro das despesas relativas à adequação do padrão interno da unidade consumidora.
+III. RAZÕES DE DECIDIR
+3. Ausência de interesse recursal da concessionária agravante quanto à pretensão de reconhecer a responsabilidade do Estado de Alagoas, notadamente porque a decisão agravada impôs expressamente ao ente público estadual e municipal a obrigação de custeio financeiro do incremento do valor cobrado de energia elétrica da residência da parte agravada, oriundo da instalação dos equipamentos necessários à garantia do direito à saúde e à vida do esposo da agravado. O valor remanescente continua sendo imputável à agravada, não havendo que se falar em fornecimento gratuito do serviço essencial.
+4. A internação domiciliar representa a continuação do tratamento médico, de modo que recusar seu fornecimento significa interromper o processo terapêutico, com o agravamento das sequelas e limitações da autora. O funcionamento dos equipamentos hospitalares e demais aparelhos necessários ao atendimento da paciente depende da utilização de energia elétrica, tendo restado demonstrada a insuficiência econômica da parte para arcar com tais despesas.
+5. Ainda não foi cumprida a determinação para que seja instalada uma nova unidade consumidora para medição exclusivamente do consumo de energia elétrica dos equipamentos vinculados ao sistema de home care, não podendo haver a interrupção do fornecimento do serviço, uma vez que tal conduta afetaria diretamente a beneficiária do tratamento domiciliar. Desse modo, privilegia-se o direito à saúde e à própria vida, em detrimento de valores financeiros.
+6. O ônus financeiro da adequação interna adequada para implementação e instalação do novo ponto de energia para medição exclusiva do home care deverá ser imputado aos entes públicos.
+IV. DISPOSITIVO
+7. Recurso parcialmente conhecido e, na parte conhecida, parcialmente provido.
+_____________
+Dispositivos relevantes citados: CF, arts. 6º e 196; Dec-Lei n° 4.657/42, art. 20; Res. nº 1.000/2021 da ANEEL, art. 2º  XLIV, c, art. 40;
+Jurisprudência relevante citada: n/a.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812046" cdForo="0" >
+										0720591-34.2025.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812046" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812046);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812046" style="display: none;" >
+	<div id="textAreaDados_812046" class="mensagemSemFormatacao" >
+		Direito processual civil. Embargos de declara&ccedil;&atilde;o em apela&ccedil;&atilde;o c&iacute;vel. Alega&ccedil;&atilde;o de exist&ecirc;ncia de omiss&atilde;o no ac&oacute;rd&atilde;o. AUS&Ecirc;NCIA DE V&Iacute;CIOS. EMBARGOS n&atilde;o acolhidoS.
+I. Caso em exame
+1. Embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que deu parcial provimento ao apelo da parte embargada, para declarar a inexist&ecirc;ncia dos d&eacute;bitos relativos aos empr&eacute;stimos banc&aacute;rios irregularmente pactuados, com a consequente restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados da parte autora. Ademais, condenou a institui&ccedil;&atilde;o financeira ao pagamento de compensa&ccedil;&atilde;o por danos morais no montante de R$ 2.000,00 (dois mil reais).
+II. Quest&atilde;o em discuss&atilde;o
+2.  A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; omiss&atilde;o no julgado, mais precisamente quanto &agrave; aus&ecirc;ncia de an&aacute;lise da inexist&ecirc;ncia de m&aacute;-f&eacute; da parte embargante e da necessidade de compensa&ccedil;&atilde;o dos valores disponibilizados &agrave; parte autora.
+iii. raz&otilde;es de decidir
+3. O ac&oacute;rd&atilde;o embargado se manifestou de maneira suficientemente clara, coerente e &iacute;ntegra quanto &agrave; discuss&atilde;o trazida ao conhecimento desta Corte, tratando expressamente das quest&otilde;es apontadas pelo embargante.
+4. O ac&oacute;rd&atilde;o embargado enfrentou todos os argumentos relevantes, especialmente aqueles mencionados no presente recurso. Mera irresigna&ccedil;&atilde;o da parte recorrente.
+iv. Dispositivo e tese
+5. Recurso conhecido e n&atilde;o acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017;  <br><br>(N&uacute;mero do Processo: 0720591-34.2025.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(17 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Interpretação / Revisão de Contrato
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									720591342025802000150000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIOS. EMBARGOS não acolhidoS.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que deu parcial provimento ao apelo da parte embargada, para declarar a inexistência dos débitos relativos aos empréstimos bancários irregularmente pactuados, com a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIOS. EMBARGOS não acolhidoS.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que deu parcial provimento ao apelo da parte embargada, para declarar a inexistência dos débitos relativos aos empréstimos bancários irregularmente pactuados, com a consequente restituição em dobro dos valores indevidamente descontados da parte autora. Ademais, condenou a instituição financeira ao pagamento de compensação por <em>danos</em> <em>morais</em> no montante de R$ 2.000,00 (dois mil reais).
+II. Questão em discussão
+2.  A questão em discussão consiste em saber se há omissão no julgado, mais precisamente quanto à ausência de análise da inexistência de má-fé da parte embargante e da necessidade de compensação dos valores disponibilizados à parte autora.
+iii. razões de decidir
+3. O acórdão embargado se manifestou de maneira suficientemente clara, coerente e íntegra quanto à discussão trazida ao conhecimento desta Corte, tratando expressamente das questões apontadas pelo embargante.
+4. O acórdão embargado enfrentou todos os argumentos relevantes, especialmente aqueles mencionados no presente recurso. Mera irresignação da parte recorrente.
+iv. Dispositivo e tese
+5. Recurso conhecido e não acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Seção, j. 08.11.2017;
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			</div>
+		</td>
+		<td width="20px">
+			&nbsp;
+		</td>
+		<td valign="top" width="230px">
+			<div id="adicionarPesquisa-A">
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="RECURSO">
+									<label for="ckTermo1">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="CONHECIDO">
+									<label for="ckTermo2">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="APELAÇÃO">
+									<label for="ckTermo3">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="PROVIDO">
+									<label for="ckTermo4">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="DIREITO">
+									<label for="ckTermo5">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="CÍVEL">
+									<label for="ckTermo6">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="AÇÃO">
+									<label for="ckTermo7">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="CIVIL">
+									<label for="ckTermo8">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="DANOS">
+									<label for="ckTermo9">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="CONSUMIDOR">
+									<label for="ckTermo10">
+										CONSUMIDOR
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="MORAIS">
+									<label for="ckTermo11">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="SENTENÇA">
+									<label for="ckTermo12">
+										SENTENÇA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="INDENIZAÇÃO">
+									<label for="ckTermo13">
+										INDENIZAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="INEXISTÊNCIA">
+									<label for="ckTermo14">
+										INEXISTÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="DECISÃO">
+									<label for="ckTermo15">
+										DECISÃO
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			</div>
+
+		</td>
+	</tr>
+</table>
+<div id="paginacaoInferior-A">
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 20
+			</strong>
+			de 136804
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+							<script>
+							$(function(){
+								$.saj.cjsg.bindsAbaInicial('A');
+							});
+							</script>
+
+
+
+						</div>
+
+				</div>
+
+			<!-- Resultado consulta -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</td>
+</tr>
+</table>
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaRodape" summary=" " role="presentation">
+    <tr>
+        <td class="esajCelulaRodapeCentro">
+            Desenvolvido pela Softplan em parceria com o Tribunal de Justiça de Alagoas
+
+        </td>
+    </tr>
+</table>
+<link href="https://www2.tjal.jus.br/esaj-layout/tema/padrao/css/saj-popup-modal.css" rel="stylesheet" type="text/css">
+<link href="https://www2.tjal.jus.br/esaj-layout/tema/padrao/css/popup-beta.css" rel="stylesheet" type="text/css">
+
+
+<script>
+    var appEsajLayout = appEsajLayout || {};
+    appEsajLayout.tituloCertificadoDigital = 'Certificado digital';
+    appEsajLayout.cliente = 'AL';
+    appEsajLayout.emailParaContato = '';
+    appEsajLayout.utilizarBotaoContato = 'false';
+    appEsajLayout.contexto = 'https://www2.tjal.jus.br/esaj-layout';
+    appEsajLayout.webSignerParametro = '';
+
+    if(window.jQuery) {
+        jQuery.saj = jQuery.saj || {};
+        jQuery.saj.certificado = jQuery.saj.certificado || {};
+        jQuery.saj.certificado.cliente = 'AL';
+        jQuery.saj.certificado.urlConteudoAjudaWebSigner = appEsajLayout.contexto + '/ajudaWebSigner.do';
+        jQuery.saj.certificado.licenca = 'AqYAKi5zYWphZG0udGpzcC5qdXMuYnIsKi5zZWEuc2MuZ292LmJyLCouc29mdHBsYW4uY29tLmJyLCoudGphYy5qdXMuYnIsKi50amFsLmp1cy5iciwqLnRqYW0uanVzLmJyLCoudGpjZS5qdXMuYnIsKi50am1zLmp1cy5iciwqLnRqcHIuanVzLmJyLCoudGpzYy5qdXMuYnIsKi50anNwLmp1cy5ickMAaXA0OjEwLjAuMC4wLzgsaXA0OjEyNy4wLjAuMC84LGlwNDoxNzIuMTYuMC4wLzEyLGlwNDoxOTIuMTY4LjAuMC8xNggAU3RhbmRhcmQAAAABcfpZUu/QD3s2bqedB8v9T7MiMQxcHNu0pUzGzO+7Ta++o+BbAVgPau7lzj6IUFI7RPFkPSnm0ZbCFAVBnKrqinyvE8MwEvmQhFcjlhGK+FfVV5mhVkkxSC3khDEUR8gsAPVvFncyyW2vTU2ODkyGdU0S/g62wHFtSwfGP6OFqlWpZTqbxbEGd1vfe9yHHulTYI7RcsGxaTMD6XgtPlStbOn9DxSYhN3S+4oTtIq7pUR6ETavPqYlXh5hwkxIpTe3Sf4awQucSigQ95sS9g7QpcGyVUVscm0J/rah9YwPCnHShzsttWA9aCmKrNdgFSTTo8TUOmESEP93TH6Z3dss+A==';
+        jQuery.saj.certificado.webSignerParametro = '';
+        jQuery.saj.certificado.cofreDigital = jQuery.saj.certificado.cofreDigital || {};
+        jQuery.saj.certificado.cofreDigital.habilitado = 'true' === 'true';
+        jQuery.saj.certificado.cofreDigital.enderecoBase = 'https://www2.tjal.jus.br/esaj-layout';
+    }
+
+</script>
+<script src="https://www2.tjal.jus.br/esaj-layout/js/app-bundle.js?n=2978165087"></script>
+<script src="https://www2.tjal.jus.br/esaj-layout/seletorVersaoBeta.js?n=32db3647-04d8-4058-8c7b-79513d6c2143&versao=1"></script>
+<script language="javascript" type="text/JavaScript" src="https://www2.tjal.jus.br/esaj-layout/js/softplan-websigner-2.5.1.js?n=736057767"></script>
+<script language="javascript" type="text/JavaScript" src=""></script>
+
+<script language="javascript" type="text/JavaScript" src="https://www2.tjal.jus.br/esaj-layout/js/saj-certificado.js?n=47741893"></script>
+
+
+
+<div id="webSignerNaoInstalado" style="display: none;">
+    <p>Para utilização do certificado digital no Portal e-SAJ é necessário a instalação do plug-in Web Signer. Por favor, realize a instalação antes de continuar.</p>
+    <div class="footer_certificado">
+        <button id="redirecionarParaPaginaInstalacao" class="actionPrincipal spwBotaoDefault">Instalar</button>
+        <button class="fecharModalInstalacao spwBotao">Cancelar</button>
+        <button class="spwBotao" onclick="window.open('https://www2.tjal.jus.br/WebHelp//#id_instalacao_lacuna.htm','_blank')">Ajuda</button>
+    </div>
+</div>
+
+<div id="webSignerNaoSuportado" style="display: none;">
+    <p>O navegador utilizado não é compatível com a tecnologia (Web Signer) necessária para utilização do certificado digital. Por favor, utilize um dos navegadores homologados. Em caso de dúvidas, efetue a validação de requisitos <a href="https://www2.tjal.jus.br/petpg/abrirVerificacaoRequisitosPet.do" target="_blank">aqui</a>.</p>
+    <div class="footer_certificado">
+        <button class="fecharModalInstalacao spwBotaoDefault actionPrincipal">OK</button>
+    </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+	</body>
+</html>

--- a/tests/tjal/samples/cjsg/results_normal_page_01.html
+++ b/tests/tjal/samples/cjsg/results_normal_page_01.html
@@ -1,0 +1,3806 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(136804)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="136804" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812970" cdForo="0" >
+										0709767-89.2020.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812970" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812970);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812970" style="display: none;" >
+	<div id="textAreaDados_812970" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. CRIMES CONTRA A HONRA. CAL&Uacute;NIA E DIFAMA&Ccedil;&Atilde;O. IMPUTA&Ccedil;&Atilde;O DE CRIMES A MAGISTRADO EM V&Iacute;DEO DIVULGADO EM REDE SOCIAL. ABUSO DO DIREITO &Agrave; LIBERDADE DE EXPRESS&Atilde;O. DOLO ESPEC&Iacute;FICO CONFIGURADO. DOSIMETRIA DA PENA. REGULARIDADE. FIXA&Ccedil;&Atilde;O DE VALOR M&Iacute;NIMO DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. ART. 387, IV, DO CPP. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A CONDENAT&Oacute;RIA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a que condenou a apelante pela pr&aacute;tica dos crimes de cal&uacute;nia e difama&ccedil;&atilde;o (arts. 138 e 139 do C&oacute;digo Penal), com incid&ecirc;ncia das causas de aumento previstas no art. 141, incisos II e III e &sect;2&ordm;, do mesmo diploma legal, em concurso formal (art. 70 do C&oacute;digo Penal), em raz&atilde;o da divulga&ccedil;&atilde;o de v&iacute;deo em rede social no qual imputou a Desembargador do Tribunal de Justi&ccedil;a de Alagoas a pr&aacute;tica de condutas criminosas relacionadas ao suposto acobertamento de homic&iacute;dio e manipula&ccedil;&atilde;o de processo judicial. A pena foi fixada em 03 anos, 07 meses e 27 dias de deten&ccedil;&atilde;o, em regime inicial aberto, substitu&iacute;da por penas restritivas de direitos, al&eacute;m de 63 dias-multa e fixa&ccedil;&atilde;o de valor m&iacute;nimo de R$ 7.545,00 a t&iacute;tulo de repara&ccedil;&atilde;o por danos morais. A defesa pleiteia a absolvi&ccedil;&atilde;o por atipicidade da conduta e aus&ecirc;ncia de dolo espec&iacute;fico, invocando a liberdade de express&atilde;o. Subsidiariamente, requer a revis&atilde;o da dosimetria da pena, a exclus&atilde;o ou redu&ccedil;&atilde;o do valor fixado a t&iacute;tulo de repara&ccedil;&atilde;o civil e a concess&atilde;o dos benef&iacute;cios da justi&ccedil;a gratuita.
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se as declara&ccedil;&otilde;es divulgadas pela apelante em rede social configuram exerc&iacute;cio leg&iacute;timo da liberdade de express&atilde;o ou se caracterizam os crimes de cal&uacute;nia e difama&ccedil;&atilde;o; (ii) estabelecer se houve irregularidade ou despropor&ccedil;&atilde;o na dosimetria da pena aplicada; e (iii) determinar se deve ser afastada ou reduzida a indeniza&ccedil;&atilde;o por danos morais fixada na senten&ccedil;a, bem como se &eacute; cab&iacute;vel a concess&atilde;o imediata da gratuidade da justi&ccedil;a.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A materialidade e a autoria delitivas encontram-se comprovadas pelo conte&uacute;do das manifesta&ccedil;&otilde;es divulgadas em rede social, nas quais a apelante imputou diretamente ao querelante a pr&aacute;tica de crimes graves, sem qualquer suporte probat&oacute;rio m&iacute;nimo.
+4. As declara&ccedil;&otilde;es extrapolam os limites do direito de cr&iacute;tica ou de narrativa de fatos de interesse p&uacute;blico, pois consistem em imputa&ccedil;&otilde;es categ&oacute;ricas de condutas criminosas dirigidas &agrave; v&iacute;tima, o que caracteriza os delitos de cal&uacute;nia e difama&ccedil;&atilde;o.
+5. O dolo espec&iacute;fico dos crimes contra a honra pode ser inferido das circunst&acirc;ncias f&aacute;ticas da conduta, especialmente do teor das afirma&ccedil;&otilde;es, do contexto em que foram proferidas e da ampla divulga&ccedil;&atilde;o em ambiente virtual.
+6. A liberdade de express&atilde;o n&atilde;o possui car&aacute;ter absoluto e encontra limites na prote&ccedil;&atilde;o &agrave; honra, &agrave; imagem e &agrave; dignidade das pessoas, n&atilde;o podendo ser invocada para justificar a imputa&ccedil;&atilde;o irrespons&aacute;vel de fatos criminosos a terceiros.
+7. A ampla divulga&ccedil;&atilde;o das ofensas em plataformas digitais potencializa o alcance das imputa&ccedil;&otilde;es e intensifica a les&atilde;o &agrave; honra e &agrave; reputa&ccedil;&atilde;o da v&iacute;tima, especialmente em raz&atilde;o de sua condi&ccedil;&atilde;o institucional de magistrado.
+8. A dosimetria da pena foi realizada de forma fundamentada e em conson&acirc;ncia com os crit&eacute;rios previstos nos arts. 59 e 68 do C&oacute;digo Penal, inexistindo ilegalidade ou despropor&ccedil;&atilde;o que justifique interven&ccedil;&atilde;o da inst&acirc;ncia revisora.
+9. A fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos morais encontra amparo no art. 387, IV, do C&oacute;digo de Processo Penal, sendo compat&iacute;vel com a gravidade das imputa&ccedil;&otilde;es, a ampla divulga&ccedil;&atilde;o das ofensas e a intensidade do dano causado &agrave; honra do ofendido.
+10. A an&aacute;lise acerca da eventual impossibilidade de pagamento das custas processuais pode ser realizada oportunamente na fase de execu&ccedil;&atilde;o, quando ser&aacute; poss&iacute;vel aferir concretamente a condi&ccedil;&atilde;o econ&ocirc;mica da condenada.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e n&atilde;o provido.
+Tese de julgamento: A imputa&ccedil;&atilde;o p&uacute;blica de fatos definidos como crime, sem suporte probat&oacute;rio m&iacute;nimo, configura os delitos de cal&uacute;nia e difama&ccedil;&atilde;o, ainda que veiculada sob o argumento de exerc&iacute;cio da liberdade de express&atilde;o. A liberdade de express&atilde;o n&atilde;o autoriza acusa&ccedil;&otilde;es criminosas infundadas que atinjam a honra e a reputa&ccedil;&atilde;o de terceiros. A divulga&ccedil;&atilde;o de ofensas em redes sociais, com amplo alcance, evidencia o dolo espec&iacute;fico e agrava a lesividade dos crimes contra a honra. &Eacute; leg&iacute;tima a fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos morais na senten&ccedil;a penal condenat&oacute;ria, nos termos do art. 387, IV, do C&oacute;digo de Processo Penal.
+_________
+Dispositivos relevantes citados: C&oacute;digo Penal, arts. 70, 138, 139 e 141; C&oacute;digo de Processo Penal, art. 387, IV; Constitui&ccedil;&atilde;o Federal, art. 5&ordm;, IV e IX.
+Jurisprud&ecirc;ncia relevante citada: TJAL, Apela&ccedil;&atilde;o Criminal n&ordm; 0500872-21.2023.8.02.0001, rel. Des. F&aacute;bio Costa de Almeida Ferrario, j. 29.11.2023. <br><br>(N&uacute;mero do Processo: 0709767-89.2020.8.02.0001; Relator (a):&nbsp;Des. M&aacute;rcio Roberto Ten&oacute;rio de Albuquerque; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 08/04/2026; Data de registro: 16/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Desclassificação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Márcio Roberto Tenório de Albuquerque
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. CRIMES CONTRA A HONRA. CALÚNIA E DIFAMAÇÃO. IMPUTAÇÃO DE CRIMES A MAGISTRADO EM VÍDEO DIVULGADO EM REDE SOCIAL. ABUSO DO DIREITO À LIBERDADE DE EXPRESSÃO. DOLO ESPECÍFICO CONFIGURADO. DOSIMETRIA DA PENA. REGULARIDADE. FIXAÇÃO DE VALOR MÍNIMO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. ART. 387, IV, DO CPP. MANUTENÇÃO DA SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. CRIMES CONTRA A HONRA. CALÚNIA E DIFAMAÇÃO. IMPUTAÇÃO DE CRIMES A MAGISTRADO EM VÍDEO DIVULGADO EM REDE SOCIAL. ABUSO DO DIREITO À LIBERDADE DE EXPRESSÃO. DOLO ESPECÍFICO CONFIGURADO. DOSIMETRIA DA PENA. REGULARIDADE. FIXAÇÃO DE VALOR MÍNIMO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. ART. 387, IV, DO CPP. MANUTENÇÃO DA SENTENÇA CONDENATÓRIA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação criminal interposta contra sentença que condenou a apelante pela prática dos crimes de calúnia e difamação (arts. 138 e 139 do Código Penal), com incidência das causas de aumento previstas no art. 141, incisos II e III e §2º, do mesmo diploma legal, em concurso formal (art. 70 do Código Penal), em razão da divulgação de vídeo em rede social no qual imputou a Desembargador do Tribunal de Justiça de Alagoas a prática de condutas criminosas relacionadas ao suposto acobertamento de homicídio e manipulação de processo judicial. A pena foi fixada em 03 anos, 07 meses e 27 dias de detenção, em regime inicial aberto, substituída por penas restritivas de direitos, além de 63 dias-multa e fixação de valor mínimo de R$ 7.545,00 a título de reparação por <em>danos</em> <em>morais</em>. A defesa pleiteia a absolvição por atipicidade da conduta e ausência de dolo específico, invocando a liberdade de expressão. Subsidiariamente, requer a revisão da dosimetria da pena, a exclusão ou redução do valor fixado a título de reparação civil e a concessão dos benefícios da justiça gratuita.
+2. Há três questões em discussão: (i) definir se as declarações divulgadas pela apelante em rede social configuram exercício legítimo da liberdade de expressão ou se caracterizam os crimes de calúnia e difamação; (ii) estabelecer se houve irregularidade ou desproporção na dosimetria da pena aplicada; e (iii) determinar se deve ser afastada ou reduzida a indenização por <em>danos</em> <em>morais</em> fixada na sentença, bem como se é cabível a concessão imediata da gratuidade da justiça.
+III. RAZÕES DE DECIDIR
+3. A materialidade e a autoria delitivas encontram-se comprovadas pelo conteúdo das manifestações divulgadas em rede social, nas quais a apelante imputou diretamente ao querelante a prática de crimes graves, sem qualquer suporte probatório mínimo.
+4. As declarações extrapolam os limites do direito de crítica ou de narrativa de fatos de interesse público, pois consistem em imputações categóricas de condutas criminosas dirigidas à vítima, o que caracteriza os delitos de calúnia e difamação.
+5. O dolo específico dos crimes contra a honra pode ser inferido das circunstâncias fáticas da conduta, especialmente do teor das afirmações, do contexto em que foram proferidas e da ampla divulgação em ambiente virtual.
+6. A liberdade de expressão não possui caráter absoluto e encontra limites na proteção à honra, à imagem e à dignidade das pessoas, não podendo ser invocada para justificar a imputação irresponsável de fatos criminosos a terceiros.
+7. A ampla divulgação das ofensas em plataformas digitais potencializa o alcance das imputações e intensifica a lesão à honra e à reputação da vítima, especialmente em razão de sua condição institucional de magistrado.
+8. A dosimetria da pena foi realizada de forma fundamentada e em consonância com os critérios previstos nos arts. 59 e 68 do Código Penal, inexistindo ilegalidade ou desproporção que justifique intervenção da instância revisora.
+9. A fixação de valor mínimo para reparação dos <em>danos</em> <em>morais</em> encontra amparo no art. 387, IV, do Código de Processo Penal, sendo compatível com a gravidade das imputações, a ampla divulgação das ofensas e a intensidade do <em>dano</em> causado à honra do ofendido.
+10. A análise acerca da eventual impossibilidade de pagamento das custas processuais pode ser realizada oportunamente na fase de execução, quando será possível aferir concretamente a condição econômica da condenada.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e não provido.
+Tese de julgamento: A imputação pública de fatos definidos como crime, sem suporte probatório mínimo, configura os delitos de calúnia e difamação, ainda que veiculada sob o argumento de exercício da liberdade de expressão. A liberdade de expressão não autoriza acusações criminosas infundadas que atinjam a honra e a reputação de terceiros. A divulgação de ofensas em redes sociais, com amplo alcance, evidencia o dolo específico e agrava a lesividade dos crimes contra a honra. É legítima a fixação de valor mínimo para reparação dos <em>danos</em> <em>morais</em> na sentença penal condenatória, nos termos do art. 387, IV, do Código de Processo Penal.
+_________
+Dispositivos relevantes citados: Código Penal, arts. 70, 138, 139 e 141; Código de Processo Penal, art. 387, IV; Constituição Federal, art. 5º, IV e IX.
+Jurisprudência relevante citada: TJAL, Apelação Criminal nº 0500872-21.2023.8.02.0001, rel. Des. Fábio Costa de Almeida Ferrario, j. 29.11.2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="813031" cdForo="0" >
+										0731106-12.2017.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="813031" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(813031);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_813031" style="display: none;" >
+	<div id="textAreaDados_813031" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. PETI&Ccedil;&Atilde;O INCIDENTAL. MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA. PRESCRI&Ccedil;&Atilde;O DA PRETENS&Atilde;O PUNITIVA RETROATIVA. R&Eacute;U MENOR DE 21 ANOS &Agrave; &Eacute;POCA DOS FATOS. REDU&Ccedil;&Atilde;O DO PRAZO PRESCRICIONAL. TRANSCURSO SUPERIOR AO PRAZO ENTRE MARCOS INTERRUPTIVOS. EXTIN&Ccedil;&Atilde;O DA PUNIBILIDADE. DECLARA&Ccedil;&Atilde;O.
+I. CASO EM EXAME
+Peti&ccedil;&atilde;o criminal apresentada pela defesa no curso de apela&ccedil;&atilde;o, na qual se suscita mat&eacute;ria de ordem p&uacute;blica consistente no reconhecimento da prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa, ap&oacute;s a redu&ccedil;&atilde;o da pena para 3 anos, 11 meses e 15 dias de reclus&atilde;o para os crimes de homic&iacute;dio tentado e roubo, totalizando 7 anos, 11 meses e 15 dias, alegando que o r&eacute;u era menor de 21 anos &agrave; &eacute;poca dos fatos e que transcorreu lapso superior ao prazo prescricional entre a decis&atilde;o de pron&uacute;ncia e a senten&ccedil;a.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em definir se ocorreu a prescri&ccedil;&atilde;o da pretens&atilde;o punitiva estatal, na modalidade retroativa, considerada a pena aplicada em concreto, a redu&ccedil;&atilde;o do prazo prescricional pela menoridade relativa e o lapso temporal entre os marcos interruptivos.
+III. RAZ&Otilde;ES DE DECIDIR
+A prescri&ccedil;&atilde;o, ap&oacute;s o tr&acirc;nsito em julgado para a acusa&ccedil;&atilde;o, regula-se pela pena aplicada em concreto, nos termos do art. 110, &sect; 1&ordm;, do C&oacute;digo Penal.
+Para penas superiores a 2 anos e n&atilde;o superiores a 4 anos, o prazo prescricional &eacute; de 8 anos, conforme o art. 109, IV, do C&oacute;digo Penal.
+O prazo prescricional deve ser reduzido pela metade quando o agente era menor de 21 anos &agrave; &eacute;poca dos fatos, nos termos do art. 115 do C&oacute;digo Penal.
+No caso, o r&eacute;u possu&iacute;a menos de 21 anos ao tempo do crime, reduzindo-se o prazo prescricional para 4 anos.
+Transcorreu lapso temporal superior a 4 anos entre a decis&atilde;o de pron&uacute;ncia e a senten&ccedil;a condenat&oacute;ria, sem causas interruptivas ou suspensivas aptas a afastar a prescri&ccedil;&atilde;o.
+A ocorr&ecirc;ncia da prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa imp&otilde;e o reconhecimento da extin&ccedil;&atilde;o da punibilidade, por se tratar de mat&eacute;ria de ordem p&uacute;blica cognosc&iacute;vel a qualquer tempo.
+IV. DISPOSITIVO E TESE
+Punibilidade extinta.
+Tese de julgamento: 1. A prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa regula-se pela pena aplicada em concreto ap&oacute;s o tr&acirc;nsito em julgado para a acusa&ccedil;&atilde;o. 2. O prazo prescricional &eacute; reduzido pela metade quando o agente era menor de 21 anos &agrave; &eacute;poca dos fatos. 3. O transcurso de prazo superior ao prescricional entre marcos interruptivos imp&otilde;e o reconhecimento da extin&ccedil;&atilde;o da punibilidade.
+Dispositivos relevantes citados: CP, arts. 109, IV; 110, &sect; 1&ordm;; 115.
+Jurisprud&ecirc;ncia relevante citada: TJAL, Apela&ccedil;&atilde;o Criminal n&ordm; 0708028-81.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 05.02.2025; TJAL, Apela&ccedil;&atilde;o Criminal n&ordm; 0720858-79.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 02.10.2024.  <br><br>(N&uacute;mero do Processo: 0731106-12.2017.8.02.0001; Relator (a):&nbsp;Des. Tutm&eacute;s Airan de Albuquerque Melo; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Tutmés Airan de Albuquerque Melo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. PETIÇÃO INCIDENTAL. MATÉRIA DE ORDEM PÚBLICA. PRESCRIÇÃO DA PRETENSÃO PUNITIVA RETROATIVA. RÉU MENOR DE 21 ANOS À ÉPOCA DOS FATOS. REDUÇÃO DO PRAZO PRESCRICIONAL. TRANSCURSO SUPERIOR AO PRAZO ENTRE MARCOS INTERRUPTIVOS. EXTINÇÃO DA PUNIBILIDADE. DECLARAÇÃO.
+I. CASO EM EXAME
+Petição criminal apresentada pela defesa no curso de apelação, na
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. PETIÇÃO INCIDENTAL. MATÉRIA DE ORDEM PÚBLICA. PRESCRIÇÃO DA PRETENSÃO PUNITIVA RETROATIVA. RÉU MENOR DE 21 ANOS À ÉPOCA DOS FATOS. REDUÇÃO DO PRAZO PRESCRICIONAL. TRANSCURSO SUPERIOR AO PRAZO ENTRE MARCOS INTERRUPTIVOS. EXTINÇÃO DA PUNIBILIDADE. DECLARAÇÃO.
+I. CASO EM EXAME
+Petição criminal apresentada pela defesa no curso de apelação, na qual se suscita matéria de ordem pública consistente no reconhecimento da prescrição da pretensão punitiva retroativa, após a redução da pena para 3 anos, 11 meses e 15 dias de reclusão para os crimes de homicídio tentado e roubo, totalizando 7 anos, 11 meses e 15 dias, alegando que o réu era menor de 21 anos à época dos fatos e que transcorreu lapso superior ao prazo prescricional entre a decisão de pronúncia e a sentença.
+II. QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em definir se ocorreu a prescrição da pretensão punitiva estatal, na modalidade retroativa, considerada a pena aplicada em concreto, a redução do prazo prescricional pela menoridade relativa e o lapso temporal entre os marcos interruptivos.
+III. RAZÕES DE DECIDIR
+A prescrição, após o trânsito em julgado para a acusação, regula-se pela pena aplicada em concreto, nos termos do art. 110, § 1º, do Código Penal.
+Para penas superiores a 2 anos e não superiores a 4 anos, o prazo prescricional é de 8 anos, conforme o art. 109, IV, do Código Penal.
+O prazo prescricional deve ser reduzido pela metade quando o agente era menor de 21 anos à época dos fatos, nos termos do art. 115 do Código Penal.
+No caso, o réu possuía menos de 21 anos ao tempo do crime, reduzindo-se o prazo prescricional para 4 anos.
+Transcorreu lapso temporal superior a 4 anos entre a decisão de pronúncia e a sentença condenatória, sem causas interruptivas ou suspensivas aptas a afastar a prescrição.
+A ocorrência da prescrição da pretensão punitiva retroativa impõe o reconhecimento da extinção da punibilidade, por se tratar de matéria de ordem pública cognoscível a qualquer tempo.
+IV. DISPOSITIVO E TESE
+Punibilidade extinta.
+Tese de julgamento: 1. A prescrição da pretensão punitiva retroativa regula-se pela pena aplicada em concreto após o trânsito em julgado para a acusação. 2. O prazo prescricional é reduzido pela metade quando o agente era menor de 21 anos à época dos fatos. 3. O transcurso de prazo superior ao prescricional entre marcos interruptivos impõe o reconhecimento da extinção da punibilidade.
+Dispositivos relevantes citados: CP, arts. 109, IV; 110, § 1º; 115.
+Jurisprudência relevante citada: TJAL, Apelação Criminal nº 0708028-81.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 05.02.2025; TJAL, Apelação Criminal nº 0720858-79.2020.8.02.0001, Rel. Juiz Conv. Alberto Jorge Correia de Barros Lima, j. 02.10.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812972" cdForo="0" >
+										0700457-96.2017.8.02.0055
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812972" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812972);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812972" style="display: none;" >
+	<div id="textAreaDados_812972" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. FURTO QUALIFICADO PELO CONCURSO DE AGENTES. SUBTRA&Ccedil;&Atilde;O DE SEMOVENTES EM PROPRIEDADE RURAL. PARTICIPA&Ccedil;&Atilde;O DE ADOLESCENTES. CORRUP&Ccedil;&Atilde;O DE MENORES. CRIME FORMAL. S&Uacute;MULA 500 DO STJ. CONCURSO FORMAL COM RESULTADOS AUT&Ocirc;NOMOS EM RELA&Ccedil;&Atilde;O A CADA MENOR. DOSIMETRIA DA PENA. VALORA&Ccedil;&Atilde;O NEGATIVA DA CULPABILIDADE E DAS CIRCUNST&Acirc;NCIAS DO CRIME. PR&Aacute;TICA NO PER&Iacute;ODO NOTURNO E SUBTRA&Ccedil;&Atilde;O DE ANIMAIS DOMESTIC&Aacute;VEIS DE PRODU&Ccedil;&Atilde;O. METODOLOGIA DO INTERVALO ENTRE PENAS M&Iacute;NIMA E M&Aacute;XIMA. PROPORCIONALIDADE. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta pela Defensoria P&uacute;blica do Estado de Alagoas contra senten&ccedil;a da 3&ordf; Vara Criminal da Comarca de Santana do Ipanema/AL que condenou o r&eacute;u pela pr&aacute;tica do crime de furto qualificado pelo concurso de agentes (art. 155, &sect;4&ordm;, IV, do CP) e corrup&ccedil;&atilde;o de menores (art. 244-B do ECA, por tr&ecirc;s vezes), em concurso formal, &agrave; pena de 4 anos, 4 meses e 15 dias de reclus&atilde;o e 97 dias-multa. Os fatos ocorreram em 28/05/2017, quando o apelante, em companhia de tr&ecirc;s adolescentes, subtraiu quatro ovelhas de propriedade rural da v&iacute;tima. A defesa pleiteia absolvi&ccedil;&atilde;o por insufici&ecirc;ncia probat&oacute;ria, absolvi&ccedil;&atilde;o quanto ao delito de corrup&ccedil;&atilde;o de menores por exigir prova da efetiva corrup&ccedil;&atilde;o, e, subsidiariamente, a revis&atilde;o da dosimetria da pena.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se o conjunto probat&oacute;rio &eacute; suficiente para comprovar a autoria do furto qualificado imputado ao r&eacute;u; (ii) estabelecer se o crime de corrup&ccedil;&atilde;o de menores previsto no art. 244-B do ECA exige prova da efetiva corrup&ccedil;&atilde;o do adolescente; (iii) determinar se houve ilegalidade na valora&ccedil;&atilde;o das circunst&acirc;ncias judiciais e no crit&eacute;rio adotado para a fixa&ccedil;&atilde;o da pena-base.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O conjunto probat&oacute;rio &eacute; consistente e suficiente para comprovar a autoria do furto qualificado, pois depoimentos de adolescentes participantes do fato, colhidos sob contradit&oacute;rio, confirmam a participa&ccedil;&atilde;o ativa do r&eacute;u na subtra&ccedil;&atilde;o das ovelhas, sendo corroborados por prova material consistente na apreens&atilde;o e restitui&ccedil;&atilde;o dos animais.
+4. A aus&ecirc;ncia de oitiva da v&iacute;tima em ju&iacute;zo n&atilde;o gera d&uacute;vida probat&oacute;ria apta a ensejar absolvi&ccedil;&atilde;o quando a pr&oacute;pria defesa anuiu expressamente &agrave; sua dispensa na audi&ecirc;ncia de instru&ccedil;&atilde;o, n&atilde;o podendo posteriormente invocar tal circunst&acirc;ncia como fundamento recursal.
+5. O crime de corrup&ccedil;&atilde;o de menores previsto no art. 244-B do ECA possui natureza formal, consumando-se com a pr&aacute;tica da infra&ccedil;&atilde;o penal em companhia de adolescente, independentemente de prova da efetiva corrup&ccedil;&atilde;o do menor, conforme entendimento consolidado na S&uacute;mula 500 do STJ.
+6. A participa&ccedil;&atilde;o do r&eacute;u em infra&ccedil;&atilde;o penal juntamente com tr&ecirc;s adolescentes caracteriza tr&ecirc;s crimes aut&ocirc;nomos de corrup&ccedil;&atilde;o de menores, admitindo-se o reconhecimento de concurso formal quando uma &uacute;nica a&ccedil;&atilde;o do agente adulto produz resultados independentes em rela&ccedil;&atilde;o a cada menor.
+7. A valora&ccedil;&atilde;o negativa da culpabilidade &eacute; leg&iacute;tima quando fundamentada na pr&aacute;tica do crime durante o per&iacute;odo noturno, circunst&acirc;ncia que demonstra maior intensidade do dolo e aproveitamento do repouso das v&iacute;timas para facilitar a empreitada criminosa.
+8. A valora&ccedil;&atilde;o negativa das circunst&acirc;ncias do crime &eacute; v&aacute;lida quando fundamentada na subtra&ccedil;&atilde;o de animais semoventes domestic&aacute;veis de produ&ccedil;&atilde;o, situa&ccedil;&atilde;o que revela maior gravidade concreta da conduta, sem configurar bis in idem quando a qualificadora aplicada &eacute; o concurso de agentes.
+9. A fixa&ccedil;&atilde;o da pena-base mediante aplica&ccedil;&atilde;o da fra&ccedil;&atilde;o de 1/8 para cada circunst&acirc;ncia judicial negativa sobre o intervalo entre as penas m&iacute;nima e m&aacute;xima do tipo penal constitui metodologia admitida pela jurisprud&ecirc;ncia do STJ e revela-se proporcional &agrave; gravidade concreta do fato.
+10. A aplica&ccedil;&atilde;o do concurso formal entre o furto qualificado e os tr&ecirc;s crimes de corrup&ccedil;&atilde;o de menores, com aumento de 1/4 sobre a pena mais grave, observa os par&acirc;metros do art. 70 do C&oacute;digo Penal e encontra respaldo na jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento:
+1. O crime de corrup&ccedil;&atilde;o de menores previsto no art. 244-B do ECA possui natureza formal e se consuma com a pr&aacute;tica de infra&ccedil;&atilde;o penal em companhia de adolescente, sendo desnecess&aacute;ria a prova da efetiva corrup&ccedil;&atilde;o do menor.
+2. A participa&ccedil;&atilde;o de agente adulto em infra&ccedil;&atilde;o penal praticada com m&uacute;ltiplos adolescentes configura crimes aut&ocirc;nomos de corrup&ccedil;&atilde;o de menores, admitindo-se concurso formal quando uma &uacute;nica conduta produz resultados independentes em rela&ccedil;&atilde;o a cada menor.
+3. A pr&aacute;tica do crime no per&iacute;odo noturno e a subtra&ccedil;&atilde;o de animais semoventes domestic&aacute;veis de produ&ccedil;&atilde;o podem justificar a valora&ccedil;&atilde;o negativa das circunst&acirc;ncias judiciais da culpabilidade e das circunst&acirc;ncias do crime, desde que n&atilde;o coincidam com qualificadoras aplicadas.
+4. A fixa&ccedil;&atilde;o da pena-base com utiliza&ccedil;&atilde;o do crit&eacute;rio do intervalo entre as penas m&iacute;nima e m&aacute;xima do tipo penal, mediante fra&ccedil;&atilde;o proporcional &agrave;s circunst&acirc;ncias judiciais desfavor&aacute;veis, &eacute; metodologia leg&iacute;tima no sistema de individualiza&ccedil;&atilde;o da pena.
+Dispositivos relevantes citados: CP, arts. 33, &sect;2&ordm;, &quot;b&quot; e &quot;c&quot;, 59, 70 e 155, &sect;4&ordm;, IV; ECA, art. 244-B; CPP, art. 593, I; LEP, art. 112, I; LC 80/1990, art. 128, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula 500; STJ, REsp 1.680.114/GO, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, j. 10.10.2017, DJe 16.10.2017; STJ, REsp 1.719.489/GO, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, j. 23.08.2018, DJe 04.09.2018; STJ, REsp 1.890.981/SP, Rel. Min. Jo&atilde;o Ot&aacute;vio de Noronha, Terceira Se&ccedil;&atilde;o, Tema 1087, j. 25.05.2022; STJ, AgRg no AREsp 1.799.289/DF.  <br><br>(N&uacute;mero do Processo: 0700457-96.2017.8.02.0055; Relator (a):&nbsp;Des. Tutm&eacute;s Airan de Albuquerque Melo; Comarca:&nbsp;Foro de Santana do Ipanema; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Roubo qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Tutmés Airan de Albuquerque Melo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Santana do Ipanema
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO PELO CONCURSO DE AGENTES. SUBTRAÇÃO DE SEMOVENTES EM PROPRIEDADE RURAL. PARTICIPAÇÃO DE ADOLESCENTES. CORRUPÇÃO DE MENORES. CRIME FORMAL. SÚMULA 500 DO STJ. CONCURSO FORMAL COM RESULTADOS AUTÔNOMOS EM RELAÇÃO A CADA MENOR. DOSIMETRIA DA PENA. VALORAÇÃO NEGATIVA DA CULPABILIDADE E DAS CIRCUNSTÂNCIAS DO CRIME. PRÁTICA NO PERÍODO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO PELO CONCURSO DE AGENTES. SUBTRAÇÃO DE SEMOVENTES EM PROPRIEDADE RURAL. PARTICIPAÇÃO DE ADOLESCENTES. CORRUPÇÃO DE MENORES. CRIME FORMAL. SÚMULA 500 DO STJ. CONCURSO FORMAL COM RESULTADOS AUTÔNOMOS EM RELAÇÃO A CADA MENOR. DOSIMETRIA DA PENA. VALORAÇÃO NEGATIVA DA CULPABILIDADE E DAS CIRCUNSTÂNCIAS DO CRIME. PRÁTICA NO PERÍODO NOTURNO E SUBTRAÇÃO DE ANIMAIS DOMESTICÁVEIS DE PRODUÇÃO. METODOLOGIA DO INTERVALO ENTRE PENAS MÍNIMA E MÁXIMA. PROPORCIONALIDADE. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta pela Defensoria Pública do Estado de Alagoas contra sentença da 3ª Vara Criminal da Comarca de Santana do Ipanema/AL que condenou o réu pela prática do crime de furto qualificado pelo concurso de agentes (art. 155, §4º, IV, do CP) e corrupção de menores (art. 244-B do ECA, por três vezes), em concurso formal, à pena de 4 anos, 4 meses e 15 dias de reclusão e 97 dias-multa. Os fatos ocorreram em 28/05/2017, quando o apelante, em companhia de três adolescentes, subtraiu quatro ovelhas de propriedade rural da vítima. A defesa pleiteia absolvição por insuficiência probatória, absolvição quanto ao delito de corrupção de menores por exigir prova da efetiva corrupção, e, subsidiariamente, a revisão da dosimetria da pena.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se o conjunto probatório é suficiente para comprovar a autoria do furto qualificado imputado ao réu; (ii) estabelecer se o crime de corrupção de menores previsto no art. 244-B do ECA exige prova da efetiva corrupção do adolescente; (iii) determinar se houve ilegalidade na valoração das circunstâncias judiciais e no critério adotado para a fixação da pena-base.
+III. RAZÕES DE DECIDIR
+3. O conjunto probatório é consistente e suficiente para comprovar a autoria do furto qualificado, pois depoimentos de adolescentes participantes do fato, colhidos sob contraditório, confirmam a participação ativa do réu na subtração das ovelhas, sendo corroborados por prova material consistente na apreensão e restituição dos animais.
+4. A ausência de oitiva da vítima em juízo não gera dúvida probatória apta a ensejar absolvição quando a própria defesa anuiu expressamente à sua dispensa na audiência de instrução, não podendo posteriormente invocar tal circunstância como fundamento recursal.
+5. O crime de corrupção de menores previsto no art. 244-B do ECA possui natureza formal, consumando-se com a prática da infração penal em companhia de adolescente, independentemente de prova da efetiva corrupção do menor, conforme entendimento consolidado na Súmula 500 do STJ.
+6. A participação do réu em infração penal juntamente com três adolescentes caracteriza três crimes autônomos de corrupção de menores, admitindo-se o reconhecimento de concurso formal quando uma única ação do agente adulto produz resultados independentes em relação a cada menor.
+7. A valoração negativa da culpabilidade é legítima quando fundamentada na prática do crime durante o período noturno, circunstância que demonstra maior intensidade do dolo e aproveitamento do repouso das vítimas para facilitar a empreitada criminosa.
+8. A valoração negativa das circunstâncias do crime é válida quando fundamentada na subtração de animais semoventes domesticáveis de produção, situação que revela maior gravidade concreta da conduta, sem configurar bis in idem quando a qualificadora aplicada é o concurso de agentes.
+9. A fixação da pena-base mediante aplicação da fração de 1/8 para cada circunstância judicial negativa sobre o intervalo entre as penas mínima e máxima do tipo penal constitui metodologia admitida pela jurisprudência do STJ e revela-se proporcional à gravidade concreta do fato.
+10. A aplicação do concurso formal entre o furto qualificado e os três crimes de corrupção de menores, com aumento de 1/4 sobre a pena mais grave, observa os parâmetros do art. 70 do Código Penal e encontra respaldo na jurisprudência do Superior Tribunal de Justiça.
+IV. DISPOSITIVO E TESE
+11. Recurso desprovido.
+Tese de julgamento:
+1. O crime de corrupção de menores previsto no art. 244-B do ECA possui natureza formal e se consuma com a prática de infração penal em companhia de adolescente, sendo desnecessária a prova da efetiva corrupção do menor.
+2. A participação de agente adulto em infração penal praticada com múltiplos adolescentes configura crimes autônomos de corrupção de menores, admitindo-se concurso formal quando uma única conduta produz resultados independentes em relação a cada menor.
+3. A prática do crime no período noturno e a subtração de animais semoventes domesticáveis de produção podem justificar a valoração negativa das circunstâncias judiciais da culpabilidade e das circunstâncias do crime, desde que não coincidam com qualificadoras aplicadas.
+4. A fixação da pena-base com utilização do critério do intervalo entre as penas mínima e máxima do tipo penal, mediante fração proporcional às circunstâncias judiciais desfavoráveis, é metodologia legítima no sistema de individualização da pena.
+Dispositivos relevantes citados: CP, arts. 33, §2º, "b" e "c", 59, 70 e 155, §4º, IV; ECA, art. 244-B; CPP, art. 593, I; LEP, art. 112, I; LC 80/1990, art. 128, I.
+Jurisprudência relevante citada: STJ, Súmula 500; STJ, REsp 1.680.114/GO, Rel. Min. Sebastião Reis Júnior, Sexta Turma, j. 10.10.2017, DJe 16.10.2017; STJ, REsp 1.719.489/GO, Rel. Min. Sebastião Reis Júnior, Sexta Turma, j. 23.08.2018, DJe 04.09.2018; STJ, REsp 1.890.981/SP, Rel. Min. João Otávio de Noronha, Terceira Seção, Tema 1087, j. 25.05.2022; STJ, AgRg no AREsp 1.799.289/DF.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812477" cdForo="0" >
+										0500036-12.2026.8.02.9000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812477" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812477);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812477" style="display: none;" >
+	<div id="textAreaDados_812477" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL PENAL. CONFLITO NEGATIVO DE COMPET&Ecirc;NCIA. VIOL&Ecirc;NCIA DOM&Eacute;STICA E FAMILIAR CONTRA A MULHER. AMEA&Ccedil;A DE FILHA CONTRA M&Atilde;E. INCID&Ecirc;NCIA DA LEI MARIA DA PENHA. INAPLICABILIDADE DA LEI DOS JUIZADOS ESPECIAIS CRIMINAIS. COMPET&Ecirc;NCIA DO JUIZADO DE VIOL&Ecirc;NCIA DOM&Eacute;STICA.
+I. CASO EM EXAME
+Conflito de jurisdi&ccedil;&atilde;o suscitado pelo Juizado Especial Criminal e do Torcedor da Capital em face do Ju&iacute;zo da 6&ordf; Vara Criminal da Capital, visando definir a compet&ecirc;ncia para processar e julgar a&ccedil;&atilde;o penal decorrente de amea&ccedil;a proferida por filha contra sua genitora no &acirc;mbito dom&eacute;stico e familiar, tendo ambos os ju&iacute;zos declinado da compet&ecirc;ncia, enquanto o Juizado de Viol&ecirc;ncia Dom&eacute;stica afastou sua atua&ccedil;&atilde;o por aus&ecirc;ncia de quest&atilde;o de g&ecirc;nero.
+H&aacute; 2 quest&otilde;es em discuss&atilde;o: (i) definir se a amea&ccedil;a praticada por filha contra m&atilde;e, no contexto dom&eacute;stico, atrai a incid&ecirc;ncia da Lei n&ordm; 11.340/2006; (ii) estabelecer se, nessa hip&oacute;tese, &eacute; competente o Juizado de Viol&ecirc;ncia Dom&eacute;stica e Familiar contra a Mulher ou o Juizado Especial Criminal.
+A conduta de amea&ccedil;a praticada no &acirc;mbito da unidade familiar configura viol&ecirc;ncia dom&eacute;stica e familiar contra a mulher, nos termos do art. 5&ordm;, II, da Lei n&ordm; 11.340/2006, ao envolver agress&atilde;o psicol&oacute;gica contra a v&iacute;tima.
+A incid&ecirc;ncia da Lei Maria da Penha n&atilde;o exige demonstra&ccedil;&atilde;o de motiva&ccedil;&atilde;o de g&ecirc;nero espec&iacute;fica, bastando que a viol&ecirc;ncia ocorra em contexto dom&eacute;stico ou familiar, no qual a vulnerabilidade da mulher &eacute; juridicamente presumida.
+O art. 40-A da Lei n&ordm; 11.340/2006 amplia a prote&ccedil;&atilde;o legal ao estabelecer sua aplica&ccedil;&atilde;o independentemente da condi&ccedil;&atilde;o do ofensor, desde que presente o contexto de viol&ecirc;ncia dom&eacute;stica.
+A jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a admite a aplica&ccedil;&atilde;o da Lei Maria da Penha mesmo quando a agressora &eacute; mulher, desde que caracterizada a viol&ecirc;ncia dom&eacute;stica (HC 277.561/AL).
+O art. 41 da Lei n&ordm; 11.340/2006 afasta a incid&ecirc;ncia dos institutos despenalizadores da Lei n&ordm; 9.099/1995, excluindo a compet&ecirc;ncia do Juizado Especial Criminal.
+A tramita&ccedil;&atilde;o do feito fora da vara especializada compromete a finalidade protetiva da Lei Maria da Penha, voltada &agrave; repress&atilde;o e preven&ccedil;&atilde;o da viol&ecirc;ncia no ambiente dom&eacute;stico.
+Conflito procedente.
+Jurisprud&ecirc;ncia relevante citada: STJ, HC 277.561/AL, Rel. Min. Jorge Mussi, 5&ordf; Turma, j. 06.11.2014.  <br><br>(N&uacute;mero do Processo: 0500036-12.2026.8.02.9000; Relator (a):&nbsp;Des. Jo&atilde;o Luiz Azevedo Lessa; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Conflito de Jurisdição / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. João Luiz Azevedo Lessa
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. CONFLITO NEGATIVO DE COMPETÊNCIA. VIOLÊNCIA DOMÉSTICA E FAMILIAR CONTRA A MULHER. AMEAÇA DE FILHA CONTRA MÃE. INCIDÊNCIA DA LEI MARIA DA PENHA. INAPLICABILIDADE DA LEI DOS JUIZADOS ESPECIAIS CRIMINAIS. COMPETÊNCIA DO JUIZADO DE VIOLÊNCIA DOMÉSTICA.
+I. CASO EM EXAME
+Conflito de jurisdição suscitado pelo Juizado Especial Criminal e do Torcedor da Capital em face do Juízo
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. CONFLITO NEGATIVO DE COMPETÊNCIA. VIOLÊNCIA DOMÉSTICA E FAMILIAR CONTRA A MULHER. AMEAÇA DE FILHA CONTRA MÃE. INCIDÊNCIA DA LEI MARIA DA PENHA. INAPLICABILIDADE DA LEI DOS JUIZADOS ESPECIAIS CRIMINAIS. COMPETÊNCIA DO JUIZADO DE VIOLÊNCIA DOMÉSTICA.
+I. CASO EM EXAME
+Conflito de jurisdição suscitado pelo Juizado Especial Criminal e do Torcedor da Capital em face do Juízo da 6ª Vara Criminal da Capital, visando definir a competência para processar e julgar ação penal decorrente de ameaça proferida por filha contra sua genitora no âmbito doméstico e familiar, tendo ambos os juízos declinado da competência, enquanto o Juizado de Violência Doméstica afastou sua atuação por ausência de questão de gênero.
+Há 2 questões em discussão: (i) definir se a ameaça praticada por filha contra mãe, no contexto doméstico, atrai a incidência da Lei nº 11.340/2006; (ii) estabelecer se, nessa hipótese, é competente o Juizado de Violência Doméstica e Familiar contra a Mulher ou o Juizado Especial Criminal.
+A conduta de ameaça praticada no âmbito da unidade familiar configura violência doméstica e familiar contra a mulher, nos termos do art. 5º, II, da Lei nº 11.340/2006, ao envolver agressão psicológica contra a vítima.
+A incidência da Lei Maria da Penha não exige demonstração de motivação de gênero específica, bastando que a violência ocorra em contexto doméstico ou familiar, no qual a vulnerabilidade da mulher é juridicamente presumida.
+O art. 40-A da Lei nº 11.340/2006 amplia a proteção legal ao estabelecer sua aplicação independentemente da condição do ofensor, desde que presente o contexto de violência doméstica.
+A jurisprudência do Superior Tribunal de Justiça admite a aplicação da Lei Maria da Penha mesmo quando a agressora é mulher, desde que caracterizada a violência doméstica (HC 277.561/AL).
+O art. 41 da Lei nº 11.340/2006 afasta a incidência dos institutos despenalizadores da Lei nº 9.099/1995, excluindo a competência do Juizado Especial Criminal.
+A tramitação do feito fora da vara especializada compromete a finalidade protetiva da Lei Maria da Penha, voltada à repressão e prevenção da violência no ambiente doméstico.
+Conflito procedente.
+Jurisprudência relevante citada: STJ, HC 277.561/AL, Rel. Min. Jorge Mussi, 5ª Turma, j. 06.11.2014.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812660" cdForo="0" >
+										0000015-95.2025.8.02.0022
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812660" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812660);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812660" style="display: none;" >
+	<div id="textAreaDados_812660" class="mensagemSemFormatacao" >
+		Direito penal. Apela&ccedil;&atilde;o criminal. Vias de fato e amea&ccedil;a em contexto de viol&ecirc;ncia dom&eacute;stica. Senten&ccedil;a condenat&oacute;ria. Recurso conhecido e parcialmente provido.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o criminal de senten&ccedil;a que condenou o r&eacute;u pelas infra&ccedil;&otilde;es penais de vias de fato e amea&ccedil;a, em contexto de viol&ecirc;ncia dom&eacute;stica, fixando-lhe pena de 3 (tr&ecirc;s) meses de deten&ccedil;&atilde;o, em regime inicial aberto, e 3 (tr&ecirc;s) meses de pris&atilde;o simples.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se o conjunto probat&oacute;rio autoriza a manuten&ccedil;&atilde;o da condena&ccedil;&atilde;o pelo crime de amea&ccedil;a; (ii) estabelecer se &eacute; id&ocirc;nea a fundamenta&ccedil;&atilde;o para a negativa&ccedil;&atilde;o da culpabilidade e das circunst&acirc;ncias do delito na dosimetria da contraven&ccedil;&atilde;o de vias de fato; (iii) determinar se deve incidir a atenuante da confiss&atilde;o espont&acirc;nea; (iv) verificar se a majorante prevista no art. 21, &sect;2&ordm;, da Lei de Contraven&ccedil;&otilde;es Penais foi corretamente aplicada.
+III. Raz&otilde;es de decidir
+3. O crime de amea&ccedil;a &eacute; formal e consuma-se com a idoneidade intimidativa da conduta, sendo irrelevante a efetiva concretiza&ccedil;&atilde;o do mal anunciado ou a dura&ccedil;&atilde;o do temor experimentado pela v&iacute;tima. A amea&ccedil;a pode ser praticada por palavras, de forma direta ou indireta, ainda que condicional, sendo suficiente que a conduta seja apta a intimidar o sujeito passivo.
+4. O relato da v&iacute;tima, quando corroborado pelos demais elementos de prova constante nos autos, possui relev&acirc;ncia destacada para fins probat&oacute;rios, sendo suficiente, inclusive, para sustentar o &eacute;dito condenat&oacute;rio, na linha da jurisprud&ecirc;ncia do STJ.
+5. No caso, a palavra da ofendida mostrou-se harm&ocirc;nica e consistente desde a fase inquisitorial at&eacute; a instru&ccedil;&atilde;o judicial, encontrando respaldo na prova oral colhida,no sentido de que seu ex-companheiro a amea&ccedil;ou de morte, afirmando que &quot;daquele dia ela n&atilde;o passaria&quot; e que ele iria mat&aacute;-la. O conjunto probat&oacute;rio &eacute; suficiente para a manuten&ccedil;&atilde;o da condena&ccedil;&atilde;o.
+6. O fato de as amea&ccedil;as terem ocorrido em contexto de discuss&atilde;o ou exalta&ccedil;&atilde;o de &acirc;nimos n&atilde;o afasta a tipicidade do crime de amea&ccedil;a, conforme jurisprud&ecirc;ncia do STJ.
+7. A pr&aacute;tica da infra&ccedil;&atilde;o na presen&ccedil;a dos filhos do casal evidencia maior reprovabilidade da conduta, justificando a negativa&ccedil;&atilde;o da culpabilidade.
+8. A confiss&atilde;o do r&eacute;u, ainda que acompanhada de alega&ccedil;&atilde;o de leg&iacute;tima defesa, configura confiss&atilde;o qualificada e autoriza a incid&ecirc;ncia da atenuante prevista no art. 65, III, &quot;d&quot;, do CP, por&eacute;m em patamar inferior, conforme  Tema Repetitivo 1.194 do STJ.
+9. A causa de aumento prevista no art. 21, &sect;2&ordm;, da Lei de Contraven&ccedil;&otilde;es Penais determina a aplica&ccedil;&atilde;o da pena em triplo quando a infra&ccedil;&atilde;o &eacute; praticada contra a mulher por raz&otilde;es da condi&ccedil;&atilde;o do sexo feminino, inexistindo o erro material alegado.
+IV. Dispositivo
+10. Recurso conhecido e parcialmente provido.
+_________
+Dispositivos relevantes citados: CP, arts. 59 e 65, III, &quot;d&quot;; Lei n&ordm; 3.688/41, art. 21, &sect;2&ordm;; Lei n&ordm; 14.994/2024.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no AREsp n&ordm; 2.974.992/DF, Rel. Min. Joel Ilan Paciornik, Quinta Turma, j. 17.12.2025; STJ, AgRg no RHC n&ordm; 162.389/DF, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, j. 13.9.2022; STJ, AgRg no AREsp n&ordm; 2.650.606/RR, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 5.11.2024; STJ, AgRg no AREsp n&ordm; 2.916.517/AL, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, j. 17.6.2025; STJ, Tema Repetitivo 1.194; STJ, AgRg no AREsp n. 1.964.508/MS, Rel. Ministro Ribeiro Dantas, Quinta Turma, j. 29/3/2022; STJ, AgRg no AREsp n. 2.595.604/SC, Rel. Ministro Messod Azulay Neto, Quinta Turma, j. 2/9/2025  <br><br>(N&uacute;mero do Processo: 0000015-95.2025.8.02.0022; Relator (a):&nbsp;Des. Ivan Vasconcelos Brito J&uacute;nior; Comarca:&nbsp;Foro de Mata Grande; &Oacute;rg&atilde;o julgador: C&acirc;mara Criminal; Data do julgamento: 15/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Ivan Vasconcelos Brito Júnior
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mata Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito penal. Apelação criminal. Vias de fato e ameaça em contexto de violência doméstica. Sentença condenatória. Recurso conhecido e parcialmente provido.
+I. Caso em exame
+1. Apelação criminal de sentença que condenou o réu pelas infrações penais de vias de fato e ameaça, em contexto de violência doméstica, fixando-lhe pena de 3 (três) meses de detenção, em regime inicial aberto, e 3 (três)
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito penal. Apelação criminal. Vias de fato e ameaça em contexto de violência doméstica. Sentença condenatória. Recurso conhecido e parcialmente provido.
+I. Caso em exame
+1. Apelação criminal de sentença que condenou o réu pelas infrações penais de vias de fato e ameaça, em contexto de violência doméstica, fixando-lhe pena de 3 (três) meses de detenção, em regime inicial aberto, e 3 (três) meses de prisão simples.
+II. Questão em discussão
+2. Há quatro questões em discussão: (i) definir se o conjunto probatório autoriza a manutenção da condenação pelo crime de ameaça; (ii) estabelecer se é idônea a fundamentação para a negativação da culpabilidade e das circunstâncias do delito na dosimetria da contravenção de vias de fato; (iii) determinar se deve incidir a atenuante da confissão espontânea; (iv) verificar se a majorante prevista no art. 21, §2º, da Lei de Contravenções Penais foi corretamente aplicada.
+III. Razões de decidir
+3. O crime de ameaça é formal e consuma-se com a idoneidade intimidativa da conduta, sendo irrelevante a efetiva concretização do mal anunciado ou a duração do temor experimentado pela vítima. A ameaça pode ser praticada por palavras, de forma direta ou indireta, ainda que condicional, sendo suficiente que a conduta seja apta a intimidar o sujeito passivo.
+4. O relato da vítima, quando corroborado pelos demais elementos de prova constante nos autos, possui relevância destacada para fins probatórios, sendo suficiente, inclusive, para sustentar o édito condenatório, na linha da jurisprudência do STJ.
+5. No caso, a palavra da ofendida mostrou-se harmônica e consistente desde a fase inquisitorial até a instrução judicial, encontrando respaldo na prova oral colhida,no sentido de que seu ex-companheiro a ameaçou de morte, afirmando que "daquele dia ela não passaria" e que ele iria matá-la. O conjunto probatório é suficiente para a manutenção da condenação.
+6. O fato de as ameaças terem ocorrido em contexto de discussão ou exaltação de ânimos não afasta a tipicidade do crime de ameaça, conforme jurisprudência do STJ.
+7. A prática da infração na presença dos filhos do casal evidencia maior reprovabilidade da conduta, justificando a negativação da culpabilidade.
+8. A confissão do réu, ainda que acompanhada de alegação de legítima defesa, configura confissão qualificada e autoriza a incidência da atenuante prevista no art. 65, III, "d", do CP, porém em patamar inferior, conforme  Tema Repetitivo 1.194 do STJ.
+9. A causa de aumento prevista no art. 21, §2º, da Lei de Contravenções Penais determina a aplicação da pena em triplo quando a infração é praticada contra a mulher por razões da condição do sexo feminino, inexistindo o erro material alegado.
+IV. Dispositivo
+10. Recurso conhecido e parcialmente provido.
+_________
+Dispositivos relevantes citados: CP, arts. 59 e 65, III, "d"; Lei nº 3.688/41, art. 21, §2º; Lei nº 14.994/2024.
+Jurisprudência relevante citada: STJ, AgRg no AREsp nº 2.974.992/DF, Rel. Min. Joel Ilan Paciornik, Quinta Turma, j. 17.12.2025; STJ, AgRg no RHC nº 162.389/DF, Rel. Min. Sebastião Reis Júnior, Sexta Turma, j. 13.9.2022; STJ, AgRg no AREsp nº 2.650.606/RR, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 5.11.2024; STJ, AgRg no AREsp nº 2.916.517/AL, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, j. 17.6.2025; STJ, Tema Repetitivo 1.194; STJ, AgRg no AREsp n. 1.964.508/MS, Rel. Ministro Ribeiro Dantas, Quinta Turma, j. 29/3/2022; STJ, AgRg no AREsp n. 2.595.604/SC, Rel. Ministro Messod Azulay Neto, Quinta Turma, j. 2/9/2025
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812588" cdForo="0" >
+										0809933-59.2025.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812588" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812588);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812588" style="display: none;" >
+	<div id="textAreaDados_812588" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL E PROCESSUAL CIVIL. MANDADO DE SEGURAN&Ccedil;A. MULTA POR LITIG&Acirc;NCIA DE M&Aacute;-F&Eacute; IMPOSTA AO ADVOGADO. IMPOSSIBILIDADE. NECESSIDADE DE APURA&Ccedil;&Atilde;O EM A&Ccedil;&Atilde;O PR&Oacute;PRIA. AUS&Ecirc;NCIA DE DOLO. MERO ERRO MATERIAL CORRIGIDO. VIOLA&Ccedil;&Atilde;O AO CONTRADIT&Oacute;RIO E &Agrave; AMPLA DEFESA. SEGURAN&Ccedil;A CONCEDIDA.
+I. CASO EM EXAME
+1. O recurso
+Mandado de seguran&ccedil;a impetrado contra ato judicial que aplicou multa por litig&acirc;ncia de m&aacute;-f&eacute; diretamente ao advogado subscritor da peti&ccedil;&atilde;o, no percentual de 1% sobre o valor da causa.
+2. O fato relevante
+A multa foi aplicada em raz&atilde;o de equ&iacute;voco material na cita&ccedil;&atilde;o de dispositivo legal (art. 115 do CPC), posteriormente reconhecido e corrigido espontaneamente pelo advogado, sem preju&iacute;zo ao andamento processual e sem demonstra&ccedil;&atilde;o de dolo.
+3. A decis&atilde;o recorrida
+Decis&atilde;o que condenou o advogado por litig&acirc;ncia de m&aacute;-f&eacute;, nos pr&oacute;prios autos, com fundamento nos arts. 80 e 81 do CPC. Em sede inicial do mandado de seguran&ccedil;a, reconheceu-se a ilegitimidade de litisconsortes e deferiu-se liminar para suspender a exigibilidade da multa.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+Saber se &eacute; legal a imposi&ccedil;&atilde;o direta de multa por litig&acirc;ncia de m&aacute;-f&eacute; ao advogado, nos autos da causa origin&aacute;ria, sem pr&eacute;via instaura&ccedil;&atilde;o de procedimento pr&oacute;prio e sem comprova&ccedil;&atilde;o de dolo ou abuso.
+III. RAZ&Otilde;ES DE DECIDIR
+As penalidades por litig&acirc;ncia de m&aacute;-f&eacute; previstas nos arts. 79 e 80 do CPC s&atilde;o destinadas &agrave;s partes, n&atilde;o se estendendo ao advogado, cuja eventual responsabiliza&ccedil;&atilde;o deve ocorrer em a&ccedil;&atilde;o pr&oacute;pria, nos termos do art. 32 da Lei n&ordm; 8.906/1994.
+A jurisprud&ecirc;ncia consolidada do STJ admite, de forma excepcional, o mandado de seguran&ccedil;a contra ato judicial manifestamente ilegal, como na hip&oacute;tese de imposi&ccedil;&atilde;o de multa diretamente ao advogado.
+No caso concreto, o erro na indica&ccedil;&atilde;o do dispositivo legal foi meramente material, corrigido de forma espont&acirc;nea e sem causar preju&iacute;zo ao processo, inexistindo demonstra&ccedil;&atilde;o do elemento subjetivo indispens&aacute;vel &agrave; caracteriza&ccedil;&atilde;o da litig&acirc;ncia de m&aacute;-f&eacute;.
+IV. DISPOSITIVO
+Concede-se a seguran&ccedil;a para afastar a multa por litig&acirc;ncia de m&aacute;-f&eacute; imposta ao advogado impetrante.
+Atos normativos citados:
+CF/1988, art. 5&ordm;, LXIX;
+Lei n&ordm; 12.016/2009, arts. 1&ordm;, 23 e 25;
+CPC, arts. 79, 80 e 81;
+Lei n&ordm; 8.906/1994 (Estatuto da Advocacia), art. 32.
+Jurisprud&ecirc;ncia citada:
+STJ, AgInt no AREsp 1.722.332/MT, Quarta Turma, j. 13/06/2022;
+STJ, RMS 59.322/MG, Quarta Turma, j. 05/02/2019;
+STJ, RMS 71.836/MT, Quarta Turma, j. 26/09/2023;
+TJ/AL, Mandado de Seguran&ccedil;a n&ordm; 0803211-19.2019.8.02.0000, Se&ccedil;&atilde;o Especializada C&iacute;vel, j. 13/03/2020.  <br><br>(N&uacute;mero do Processo: 0809933-59.2025.8.02.0000; Relator (a):&nbsp;Des. Klever R&ecirc;go Loureiro; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: Se&ccedil;&atilde;o Especializada C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Mandado de Segurança Cível / Litisconsórcio
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Klever Rêgo Loureiro
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Especializada Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E PROCESSUAL CIVIL. MANDADO DE SEGURANÇA. MULTA POR LITIGÂNCIA DE MÁ-FÉ IMPOSTA AO ADVOGADO. IMPOSSIBILIDADE. NECESSIDADE DE APURAÇÃO EM AÇÃO PRÓPRIA. AUSÊNCIA DE DOLO. MERO ERRO MATERIAL CORRIGIDO. VIOLAÇÃO AO CONTRADITÓRIO E À AMPLA DEFESA. SEGURANÇA CONCEDIDA.
+I. CASO EM EXAME
+1. O recurso
+Mandado de segurança impetrado contra ato judicial que aplicou multa por
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E PROCESSUAL CIVIL. MANDADO DE SEGURANÇA. MULTA POR LITIGÂNCIA DE MÁ-FÉ IMPOSTA AO ADVOGADO. IMPOSSIBILIDADE. NECESSIDADE DE APURAÇÃO EM AÇÃO PRÓPRIA. AUSÊNCIA DE DOLO. MERO ERRO MATERIAL CORRIGIDO. VIOLAÇÃO AO CONTRADITÓRIO E À AMPLA DEFESA. SEGURANÇA CONCEDIDA.
+I. CASO EM EXAME
+1. O recurso
+Mandado de segurança impetrado contra ato judicial que aplicou multa por litigância de má-fé diretamente ao advogado subscritor da petição, no percentual de 1% sobre o valor da causa.
+2. O fato relevante
+A multa foi aplicada em razão de equívoco material na citação de dispositivo legal (art. 115 do CPC), posteriormente reconhecido e corrigido espontaneamente pelo advogado, sem prejuízo ao andamento processual e sem demonstração de dolo.
+3. A decisão recorrida
+Decisão que condenou o advogado por litigância de má-fé, nos próprios autos, com fundamento nos arts. 80 e 81 do CPC. Em sede inicial do mandado de segurança, reconheceu-se a ilegitimidade de litisconsortes e deferiu-se liminar para suspender a exigibilidade da multa.
+II. QUESTÃO EM DISCUSSÃO
+Saber se é legal a imposição direta de multa por litigância de má-fé ao advogado, nos autos da causa originária, sem prévia instauração de procedimento próprio e sem comprovação de dolo ou abuso.
+III. RAZÕES DE DECIDIR
+As penalidades por litigância de má-fé previstas nos arts. 79 e 80 do CPC são destinadas às partes, não se estendendo ao advogado, cuja eventual responsabilização deve ocorrer em ação própria, nos termos do art. 32 da Lei nº 8.906/1994.
+A jurisprudência consolidada do STJ admite, de forma excepcional, o mandado de segurança contra ato judicial manifestamente ilegal, como na hipótese de imposição de multa diretamente ao advogado.
+No caso concreto, o erro na indicação do dispositivo legal foi meramente material, corrigido de forma espontânea e sem causar prejuízo ao processo, inexistindo demonstração do elemento subjetivo indispensável à caracterização da litigância de má-fé.
+IV. DISPOSITIVO
+Concede-se a segurança para afastar a multa por litigância de má-fé imposta ao advogado impetrante.
+Atos normativos citados:
+CF/1988, art. 5º, LXIX;
+Lei nº 12.016/2009, arts. 1º, 23 e 25;
+CPC, arts. 79, 80 e 81;
+Lei nº 8.906/1994 (Estatuto da Advocacia), art. 32.
+Jurisprudência citada:
+STJ, AgInt no AREsp 1.722.332/MT, Quarta Turma, j. 13/06/2022;
+STJ, RMS 59.322/MG, Quarta Turma, j. 05/02/2019;
+STJ, RMS 71.836/MT, Quarta Turma, j. 26/09/2023;
+TJ/AL, Mandado de Segurança nº 0803211-19.2019.8.02.0000, Seção Especializada Cível, j. 13/03/2020.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812578" cdForo="0" >
+										0804189-83.2025.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812578" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812578);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812578" style="display: none;" >
+	<div id="textAreaDados_812578" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL E DIREITO CIVIL. RECLAMA&Ccedil;&Atilde;O. ATRASO NA ENTREGA DE IM&Oacute;VEL NA PLANTA. CL&Aacute;USULA PENAL MORAT&Oacute;RIA. LUCROS CESSANTES. POSSIBILIDADE DE CUMULA&Ccedil;&Atilde;O. TEMA 970 DO STJ. VIOLA&Ccedil;&Atilde;O A PRECEDENTE OBRIGAT&Oacute;RIO. PROCED&Ecirc;NCIA.
+I. CASO EM EXAME
+1. Reclama&ccedil;&atilde;o ajuizada contra ac&oacute;rd&atilde;o da Turma Recursal de Alagoas que, em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por atraso na entrega de im&oacute;vel adquirido na planta, reconheceu o inadimplemento contratual, mas afastou a cumula&ccedil;&atilde;o entre cl&aacute;usula penal morat&oacute;ria e lucros cessantes, sob o fundamento de veda&ccedil;&atilde;o ao bis in idem.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; cab&iacute;vel reclama&ccedil;&atilde;o para garantir a observ&acirc;ncia de tese firmada em recurso especial repetitivo; (ii) estabelecer se &eacute; poss&iacute;vel a cumula&ccedil;&atilde;o entre cl&aacute;usula penal morat&oacute;ria fixada em percentual &uacute;nico e lucros cessantes em caso de atraso na entrega de im&oacute;vel.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O art. 234, IV, do RITJAL admite expressamente a reclama&ccedil;&atilde;o para dirimir diverg&ecirc;ncia entre ac&oacute;rd&atilde;o de Turma Recursal e tese firmada em recurso repetitivo do STJ.
+4. O CPC/2015 imp&otilde;e a observ&acirc;ncia obrigat&oacute;ria dos precedentes qualificados, sendo a reclama&ccedil;&atilde;o instrumento adequado para assegurar a uniformidade e coer&ecirc;ncia da jurisprud&ecirc;ncia (art. 927, III).
+5. O Tema 970 do STJ estabelece que a cl&aacute;usula penal morat&oacute;ria, quando equivalente ao valor locativo, afasta a cumula&ccedil;&atilde;o com lucros cessantes, para evitar bis in idem.
+6. A veda&ccedil;&atilde;o &agrave; cumula&ccedil;&atilde;o n&atilde;o &eacute; absoluta, pois depende da equival&ecirc;ncia entre a multa contratual e o valor locativo do im&oacute;vel.
+7. Cl&aacute;usula penal fixada em percentual &uacute;nico sobre o valor do contrato, sem vincula&ccedil;&atilde;o &agrave; dura&ccedil;&atilde;o da mora, n&atilde;o possui natureza compensat&oacute;ria suficiente para recompor o preju&iacute;zo do adquirente.
+8. A insufici&ecirc;ncia da cl&aacute;usula penal autoriza a cumula&ccedil;&atilde;o com lucros cessantes para assegurar a repara&ccedil;&atilde;o integral do dano.
+9. A previs&atilde;o contratual expressa de cumula&ccedil;&atilde;o entre multa e perdas e danos refor&ccedil;a a inexist&ecirc;ncia de car&aacute;ter substitutivo da cl&aacute;usula penal.
+10. O ac&oacute;rd&atilde;o reclamado diverge do Tema 970 ao afastar automaticamente a cumula&ccedil;&atilde;o sem analisar a equival&ecirc;ncia ao locativo, violando precedente obrigat&oacute;rio.
+IV. DISPOSITIVO
+11. Reclama&ccedil;&atilde;o julgada procedente.
+_______________
+Dispositivos relevantes citados: CPC/2015, arts. 85, &sect;&sect; 2&ordm; e 8&ordm;, 927, III, e 988; CC, art. 424; RITJAL, art. 234, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, Tema Repetitivo n&ordm; 970. <br><br>(N&uacute;mero do Processo: 0804189-83.2025.8.02.0000; Relator (a):&nbsp;Ju&iacute;za Conv. Adriana Carla Feitosa Martins; Comarca:&nbsp;1&ordm; Juizado Especial C&iacute;vel da Capital; &Oacute;rg&atilde;o julgador: Tribunal Pleno; Data do julgamento: 14/04/2026; Data de registro: 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Reclamação / Vícios de Construção
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Conv. Adriana Carla Feitosa Martins
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Tribunal Pleno
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO CIVIL. RECLAMAÇÃO. ATRASO NA ENTREGA DE IMÓVEL NA PLANTA. CLÁUSULA PENAL MORATÓRIA. LUCROS CESSANTES. POSSIBILIDADE DE CUMULAÇÃO. TEMA 970 DO STJ. VIOLAÇÃO A PRECEDENTE OBRIGATÓRIO. PROCEDÊNCIA.
+I. CASO EM EXAME
+1. Reclamação ajuizada contra acórdão da Turma Recursal de Alagoas que, em ação de indenização por atraso na entrega de imóvel adquirido na planta,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO CIVIL. RECLAMAÇÃO. ATRASO NA ENTREGA DE IMÓVEL NA PLANTA. CLÁUSULA PENAL MORATÓRIA. LUCROS CESSANTES. POSSIBILIDADE DE CUMULAÇÃO. TEMA 970 DO STJ. VIOLAÇÃO A PRECEDENTE OBRIGATÓRIO. PROCEDÊNCIA.
+I. CASO EM EXAME
+1. Reclamação ajuizada contra acórdão da Turma Recursal de Alagoas que, em ação de indenização por atraso na entrega de imóvel adquirido na planta, reconheceu o inadimplemento contratual, mas afastou a cumulação entre cláusula penal moratória e lucros cessantes, sob o fundamento de vedação ao bis in idem.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se é cabível reclamação para garantir a observância de tese firmada em recurso especial repetitivo; (ii) estabelecer se é possível a cumulação entre cláusula penal moratória fixada em percentual único e lucros cessantes em caso de atraso na entrega de imóvel.
+III. RAZÕES DE DECIDIR
+3. O art. 234, IV, do RITJAL admite expressamente a reclamação para dirimir divergência entre acórdão de Turma Recursal e tese firmada em recurso repetitivo do STJ.
+4. O CPC/2015 impõe a observância obrigatória dos precedentes qualificados, sendo a reclamação instrumento adequado para assegurar a uniformidade e coerência da jurisprudência (art. 927, III).
+5. O Tema 970 do STJ estabelece que a cláusula penal moratória, quando equivalente ao valor locativo, afasta a cumulação com lucros cessantes, para evitar bis in idem.
+6. A vedação à cumulação não é absoluta, pois depende da equivalência entre a multa contratual e o valor locativo do imóvel.
+7. Cláusula penal fixada em percentual único sobre o valor do contrato, sem vinculação à duração da mora, não possui natureza compensatória suficiente para recompor o prejuízo do adquirente.
+8. A insuficiência da cláusula penal autoriza a cumulação com lucros cessantes para assegurar a reparação integral do <em>dano</em>.
+9. A previsão contratual expressa de cumulação entre multa e perdas e <em>danos</em> reforça a inexistência de caráter substitutivo da cláusula penal.
+10. O acórdão reclamado diverge do Tema 970 ao afastar automaticamente a cumulação sem analisar a equivalência ao locativo, violando precedente obrigatório.
+IV. DISPOSITIVO
+11. Reclamação julgada procedente.
+_______________
+Dispositivos relevantes citados: CPC/2015, arts. 85, §§ 2º e 8º, 927, III, e 988; CC, art. 424; RITJAL, art. 234, IV.
+Jurisprudência relevante citada: STJ, Tema Repetitivo nº 970.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812572" cdForo="0" >
+										0728669-56.2021.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812572" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812572);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812572" style="display: none;" >
+	<div id="textAreaDados_812572" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM AGRAVO INTERNO EM RECURSO ESPECIAL. AC&Oacute;RD&Atilde;O QUE CONHECEU E NEGOU PROVIMENTO AO AGRAVO INTERNO MANEJADO CONTRA DECIS&Atilde;O QUE SUSPENDEU O RECURSO ESPECIAL EM RAZ&Atilde;O DA INCID&Ecirc;NCIA DO TEMA 929 DO STJ. OBSCURIDADE CONSTATADA. AUS&Ecirc;NCIA DE ADER&Ecirc;NCIA ESTRITA. ACOLHIMENTO DOS ACLARAT&Oacute;RIOS COM EFEITOS INFRINGENTES.
+I. Caso em exame
+Embargos de declara&ccedil;&atilde;o em face de ac&oacute;rd&atilde;o que negou provimento ao agravo interno.
+II. Quest&atilde;o em discuss&atilde;o
+2. Verificar a exist&ecirc;ncia de omiss&atilde;o e obscuridade quanto &agrave;s mat&eacute;rias suscitadas nas raz&otilde;es do agravo interno.
+3. Verificados os v&iacute;cios de omiss&atilde;o e obscuridade alegados, uma vez que o agravo interno contemplava quest&otilde;es que demonstravam a exist&ecirc;ncia de mat&eacute;rias debatidas no recurso especial que n&atilde;o atrairiam a incid&ecirc;ncia do precedente vinculante que ensejou a suspens&atilde;o.
+4. O Tema 929 dos recursos repetitivos visa definir se a repeti&ccedil;&atilde;o em dobro prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC necessita ou n&atilde;o da comprova&ccedil;&atilde;o da m&aacute;-f&eacute; do prestador de servi&ccedil;os.
+5. Se o &oacute;rg&atilde;o fracion&aacute;rio sequer reconheceu a ocorr&ecirc;ncia da falha na presta&ccedil;&atilde;o de servi&ccedil;os que ensejaria a repeti&ccedil;&atilde;o do ind&eacute;bito, imp&otilde;e-se reconhecer a aus&ecirc;ncia de ader&ecirc;ncia estrita entre a mat&eacute;ria debatida no recurso especial e a quest&atilde;o afetada ao precedente vinculante.
+6. Afastada a incid&ecirc;ncia do tema que ensejou a suspens&atilde;o do feito, deve ser promovido o ju&iacute;zo de admissibilidade do ju&iacute;zo especial.
+IV. Dispositivo
+7. Embargos de declara&ccedil;&atilde;o conhecidos e acolhidos com efeitos infringentes. Decis&atilde;o un&acirc;nime.
+______________________
+Dispositivos relevantes citados: CPC, art. 1.022; CDC, arts. 14 e 42, par&aacute;grafo &uacute;nico.
+Jurisprud&ecirc;ncia relevante: ProAfR no REsp 1.823.218/AC .  <br><br>(N&uacute;mero do Processo: 0728669-56.2021.8.02.0001; Relator (a):&nbsp;Presidente do Tribunal de Justi&ccedil;a de Alagoas; Comarca:&nbsp;Foro de Arapiraca; &Oacute;rg&atilde;o julgador: Tribunal Pleno; Data do julgamento: 14/04/2026; Data de registro: 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Presidente do Tribunal de Justiça de Alagoas
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Arapiraca
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Tribunal Pleno
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									728669562021802000150002
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO INTERNO EM RECURSO ESPECIAL. ACÓRDÃO QUE CONHECEU E NEGOU PROVIMENTO AO AGRAVO INTERNO MANEJADO CONTRA DECISÃO QUE SUSPENDEU O RECURSO ESPECIAL EM RAZÃO DA INCIDÊNCIA DO TEMA 929 DO STJ. OBSCURIDADE CONSTATADA. AUSÊNCIA DE ADERÊNCIA ESTRITA. ACOLHIMENTO DOS ACLARATÓRIOS COM EFEITOS INFRINGENTES.
+I. Caso em exame
+Embargos de declaração em face de acórdão que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM AGRAVO INTERNO EM RECURSO ESPECIAL. ACÓRDÃO QUE CONHECEU E NEGOU PROVIMENTO AO AGRAVO INTERNO MANEJADO CONTRA DECISÃO QUE SUSPENDEU O RECURSO ESPECIAL EM RAZÃO DA INCIDÊNCIA DO TEMA 929 DO STJ. OBSCURIDADE CONSTATADA. AUSÊNCIA DE ADERÊNCIA ESTRITA. ACOLHIMENTO DOS ACLARATÓRIOS COM EFEITOS INFRINGENTES.
+I. Caso em exame
+Embargos de declaração em face de acórdão que negou provimento ao agravo interno.
+II. Questão em discussão
+2. Verificar a existência de omissão e obscuridade quanto às matérias suscitadas nas razões do agravo interno.
+3. Verificados os vícios de omissão e obscuridade alegados, uma vez que o agravo interno contemplava questões que demonstravam a existência de matérias debatidas no recurso especial que não atrairiam a incidência do precedente vinculante que ensejou a suspensão.
+4. O Tema 929 dos recursos repetitivos visa definir se a repetição em dobro prevista no art. 42, parágrafo único, do CDC necessita ou não da comprovação da má-fé do prestador de serviços.
+5. Se o órgão fracionário sequer reconheceu a ocorrência da falha na prestação de serviços que ensejaria a repetição do indébito, impõe-se reconhecer a ausência de aderência estrita entre a matéria debatida no recurso especial e a questão afetada ao precedente vinculante.
+6. Afastada a incidência do tema que ensejou a suspensão do feito, deve ser promovido o juízo de admissibilidade do juízo especial.
+IV. Dispositivo
+7. Embargos de declaração conhecidos e acolhidos com efeitos infringentes. Decisão unânime.
+______________________
+Dispositivos relevantes citados: CPC, art. 1.022; CDC, arts. 14 e 42, parágrafo único.
+Jurisprudência relevante: ProAfR no REsp 1.823.218/AC .
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811845" cdForo="0" >
+										0801684-22.2025.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811845" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811845);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811845" style="display: none;" >
+	<div id="textAreaDados_811845" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL E DIREITO ADMINISTRATIVO. A&Ccedil;&Atilde;O RESCIS&Oacute;RIA. RESPONSABILIDADE CIVIL DO ESTADO. PRIS&Atilde;O PREVENTIVA. POSTERIOR ABSOLVI&Ccedil;&Atilde;O POR INSUFICI&Ecirc;NCIA DE PROVAS. AUS&Ecirc;NCIA DE ERRO DE FATO E DE VIOLA&Ccedil;&Atilde;O MANIFESTA A NORMA JUR&Iacute;DICA. UTILIZA&Ccedil;&Atilde;O DA RESCIS&Oacute;RIA COMO SUCED&Acirc;NEO RECURSAL. IMPROCED&Ecirc;NCIA.
+I. CASO EM EXAME
+1. A&ccedil;&atilde;o rescis&oacute;ria proposta por particular em face do Estado de Alagoas, com fundamento no art. 966, incisos IV, V e VIII, do CPC, visando &agrave; desconstitui&ccedil;&atilde;o de senten&ccedil;a que julgou improcedente pedido de indeniza&ccedil;&atilde;o por danos morais decorrentes de pris&atilde;o preventiva posteriormente seguida de absolvi&ccedil;&atilde;o pelo Tribunal do J&uacute;ri por insufici&ecirc;ncia de provas.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se a senten&ccedil;a rescindenda incorreu em erro de fato, nos termos do art. 966, &sect; 1&ordm;, do CPC, ao afastar o dever de indenizar mesmo diante de absolvi&ccedil;&atilde;o criminal; e (ii) estabelecer se houve viola&ccedil;&atilde;o manifesta a norma jur&iacute;dica apta a ensejar a rescis&atilde;o do julgado.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A a&ccedil;&atilde;o rescis&oacute;ria possui natureza excepcional e cogni&ccedil;&atilde;o restrita, limitando-se &agrave;s hip&oacute;teses taxativas do art. 966 do CPC, n&atilde;o se prestando ao reexame de mat&eacute;ria f&aacute;tica ou &agrave; rediscuss&atilde;o da justi&ccedil;a da decis&atilde;o rescindenda.
+4. Configura erro de fato apenas a admiss&atilde;o de fato inexistente ou a desconsidera&ccedil;&atilde;o de fato efetivamente ocorrido, desde que n&atilde;o tenha havido controv&eacute;rsia ou pronunciamento judicial sobre ele, conforme entendimento consolidado do STJ.
+5. A senten&ccedil;a rescindenda reconhece expressamente a absolvi&ccedil;&atilde;o do autor, mas conclui que tal circunst&acirc;ncia, por si s&oacute;, n&atilde;o caracteriza erro judici&aacute;rio nem responsabilidade civil do Estado, ausente demonstra&ccedil;&atilde;o de ilegalidade na decreta&ccedil;&atilde;o e manuten&ccedil;&atilde;o da pris&atilde;o preventiva.
+6. A pretens&atilde;o autoral busca rediscutir a valora&ccedil;&atilde;o jur&iacute;dica conferida aos fatos j&aacute; examinados na a&ccedil;&atilde;o origin&aacute;ria, o que revela indevida utiliza&ccedil;&atilde;o da a&ccedil;&atilde;o rescis&oacute;ria como suced&acirc;neo recursal.
+7. A absolvi&ccedil;&atilde;o por insufici&ecirc;ncia de provas n&atilde;o gera, automaticamente, dever de indenizar quando a pris&atilde;o preventiva foi decretada com fundamento nos requisitos legais e em decis&otilde;es devidamente motivadas.
+8. A responsabilidade civil do Estado por atos jurisdicionais &eacute; excepcional, restringindo-se &agrave;s hip&oacute;teses do art. 5&ordm;, LXXV, da Constitui&ccedil;&atilde;o Federal &ndash; erro judici&aacute;rio ou pris&atilde;o al&eacute;m do tempo fixado na senten&ccedil;a &ndash; ou &agrave; demonstra&ccedil;&atilde;o de ilegalidade manifesta, n&atilde;o verificada no caso.
+IV. DISPOSITIVO
+9. A&ccedil;&atilde;o rescis&oacute;ria julgada improcedente.
+__________
+Dispositivos relevantes citados: CF/1988, arts. 5&ordm;, V, X e LXXV, e 37, &sect; 6&ordm;; CPC, art. 966, incisos IV, V, VIII e &sect; 1&ordm;, e art. 975; CC, arts. 186 e 927.
+
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no AREsp 1958417/ES, Rel. Min. Raul Ara&uacute;jo, T4, j. 20.05.2024, DJe 04.06.2024; STJ, AR 5.254/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, Segunda Se&ccedil;&atilde;o, DJe 30.05.2022; STJ, AgInt na AR 6.562/DF, Rel. Min. Antonio Carlos Ferreira, Segunda Se&ccedil;&atilde;o, DJe 16.12.2019; STJ, AgInt na AR 6.991/BA, Rel. Min. Nancy Andrighi, Segunda Se&ccedil;&atilde;o, DJe 07.03.2024; STJ, AR 5.223/SP, Rel. Min. Gurgel de Faria, Primeira Se&ccedil;&atilde;o, DJe 25.08.2022; STJ, AR 6.052/SP, Rel. Min. Marco Aur&eacute;lio Bellizze, Segunda Se&ccedil;&atilde;o, DJe 14.02.2023; TJAL, Apela&ccedil;&atilde;o n&ordm; 0735401-82.2023.8.02.0001, Rel. Des. Fernando Tourinho de Omena Souza, 3&ordf; C&acirc;mara C&iacute;vel, j. 06.05.2025. <br><br>(N&uacute;mero do Processo: 0801684-22.2025.8.02.0000; Relator (a):&nbsp;Ju&iacute;za Conv. Adriana Carla Feitosa Martins; Comarca:&nbsp;Foro de Traipu; &Oacute;rg&atilde;o julgador: Se&ccedil;&atilde;o Especializada C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Ação Rescisória / Rescisão / Resolução
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Conv. Adriana Carla Feitosa Martins
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Traipu
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Especializada Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO ADMINISTRATIVO. AÇÃO RESCISÓRIA. RESPONSABILIDADE CIVIL DO ESTADO. PRISÃO PREVENTIVA. POSTERIOR ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. AUSÊNCIA DE ERRO DE FATO E DE VIOLAÇÃO MANIFESTA A NORMA JURÍDICA. UTILIZAÇÃO DA RESCISÓRIA COMO SUCEDÂNEO RECURSAL. IMPROCEDÊNCIA.
+I. CASO EM EXAME
+1. Ação rescisória proposta por particular em face do Estado de Alagoas, com
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DIREITO ADMINISTRATIVO. AÇÃO RESCISÓRIA. RESPONSABILIDADE CIVIL DO ESTADO. PRISÃO PREVENTIVA. POSTERIOR ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. AUSÊNCIA DE ERRO DE FATO E DE VIOLAÇÃO MANIFESTA A NORMA JURÍDICA. UTILIZAÇÃO DA RESCISÓRIA COMO SUCEDÂNEO RECURSAL. IMPROCEDÊNCIA.
+I. CASO EM EXAME
+1. Ação rescisória proposta por particular em face do Estado de Alagoas, com fundamento no art. 966, incisos IV, V e VIII, do CPC, visando à desconstituição de sentença que julgou improcedente pedido de indenização por <em>danos</em> <em>morais</em> decorrentes de prisão preventiva posteriormente seguida de absolvição pelo Tribunal do Júri por insuficiência de provas.
+II. QUESTÕES EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se a sentença rescindenda incorreu em erro de fato, nos termos do art. 966, § 1º, do CPC, ao afastar o dever de indenizar mesmo diante de absolvição criminal; e (ii) estabelecer se houve violação manifesta a norma jurídica apta a ensejar a rescisão do julgado.
+III. RAZÕES DE DECIDIR
+3. A ação rescisória possui natureza excepcional e cognição restrita, limitando-se às hipóteses taxativas do art. 966 do CPC, não se prestando ao reexame de matéria fática ou à rediscussão da justiça da decisão rescindenda.
+4. Configura erro de fato apenas a admissão de fato inexistente ou a desconsideração de fato efetivamente ocorrido, desde que não tenha havido controvérsia ou pronunciamento judicial sobre ele, conforme entendimento consolidado do STJ.
+5. A sentença rescindenda reconhece expressamente a absolvição do autor, mas conclui que tal circunstância, por si só, não caracteriza erro judiciário nem responsabilidade civil do Estado, ausente demonstração de ilegalidade na decretação e manutenção da prisão preventiva.
+6. A pretensão autoral busca rediscutir a valoração jurídica conferida aos fatos já examinados na ação originária, o que revela indevida utilização da ação rescisória como sucedâneo recursal.
+7. A absolvição por insuficiência de provas não gera, automaticamente, dever de indenizar quando a prisão preventiva foi decretada com fundamento nos requisitos legais e em decisões devidamente motivadas.
+8. A responsabilidade civil do Estado por atos jurisdicionais é excepcional, restringindo-se às hipóteses do art. 5º, LXXV, da Constituição Federal – erro judiciário ou prisão além do tempo fixado na sentença – ou à demonstração de ilegalidade manifesta, não verificada no caso.
+IV. DISPOSITIVO
+9. Ação rescisória julgada improcedente.
+__________
+Dispositivos relevantes citados: CF/1988, arts. 5º, V, X e LXXV, e 37, § 6º; CPC, art. 966, incisos IV, V, VIII e § 1º, e art. 975; CC, arts. 186 e 927.
+
+Jurisprudência relevante citada: STJ, AgInt no AREsp 1958417/ES, Rel. Min. Raul Araújo, T4, j. 20.05.2024, DJe 04.06.2024; STJ, AR 5.254/SP, Rel. Min. Ricardo Villas Bôas Cueva, Segunda Seção, DJe 30.05.2022; STJ, AgInt na AR 6.562/DF, Rel. Min. Antonio Carlos Ferreira, Segunda Seção, DJe 16.12.2019; STJ, AgInt na AR 6.991/BA, Rel. Min. Nancy Andrighi, Segunda Seção, DJe 07.03.2024; STJ, AR 5.223/SP, Rel. Min. Gurgel de Faria, Primeira Seção, DJe 25.08.2022; STJ, AR 6.052/SP, Rel. Min. Marco Aurélio Bellizze, Segunda Seção, DJe 14.02.2023; TJAL, Apelação nº 0735401-82.2023.8.02.0001, Rel. Des. Fernando Tourinho de Omena Souza, 3ª Câmara Cível, j. 06.05.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811835" cdForo="0" >
+										0724834-31.2019.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811835" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811835);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811835" style="display: none;" >
+	<div id="textAreaDados_811835" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. PLANO DE SA&Uacute;DE. DEVER DE COBERTURA DE PROCEDIMENTO. PREVIS&Atilde;O NO ROL DA ANS. REEMBOLSO LIMITADO AO VALOR DE TABELA. DANO MORAL CONFIGURADO. RECURSO CONHECIDO E PROVIDO EM PARTE.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pela Unimed Macei&oacute; em face de senten&ccedil;a que julgou parcialmente procedente a pretens&atilde;o autoral, no sentido de no sentido de: (i) confirmar a tutela de urg&ecirc;ncia, que determinou que a parte demandada autorizasse e custeasse a cirurgia de les&atilde;o por radiofrequ&ecirc;ncia de nervos espl&acirc;ncnicos bilaterais; (ii) condenar o r&eacute;u ao reembolso integral das despesas relativas ao procedimento de bloqueio anest&eacute;sico de plexo cel&iacute;aco; e (iii) condenar a operadora de sa&uacute;de ao pagamento de indeniza&ccedil;&atilde;o por danos morais no importe de R$ 10.000,00 (dez mil reais).
+II. Quest&atilde;o em discuss&atilde;o
+2. O cerne da controv&eacute;rsia em sede recursal consiste em verificar: (i) se houve negativa de cobertura em rela&ccedil;&atilde;o ao procedimento de bloqueio anest&eacute;sico de plexo cel&iacute;aco; (ii) se o reembolso das despesas realizadas pelo autor em rede particular deve ser integral ou limitado ao valor de tabela do plano; (iii) se a operadora de sa&uacute;de tem a obriga&ccedil;&atilde;o de custear a cirurgia de les&atilde;o por radiofrequ&ecirc;ncia de nervos espl&acirc;ncnicos bilaterais; e (iv) se foi configurado abalo moral.
+III. Raz&otilde;es de decidir
+3. O reembolso das despesas realizadas pela paciente em rede particular deve ser limitado ao valor da tabela do plano, quando demonstrada a exist&ecirc;ncia de rede credenciada apta e n&atilde;o restar configurada a urg&ecirc;ncia. 3.1. No presente caso, n&atilde;o h&aacute; nos autos prova da negativa do plano em realizar a cobertura do procedimento de bloqueio anest&eacute;sico de plexo cel&iacute;aco, somando-se a isso o fato de ter sido demonstrada a exist&ecirc;ncia de rede credenciada e n&atilde;o haver prova da urg&ecirc;ncia alegada, restando evidente que a autora optou por espont&acirc;nea vontade realizar procedimento com profissional n&atilde;o credenciado, de modo que o reembolso deve ser limitado ao valor de tabela do plano.
+4. O STF, em recente julgamento da ADI 7265, adotou novo entendimento no sentido de que a aus&ecirc;ncia de inclus&atilde;o do procedimento ou tratamento no rol da ANS impede, como regra geral, a sua concess&atilde;o judicial, salvo quando preenchidos determinados crit&eacute;rios cumulativos estabelecidos pela Corte Suprema. 4.1. No presente caso, o procedimento de bloqueio neurol&iacute;tico plexo cel&iacute;aco est&aacute; previsto no rol da ANS, sendo, portanto, de cobertura obrigat&oacute;ria.
+5. A Resolu&ccedil;&atilde;o Normativa n. 465/2021 da ANS estabelece que os procedimentos por radiofrequ&ecirc;ncia ser&atilde;o de cobertura obrigat&oacute;ria quando o procedimento pleiteado estiver previsto no rol da ANS.
+6 Os julgados mais recentes do STJ s&atilde;o no sentido de que os danos morais decorrentes de negativa de cobertura pelo plano de sa&uacute;de n&atilde;o se configuram in re ipsa. 6.1. Caso concreto em que restou demonstrada a viola&ccedil;&atilde;o aos direitos da personalidade da autora, diante do agravamento da dor e preju&iacute;zos &agrave; sa&uacute;de da paciente.  6.2. Quantum indenizat&oacute;rio fixado no primeiro grau est&aacute; de acordo com o valor arbitrado por esta C&acirc;mara C&iacute;vel, devendo, portanto, ser mantido.
+IV. Dispositivo
+7. Dispositivo: recurso conhecido e provido em parte.
+__________
+Dispositivos relevantes citados:
+Jurisprud&ecirc;ncia relevante citada: STF, ADI 7265, Rel. Ministro Lu&iacute;s Roberto Barroso, Plen&aacute;rio, Data de julgamento: 18/09/2025; STJ, S&uacute;mula 608; STJ, REsp: 1760955 SP 2018/0144917-1, Rel. Ministro Marco Aur&eacute;lio Bellizze,  Terceira Turma, Data de Julgamento: 11/06/2019; STJ, REsp: 1882584 DF 2020/0163550-9, Rel. Ministro Humberto Martins, Terceira Turma, Data de Julgamento: 28/04/2025; STJ, AgInt no AREsp: 2433593 SE 2023/0287822-2, Rel. Ministro Jo&atilde;o Ot&aacute;vio de Noronha, Quarta Turma, Data de Julgamento: 13/05/2024; TJAL, AI 0809231-50.2024.8.02.0000, Rel. Des. F&aacute;bio Jos&eacute; Bittencourt Ara&uacute;jo, 3&ordf; C&acirc;mara C&iacute;vel, Data do julgamento: 10/10/2024; TJAL, AC  0726157-03.2021.8.02.0001, Rel. Des. Alcides Gusm&atilde;o da Silva, 3&ordf; C&acirc;mara C&iacute;vel, Data do julgamento: 17/07/2024. <br><br>(N&uacute;mero do Processo: 0724834-31.2019.8.02.0001; Relator (a):&nbsp;Des. Paulo Zacarias da Silva; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 3&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 06/04/2026; Data de registro: 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(44 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Zacarias da Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									06/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PLANO DE SAÚDE. DEVER DE COBERTURA DE PROCEDIMENTO. PREVISÃO NO ROL DA ANS. REEMBOLSO LIMITADO AO VALOR DE TABELA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO CONHECIDO E PROVIDO EM PARTE.
+I. Caso em exame
+1. Apelação cível interposta pela Unimed Maceió em face de sentença que julgou parcialmente procedente a pretensão autoral, no sentido de no
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. PLANO DE SAÚDE. DEVER DE COBERTURA DE PROCEDIMENTO. PREVISÃO NO ROL DA ANS. REEMBOLSO LIMITADO AO VALOR DE TABELA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO CONHECIDO E PROVIDO EM PARTE.
+I. Caso em exame
+1. Apelação cível interposta pela Unimed Maceió em face de sentença que julgou parcialmente procedente a pretensão autoral, no sentido de no sentido de: (i) confirmar a tutela de urgência, que determinou que a parte demandada autorizasse e custeasse a cirurgia de lesão por radiofrequência de nervos esplâncnicos bilaterais; (ii) condenar o réu ao reembolso integral das despesas relativas ao procedimento de bloqueio anestésico de plexo celíaco; e (iii) condenar a operadora de saúde ao pagamento de indenização por <em>danos</em> <em>morais</em> no importe de R$ 10.000,00 (dez mil reais).
+II. Questão em discussão
+2. O cerne da controvérsia em sede recursal consiste em verificar: (i) se houve negativa de cobertura em relação ao procedimento de bloqueio anestésico de plexo celíaco; (ii) se o reembolso das despesas realizadas pelo autor em rede particular deve ser integral ou limitado ao valor de tabela do plano; (iii) se a operadora de saúde tem a obrigação de custear a cirurgia de lesão por radiofrequência de nervos esplâncnicos bilaterais; e (iv) se foi configurado abalo <em>moral</em>.
+III. Razões de decidir
+3. O reembolso das despesas realizadas pela paciente em rede particular deve ser limitado ao valor da tabela do plano, quando demonstrada a existência de rede credenciada apta e não restar configurada a urgência. 3.1. No presente caso, não há nos autos prova da negativa do plano em realizar a cobertura do procedimento de bloqueio anestésico de plexo celíaco, somando-se a isso o fato de ter sido demonstrada a existência de rede credenciada e não haver prova da urgência alegada, restando evidente que a autora optou por espontânea vontade realizar procedimento com profissional não credenciado, de modo que o reembolso deve ser limitado ao valor de tabela do plano.
+4. O STF, em recente julgamento da ADI 7265, adotou novo entendimento no sentido de que a ausência de inclusão do procedimento ou tratamento no rol da ANS impede, como regra geral, a sua concessão judicial, salvo quando preenchidos determinados critérios cumulativos estabelecidos pela Corte Suprema. 4.1. No presente caso, o procedimento de bloqueio neurolítico plexo celíaco está previsto no rol da ANS, sendo, portanto, de cobertura obrigatória.
+5. A Resolução Normativa n. 465/2021 da ANS estabelece que os procedimentos por radiofrequência serão de cobertura obrigatória quando o procedimento pleiteado estiver previsto no rol da ANS.
+6 Os julgados mais recentes do STJ são no sentido de que os <em>danos</em> <em>morais</em> decorrentes de negativa de cobertura pelo plano de saúde não se configuram in re ipsa. 6.1. Caso concreto em que restou demonstrada a violação aos direitos da personalidade da autora, diante do agravamento da dor e prejuízos à saúde da paciente.  6.2. Quantum indenizatório fixado no primeiro grau está de acordo com o valor arbitrado por esta Câmara Cível, devendo, portanto, ser mantido.
+IV. Dispositivo
+7. Dispositivo: recurso conhecido e provido em parte.
+__________
+Dispositivos relevantes citados:
+Jurisprudência relevante citada: STF, ADI 7265, Rel. Ministro Luís Roberto Barroso, Plenário, Data de julgamento: 18/09/2025; STJ, Súmula 608; STJ, REsp: 1760955 SP 2018/0144917-1, Rel. Ministro Marco Aurélio Bellizze,  Terceira Turma, Data de Julgamento: 11/06/2019; STJ, REsp: 1882584 DF 2020/0163550-9, Rel. Ministro Humberto Martins, Terceira Turma, Data de Julgamento: 28/04/2025; STJ, AgInt no AREsp: 2433593 SE 2023/0287822-2, Rel. Ministro João Otávio de Noronha, Quarta Turma, Data de Julgamento: 13/05/2024; TJAL, AI 0809231-50.2024.8.02.0000, Rel. Des. Fábio José Bittencourt Araújo, 3ª Câmara Cível, Data do julgamento: 10/10/2024; TJAL, AC  0726157-03.2021.8.02.0001, Rel. Des. Alcides Gusmão da Silva, 3ª Câmara Cível, Data do julgamento: 17/07/2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811848" cdForo="0" >
+										0720874-96.2021.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811848" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811848);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811848" style="display: none;" >
+	<div id="textAreaDados_811848" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO CIVIL. ACIDENTE DE TR&Acirc;NSITO ENTRE PARTICULARES. COLIS&Atilde;O. A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA POR DANOS MORAIS E MATERIAIS (LUCROS CESSANTES). SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. COLIS&Atilde;O TRASEIRA.  ART.&nbsp;29&nbsp;,&nbsp;II&nbsp;,&nbsp;CTB. N&Atilde;O COMPROVADO. PRESUN&Ccedil;&Atilde;O AFASTADA. RESPONSABILIDADE CIVIL N&Atilde;O CONFIGURADA. PARTE AUTORA QUE N&Atilde;O SE DESINCUMBIU DO SEU &Ocirc;NUS PROBAT&Oacute;RIO. ART. 373, I, DO CPC/15. SENTEN&Ccedil;A MANTIDA. MAJORA&Ccedil;&Atilde;O DE HONOR&Aacute;RIOS. RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedente a&ccedil;&atilde;o indenizat&oacute;ria por danos materiais, a t&iacute;tulo de lucros cessantes, e danos morais, decorrentes de acidente de tr&acirc;nsito envolvendo colis&atilde;o traseira entre ve&iacute;culos particulares.
+2. A parte autora sustentou que o r&eacute;u teria agido com culpa ao colidir na traseira de seu ve&iacute;culo. A senten&ccedil;a concluiu pela aus&ecirc;ncia de comprova&ccedil;&atilde;o suficiente da din&acirc;mica do acidente e da culpa do demandado, afastando a responsabilidade civil.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+3. A quest&atilde;o em discuss&atilde;o consiste em saber se (i) a colis&atilde;o traseira gera presun&ccedil;&atilde;o absoluta de culpa do condutor que colide; e (ii) se est&atilde;o presentes os requisitos da responsabilidade civil aptos a ensejar indeniza&ccedil;&atilde;o por danos materiais e morais.
+III. RAZ&Otilde;ES DE DECIDIR
+4. A regra do art. 29, II, do C&oacute;digo de Tr&acirc;nsito Brasileiro imp&otilde;e ao condutor o dever de guardar dist&acirc;ncia de seguran&ccedil;a, sendo certo que a colis&atilde;o traseira enseja presun&ccedil;&atilde;o relativa de culpa.
+5. Referida presun&ccedil;&atilde;o admite prova em contr&aacute;rio, cabendo &agrave; parte autora demonstrar os fatos constitutivos de seu direito, nos termos do art. 373, I, do CPC.
+6. Ausente comprova&ccedil;&atilde;o segura acerca da din&acirc;mica do acidente e da conduta culposa do r&eacute;u, n&atilde;o se evidenciam os pressupostos da responsabilidade civil, especialmente o nexo causal e a culpa, inviabilizando a indeniza&ccedil;&atilde;o pretendida.
+7. Mantida a senten&ccedil;a de improced&ecirc;ncia, imp&otilde;e-se a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios, nos termos do art. 85, &sect;11, do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e n&atilde;o provido.
+    Dispositivos relevantes citados: CTB, art. 29, II; CPC, arts. 373, I, e 85, &sect;11.
+Jurisprud&ecirc;ncia relevante citada: TJ-MG - AC: 18518738920148130024 Belo Horizonte, Relator.: Des.(a) Evangelina Castilho Duarte, Data de Julgamento: 03/08/2023, 14&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 03/08/2023; AP 1.0433.05.145675-7/001 - Rel. Des. Alberto Alu&iacute;zio Pacheco de Andrade - j. 15.05.2007, DJ 25.05.2007; TJ-MG - AC: 10000222796807001 MG, Relator.: M&ocirc;nica Lib&acirc;nio, Data de Julgamento: 15/02/2023, C&acirc;maras C&iacute;veis / 11&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 15/02/2023; TJ-MG - AC: 10000220275721001 MG, Relator.: Habib Felippe Jabour, Data de Julgamento: 26/04/2022, C&acirc;maras C&iacute;veis / 18&ordf; C&Acirc;MARA C&Iacute;VEL, Data de Publica&ccedil;&atilde;o: 26/04/2022. <br><br>(N&uacute;mero do Processo: 0720874-96.2021.8.02.0001; Relator (a):&nbsp;Des. Paulo Barros da Silva Lima; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 1&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 08/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Barros da Silva Lima
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. ACIDENTE DE TRÂNSITO ENTRE PARTICULARES. COLISÃO. AÇÃO INDENIZATÓRIA POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS (LUCROS CESSANTES). SENTENÇA DE IMPROCEDÊNCIA. COLISÃO TRASEIRA.  ART. 29 , II , CTB. NÃO COMPROVADO. PRESUNÇÃO AFASTADA. RESPONSABILIDADE CIVIL NÃO CONFIGURADA. PARTE AUTORA QUE NÃO SE DESINCUMBIU DO SEU ÔNUS PROBATÓRIO. ART. 373, I, DO CPC/15.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. ACIDENTE DE TRÂNSITO ENTRE PARTICULARES. COLISÃO. AÇÃO INDENIZATÓRIA POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS (LUCROS CESSANTES). SENTENÇA DE IMPROCEDÊNCIA. COLISÃO TRASEIRA.  ART. 29 , II , CTB. NÃO COMPROVADO. PRESUNÇÃO AFASTADA. RESPONSABILIDADE CIVIL NÃO CONFIGURADA. PARTE AUTORA QUE NÃO SE DESINCUMBIU DO SEU ÔNUS PROBATÓRIO. ART. 373, I, DO CPC/15. SENTENÇA MANTIDA. MAJORAÇÃO DE HONORÁRIOS. RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que julgou improcedente ação indenizatória por <em>danos</em> materiais, a título de lucros cessantes, e <em>danos</em> <em>morais</em>, decorrentes de acidente de trânsito envolvendo colisão traseira entre veículos particulares.
+2. A parte autora sustentou que o réu teria agido com culpa ao colidir na traseira de seu veículo. A sentença concluiu pela ausência de comprovação suficiente da dinâmica do acidente e da culpa do demandado, afastando a responsabilidade civil.
+II. QUESTÃO EM DISCUSSÃO
+3. A questão em discussão consiste em saber se (i) a colisão traseira gera presunção absoluta de culpa do condutor que colide; e (ii) se estão presentes os requisitos da responsabilidade civil aptos a ensejar indenização por <em>danos</em> materiais e <em>morais</em>.
+III. RAZÕES DE DECIDIR
+4. A regra do art. 29, II, do Código de Trânsito Brasileiro impõe ao condutor o dever de guardar distância de segurança, sendo certo que a colisão traseira enseja presunção relativa de culpa.
+5. Referida presunção admite prova em contrário, cabendo à parte autora demonstrar os fatos constitutivos de seu direito, nos termos do art. 373, I, do CPC.
+6. Ausente comprovação segura acerca da dinâmica do acidente e da conduta culposa do réu, não se evidenciam os pressupostos da responsabilidade civil, especialmente o nexo causal e a culpa, inviabilizando a indenização pretendida.
+7. Mantida a sentença de improcedência, impõe-se a majoração dos honorários advocatícios, nos termos do art. 85, §11, do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e não provido.
+    Dispositivos relevantes citados: CTB, art. 29, II; CPC, arts. 373, I, e 85, §11.
+Jurisprudência relevante citada: TJ-MG - AC: 18518738920148130024 Belo Horizonte, Relator.: Des.(a) Evangelina Castilho Duarte, Data de Julgamento: 03/08/2023, 14ª CÂMARA CÍVEL, Data de Publicação: 03/08/2023; AP 1.0433.05.145675-7/001 - Rel. Des. Alberto Aluízio Pacheco de Andrade - j. 15.05.2007, DJ 25.05.2007; TJ-MG - AC: 10000222796807001 MG, Relator.: Mônica Libânio, Data de Julgamento: 15/02/2023, Câmaras Cíveis / 11ª CÂMARA CÍVEL, Data de Publicação: 15/02/2023; TJ-MG - AC: 10000220275721001 MG, Relator.: Habib Felippe Jabour, Data de Julgamento: 26/04/2022, Câmaras Cíveis / 18ª CÂMARA CÍVEL, Data de Publicação: 26/04/2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811840" cdForo="0" >
+										0746851-22.2023.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811840" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811840);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811840" style="display: none;" >
+	<div id="textAreaDados_811840" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E CIVIL. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. PLANO DE SA&Uacute;DE. TRANSTORNO DO ESPECTRO AUTISTA. TRATAMENTO MULTIDISCIPLINAR. COBERTURA ASSISTENCIAL. EXCLUS&Atilde;O DO ASSISTENTE TERAP&Ecirc;UTICO EM AMBIENTE DOMICILIAR E ESCOLAR. REDE CREDENCIADA E REEMBOLSO. DANO MORAL. MAJORA&Ccedil;&Atilde;O. HONOR&Aacute;RIOS SUCUMBENCIAIS. RECURSO DA OPERADORA PROVIDO. RECURSO DA AUTORA PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&otilde;es C&iacute;veis interpostas contra senten&ccedil;a que julgou parcialmente procedente a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer cumulada com indeniza&ccedil;&atilde;o por danos morais, determinando o custeio de tratamento multidisciplinar para paciente diagnosticada com Transtorno do Espectro Autista, bem como condenando a r&eacute; ao pagamento de indeniza&ccedil;&atilde;o por dano moral no valor de R$ 3.000,00.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; obrigat&oacute;ria a cobertura, pelo plano de sa&uacute;de, do servi&ccedil;o de Assistente Terap&ecirc;utico em ambiente domiciliar ou escolar; (ii) estabelecer as condi&ccedil;&otilde;es de custeio ou reembolso do tratamento multidisciplinar realizado fora da rede credenciada; (iii) determinar a configura&ccedil;&atilde;o e o quantum indenizat&oacute;rio do dano moral decorrente da negativa de cobertura; (iv) examinar a corre&ccedil;&atilde;o da base de c&aacute;lculo e do percentual dos honor&aacute;rios advocat&iacute;cios sucumbenciais.
+III. RAZ&Otilde;ES DE DECIDIR
+1. A rela&ccedil;&atilde;o entre as partes &eacute; de consumo, submetida ao C&oacute;digo de Defesa do Consumidor, aplicando-se a interpreta&ccedil;&atilde;o mais favor&aacute;vel ao consumidor e a veda&ccedil;&atilde;o de cl&aacute;usulas abusivas.
+2. O direito fundamental &agrave; sa&uacute;de, aliado aos princ&iacute;pios da dignidade da pessoa humana e da inafastabilidade da jurisdi&ccedil;&atilde;o, imp&otilde;e a cobertura do tratamento prescrito por m&eacute;dico assistente para paciente com TEA.
+3. A Resolu&ccedil;&atilde;o Normativa ANS n&ordm; 539/2022 ampliou a cobertura assistencial para benefici&aacute;rios com transtornos globais do desenvolvimento, tornando obrigat&oacute;ria a cobertura dos m&eacute;todos e t&eacute;cnicas indicados pelo m&eacute;dico assistente, desde que executados por profissionais de sa&uacute;de habilitados.
+4. A imposi&ccedil;&atilde;o de custeio de Assistente Terap&ecirc;utico em ambiente natural do paciente extrapola o objeto do contrato de plano de sa&uacute;de e implica risco de desequil&iacute;brio da equa&ccedil;&atilde;o contratual, inexistindo obriga&ccedil;&atilde;o legal ou contratual de cobertura.
+5. A operadora deve fornecer o tratamento multidisciplinar indicado, na carga hor&aacute;ria prescrita, por meio de profissionais ou cl&iacute;nicas credenciadas tecnicamente habilitadas.
+6. Comprovada a inexist&ecirc;ncia ou indisponibilidade de prestadores aptos na rede credenciada, imp&otilde;e-se o custeio ou reembolso integral das despesas realizadas com profissionais n&atilde;o credenciados. Existindo rede credenciada dispon&iacute;vel e optando o benefici&aacute;rio por atendimento particular, o reembolso deve observar os limites da tabela contratual.
+7. A negativa indevida de cobertura de tratamento essencial configura dano moral in re ipsa, dispensando prova do preju&iacute;zo extrapatrimonial. O valor da indeniza&ccedil;&atilde;o por dano moral deve ser majorado para atender aos princ&iacute;pios da razoabilidade e proporcionalidade, considerando a gravidade da conduta, a condi&ccedil;&atilde;o das partes e o car&aacute;ter pedag&oacute;gico da condena&ccedil;&atilde;o.
+8. Os honor&aacute;rios advocat&iacute;cios sucumbenciais foram corretamente fixados no percentual m&iacute;nimo legal sobre o valor da condena&ccedil;&atilde;o, nos termos do art. 85, &sect; 2&ordm;, do CPC e da jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a.
+IV. DISPOSITIVO E TESE
+Recurso da operadora provido. Recurso da autora parcialmente provido.
+Dispositivos relevantes citados: CF/1988, arts. 1&ordm;, III; 5&ordm;, XXXV; 6&ordm;; 196; CDC, arts. 14, 47, 51; CC/2002, arts. 186 e 927; CPC/2015, art. 85, &sect; 2&ordm;; Lei n&ordm; 9.656/98, art. 10, &sect;&sect; 12 e 13; Resolu&ccedil;&atilde;o Normativa ANS n&ordm; 539/2022.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no AREsp n&ordm; 2.153.601/MA, Rel. Min. Moura Ribeiro, 3&ordf; Turma, j. 24.10.2022; STJ, REsp n&ordm; 2.064.964/SP, Rel. Min. Nancy Andrighi, 3&ordf; Turma, j. 20.02.2024; STJ, EAREsp n&ordm; 1.459.849/ES, Rel. Min. Marco Aur&eacute;lio Bellizze, 2&ordf; Se&ccedil;&atilde;o, j. 14.10.2020; TJAL, AI n&ordm; 0805789-13.2023.8.02.0000, Rel. Des. Ivan Vasconcelos Brito J&uacute;nior, 4&ordf; C&acirc;mara C&iacute;vel, j. 13.09.2023. <br><br>(N&uacute;mero do Processo: 0746851-22.2023.8.02.0001; Relator (a):&nbsp;Des. Paulo Barros da Silva Lima; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 1&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(69 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento da Própria Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Barros da Silva Lima
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÕES CÍVEIS. PLANO DE SAÚDE. TRANSTORNO DO ESPECTRO AUTISTA. TRATAMENTO MULTIDISCIPLINAR. COBERTURA ASSISTENCIAL. EXCLUSÃO DO ASSISTENTE TERAPÊUTICO EM AMBIENTE DOMICILIAR E ESCOLAR. REDE CREDENCIADA E REEMBOLSO. <em>DANO</em> <em>MORAL</em>. MAJORAÇÃO. HONORÁRIOS SUCUMBENCIAIS. RECURSO DA OPERADORA PROVIDO. RECURSO DA AUTORA PARCIALMENTE PROVIDO.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÕES CÍVEIS. PLANO DE SAÚDE. TRANSTORNO DO ESPECTRO AUTISTA. TRATAMENTO MULTIDISCIPLINAR. COBERTURA ASSISTENCIAL. EXCLUSÃO DO ASSISTENTE TERAPÊUTICO EM AMBIENTE DOMICILIAR E ESCOLAR. REDE CREDENCIADA E REEMBOLSO. <em>DANO</em> <em>MORAL</em>. MAJORAÇÃO. HONORÁRIOS SUCUMBENCIAIS. RECURSO DA OPERADORA PROVIDO. RECURSO DA AUTORA PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apelações Cíveis interpostas contra sentença que julgou parcialmente procedente ação de obrigação de fazer cumulada com indenização por <em>danos</em> <em>morais</em>, determinando o custeio de tratamento multidisciplinar para paciente diagnosticada com Transtorno do Espectro Autista, bem como condenando a ré ao pagamento de indenização por <em>dano</em> <em>moral</em> no valor de R$ 3.000,00.
+II. QUESTÃO EM DISCUSSÃO
+Há quatro questões em discussão: (i) definir se é obrigatória a cobertura, pelo plano de saúde, do serviço de Assistente Terapêutico em ambiente domiciliar ou escolar; (ii) estabelecer as condições de custeio ou reembolso do tratamento multidisciplinar realizado fora da rede credenciada; (iii) determinar a configuração e o quantum indenizatório do <em>dano</em> <em>moral</em> decorrente da negativa de cobertura; (iv) examinar a correção da base de cálculo e do percentual dos honorários advocatícios sucumbenciais.
+III. RAZÕES DE DECIDIR
+1. A relação entre as partes é de consumo, submetida ao Código de Defesa do Consumidor, aplicando-se a interpretação mais favorável ao consumidor e a vedação de cláusulas abusivas.
+2. O direito fundamental à saúde, aliado aos princípios da dignidade da pessoa humana e da inafastabilidade da jurisdição, impõe a cobertura do tratamento prescrito por médico assistente para paciente com TEA.
+3. A Resolução Normativa ANS nº 539/2022 ampliou a cobertura assistencial para beneficiários com transtornos globais do desenvolvimento, tornando obrigatória a cobertura dos métodos e técnicas indicados pelo médico assistente, desde que executados por profissionais de saúde habilitados.
+4. A imposição de custeio de Assistente Terapêutico em ambiente natural do paciente extrapola o objeto do contrato de plano de saúde e implica risco de desequilíbrio da equação contratual, inexistindo obrigação legal ou contratual de cobertura.
+5. A operadora deve fornecer o tratamento multidisciplinar indicado, na carga horária prescrita, por meio de profissionais ou clínicas credenciadas tecnicamente habilitadas.
+6. Comprovada a inexistência ou indisponibilidade de prestadores aptos na rede credenciada, impõe-se o custeio ou reembolso integral das despesas realizadas com profissionais não credenciados. Existindo rede credenciada disponível e optando o beneficiário por atendimento particular, o reembolso deve observar os limites da tabela contratual.
+7. A negativa indevida de cobertura de tratamento essencial configura <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo extrapatrimonial. O valor da indenização por <em>dano</em> <em>moral</em> deve ser majorado para atender aos princípios da razoabilidade e proporcionalidade, considerando a gravidade da conduta, a condição das partes e o caráter pedagógico da condenação.
+8. Os honorários advocatícios sucumbenciais foram corretamente fixados no percentual mínimo legal sobre o valor da condenação, nos termos do art. 85, § 2º, do CPC e da jurisprudência do Superior Tribunal de Justiça.
+IV. DISPOSITIVO E TESE
+Recurso da operadora provido. Recurso da autora parcialmente provido.
+Dispositivos relevantes citados: CF/1988, arts. 1º, III; 5º, XXXV; 6º; 196; CDC, arts. 14, 47, 51; CC/2002, arts. 186 e 927; CPC/2015, art. 85, § 2º; Lei nº 9.656/98, art. 10, §§ 12 e 13; Resolução Normativa ANS nº 539/2022.
+Jurisprudência relevante citada: STJ, AgInt no AREsp nº 2.153.601/MA, Rel. Min. Moura Ribeiro, 3ª Turma, j. 24.10.2022; STJ, REsp nº 2.064.964/SP, Rel. Min. Nancy Andrighi, 3ª Turma, j. 20.02.2024; STJ, EAREsp nº 1.459.849/ES, Rel. Min. Marco Aurélio Bellizze, 2ª Seção, j. 14.10.2020; TJAL, AI nº 0805789-13.2023.8.02.0000, Rel. Des. Ivan Vasconcelos Brito Júnior, 4ª Câmara Cível, j. 13.09.2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811921" cdForo="0" >
+										0745115-95.2025.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811921" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811921);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811921" style="display: none;" >
+	<div id="textAreaDados_811921" class="mensagemSemFormatacao" >
+		DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E &Agrave; SA&Uacute;DE. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS. REAJUSTE DE MENSALIDADE DE PLANO DE SA&Uacute;DE COLETIVO COM MENOS DE TRINTA USU&Aacute;RIOS. &quot;FALSO COLETIVO&quot;. PRESCRI&Ccedil;&Atilde;O TRIENAL. POSSIBILIDADE DE APLICA&Ccedil;&Atilde;O APENAS DOS REAJUSTES POR FAIXA ET&Aacute;RIA E DOS REAJUSTES ANUAIS SEGUNDO OS &Iacute;NDICES DA ANS. PROVIMENTO.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta caontra senten&ccedil;a que julgou parcialmente procedentes os pedidos na inicial, reconhecendo a abusividade do reajuste superior ao &iacute;ndice aplicado pela ANS para planos individuais e familiares, com a determina&ccedil;&atilde;o da restitui&ccedil;&atilde;o, na forma simples, do que foi pago a maior, limitado ao quinqu&ecirc;nio anterior ao ajuizamento da demanda.
+ii. Quest&atilde;o em discuss&atilde;o
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) apreciar se houve cerceamento de defesa ao indeferir a prova atuarial; (ii) apreciar a incid&ecirc;ncia da prescri&ccedil;&atilde;o; (iii) verificar a regularidade dos reajustes aplicados sobre a mensalidade do plano de sa&uacute;de da parte autora.
+iii. raz&otilde;es de decidir
+3. Cerceamento de defesa n&atilde;o configurado. Prova manifestamente desnecess&aacute;ria para o deslinde da controv&eacute;rsia.
+4. Incid&ecirc;ncia do prazo prescricional de tr&ecirc;s anos, aplic&aacute;vel para o ressarcimento decorrente do enriquecimento sem causa.
+5. Em casos de contratos considerados &quot;falsos coletivos&quot;, quando o plano coletivo &eacute;, na pr&aacute;tica, similar a um plano individual ou familiar, o Superior Tribunal de Justi&ccedil;a tem decidido que esses contratos podem ser equiparados a planos individuais ou familiares.&nbsp;Permite-se, por consequ&ecirc;ncia, que lhe sejam aplicados apenas os reajustes por faixa et&aacute;ria e os reajustes anuais segundo os &iacute;ndices da ANS, tendo em vista a hipossufici&ecirc;ncia da empresa contratante perante as operadoras de plano de sa&uacute;de em tais hip&oacute;teses.
+6. O c&aacute;lculo dos valores devidos deve ser realizado com base nos &iacute;ndices de reajuste estabelecidos pela ANS.
+iv. Dispositivo e tese
+7. Recurso conhecido e parcialmente provido, apenas para reconhecer a incid&ecirc;ncia da prescri&ccedil;&atilde;o trienal.
+_________
+Dispositivos relevantes citados: CDC, art. 2&ordm;, art. 3&ordm;; Resolu&ccedil;&atilde;o Normativa n&ordm; 309/2012 ANS, art. 9&ordm;; CC , art. 206, &sect; 3&ordm;, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no REsp 1568244 RJ 2015/0297278-0, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 2&ordf;Se&ccedil;&atilde;o, j. 22.02.2018; STJ, AgRg nos EDcl no AREsp 235.553/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 3&ordf; Turma, j. 02.06.2015; STJ, AgInt no AREsp: 2366300 SP 2023/0175392-1, Rel. Min. Antonio Carlos Ferreira, 4&ordf; Turma, j. 30.10.2023; STJ, AgInt no AREsp 2285008 SP 2023/0020654-2, Rel. Min. Humberto Martins, 3&ordf; Turma, j. 08.04.2024; STJ, REM 56.333/BA, Rel. Min. Mauro Campbell Marques, 2&ordf; Turma, j. 01.03.2018; STJ, AgInt no AREsp 1170544/MG, Rel. Min. Luis Felipe Salom&atilde;o, 4&ordf; Turma, j. 06.02.2018. <br><br>(N&uacute;mero do Processo: 0745115-95.2025.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANOS</em> MATERIAIS. REAJUSTE DE MENSALIDADE DE PLANO DE SAÚDE COLETIVO COM MENOS DE TRINTA USUÁRIOS. "FALSO COLETIVO". PRESCRIÇÃO TRIENAL. POSSIBILIDADE DE APLICAÇÃO APENAS DOS REAJUSTES POR FAIXA ETÁRIA E DOS REAJUSTES ANUAIS SEGUNDO OS ÍNDICES DA ANS. PROVIMENTO.
+I.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANOS</em> MATERIAIS. REAJUSTE DE MENSALIDADE DE PLANO DE SAÚDE COLETIVO COM MENOS DE TRINTA USUÁRIOS. "FALSO COLETIVO". PRESCRIÇÃO TRIENAL. POSSIBILIDADE DE APLICAÇÃO APENAS DOS REAJUSTES POR FAIXA ETÁRIA E DOS REAJUSTES ANUAIS SEGUNDO OS ÍNDICES DA ANS. PROVIMENTO.
+I. Caso em exame
+1. Apelação cível interposta caontra sentença que julgou parcialmente procedentes os pedidos na inicial, reconhecendo a abusividade do reajuste superior ao índice aplicado pela ANS para planos individuais e familiares, com a determinação da restituição, na forma simples, do que foi pago a maior, limitado ao quinquênio anterior ao ajuizamento da demanda.
+ii. Questão em discussão
+2. As questões em discussão consistem em: (i) apreciar se houve cerceamento de defesa ao indeferir a prova atuarial; (ii) apreciar a incidência da prescrição; (iii) verificar a regularidade dos reajustes aplicados sobre a mensalidade do plano de saúde da parte autora.
+iii. razões de decidir
+3. Cerceamento de defesa não configurado. Prova manifestamente desnecessária para o deslinde da controvérsia.
+4. Incidência do prazo prescricional de três anos, aplicável para o ressarcimento decorrente do enriquecimento sem causa.
+5. Em casos de contratos considerados "falsos coletivos", quando o plano coletivo é, na prática, similar a um plano individual ou familiar, o Superior Tribunal de Justiça tem decidido que esses contratos podem ser equiparados a planos individuais ou familiares. Permite-se, por consequência, que lhe sejam aplicados apenas os reajustes por faixa etária e os reajustes anuais segundo os índices da ANS, tendo em vista a hipossuficiência da empresa contratante perante as operadoras de plano de saúde em tais hipóteses.
+6. O cálculo dos valores devidos deve ser realizado com base nos índices de reajuste estabelecidos pela ANS.
+iv. Dispositivo e tese
+7. Recurso conhecido e parcialmente provido, apenas para reconhecer a incidência da prescrição trienal.
+_________
+Dispositivos relevantes citados: CDC, art. 2º, art. 3º; Resolução Normativa nº 309/2012 ANS, art. 9º; CC , art. 206, § 3º, IV.
+Jurisprudência relevante citada: STJ, EDcl no REsp 1568244 RJ 2015/0297278-0, Rel. Min. Ricardo Villas Bôas Cueva, 2ªSeção, j. 22.02.2018; STJ, AgRg nos EDcl no AREsp 235.553/SP, Rel. Min. Ricardo Villas Bôas Cueva, 3ª Turma, j. 02.06.2015; STJ, AgInt no AREsp: 2366300 SP 2023/0175392-1, Rel. Min. Antonio Carlos Ferreira, 4ª Turma, j. 30.10.2023; STJ, AgInt no AREsp 2285008 SP 2023/0020654-2, Rel. Min. Humberto Martins, 3ª Turma, j. 08.04.2024; STJ, REM 56.333/BA, Rel. Min. Mauro Campbell Marques, 2ª Turma, j. 01.03.2018; STJ, AgInt no AREsp 1170544/MG, Rel. Min. Luis Felipe Salomão, 4ª Turma, j. 06.02.2018.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811915" cdForo="0" >
+										0802158-56.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811915" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811915);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811915" style="display: none;" >
+	<div id="textAreaDados_811915" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. EXTIN&Ccedil;&Atilde;O DO PROCESSO DE ORIGEM EM RELA&Ccedil;&Atilde;O &Agrave;S PARTES AGRAVANTES. REALIZA&Ccedil;&Atilde;O DE ACORDO COM A EMPRESA RECORRIDA NOS AUTOS DO CUMPRIMENTO DE SENTEN&Ccedil;A QUE TRAMITA NA 3&ordf; VARA FEDERAL DE ALAGOAS, QUE ENGLOBA O OBJETO DA DEMANDA. POSSIBILIDADE DE REQUERIMENTO DE FIXA&Ccedil;&Atilde;O E RETEN&Ccedil;&Atilde;O DE HONOR&Aacute;RIOS EM FAVOR DO PATRONO DAS PARTES AGRAVANTES, DESDE QUE PERANTE AO JU&Iacute;ZO QUE PROCEDEU &Agrave; HOMOLOGA&Ccedil;&Atilde;O DO ACORDO. INCOMPET&Ecirc;NCIA DA JUSTI&Ccedil;A ESTADUAL. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa &agrave; reforma da decis&atilde;o de primeiro grau, que indeferiu os pedidos de produ&ccedil;&atilde;o de prova oral e de invers&atilde;o do &ocirc;nus da prova, assim como extinguiu parcialmente o feito, sem resolu&ccedil;&atilde;o de m&eacute;rito, em rela&ccedil;&atilde;o a 4 (quatro) partes autoras, uma vez que estas teriam optado pela ades&atilde;o ao Programa de Compensa&ccedil;&atilde;o Financeira, ao celebrar acordo nos autos dos cumprimentos de senten&ccedil;as vinculados &agrave; A&ccedil;&atilde;o Civil P&uacute;blica n&ordm; 0803836-61.2019.4.05.8000, em tr&acirc;mite perante a 3&ordf; Vara Federal de Alagoas.
+ii. Quest&atilde;o em discuss&atilde;o
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) saber se as partes agravantes fazem jus &agrave; concess&atilde;o dos benef&iacute;cios da justi&ccedil;a gratuita; (ii) verificar o cabimento da insurg&ecirc;ncia recursal relativa ao indeferimento da produ&ccedil;&atilde;o de prova oral; (iii) analisar se os pedidos de desmembramento do feito em rela&ccedil;&atilde;o &agrave;s partes que n&atilde;o fizeram acordo na Justi&ccedil;a Federal e de sobrestamento do processo at&eacute; o julgamento definitivo da a&ccedil;&atilde;o civil p&uacute;blica n. 0807343-54.2024.4.05.8000, observam o princ&iacute;pio da dialeticidade; (iv) saber se os acordos firmados entre as partes agravantes, os quais foram submetidos &agrave; homologa&ccedil;&atilde;o do Ju&iacute;zo Federal da 3&ordf; Vara Federal em Macei&oacute;, nos autos dos cumprimentos de senten&ccedil;a vinculados &agrave; a&ccedil;&atilde;o civil p&uacute;blica n. 0803836-61.2019.4.05.8000, ensejam a perda superveniente do interesse de agir dos recorrentes quanto ao pedido de indeniza&ccedil;&atilde;o por danos morais; (v) aferir a suposta abusividade do acordo, tendo em vista que conteria cl&aacute;usulas leoninas; (vi) analisar o pedido subsidi&aacute;rio de resguardo dos direitos do patrono das partes agravantes, em raz&atilde;o da suposta viola&ccedil;&atilde;o do contrato de presta&ccedil;&atilde;o de servi&ccedil;o outrora firmado; e (vii) averiguar se a conduta das partes recorrentes configura&nbsp;litig&acirc;ncia&nbsp;de&nbsp;m&aacute;-f&eacute;.
+iii. raz&otilde;es de decidir
+3. N&atilde;o conhecimento do recurso, por&nbsp;aus&ecirc;ncia&nbsp;de&nbsp;interesse&nbsp;recursal, no ponto em que pleiteia a concess&atilde;o do benef&iacute;cio&nbsp;de&nbsp;justi&ccedil;a&nbsp;gratuita, tendo em vista que a gratuidade&nbsp;de&nbsp;justi&ccedil;a&nbsp;j&aacute; havia sido deferida na origem.&nbsp;
+4. Na esp&eacute;cie, o depoimento pessoal das partes e a oitiva de testemunhas se destinariam a comprovar que os agravantes s&atilde;o moradores inseridos na &aacute;rea de risco e nos bairros afetados pelo desastre socioambiental. Aus&ecirc;ncia de risco de perecimento do objeto da prova neste caso. Inexist&ecirc;ncia de inutilidade da aprecia&ccedil;&atilde;o do indeferimento da prova oral em sede de apela&ccedil;&atilde;o. N&atilde;o conhecimento desse ponto.
+5. Alega&ccedil;&atilde;o de necessidade de desmembramento e&nbsp;sobrestamento&nbsp;do feito que n&atilde;o dialoga com os fundamentos do decisum recorrido. Viola&ccedil;&atilde;o ao princ&iacute;pio da&nbsp;dialeticidade&nbsp;verificada.&nbsp;N&atilde;o conhecimento dessa parcela da insurg&ecirc;ncia recursal.
+6. Inexist&ecirc;ncia de interesse de agir dos agravantes, tendo em vista que suas pretens&otilde;es j&aacute; foram abarcadas pelos acordos firmados no Programa de Compensa&ccedil;&atilde;o Financeira - PCF, homologados perante a Justi&ccedil;a Federal, que contemplam os danos materiais e morais, direta ou indiretamente relacionados &agrave; desocupa&ccedil;&atilde;o de im&oacute;vel, em raz&atilde;o do fen&ocirc;meno geol&oacute;gico. Exist&ecirc;ncia de ren&uacute;ncia expressa dos referidos demandantes a quaisquer direitos remanescentes decorrentes da desocupa&ccedil;&atilde;o.
+7. O presente recurso n&atilde;o &eacute; a via adequada para questionar a regularidade dos acordos firmados pelos recorrentes, cabendo a eles, primeiramente, impugnar a aven&ccedil;a junto &agrave; Justi&ccedil;a Federal, visto que o acordo foi homologado pelo Ju&iacute;zo da 3&ordf; Vara Federal, para s&oacute; ent&atilde;o pleitear o direito que entendem devido perante a Justi&ccedil;a Estadual.
+8. Cabimento do pedido de preserva&ccedil;&atilde;o do direito de honor&aacute;rios, em benef&iacute;cio do patrono das partes recorrentes, tendo em vista que a realiza&ccedil;&atilde;o de acordo extrajudicial, posteriormente homologado judicialmente, n&atilde;o implica ren&uacute;ncia autom&aacute;tica &agrave; verba honor&aacute;ria. No entanto, considerando que os acordos firmados tiveram sua homologa&ccedil;&atilde;o firmada perante a Justi&ccedil;a Federal, este &eacute; competente para a an&aacute;lise do direito do patrono das partes agravantes ao recebimento dos seus respectivos honor&aacute;rios.
+9. O art. 80 do CPC exige a presen&ccedil;a inequ&iacute;voca de m&aacute;-f&eacute; na&nbsp;litig&acirc;ncia&nbsp;para a aplica&ccedil;&atilde;o da multa, sendo essa requisito indispens&aacute;vel, sem o qual n&atilde;o se autoriza a aplica&ccedil;&atilde;o da penalidade prevista.&nbsp;Litig&acirc;ncia&nbsp;de m&aacute;-f&eacute; n&atilde;o caracterizada.
+iv. Dispositivo e tese
+10. Recurso parcialmente conhecido e, nesta parte, desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 80, art. 81, e art. 85, &sect;14; CC, art. 844; Lei n. 8.906/1994, art. 24, &sect;4&ordm;, &sect;5&ordm; e &sect;6&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, 1.613..672/RJ, Rel. Min. Marco Aur&eacute;lio Bellizze, Terceira Turma, j. 14.02.2017; STJ, AgInt no AREsp n. 1.636.268/RJ, Rel. Min. Luis Felipe Salom&atilde;o, Rel. para ac&oacute;rd&atilde;o Min. Raul Ara&uacute;jo, Quarta Turma, j. 24.08.2021. <br><br>(N&uacute;mero do Processo: 0802158-56.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Litisconsórcio
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. EXTINÇÃO DO PROCESSO DE ORIGEM EM RELAÇÃO ÀS PARTES AGRAVANTES. REALIZAÇÃO DE ACORDO COM A EMPRESA RECORRIDA NOS AUTOS DO CUMPRIMENTO DE SENTENÇA QUE TRAMITA NA 3ª VARA FEDERAL DE ALAGOAS, QUE ENGLOBA O OBJETO DA DEMANDA. POSSIBILIDADE DE REQUERIMENTO DE FIXAÇÃO E RETENÇÃO DE HONORÁRIOS EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. EXTINÇÃO DO PROCESSO DE ORIGEM EM RELAÇÃO ÀS PARTES AGRAVANTES. REALIZAÇÃO DE ACORDO COM A EMPRESA RECORRIDA NOS AUTOS DO CUMPRIMENTO DE SENTENÇA QUE TRAMITA NA 3ª VARA FEDERAL DE ALAGOAS, QUE ENGLOBA O OBJETO DA DEMANDA. POSSIBILIDADE DE REQUERIMENTO DE FIXAÇÃO E RETENÇÃO DE HONORÁRIOS EM FAVOR DO PATRONO DAS PARTES AGRAVANTES, DESDE QUE PERANTE AO JUÍZO QUE PROCEDEU À HOMOLOGAÇÃO DO ACORDO. INCOMPETÊNCIA DA JUSTIÇA ESTADUAL. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa à reforma da decisão de primeiro grau, que indeferiu os pedidos de produção de prova oral e de inversão do ônus da prova, assim como extinguiu parcialmente o feito, sem resolução de mérito, em relação a 4 (quatro) partes autoras, uma vez que estas teriam optado pela adesão ao Programa de Compensação Financeira, ao celebrar acordo nos autos dos cumprimentos de sentenças vinculados à Ação Civil Pública nº 0803836-61.2019.4.05.8000, em trâmite perante a 3ª Vara Federal de Alagoas.
+ii. Questão em discussão
+2. As questões em discussão consistem em: (i) saber se as partes agravantes fazem jus à concessão dos benefícios da justiça gratuita; (ii) verificar o cabimento da insurgência recursal relativa ao indeferimento da produção de prova oral; (iii) analisar se os pedidos de desmembramento do feito em relação às partes que não fizeram acordo na Justiça Federal e de sobrestamento do processo até o julgamento definitivo da ação civil pública n. 0807343-54.2024.4.05.8000, observam o princípio da dialeticidade; (iv) saber se os acordos firmados entre as partes agravantes, os quais foram submetidos à homologação do Juízo Federal da 3ª Vara Federal em Maceió, nos autos dos cumprimentos de sentença vinculados à ação civil pública n. 0803836-61.2019.4.05.8000, ensejam a perda superveniente do interesse de agir dos recorrentes quanto ao pedido de indenização por <em>danos</em> <em>morais</em>; (v) aferir a suposta abusividade do acordo, tendo em vista que conteria cláusulas leoninas; (vi) analisar o pedido subsidiário de resguardo dos direitos do patrono das partes agravantes, em razão da suposta violação do contrato de prestação de serviço outrora firmado; e (vii) averiguar se a conduta das partes recorrentes configura litigância de má-fé.
+iii. razões de decidir
+3. Não conhecimento do recurso, por ausência de interesse recursal, no ponto em que pleiteia a concessão do benefício de justiça gratuita, tendo em vista que a gratuidade de justiça já havia sido deferida na origem. 
+4. Na espécie, o depoimento pessoal das partes e a oitiva de testemunhas se destinariam a comprovar que os agravantes são moradores inseridos na área de risco e nos bairros afetados pelo desastre socioambiental. Ausência de risco de perecimento do objeto da prova neste caso. Inexistência de inutilidade da apreciação do indeferimento da prova oral em sede de apelação. Não conhecimento desse ponto.
+5. Alegação de necessidade de desmembramento e sobrestamento do feito que não dialoga com os fundamentos do decisum recorrido. Violação ao princípio da dialeticidade verificada. Não conhecimento dessa parcela da insurgência recursal.
+6. Inexistência de interesse de agir dos agravantes, tendo em vista que suas pretensões já foram abarcadas pelos acordos firmados no Programa de Compensação Financeira - PCF, homologados perante a Justiça Federal, que contemplam os <em>danos</em> materiais e <em>morais</em>, direta ou indiretamente relacionados à desocupação de imóvel, em razão do fenômeno geológico. Existência de renúncia expressa dos referidos demandantes a quaisquer direitos remanescentes decorrentes da desocupação.
+7. O presente recurso não é a via adequada para questionar a regularidade dos acordos firmados pelos recorrentes, cabendo a eles, primeiramente, impugnar a avença junto à Justiça Federal, visto que o acordo foi homologado pelo Juízo da 3ª Vara Federal, para só então pleitear o direito que entendem devido perante a Justiça Estadual.
+8. Cabimento do pedido de preservação do direito de honorários, em benefício do patrono das partes recorrentes, tendo em vista que a realização de acordo extrajudicial, posteriormente homologado judicialmente, não implica renúncia automática à verba honorária. No entanto, considerando que os acordos firmados tiveram sua homologação firmada perante a Justiça Federal, este é competente para a análise do direito do patrono das partes agravantes ao recebimento dos seus respectivos honorários.
+9. O art. 80 do CPC exige a presença inequívoca de má-fé na litigância para a aplicação da multa, sendo essa requisito indispensável, sem o qual não se autoriza a aplicação da penalidade prevista. Litigância de má-fé não caracterizada.
+iv. Dispositivo e tese
+10. Recurso parcialmente conhecido e, nesta parte, desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 80, art. 81, e art. 85, §14; CC, art. 844; Lei n. 8.906/1994, art. 24, §4º, §5º e §6º.
+Jurisprudência relevante citada: STJ, 1.613..672/RJ, Rel. Min. Marco Aurélio Bellizze, Terceira Turma, j. 14.02.2017; STJ, AgInt no AREsp n. 1.636.268/RJ, Rel. Min. Luis Felipe Salomão, Rel. para acórdão Min. Raul Araújo, Quarta Turma, j. 24.08.2021.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811894" cdForo="0" >
+										0802122-14.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811894" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811894);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811894" style="display: none;" >
+	<div id="textAreaDados_811894" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C REPARA&Ccedil;&Atilde;O DE DANOS MATERIAIS E MORAIS.  OCORR&Ecirc;NCIA DO SINISTRO DECORRENTE DA ATIVIDADE MINERADORA EXERCIDA PELA AGRAVADA. DEGRADA&Ccedil;&Atilde;O AMBIENTAL. FATO NOT&Oacute;RIO E INCONTROVERSO. DESNECESSIDADE DE INVERS&Atilde;O DO &Ocirc;NUS DA PROVA. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa &agrave; reforma da decis&atilde;o de primeiro grau que  rejeitou  o pedido de invers&atilde;o do &ocirc;nus da prova, ao passo em que deferiu o pedido de produ&ccedil;&atilde;o de prova pericial formulado pela parte autora.
+ii. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se &eacute; devida a invers&atilde;o do &ocirc;nus da prova.
+iii. raz&otilde;es de decidir
+3. N&atilde;o cabimento da invers&atilde;o do &ocirc;nus probat&oacute;rio nos moldes pretendidos pela parte recorrente, em raz&atilde;o de ser fato p&uacute;blico e not&oacute;rio &ndash; e incontroverso &ndash; que a atividade mineradora exercida pela empresa Braskem em alguns bairros da capital trouxe consequ&ecirc;ncias urban&iacute;sticas e ambientais, motivo pelo qual a aplica&ccedil;&atilde;o do instituto seria desnecess&aacute;ria para demonstrar que n&atilde;o causou o evento apontado pela parte agravante.
+4. Possibilidade de o perito nomeado pelo ju&iacute;zo a quo solicitar outros documentos que estejam em poder da empresa demandada, se necess&aacute;rios ao esclarecimento do objeto da per&iacute;cia, nos moldes do art. 473, &sect;3&ordm;, do CPC.
+iv. Dispositivo e tese
+5. Recurso conhecido e desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 374, I, art. 473, &sect;3&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n. 802.832/MG, Rel. Min. Paulo de Tarso Sanseverino, Segunda Se&ccedil;&atilde;o, j. 13.04.2011; S&uacute;mula n. 618/STJ; STJ, AgInt no AREsp 663.184/TO, Rel. Min. Marco Buzzi, Quarta Turma, j. 15.05.2018. <br><br>(N&uacute;mero do Processo: 0802122-14.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(31 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Dano Ambiental
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE <em>DANOS</em> MATERIAIS E <em>MORAIS</em>.  OCORRÊNCIA DO SINISTRO DECORRENTE DA ATIVIDADE MINERADORA EXERCIDA PELA AGRAVADA. DEGRADAÇÃO AMBIENTAL. FATO NOTÓRIO E INCONTROVERSO. DESNECESSIDADE DE INVERSÃO DO ÔNUS DA PROVA. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa à reforma da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE <em>DANOS</em> MATERIAIS E <em>MORAIS</em>.  OCORRÊNCIA DO SINISTRO DECORRENTE DA ATIVIDADE MINERADORA EXERCIDA PELA AGRAVADA. DEGRADAÇÃO AMBIENTAL. FATO NOTÓRIO E INCONTROVERSO. DESNECESSIDADE DE INVERSÃO DO ÔNUS DA PROVA. DESPROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento que visa à reforma da decisão de primeiro grau que  rejeitou  o pedido de inversão do ônus da prova, ao passo em que deferiu o pedido de produção de prova pericial formulado pela parte autora.
+ii. Questão em discussão
+2. A questão em discussão consiste em saber se é devida a inversão do ônus da prova.
+iii. razões de decidir
+3. Não cabimento da inversão do ônus probatório nos moldes pretendidos pela parte recorrente, em razão de ser fato público e notório – e incontroverso – que a atividade mineradora exercida pela empresa Braskem em alguns bairros da capital trouxe consequências urbanísticas e ambientais, motivo pelo qual a aplicação do instituto seria desnecessária para demonstrar que não causou o evento apontado pela parte agravante.
+4. Possibilidade de o perito nomeado pelo juízo a quo solicitar outros documentos que estejam em poder da empresa demandada, se necessários ao esclarecimento do objeto da perícia, nos moldes do art. 473, §3º, do CPC.
+iv. Dispositivo e tese
+5. Recurso conhecido e desprovido.
+_________
+Dispositivos relevantes citados: CPC, art. 374, I, art. 473, §3º.
+Jurisprudência relevante citada: STJ, REsp n. 802.832/MG, Rel. Min. Paulo de Tarso Sanseverino, Segunda Seção, j. 13.04.2011; Súmula n. 618/STJ; STJ, AgInt no AREsp 663.184/TO, Rel. Min. Marco Buzzi, Quarta Turma, j. 15.05.2018.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811868" cdForo="0" >
+										0700737-38.2024.8.02.0050
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811868" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811868);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811868" style="display: none;" >
+	<div id="textAreaDados_811868" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. DIREITO CIVIL. JU&Iacute;ZO DE RETRATA&Ccedil;&Atilde;O EM EMBARGOS DE DECLARA&Ccedil;&Atilde;O DE APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE COBRAN&Ccedil;A C/C DANOS MORAIS. DESFALQUES EM PASEP. TEMA 1.387/STJ PUBLICADO AP&Oacute;S O JULGAMENTO PRINCIPAL E ANTES DO JULGAMENTO DOS EMBARGOS DECLARAT&Oacute;RIOS. ERRO DE PROCEDIMENTO. NECESSIDADE DE OBSERV&Acirc;NCIA AO TEMA VINCULANTE. REALIZA&Ccedil;&Atilde;O DA RETRATA&Ccedil;&Atilde;O. EMBARGOS PARCIALMENTE ACOLHIDOS.
+I. CASO EM EXAME
+1. Trata-se de poss&iacute;vel ju&iacute;zo de retrata&ccedil;&atilde;o previsto no art. 1.030, II, do CPC, ante a aparente diverg&ecirc;ncia entre o ac&oacute;rd&atilde;o proferido por esta C&acirc;mara e o entendimento firmado pela Superior Tribunal de Justi&ccedil;a no Tema n.&ordm; 1.387.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em analisar a necessidade de observar o julgamento do Tema n.&ordm; 1.387/STJ, apesar de sua publica&ccedil;&atilde;o ter ocorrido ap&oacute;s o julgamento do ac&oacute;rd&atilde;o principal da presente demanda e antes do julgamento dos embargos de declara&ccedil;&atilde;o opostos contra o ac&oacute;rd&atilde;o.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os embargos de declara&ccedil;&atilde;o t&ecirc;m efeito integrativo do ac&oacute;rd&atilde;o recorrido, que se completa apenas ap&oacute;s o fim do julgamento dos aclarat&oacute;rios.
+4. O Tema n.&ordm; 1.387/STJ foi publicado apenas ap&oacute;s o ac&oacute;rd&atilde;o embargado, mas antes do julgamento dos embargos de declara&ccedil;&atilde;o, que deveria ter observado o entendimento vinculante.
+5. Retrata&ccedil;&atilde;o do entendimento anterior desta C&acirc;mara, para adotar o saque integral como termo inicial da prescri&ccedil;&atilde;o, em aten&ccedil;&atilde;o ao Tema n&ordm; 1.387/STJ.
+6. Necessidade de acolher parcialmente os embargos de declara&ccedil;&atilde;o para, anulando a senten&ccedil;a recorrida, determinar o retorno dos autos ao primeiro grau de jurisdi&ccedil;&atilde;o para possibilitar que a instru&ccedil;&atilde;o probat&oacute;ria observe os Temas n.&ordm; 1.387/STJ e n.&ordm; 1.300/STJ.
+IV. DISPOSITIVO
+7. Ju&iacute;zo de retrata&ccedil;&atilde;o exercido. Recurso conhecido e parcialmente acolhido.
+_________________
+Dispositivos relevantes citados: CPC, art. 1.030, II.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp 2174291/PR, Rel. Min. Nancy Andrighi, Terceira Turma, j. 10.6.2025; STJ, REsp 2088734/RS, Rel. Min. Ricardo Villas B&ocirc;as Cueva, Terceira Turma, j. 10.6.2025; STJ, REsp 00000000000002214879/PE, Rel. Min. Maria Thereza de Assis Moura, Primeira Se&ccedil;&atilde;o, j. 10.12.2025;  STJ, EDcl no AgInt no REsp 2196026/SC, Rel. Min. Benedito Gon&ccedil;alves, Primeira Turma, j. 9.2.2026; STJ, REsp 1858227/PR, Rel. Min. Herman Benjamin, Segunda Turma, j. 5.3.2020. <br><br>(N&uacute;mero do Processo: 0700737-38.2024.8.02.0050; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Porto Calvo; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / PASEP
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Porto Calvo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. DIREITO CIVIL. JUÍZO DE RETRATAÇÃO EM EMBARGOS DE DECLARAÇÃO DE APELAÇÃO CÍVEL. AÇÃO DE COBRANÇA C/C <em>DANOS</em> <em>MORAIS</em>. DESFALQUES EM PASEP. TEMA 1.387/STJ PUBLICADO APÓS O JULGAMENTO PRINCIPAL E ANTES DO JULGAMENTO DOS EMBARGOS DECLARATÓRIOS. ERRO DE PROCEDIMENTO. NECESSIDADE DE OBSERVÂNCIA AO TEMA VINCULANTE. REALIZAÇÃO DA RETRATAÇÃO. EMBARGOS PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. DIREITO CIVIL. JUÍZO DE RETRATAÇÃO EM EMBARGOS DE DECLARAÇÃO DE APELAÇÃO CÍVEL. AÇÃO DE COBRANÇA C/C <em>DANOS</em> <em>MORAIS</em>. DESFALQUES EM PASEP. TEMA 1.387/STJ PUBLICADO APÓS O JULGAMENTO PRINCIPAL E ANTES DO JULGAMENTO DOS EMBARGOS DECLARATÓRIOS. ERRO DE PROCEDIMENTO. NECESSIDADE DE OBSERVÂNCIA AO TEMA VINCULANTE. REALIZAÇÃO DA RETRATAÇÃO. EMBARGOS PARCIALMENTE ACOLHIDOS.
+I. CASO EM EXAME
+1. Trata-se de possível juízo de retratação previsto no art. 1.030, II, do CPC, ante a aparente divergência entre o acórdão proferido por esta Câmara e o entendimento firmado pela Superior Tribunal de Justiça no Tema n.º 1.387.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em analisar a necessidade de observar o julgamento do Tema n.º 1.387/STJ, apesar de sua publicação ter ocorrido após o julgamento do acórdão principal da presente demanda e antes do julgamento dos embargos de declaração opostos contra o acórdão.
+III. RAZÕES DE DECIDIR
+3. Os embargos de declaração têm efeito integrativo do acórdão recorrido, que se completa apenas após o fim do julgamento dos aclaratórios.
+4. O Tema n.º 1.387/STJ foi publicado apenas após o acórdão embargado, mas antes do julgamento dos embargos de declaração, que deveria ter observado o entendimento vinculante.
+5. Retratação do entendimento anterior desta Câmara, para adotar o saque integral como termo inicial da prescrição, em atenção ao Tema nº 1.387/STJ.
+6. Necessidade de acolher parcialmente os embargos de declaração para, anulando a sentença recorrida, determinar o retorno dos autos ao primeiro grau de jurisdição para possibilitar que a instrução probatória observe os Temas n.º 1.387/STJ e n.º 1.300/STJ.
+IV. DISPOSITIVO
+7. Juízo de retratação exercido. Recurso conhecido e parcialmente acolhido.
+_________________
+Dispositivos relevantes citados: CPC, art. 1.030, II.
+Jurisprudência relevante citada: STJ, REsp 2174291/PR, Rel. Min. Nancy Andrighi, Terceira Turma, j. 10.6.2025; STJ, REsp 2088734/RS, Rel. Min. Ricardo Villas Bôas Cueva, Terceira Turma, j. 10.6.2025; STJ, REsp 00000000000002214879/PE, Rel. Min. Maria Thereza de Assis Moura, Primeira Seção, j. 10.12.2025;  STJ, EDcl no AgInt no REsp 2196026/SC, Rel. Min. Benedito Gonçalves, Primeira Turma, j. 9.2.2026; STJ, REsp 1858227/PR, Rel. Min. Herman Benjamin, Segunda Turma, j. 5.3.2020.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812008" cdForo="0" >
+										0700659-21.2024.8.02.0090
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812008" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812008);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812008" style="display: none;" >
+	<div id="textAreaDados_812008" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL. DIREITO &Agrave; SA&Uacute;DE. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. PARTE DIAGNOSTICADA COM TRANSTORNO DO ESPECTRO AUTISTA. PRETENS&Atilde;O DE FORNECIMENTO DO TRATAMENTO COM A APLICA&Ccedil;&Atilde;O DOS M&Eacute;TODOS ABA E INTEGRA&Ccedil;&Atilde;O SENSORIAL, TERAPIA OCUPACIONAL &ndash; AVDS, AL&Eacute;M DA CARGA HOR&Aacute;RIA PRESCRITA. PROVIMENTO EM PARTE. ANULA&Ccedil;&Atilde;O, EM PARTE, DA SENTEN&Ccedil;A NO PONTO EM QUE INDEFERIU A TERAPIA OCUPACIONAL &ndash; AVDS.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pelo Estado de Alagoas em face da senten&ccedil;a que  julgou parcialmente procedente a a&ccedil;&atilde;o, determinando o fornecimento, em favor da parte autora, na rede p&uacute;blica de sa&uacute;de, por tempo indeterminado, sujeito a posterior reavalia&ccedil;&atilde;o, de tratamento com os seguintes profissionais multidisciplinares: psic&oacute;logo, fonoaudi&oacute;logo e terapeuta ocupacional, permitindo, desde j&aacute;, que a carga hor&aacute;ria seja definida de acordo com a forma de disponibiliza&ccedil;&atilde;o na rede de sa&uacute;de p&uacute;blica estadual, desde que todas as terapias sejam ofertadas durante a semana. Tamb&eacute;m condenou o ente p&uacute;blico em honor&aacute;rios no valor de R$ 750,00 (setecentos e cinquenta reais).
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o cinge-se a aferir o direito do autor, menor de idade, diagnosticado com Transtorno do Espectro Autista (TEA), a receber do ente p&uacute;blico demandado tratamento multidisciplinar nos termos prescritos pelo profissional da sa&uacute;de que o acompanha.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Nas diretrizes estabelecidas pela Portaria Conjunta n&ordm; 07 de abril de 2022 do Minist&eacute;rio da Sa&uacute;de foi aprovado o Protocolo Cl&iacute;nico e Diretrizes Terap&ecirc;uticas do Comportamento Agressivo no Transtorno do Espectro do Autismo, em que h&aacute; previs&atilde;o expressa do m&eacute;todo An&aacute;lise do Comportamento Aplicada (ABA) como forma de tratamento. Ainda, a Lei Estadual de n&ordm; 8.996/23 autorizou a implementa&ccedil;&atilde;o da metodologia ABA nas escolas p&uacute;blicas de Alagoas.
+4. Quanto ao m&eacute;todo de integra&ccedil;&atilde;o sensorial, h&aacute; previs&atilde;o na Linha de Cuidado para a Aten&ccedil;&atilde;o &agrave;s pessoas com Transtornos do Espectro do Autismo e suas Fam&iacute;lias na rede de Aten&ccedil;&atilde;o Psicossocial do Sistema &Uacute;nico de Sa&uacute;de. O terapeuta ocupacional faz uso da terapia de integra&ccedil;&atilde;o sensorial buscando: (a) a diminui&ccedil;&atilde;o dos n&iacute;veis elevados de atividade; (b) o incremento do repert&oacute;rio de respostas adaptativas, dos jogos com prop&oacute;sitos e do compromisso social; e (c) a melhoria da capacidade de sustenta&ccedil;&atilde;o da aten&ccedil;&atilde;o e o equil&iacute;brio do n&iacute;vel de atividade, bem como a diminui&ccedil;&atilde;o na emiss&atilde;o de comportamentos de autoagress&atilde;o ou autoestimula&ccedil;&atilde;o e a facilita&ccedil;&atilde;o de comportamentos de imita&ccedil;&atilde;o e antecipa&ccedil;&atilde;o, al&eacute;m da diminui&ccedil;&atilde;o de problemas de coordena&ccedil;&atilde;o e planejamento motor.
+5. No que se refere &agrave; terapia ocupacional com treinamento das atividades b&aacute;sicas da vida di&aacute;ria (T.O. com AVD), o seu fornecimento est&aacute; inserido na fun&ccedil;&atilde;o do profissional. Ocorre que a Resolu&ccedil;&atilde;o n&ordm; 316/2006 do Conselho Federal de Fisioterapia e Terapia Ocupacional disp&otilde;e sobre a pr&aacute;tica de Atividades de Vida Di&aacute;ria, de Atividades Instrumentais da Vida Di&aacute;ria e Tecnologia Assistiva pelo Terapeuta ocupacional e prev&ecirc; a este profissional, no &acirc;mbito da sua atua&ccedil;&atilde;o, a compet&ecirc;ncia para praticar a interven&ccedil;&atilde;o denominada AVD, cujo objetivo busca o desenvolvimento ocupacional, motor, sensorial, percepto-cognitivo, mental, emocional, comportamental, funcional, cultural, social e econ&ocirc;mico dos pacientes.
+6. Considerando a idade da crian&ccedil;a, o quantitativo de horas apresentado (Psicoterapia comportamental - 12 horas semanais, Fonoaudiologia - 4h semanais, al&eacute;m de Terapia ocupacional para integra&ccedil;&atilde;o sensorial e treino de AVDs - 4h semanais), tem-se que, por estarem em conson&acirc;ncia com o entendimento jurisprudencial e por totalizarem um quantitativo de horas adequado, quando avaliado o per&iacute;odo prescrito pelo m&eacute;dico do paciente, a carga hor&aacute;ria pode ser adotada.
+7. A continuidade do fornecimento do tratamento ficar&aacute; condicionada &agrave; apresenta&ccedil;&atilde;o, a cada 12 (doze) meses, junto ao &oacute;rg&atilde;o administrativo competente, de laudo m&eacute;dico atualizado que ateste a imprescindibilidade das medidas m&eacute;dicas, e para que especifique as necessidades do paciente, demonstrando se elas permanecem as mesmas. Dever&aacute; o apelado viabilizar o tratamento, no todo ou em parte, preferencialmente no Sistema &Uacute;nico de Sa&uacute;de e, somente em caso de sua inexist&ecirc;ncia, buscar alternativas privadas. N&atilde;o &eacute; poss&iacute;vel condicionar a realiza&ccedil;&atilde;o do tratamento &agrave; disponibiliza&ccedil;&atilde;o na rede municipal ou estadual. Trata-se de restri&ccedil;&atilde;o incompat&iacute;vel com a patologia discutida e com os dispositivos constitucionais e legais pertinentes.
+8. Em que pese a demonstra&ccedil;&atilde;o da adequa&ccedil;&atilde;o e imprescindibilidade cl&iacute;nica do tratamento com terapia ocupacional - AVDs, a negativa administrativa n&atilde;o restou comprovada, o que impossibilita o seu fornecimento, em aten&ccedil;&atilde;o aos enunciados do FONAJUS.
+9. A fase instrut&oacute;ria se fazia imprescind&iacute;vel no caso dos autos, j&aacute; que os pontos cruciais para o acolhimento ou n&atilde;o da pretens&atilde;o autoral demandam comprova&ccedil;&atilde;o pela parte autora, que deve ter oportunidade de se manifestar previamente e de produzir as provas tidas como essenciais, sob pena de viola&ccedil;&atilde;o ao princ&iacute;pio da veda&ccedil;&atilde;o &agrave; decis&atilde;o surpresa, previsto nos artigos 9&ordm; e 10 do C&oacute;digo de Processo Civil.
+IV. DISPOSITIVO
+10. Recurso conhecido e parcialmente provido, a fim de que o ente p&uacute;blico forne&ccedil;a ao autor tratamento com psicoterapia comportamental (12 horas semanais), fonoaudi&oacute;logo (4h semanais) e terapeuta ocupacional para integra&ccedil;&atilde;o sensorial (4h semanais). De of&iacute;cio, por for&ccedil;a do efeito devolutivo e translativo, anular, em parte, a senten&ccedil;a recorrida, no que atine &agrave; improced&ecirc;ncia do pleito de fornecimento de terapeuta ocupacional &ndash; AVDs, determinando o retorno dos autos &agrave; vara de origem para o regular processamento, com a deflagra&ccedil;&atilde;o da fase de instru&ccedil;&atilde;o processual.
+________
+Dispositivos relevantes citados: CF, arts. 6&ordm; e 196; Portaria Conjunta n&ordm; 07 de abril de 2022 do Minist&eacute;rio da Sa&uacute;de; Lei Estadual n&ordm; 8.996/23, arts. 1&ordm; e 3&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STF, Temas 06 e 1234, ARE 685230 AgR, Rel. Celso de Mello, Segunda Turma, j. 05/03/2013; STJ, AgRg no AREsp n. 807.820/PR, Rel. Min. Humberto Martins, Segunda Turma, j. 17/12/2015, AgRg no AREsp n. 36.394/RJ, Rel. Min. Herman Benjamin, Segunda Turma, j. 28/2/2012, REsp n. 2.064.964/SP, Rel. Min. Nancy Andrighi, Terceira Turma, j. 20/2/2024, AgInt no AgInt no REsp: 1991503 SP 2022/0076305-7, Rel. Min. Jo&atilde;o Ot&aacute;vio De Noronha, j. 07/10/2024, T4 - Quarta Turma, AgInt no REsp n. 2.049.402/RS, Rel. Min. Humberto Martins, Terceira Turma, j. 26/2/2024, AgRg no AREsp n&ordm; 740.150/SP, 3&ordf; Turma,&nbsp;Rel. Min. Marco Aur&eacute;lio Bellizze, DJe de 16/11/2015.  <br><br>(N&uacute;mero do Processo: 0700659-21.2024.8.02.0090; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;28&ordf; Vara Inf&acirc;ncia e Juventude da Capital; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento da Própria Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL. DIREITO À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER. PARTE DIAGNOSTICADA COM TRANSTORNO DO ESPECTRO AUTISTA. PRETENSÃO DE FORNECIMENTO DO TRATAMENTO COM A APLICAÇÃO DOS MÉTODOS ABA E INTEGRAÇÃO SENSORIAL, TERAPIA OCUPACIONAL – AVDS, ALÉM DA CARGA HORÁRIA PRESCRITA. PROVIMENTO EM PARTE. ANULAÇÃO, EM PARTE, DA SENTENÇA NO PONTO EM QUE INDEFERIU A TERAPIA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL. DIREITO À SAÚDE. APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER. PARTE DIAGNOSTICADA COM TRANSTORNO DO ESPECTRO AUTISTA. PRETENSÃO DE FORNECIMENTO DO TRATAMENTO COM A APLICAÇÃO DOS MÉTODOS ABA E INTEGRAÇÃO SENSORIAL, TERAPIA OCUPACIONAL – AVDS, ALÉM DA CARGA HORÁRIA PRESCRITA. PROVIMENTO EM PARTE. ANULAÇÃO, EM PARTE, DA SENTENÇA NO PONTO EM QUE INDEFERIU A TERAPIA OCUPACIONAL – AVDS.
+I. CASO EM EXAME
+1. Apelação cível interposta pelo Estado de Alagoas em face da sentença que  julgou parcialmente procedente a ação, determinando o fornecimento, em favor da parte autora, na rede pública de saúde, por tempo indeterminado, sujeito a posterior reavaliação, de tratamento com os seguintes profissionais multidisciplinares: psicólogo, fonoaudiólogo e terapeuta ocupacional, permitindo, desde já, que a carga horária seja definida de acordo com a forma de disponibilização na rede de saúde pública estadual, desde que todas as terapias sejam ofertadas durante a semana. Também condenou o ente público em honorários no valor de R$ 750,00 (setecentos e cinquenta reais).
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão cinge-se a aferir o direito do autor, menor de idade, diagnosticado com Transtorno do Espectro Autista (TEA), a receber do ente público demandado tratamento multidisciplinar nos termos prescritos pelo profissional da saúde que o acompanha.
+III. RAZÕES DE DECIDIR
+3. Nas diretrizes estabelecidas pela Portaria Conjunta nº 07 de abril de 2022 do Ministério da Saúde foi aprovado o Protocolo Clínico e Diretrizes Terapêuticas do Comportamento Agressivo no Transtorno do Espectro do Autismo, em que há previsão expressa do método Análise do Comportamento Aplicada (ABA) como forma de tratamento. Ainda, a Lei Estadual de nº 8.996/23 autorizou a implementação da metodologia ABA nas escolas públicas de Alagoas.
+4. Quanto ao método de integração sensorial, há previsão na Linha de Cuidado para a Atenção às pessoas com Transtornos do Espectro do Autismo e suas Famílias na rede de Atenção Psicossocial do Sistema Único de Saúde. O terapeuta ocupacional faz uso da terapia de integração sensorial buscando: (a) a diminuição dos níveis elevados de atividade; (b) o incremento do repertório de respostas adaptativas, dos jogos com propósitos e do compromisso social; e (c) a melhoria da capacidade de sustentação da atenção e o equilíbrio do nível de atividade, bem como a diminuição na emissão de comportamentos de autoagressão ou autoestimulação e a facilitação de comportamentos de imitação e antecipação, além da diminuição de problemas de coordenação e planejamento motor.
+5. No que se refere à terapia ocupacional com treinamento das atividades básicas da vida diária (T.O. com AVD), o seu fornecimento está inserido na função do profissional. Ocorre que a Resolução nº 316/2006 do Conselho Federal de Fisioterapia e Terapia Ocupacional dispõe sobre a prática de Atividades de Vida Diária, de Atividades Instrumentais da Vida Diária e Tecnologia Assistiva pelo Terapeuta ocupacional e prevê a este profissional, no âmbito da sua atuação, a competência para praticar a intervenção denominada AVD, cujo objetivo busca o desenvolvimento ocupacional, motor, sensorial, percepto-cognitivo, mental, emocional, comportamental, funcional, cultural, social e econômico dos pacientes.
+6. Considerando a idade da criança, o quantitativo de horas apresentado (Psicoterapia comportamental - 12 horas semanais, Fonoaudiologia - 4h semanais, além de Terapia ocupacional para integração sensorial e treino de AVDs - 4h semanais), tem-se que, por estarem em consonância com o entendimento jurisprudencial e por totalizarem um quantitativo de horas adequado, quando avaliado o período prescrito pelo médico do paciente, a carga horária pode ser adotada.
+7. A continuidade do fornecimento do tratamento ficará condicionada à apresentação, a cada 12 (doze) meses, junto ao órgão administrativo competente, de laudo médico atualizado que ateste a imprescindibilidade das medidas médicas, e para que especifique as necessidades do paciente, demonstrando se elas permanecem as mesmas. Deverá o apelado viabilizar o tratamento, no todo ou em parte, preferencialmente no Sistema Único de Saúde e, somente em caso de sua inexistência, buscar alternativas privadas. Não é possível condicionar a realização do tratamento à disponibilização na rede municipal ou estadual. Trata-se de restrição incompatível com a patologia discutida e com os dispositivos constitucionais e legais pertinentes.
+8. Em que pese a demonstração da adequação e imprescindibilidade clínica do tratamento com terapia ocupacional - AVDs, a negativa administrativa não restou comprovada, o que impossibilita o seu fornecimento, em atenção aos enunciados do FONAJUS.
+9. A fase instrutória se fazia imprescindível no caso dos autos, já que os pontos cruciais para o acolhimento ou não da pretensão autoral demandam comprovação pela parte autora, que deve ter oportunidade de se manifestar previamente e de produzir as provas tidas como essenciais, sob pena de violação ao princípio da vedação à decisão surpresa, previsto nos artigos 9º e 10 do Código de Processo Civil.
+IV. DISPOSITIVO
+10. Recurso conhecido e parcialmente provido, a fim de que o ente público forneça ao autor tratamento com psicoterapia comportamental (12 horas semanais), fonoaudiólogo (4h semanais) e terapeuta ocupacional para integração sensorial (4h semanais). De ofício, por força do efeito devolutivo e translativo, anular, em parte, a sentença recorrida, no que atine à improcedência do pleito de fornecimento de terapeuta ocupacional – AVDs, determinando o retorno dos autos à vara de origem para o regular processamento, com a deflagração da fase de instrução processual.
+________
+Dispositivos relevantes citados: CF, arts. 6º e 196; Portaria Conjunta nº 07 de abril de 2022 do Ministério da Saúde; Lei Estadual nº 8.996/23, arts. 1º e 3º.
+Jurisprudência relevante citada: STF, Temas 06 e 1234, ARE 685230 AgR, Rel. Celso de Mello, Segunda Turma, j. 05/03/2013; STJ, AgRg no AREsp n. 807.820/PR, Rel. Min. Humberto Martins, Segunda Turma, j. 17/12/2015, AgRg no AREsp n. 36.394/RJ, Rel. Min. Herman Benjamin, Segunda Turma, j. 28/2/2012, REsp n. 2.064.964/SP, Rel. Min. Nancy Andrighi, Terceira Turma, j. 20/2/2024, AgInt no AgInt no REsp: 1991503 SP 2022/0076305-7, Rel. Min. João Otávio De Noronha, j. 07/10/2024, T4 - Quarta Turma, AgInt no REsp n. 2.049.402/RS, Rel. Min. Humberto Martins, Terceira Turma, j. 26/2/2024, AgRg no AREsp nº 740.150/SP, 3ª Turma, Rel. Min. Marco Aurélio Bellizze, DJe de 16/11/2015.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811976" cdForo="0" >
+										0717500-67.2024.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811976" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811976);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811976" style="display: none;" >
+	<div id="textAreaDados_811976" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. ALEGA&Ccedil;&Atilde;O DE OMISS&Atilde;O E ERRO DE PREMISSA F&Aacute;TICA. AUS&Ecirc;NCIA DE V&Iacute;CIOS. RECURSO N&Atilde;O ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declara&ccedil;&atilde;o opostos com o objetivo de suprir supostos v&iacute;cios no ac&oacute;rd&atilde;o proferido por esta 4&ordf; C&acirc;mara C&iacute;vel, que conheceu do recurso de apela&ccedil;&atilde;o interposto pelo Plano de Sa&uacute;de para, no m&eacute;rito, dar-lhe parcial provimento, a fim de excluir o fornecimento de interven&ccedil;&atilde;o baseada em an&aacute;lise comportamental aplicada (ABA) com supervis&atilde;o de analista do comportamento e a compensa&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; omiss&atilde;o e erro de premissa f&aacute;tica no julgado, por supostamente desconsiderar provas no sentido de que a interven&ccedil;&atilde;o baseada em an&aacute;lise comportamental aplicada (ABA) com supervis&atilde;o de analista do comportamento era realizada em ambiente cl&iacute;nico.
+III. RAZ&Otilde;ES DE DECIDIR
+3. As provas juntadas pela parte autora ora caminham no sentido de que a interven&ccedil;&atilde;o baseada em an&aacute;lise comportamental aplicada (ABA) com supervis&atilde;o de analista do comportamento seria realizada ora em ambiente escolar ora em domic&iacute;lio. Contudo, tanto em um como noutro caso, n&atilde;o h&aacute; obrigatoriedade de custeio pelo plano de sa&uacute;de, conforme assentado no ac&oacute;rd&atilde;o vergastado.
+4. O ac&oacute;rd&atilde;o embargado analisou de forma clara e expressa sobre a mat&eacute;ria posta &agrave; aprecia&ccedil;&atilde;o, apresentando os fundamentos que sustentam de forma suficiente a conclus&atilde;o alcan&ccedil;ada.
+5. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o de mat&eacute;ria de m&eacute;rito ou &agrave; rean&aacute;lise de fatos e provas, sendo cab&iacute;veis apenas para sanar obscuridade, omiss&atilde;o, contradi&ccedil;&atilde;o ou erro material, conforme o art. 1.022 do CPC.
+IV. Dispositivo e tese
+6. Embargos de declara&ccedil;&atilde;o conhecidos e n&atilde;o acolhidos.
+__________
+Dispositivos relevantes citados: CPC/2015, arts. 1.022 e 1.026, &sect; 2&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017. <br><br>(N&uacute;mero do Processo: 0717500-67.2024.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									717500672024802000150000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. ALEGAÇÃO DE OMISSÃO E ERRO DE PREMISSA FÁTICA. AUSÊNCIA DE VÍCIOS. RECURSO NÃO ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos com o objetivo de suprir supostos vícios no acórdão proferido por esta 4ª Câmara Cível, que conheceu do recurso de apelação interposto pelo Plano de Saúde para, no mérito, dar-lhe parcial
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. ALEGAÇÃO DE OMISSÃO E ERRO DE PREMISSA FÁTICA. AUSÊNCIA DE VÍCIOS. RECURSO NÃO ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos com o objetivo de suprir supostos vícios no acórdão proferido por esta 4ª Câmara Cível, que conheceu do recurso de apelação interposto pelo Plano de Saúde para, no mérito, dar-lhe parcial provimento, a fim de excluir o fornecimento de intervenção baseada em análise comportamental aplicada (ABA) com supervisão de analista do comportamento e a compensação por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em saber se há omissão e erro de premissa fática no julgado, por supostamente desconsiderar provas no sentido de que a intervenção baseada em análise comportamental aplicada (ABA) com supervisão de analista do comportamento era realizada em ambiente clínico.
+III. RAZÕES DE DECIDIR
+3. As provas juntadas pela parte autora ora caminham no sentido de que a intervenção baseada em análise comportamental aplicada (ABA) com supervisão de analista do comportamento seria realizada ora em ambiente escolar ora em domicílio. Contudo, tanto em um como noutro caso, não há obrigatoriedade de custeio pelo plano de saúde, conforme assentado no acórdão vergastado.
+4. O acórdão embargado analisou de forma clara e expressa sobre a matéria posta à apreciação, apresentando os fundamentos que sustentam de forma suficiente a conclusão alcançada.
+5. Os embargos de declaração não se prestam à rediscussão de matéria de mérito ou à reanálise de fatos e provas, sendo cabíveis apenas para sanar obscuridade, omissão, contradição ou erro material, conforme o art. 1.022 do CPC.
+IV. Dispositivo e tese
+6. Embargos de declaração conhecidos e não acolhidos.
+__________
+Dispositivos relevantes citados: CPC/2015, arts. 1.022 e 1.026, § 2º.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Seção, j. 08.11.2017.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811898" cdForo="0" >
+										0803207-35.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811898" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811898);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811898" style="display: none;" >
+	<div id="textAreaDados_811898" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O ORDIN&Aacute;RIA DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C TUTELA DE URG&Ecirc;NCIA DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS.  IMPOSSIBILIDADE DE INTERRUP&Ccedil;&Atilde;O DO FORNECIMENTO DE ENERGIA EL&Eacute;TRICA.. UTILIZA&Ccedil;&Atilde;O DO SERVI&Ccedil;O DE&nbsp;HOME&nbsp;CARE. OBRIGA&Ccedil;&Atilde;O DE CUSTEIO, PELO ENTE P&Uacute;BLICO, DO CONSUMO DE ENERGIA EL&Eacute;TRICA REFERENTE AO TRATAMENTO DOMICILIAR. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela concession&aacute;ria de energia el&eacute;trica contra decis&atilde;o interlocut&oacute;ria que deferiu a tutela de urg&ecirc;ncia, para determinar que a Equatorial se abstenha de suspender os servi&ccedil;os de energia el&eacute;trica no im&oacute;vel da parte autora, bem como instale nova unidade consumidora para medi&ccedil;&atilde;o exclusiva do consumo dos equipamentos e demais aparelhos vinculados ao home care. Determinou, ainda, que a Equatorial proceda &agrave; cobran&ccedil;a com base na m&eacute;dia de consumo das &uacute;ltimas faturas antes da aferi&ccedil;&atilde;o do consumo de energia de todos os aparelhos do servi&ccedil;o de home care, enquanto n&atilde;o seja instalado o novo medidor.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) analisar o interesse recursal quanto ao reconhecimento do &ocirc;nus exclusivo do ente p&uacute;blico de arcar com as contrapresta&ccedil;&otilde;es financeiras necess&aacute;rias &agrave; manuten&ccedil;&atilde;o da sa&uacute;de da parte agravada; (ii) examinar a proibi&ccedil;&atilde;o de suspens&atilde;o do servi&ccedil;o de energia el&eacute;trica na unidade consumidora do agravado; (iii) avaliar a responsabilidade do ente p&uacute;blico estadual e municipal pela obriga&ccedil;&atilde;o de custeio financeiro das despesas relativas &agrave; adequa&ccedil;&atilde;o do padr&atilde;o interno da unidade consumidora.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Aus&ecirc;ncia de interesse recursal da concession&aacute;ria agravante quanto &agrave; pretens&atilde;o de reconhecer a responsabilidade do Estado de Alagoas, notadamente porque a decis&atilde;o agravada imp&ocirc;s expressamente ao ente p&uacute;blico estadual e municipal a obriga&ccedil;&atilde;o de custeio financeiro do incremento do valor cobrado de energia el&eacute;trica da resid&ecirc;ncia da parte agravada, oriundo da instala&ccedil;&atilde;o dos equipamentos necess&aacute;rios &agrave; garantia do direito &agrave; sa&uacute;de e &agrave; vida do esposo da agravado. O valor remanescente continua sendo imput&aacute;vel &agrave; agravada, n&atilde;o havendo que se falar em fornecimento gratuito do servi&ccedil;o essencial.
+4. A interna&ccedil;&atilde;o domiciliar representa a continua&ccedil;&atilde;o do tratamento m&eacute;dico, de modo que recusar seu fornecimento significa interromper o processo terap&ecirc;utico, com o agravamento das sequelas e limita&ccedil;&otilde;es da autora. O funcionamento dos equipamentos hospitalares e demais aparelhos necess&aacute;rios ao atendimento da paciente depende da utiliza&ccedil;&atilde;o de energia el&eacute;trica, tendo restado demonstrada a insufici&ecirc;ncia econ&ocirc;mica da parte para arcar com tais despesas.
+5. Ainda n&atilde;o foi cumprida a determina&ccedil;&atilde;o para que seja instalada uma nova unidade consumidora para medi&ccedil;&atilde;o exclusivamente do consumo de energia el&eacute;trica dos equipamentos vinculados ao sistema de home care, n&atilde;o podendo haver a interrup&ccedil;&atilde;o do fornecimento do servi&ccedil;o, uma vez que tal conduta afetaria diretamente a benefici&aacute;ria do tratamento domiciliar. Desse modo, privilegia-se o direito &agrave; sa&uacute;de e &agrave; pr&oacute;pria vida, em detrimento de valores financeiros.
+6. O &ocirc;nus financeiro da adequa&ccedil;&atilde;o interna adequada para implementa&ccedil;&atilde;o e instala&ccedil;&atilde;o do novo ponto de energia para medi&ccedil;&atilde;o exclusiva do home care dever&aacute; ser imputado aos entes p&uacute;blicos.
+IV. DISPOSITIVO
+7. Recurso parcialmente conhecido e, na parte conhecida, parcialmente provido.
+_____________
+Dispositivos relevantes citados: CF, arts. 6&ordm; e 196; Dec-Lei n&deg; 4.657/42, art. 20; Res. n&ordm; 1.000/2021 da ANEEL, art. 2&ordm;  XLIV, c, art. 40;
+Jurisprud&ecirc;ncia relevante citada: n/a.  <br><br>(N&uacute;mero do Processo: 0803207-35.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Fato Atípico
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM AÇÃO ORDINÁRIA DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>.  IMPOSSIBILIDADE DE INTERRUPÇÃO DO FORNECIMENTO DE ENERGIA ELÉTRICA.. UTILIZAÇÃO DO SERVIÇO DE HOME CARE. OBRIGAÇÃO DE CUSTEIO, PELO ENTE PÚBLICO, DO CONSUMO DE ENERGIA ELÉTRICA REFERENTE AO TRATAMENTO DOMICILIAR. PARCIAL PROVIMENTO.
+I.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM AÇÃO ORDINÁRIA DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>.  IMPOSSIBILIDADE DE INTERRUPÇÃO DO FORNECIMENTO DE ENERGIA ELÉTRICA.. UTILIZAÇÃO DO SERVIÇO DE HOME CARE. OBRIGAÇÃO DE CUSTEIO, PELO ENTE PÚBLICO, DO CONSUMO DE ENERGIA ELÉTRICA REFERENTE AO TRATAMENTO DOMICILIAR. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela concessionária de energia elétrica contra decisão interlocutória que deferiu a tutela de urgência, para determinar que a Equatorial se abstenha de suspender os serviços de energia elétrica no imóvel da parte autora, bem como instale nova unidade consumidora para medição exclusiva do consumo dos equipamentos e demais aparelhos vinculados ao home care. Determinou, ainda, que a Equatorial proceda à cobrança com base na média de consumo das últimas faturas antes da aferição do consumo de energia de todos os aparelhos do serviço de home care, enquanto não seja instalado o novo medidor.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) analisar o interesse recursal quanto ao reconhecimento do ônus exclusivo do ente público de arcar com as contraprestações financeiras necessárias à manutenção da saúde da parte agravada; (ii) examinar a proibição de suspensão do serviço de energia elétrica na unidade consumidora do agravado; (iii) avaliar a responsabilidade do ente público estadual e municipal pela obrigação de custeio financeiro das despesas relativas à adequação do padrão interno da unidade consumidora.
+III. RAZÕES DE DECIDIR
+3. Ausência de interesse recursal da concessionária agravante quanto à pretensão de reconhecer a responsabilidade do Estado de Alagoas, notadamente porque a decisão agravada impôs expressamente ao ente público estadual e municipal a obrigação de custeio financeiro do incremento do valor cobrado de energia elétrica da residência da parte agravada, oriundo da instalação dos equipamentos necessários à garantia do direito à saúde e à vida do esposo da agravado. O valor remanescente continua sendo imputável à agravada, não havendo que se falar em fornecimento gratuito do serviço essencial.
+4. A internação domiciliar representa a continuação do tratamento médico, de modo que recusar seu fornecimento significa interromper o processo terapêutico, com o agravamento das sequelas e limitações da autora. O funcionamento dos equipamentos hospitalares e demais aparelhos necessários ao atendimento da paciente depende da utilização de energia elétrica, tendo restado demonstrada a insuficiência econômica da parte para arcar com tais despesas.
+5. Ainda não foi cumprida a determinação para que seja instalada uma nova unidade consumidora para medição exclusivamente do consumo de energia elétrica dos equipamentos vinculados ao sistema de home care, não podendo haver a interrupção do fornecimento do serviço, uma vez que tal conduta afetaria diretamente a beneficiária do tratamento domiciliar. Desse modo, privilegia-se o direito à saúde e à própria vida, em detrimento de valores financeiros.
+6. O ônus financeiro da adequação interna adequada para implementação e instalação do novo ponto de energia para medição exclusiva do home care deverá ser imputado aos entes públicos.
+IV. DISPOSITIVO
+7. Recurso parcialmente conhecido e, na parte conhecida, parcialmente provido.
+_____________
+Dispositivos relevantes citados: CF, arts. 6º e 196; Dec-Lei n° 4.657/42, art. 20; Res. nº 1.000/2021 da ANEEL, art. 2º  XLIV, c, art. 40;
+Jurisprudência relevante citada: n/a.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812046" cdForo="0" >
+										0720591-34.2025.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812046" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812046);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812046" style="display: none;" >
+	<div id="textAreaDados_812046" class="mensagemSemFormatacao" >
+		Direito processual civil. Embargos de declara&ccedil;&atilde;o em apela&ccedil;&atilde;o c&iacute;vel. Alega&ccedil;&atilde;o de exist&ecirc;ncia de omiss&atilde;o no ac&oacute;rd&atilde;o. AUS&Ecirc;NCIA DE V&Iacute;CIOS. EMBARGOS n&atilde;o acolhidoS.
+I. Caso em exame
+1. Embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que deu parcial provimento ao apelo da parte embargada, para declarar a inexist&ecirc;ncia dos d&eacute;bitos relativos aos empr&eacute;stimos banc&aacute;rios irregularmente pactuados, com a consequente restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados da parte autora. Ademais, condenou a institui&ccedil;&atilde;o financeira ao pagamento de compensa&ccedil;&atilde;o por danos morais no montante de R$ 2.000,00 (dois mil reais).
+II. Quest&atilde;o em discuss&atilde;o
+2.  A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; omiss&atilde;o no julgado, mais precisamente quanto &agrave; aus&ecirc;ncia de an&aacute;lise da inexist&ecirc;ncia de m&aacute;-f&eacute; da parte embargante e da necessidade de compensa&ccedil;&atilde;o dos valores disponibilizados &agrave; parte autora.
+iii. raz&otilde;es de decidir
+3. O ac&oacute;rd&atilde;o embargado se manifestou de maneira suficientemente clara, coerente e &iacute;ntegra quanto &agrave; discuss&atilde;o trazida ao conhecimento desta Corte, tratando expressamente das quest&otilde;es apontadas pelo embargante.
+4. O ac&oacute;rd&atilde;o embargado enfrentou todos os argumentos relevantes, especialmente aqueles mencionados no presente recurso. Mera irresigna&ccedil;&atilde;o da parte recorrente.
+iv. Dispositivo e tese
+5. Recurso conhecido e n&atilde;o acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017;  <br><br>(N&uacute;mero do Processo: 0720591-34.2025.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(17 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Interpretação / Revisão de Contrato
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									720591342025802000150000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIOS. EMBARGOS não acolhidoS.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que deu parcial provimento ao apelo da parte embargada, para declarar a inexistência dos débitos relativos aos empréstimos bancários irregularmente pactuados, com a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIOS. EMBARGOS não acolhidoS.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que deu parcial provimento ao apelo da parte embargada, para declarar a inexistência dos débitos relativos aos empréstimos bancários irregularmente pactuados, com a consequente restituição em dobro dos valores indevidamente descontados da parte autora. Ademais, condenou a instituição financeira ao pagamento de compensação por <em>danos</em> <em>morais</em> no montante de R$ 2.000,00 (dois mil reais).
+II. Questão em discussão
+2.  A questão em discussão consiste em saber se há omissão no julgado, mais precisamente quanto à ausência de análise da inexistência de má-fé da parte embargante e da necessidade de compensação dos valores disponibilizados à parte autora.
+iii. razões de decidir
+3. O acórdão embargado se manifestou de maneira suficientemente clara, coerente e íntegra quanto à discussão trazida ao conhecimento desta Corte, tratando expressamente das questões apontadas pelo embargante.
+4. O acórdão embargado enfrentou todos os argumentos relevantes, especialmente aqueles mencionados no presente recurso. Mera irresignação da parte recorrente.
+iv. Dispositivo e tese
+5. Recurso conhecido e não acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Seção, j. 08.11.2017;
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="RECURSO">
+									<label for="ckTermo1">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="CONHECIDO">
+									<label for="ckTermo2">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="APELAÇÃO">
+									<label for="ckTermo3">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="PROVIDO">
+									<label for="ckTermo4">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="DIREITO">
+									<label for="ckTermo5">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="CÍVEL">
+									<label for="ckTermo6">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="AÇÃO">
+									<label for="ckTermo7">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="CIVIL">
+									<label for="ckTermo8">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="DANOS">
+									<label for="ckTermo9">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="CONSUMIDOR">
+									<label for="ckTermo10">
+										CONSUMIDOR
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="MORAIS">
+									<label for="ckTermo11">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="SENTENÇA">
+									<label for="ckTermo12">
+										SENTENÇA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="INDENIZAÇÃO">
+									<label for="ckTermo13">
+										INDENIZAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="INEXISTÊNCIA">
+									<label for="ckTermo14">
+										INEXISTÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="DECISÃO">
+									<label for="ckTermo15">
+										DECISÃO
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 20
+			</strong>
+			de 136804
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjal/samples/cjsg/results_normal_page_02.html
+++ b/tests/tjal/samples/cjsg/results_normal_page_02.html
@@ -1,0 +1,3760 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(136804)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="136804" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>21&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812045" cdForo="0" >
+										0738493-97.2025.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812045" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812045);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812045" style="display: none;" >
+	<div id="textAreaDados_812045" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. ALEGA&Ccedil;&Atilde;O DE OMISS&Atilde;O. AUS&Ecirc;NCIA DE V&Iacute;CIO. RECURSO N&Atilde;O ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declara&ccedil;&atilde;o opostos com o objetivo de suprir supostos v&iacute;cios no ac&oacute;rd&atilde;o proferido por esta 4&ordf; C&acirc;mara C&iacute;vel, que conheceu em parte do recurso de apela&ccedil;&atilde;o interposto pelo embargante para, no m&eacute;rito, negar-lhe provimento.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em saber se h&aacute; omiss&atilde;o quanto a) ao enfrentamento da S&uacute;mula Vinculante n&ordm; 56 do STF, segundo a qual a falta de estabelecimento adequado n&atilde;o autoriza a manuten&ccedil;&atilde;o do condenado em regime mais gravoso; b) &agrave; possibilidade de reconhecimento do dano moral in re ipsa em hip&oacute;teses de cumprimento de pena em regime mais gravoso que o fixado judicialmente; c) &agrave; incid&ecirc;ncia da responsabilidade objetiva na hip&oacute;tese concreta de excesso de execu&ccedil;&atilde;o pena; e d) ao equ&iacute;voco relacionado ao estabelecimento prisional onde iniciado o cumprimento da pena.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O ac&oacute;rd&atilde;o embargado analisou de forma clara e expressa sobre a mat&eacute;ria posta &agrave; aprecia&ccedil;&atilde;o, apresentando os fundamentos que sustentam de forma suficiente a conclus&atilde;o alcan&ccedil;ada.
+4. Os embargos de declara&ccedil;&atilde;o n&atilde;o se prestam &agrave; rediscuss&atilde;o de mat&eacute;ria de m&eacute;rito ou &agrave; rean&aacute;lise de fatos e provas, sendo cab&iacute;veis apenas para sanar obscuridade, omiss&atilde;o, contradi&ccedil;&atilde;o ou erro material, conforme o art. 1.022 do CPC.
+5. Em face do disposto no art. 1.025, do CPC, &eacute; desnecess&aacute;ria a manifesta&ccedil;&atilde;o do Tribunal sobre as mat&eacute;rias suscitadas em sede de embargos declarat&oacute;rios apenas para fins de prequestionamento.
+IV. Dispositivo e tese
+6. Embargos de declara&ccedil;&atilde;o conhecidos e n&atilde;o acolhidos.
+__________
+Dispositivos relevantes citados: CPC/2015, arts. 1.022, 1.025 e 1.026, &sect; 2&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017; AgInt nos EDcl no AREsp: 1563737 MS 2019/0239294-5, Rel. Min. Gurgel de Faria, j. 15/03/2021, T1 - Primeira Turma. <br><br>(N&uacute;mero do Processo: 0738493-97.2025.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(34 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Erro Médico
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									738493972025802000150000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. ALEGAÇÃO DE OMISSÃO. AUSÊNCIA DE VÍCIO. RECURSO NÃO ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos com o objetivo de suprir supostos vícios no acórdão proferido por esta 4ª Câmara Cível, que conheceu em parte do recurso de apelação interposto pelo embargante para, no mérito, negar-lhe provimento.
+II. QUESTÃO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. ALEGAÇÃO DE OMISSÃO. AUSÊNCIA DE VÍCIO. RECURSO NÃO ACOLHIDO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos com o objetivo de suprir supostos vícios no acórdão proferido por esta 4ª Câmara Cível, que conheceu em parte do recurso de apelação interposto pelo embargante para, no mérito, negar-lhe provimento.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em saber se há omissão quanto a) ao enfrentamento da Súmula Vinculante nº 56 do STF, segundo a qual a falta de estabelecimento adequado não autoriza a manutenção do condenado em regime mais gravoso; b) à possibilidade de reconhecimento do <em>dano</em> <em>moral</em> in re ipsa em hipóteses de cumprimento de pena em regime mais gravoso que o fixado judicialmente; c) à incidência da responsabilidade objetiva na hipótese concreta de excesso de execução pena; e d) ao equívoco relacionado ao estabelecimento prisional onde iniciado o cumprimento da pena.
+III. RAZÕES DE DECIDIR
+3. O acórdão embargado analisou de forma clara e expressa sobre a matéria posta à apreciação, apresentando os fundamentos que sustentam de forma suficiente a conclusão alcançada.
+4. Os embargos de declaração não se prestam à rediscussão de matéria de mérito ou à reanálise de fatos e provas, sendo cabíveis apenas para sanar obscuridade, omissão, contradição ou erro material, conforme o art. 1.022 do CPC.
+5. Em face do disposto no art. 1.025, do CPC, é desnecessária a manifestação do Tribunal sobre as matérias suscitadas em sede de embargos declaratórios apenas para fins de prequestionamento.
+IV. Dispositivo e tese
+6. Embargos de declaração conhecidos e não acolhidos.
+__________
+Dispositivos relevantes citados: CPC/2015, arts. 1.022, 1.025 e 1.026, § 2º.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Seção, j. 08.11.2017; AgInt nos EDcl no AREsp: 1563737 MS 2019/0239294-5, Rel. Min. Gurgel de Faria, j. 15/03/2021, T1 - Primeira Turma.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>22&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812044" cdForo="0" >
+										0709452-45.2024.8.02.0058
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812044" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812044);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812044" style="display: none;" >
+	<div id="textAreaDados_812044" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O DE A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER JULGADA EM CONJUNTO COM A&Ccedil;&Atilde;O DE IMISS&Atilde;O NA POSSE. ALEGA&Ccedil;&Atilde;O DE CONTRADI&Ccedil;&Atilde;O QUANTO AO TERMO INICIAL DOS JUROS DE MORA DA OBRIGA&Ccedil;&Atilde;O DE INDENIZAR AS BENFEITORIAS. REDISCUSS&Atilde;O DA MAT&Eacute;RIA. N&Atilde;O ACOLHIMENTO.
+I. CASO EM EXAME
+1. Embargos de declara&ccedil;&atilde;o opostos contra ac&oacute;rd&atilde;o que reformou parcialmente a senten&ccedil;a nos seguintes termos: i) quanto &agrave; a&ccedil;&atilde;o de imiss&atilde;o na posse autos n.&ordm; 0712262-90.2024.8.02.0058, manteve a concess&atilde;o da imiss&atilde;o na posse do im&oacute;vel em favor dos autores, Sr. Avinal Monteiro da Silva e a Sra. Ana Paula Monteiro de Oliveira Dias, condenando-os &agrave; devolu&ccedil;&atilde;o dos valores pagos pelo Sr. Franklin Andrade a t&iacute;tulo de benfeitorias &uacute;teis e necess&aacute;rias devidamente comprovadas em sede de liquida&ccedil;&atilde;o de senten&ccedil;a; ii) quanto &agrave; a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer c/c danos morais e materiais autos n.&ordm; 0709452-45.2024.8.02.0058, reconheceu a nulidade absoluta e inoponibilidade do neg&oacute;cio jur&iacute;dico em face do Sr. Avinal Monteiro e de sua esposa Ana Paula Monteiro, e a exist&ecirc;ncia, validade e efic&aacute;cia do pacto entre o Sr. Cristiano e o Sr. Franklin, condenando o Sr. Cristiano Oliveira e Silva &agrave; restitui&ccedil;&atilde;o de todos os valores pagos pelo ou em nome do Sr. Franklin Rosemberg dos Santos Sacramento Andrade, e majorando o montante da indeniza&ccedil;&atilde;o por danos morais para R$10.000,00 (seis mil reais) e condenando o Sr. Avinal Monteiro da Silva &agrave; restitui&ccedil;&atilde;o dos valores pagos pelo Sr. Franklin Andrade que n&atilde;o estiverem enquadrados como benfeitorias necess&aacute;rias e &uacute;teis.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em verificar se h&aacute; contradi&ccedil;&atilde;o na estipula&ccedil;&atilde;o da data da cita&ccedil;&atilde;o do Sr. Avinal e da Sra. Ana Paula na a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer para fins de termo inicial dos juros morat&oacute;rios.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os embargos de declara&ccedil;&atilde;o t&ecirc;m cabimento restrito &agrave;s hip&oacute;teses do art. 1.022 do CPC, n&atilde;o servindo para rediscutir o m&eacute;rito da causa.
+4. A contradi&ccedil;&atilde;o que autoriza embargos deve ser interna ao julgado, e n&atilde;o entre a decis&atilde;o e a tese defendida pela parte.
+5. Ac&oacute;rd&atilde;o que enfrentou a mat&eacute;ria trazida ao conhecimento da Corte, fixando a data da cita&ccedil;&atilde;o para fins de termo inicial dos juros morat&oacute;rios, por ser a data do inequ&iacute;voco conhecimento das partes a respeito da natureza da mat&eacute;ria controvertida relativa &agrave;s benfeitorias realizadas no im&oacute;vel.
+6. O recurso busca apenas a reaprecia&ccedil;&atilde;o de mat&eacute;ria j&aacute; decidida, finalidade incompat&iacute;vel com os embargos de declara&ccedil;&atilde;o.
+7. O Tribunal n&atilde;o est&aacute; obrigado a se manifestar sobre a mat&eacute;ria suscitada pela parte apenas para fins de prequestionamento, consoante art. 1.025 do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e n&atilde;o acolhido.
+_____________
+Dispositivos relevantes citados: CPC, arts. 1.022 e 1.026, &sect; 2&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no MS 15.828/DF, Rel. Min. Mauro Campbell Marques; STJ, EDcl no REsp 1.549.458/SP, Rel. Min. Herman Benjamin, Segunda Turma, j. 11.04.2022, DJe 25.04.2022; STJ, EDcl no AgInt no REsp 1.727.133/CE, Rel. Min. Gurgel de Faria, Primeira Turma, j. 11.04.2022, DJe 19.04.2022. <br><br>(N&uacute;mero do Processo: 0709452-45.2024.8.02.0058; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Arapiraca; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Arapiraca
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									709452452024802005850000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO DE AÇÃO DE OBRIGAÇÃO DE FAZER JULGADA EM CONJUNTO COM AÇÃO DE IMISSÃO NA POSSE. ALEGAÇÃO DE CONTRADIÇÃO QUANTO AO TERMO INICIAL DOS JUROS DE MORA DA OBRIGAÇÃO DE INDENIZAR AS BENFEITORIAS. REDISCUSSÃO DA MATÉRIA. NÃO ACOLHIMENTO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos contra acórdão que reformou parcialmente a sentença nos
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. EMBARGOS DE DECLARAÇÃO EM APELAÇÃO DE AÇÃO DE OBRIGAÇÃO DE FAZER JULGADA EM CONJUNTO COM AÇÃO DE IMISSÃO NA POSSE. ALEGAÇÃO DE CONTRADIÇÃO QUANTO AO TERMO INICIAL DOS JUROS DE MORA DA OBRIGAÇÃO DE INDENIZAR AS BENFEITORIAS. REDISCUSSÃO DA MATÉRIA. NÃO ACOLHIMENTO.
+I. CASO EM EXAME
+1. Embargos de declaração opostos contra acórdão que reformou parcialmente a sentença nos seguintes termos: i) quanto à ação de imissão na posse autos n.º 0712262-90.2024.8.02.0058, manteve a concessão da imissão na posse do imóvel em favor dos autores, Sr. Avinal Monteiro da Silva e a Sra. Ana Paula Monteiro de Oliveira Dias, condenando-os à devolução dos valores pagos pelo Sr. Franklin Andrade a título de benfeitorias úteis e necessárias devidamente comprovadas em sede de liquidação de sentença; ii) quanto à ação de obrigação de fazer c/c <em>danos</em> <em>morais</em> e materiais autos n.º 0709452-45.2024.8.02.0058, reconheceu a nulidade absoluta e inoponibilidade do negócio jurídico em face do Sr. Avinal Monteiro e de sua esposa Ana Paula Monteiro, e a existência, validade e eficácia do pacto entre o Sr. Cristiano e o Sr. Franklin, condenando o Sr. Cristiano Oliveira e Silva à restituição de todos os valores pagos pelo ou em nome do Sr. Franklin Rosemberg dos Santos Sacramento Andrade, e majorando o montante da indenização por <em>danos</em> <em>morais</em> para R$10.000,00 (seis mil reais) e condenando o Sr. Avinal Monteiro da Silva à restituição dos valores pagos pelo Sr. Franklin Andrade que não estiverem enquadrados como benfeitorias necessárias e úteis.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em verificar se há contradição na estipulação da data da citação do Sr. Avinal e da Sra. Ana Paula na ação de obrigação de fazer para fins de termo inicial dos juros moratórios.
+III. RAZÕES DE DECIDIR
+3. Os embargos de declaração têm cabimento restrito às hipóteses do art. 1.022 do CPC, não servindo para rediscutir o mérito da causa.
+4. A contradição que autoriza embargos deve ser interna ao julgado, e não entre a decisão e a tese defendida pela parte.
+5. Acórdão que enfrentou a matéria trazida ao conhecimento da Corte, fixando a data da citação para fins de termo inicial dos juros moratórios, por ser a data do inequívoco conhecimento das partes a respeito da natureza da matéria controvertida relativa às benfeitorias realizadas no imóvel.
+6. O recurso busca apenas a reapreciação de matéria já decidida, finalidade incompatível com os embargos de declaração.
+7. O Tribunal não está obrigado a se manifestar sobre a matéria suscitada pela parte apenas para fins de prequestionamento, consoante art. 1.025 do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e não acolhido.
+_____________
+Dispositivos relevantes citados: CPC, arts. 1.022 e 1.026, § 2º.
+Jurisprudência relevante citada: STJ, EDcl no MS 15.828/DF, Rel. Min. Mauro Campbell Marques; STJ, EDcl no REsp 1.549.458/SP, Rel. Min. Herman Benjamin, Segunda Turma, j. 11.04.2022, DJe 25.04.2022; STJ, EDcl no AgInt no REsp 1.727.133/CE, Rel. Min. Gurgel de Faria, Primeira Turma, j. 11.04.2022, DJe 19.04.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>23&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812043" cdForo="0" >
+										0700659-95.2025.8.02.0054
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812043" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812043);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812043" style="display: none;" >
+	<div id="textAreaDados_812043" class="mensagemSemFormatacao" >
+		Direito processual civil. Embargos de declara&ccedil;&atilde;o em apela&ccedil;&atilde;o c&iacute;vel. Alega&ccedil;&atilde;o de exist&ecirc;ncia de omiss&atilde;o no ac&oacute;rd&atilde;o. AUS&Ecirc;NCIA DE V&Iacute;CIOS. EMBARGOS n&atilde;o acolhidoS.
+I. Caso em exame
+1. Embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que negou provimento ao apelo da parte embargante, mantendo inc&oacute;lume a senten&ccedil;a de improced&ecirc;ncia.
+II. Quest&atilde;o em discuss&atilde;o
+2.  A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; v&iacute;cios de omiss&atilde;o no julgado, especialmente quanto &agrave; suposta aus&ecirc;ncia de an&aacute;lise da tese de fortuito interno e da responsabilidade objetiva da concession&aacute;ria de energia.
+iii. raz&otilde;es de decidir
+3. O ac&oacute;rd&atilde;o embargado se manifestou de maneira suficientemente clara, coerente e &iacute;ntegra quanto &agrave; discuss&atilde;o trazida ao conhecimento desta Corte, tratando expressamente das quest&otilde;es apontadas pelo embargante.
+4. O ac&oacute;rd&atilde;o embargado enfrentou todos os argumentos relevantes, especialmente aqueles mencionados no presente recurso. Mera irresigna&ccedil;&atilde;o da parte recorrente.
+iv. Dispositivo e tese
+5. Recurso conhecido e n&atilde;o acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017;   <br><br>(N&uacute;mero do Processo: 0700659-95.2025.8.02.0054; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de S&atilde;o Lu&iacute;s do Quitunde; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(19 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Fornecimento de Energia Elétrica
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									São Luiz do Quitunde
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									700659952025802005450000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIOS. EMBARGOS não acolhidoS.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que negou provimento ao apelo da parte embargante, mantendo incólume a sentença de improcedência.
+II. Questão em discussão
+2.  A questão em discussão consiste em
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIOS. EMBARGOS não acolhidoS.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que negou provimento ao apelo da parte embargante, mantendo incólume a sentença de improcedência.
+II. Questão em discussão
+2.  A questão em discussão consiste em saber se há vícios de omissão no julgado, especialmente quanto à suposta ausência de análise da tese de fortuito interno e da responsabilidade objetiva da concessionária de energia.
+iii. razões de decidir
+3. O acórdão embargado se manifestou de maneira suficientemente clara, coerente e íntegra quanto à discussão trazida ao conhecimento desta Corte, tratando expressamente das questões apontadas pelo embargante.
+4. O acórdão embargado enfrentou todos os argumentos relevantes, especialmente aqueles mencionados no presente recurso. Mera irresignação da parte recorrente.
+iv. Dispositivo e tese
+5. Recurso conhecido e não acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Seção, j. 08.11.2017;
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>24&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812042" cdForo="0" >
+										0800906-18.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812042" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812042);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812042" style="display: none;" >
+	<div id="textAreaDados_812042" class="mensagemSemFormatacao" >
+		Direito processual civil. Embargos de declara&ccedil;&atilde;o em AGRAVO DE INSTRUMENTO. Alega&ccedil;&atilde;o de exist&ecirc;ncia de omiss&atilde;o no ac&oacute;rd&atilde;o. AUS&Ecirc;NCIA DE V&Iacute;CIO. Recurso  n&atilde;o acolhido.
+I. Caso em exame
+1. Embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que negou provimento ao agravo de instrumento interposto pela embargante.
+II. Quest&atilde;o em discuss&atilde;o
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) aferir eventual omiss&atilde;o quanto &agrave;s normas que estabelecem o engenheiro civil como profissional habilitado &agrave; realiza&ccedil;&atilde;o de per&iacute;cias de avalia&ccedil;&atilde;o imobili&aacute;ria; e (ii) avaliar a viabilidade da pretens&atilde;o de&nbsp;prequestionamento&nbsp;da mat&eacute;ria embargada.
+iii. raz&otilde;es de decidir
+3. O ac&oacute;rd&atilde;o embargado se manifestou de maneira suficientemente clara, coerente e &iacute;ntegra quanto &agrave; discuss&atilde;o trazida a esta Corte, demonstrando, expressamente, os motivos pelos quais se entendeu  que o profissional nomeado pelo ju&iacute;zo a quo tem capacidade t&eacute;cnica para a realiza&ccedil;&atilde;o da per&iacute;cia de avalia&ccedil;&atilde;o imobili&aacute;ria.
+4. Ac&oacute;rd&atilde;o embargado que enfrentou todos os argumentos capazes&nbsp;de, em tese, infirmar suas pr&oacute;prias conclus&otilde;es, especialmente aqueles mencionados no presente recurso. Mera irresigna&ccedil;&atilde;o da parte recorrente.
+5. O Tribunal n&atilde;o precisa enfrentar as mat&eacute;rias apenas para fins de&nbsp;prequestionamento, nos termos do art. 1.025 do C&oacute;digo de Processo Civil.
+iv. Dispositivo e tese
+6. Recurso conhecido e n&atilde;o acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022 e art. 1.025.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min.  Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017; STJ, EDcl no MS n. 21315/DF, Rel. Min. Diva Malerbi &ndash; Convocada, Primeira Se&ccedil;&atilde;o, j. 08.06.2016.  <br><br>(N&uacute;mero do Processo: 0800906-18.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Efeitos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800906182026802000050000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em AGRAVO DE INSTRUMENTO. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIO. Recurso  não acolhido.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que negou provimento ao agravo de instrumento interposto pela embargante.
+II. Questão em discussão
+2. As questões em discussão consistem em: (i) aferir eventual
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em AGRAVO DE INSTRUMENTO. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIO. Recurso  não acolhido.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que negou provimento ao agravo de instrumento interposto pela embargante.
+II. Questão em discussão
+2. As questões em discussão consistem em: (i) aferir eventual omissão quanto às normas que estabelecem o engenheiro civil como profissional habilitado à realização de perícias de avaliação imobiliária; e (ii) avaliar a viabilidade da pretensão de prequestionamento da matéria embargada.
+iii. razões de decidir
+3. O acórdão embargado se manifestou de maneira suficientemente clara, coerente e íntegra quanto à discussão trazida a esta Corte, demonstrando, expressamente, os motivos pelos quais se entendeu  que o profissional nomeado pelo juízo a quo tem capacidade técnica para a realização da perícia de avaliação imobiliária.
+4. Acórdão embargado que enfrentou todos os argumentos capazes de, em tese, infirmar suas próprias conclusões, especialmente aqueles mencionados no presente recurso. Mera irresignação da parte recorrente.
+5. O Tribunal não precisa enfrentar as matérias apenas para fins de prequestionamento, nos termos do art. 1.025 do Código de Processo Civil.
+iv. Dispositivo e tese
+6. Recurso conhecido e não acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022 e art. 1.025.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min.  Jorge Mussi, Terceira Seção, j. 08.11.2017; STJ, EDcl no MS n. 21315/DF, Rel. Min. Diva Malerbi – Convocada, Primeira Seção, j. 08.06.2016.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>25&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812034" cdForo="0" >
+										0801905-68.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812034" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812034);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812034" style="display: none;" >
+	<div id="textAreaDados_812034" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DE CONVERS&Atilde;O DE CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO EM EMPR&Eacute;STIMO CONSIGNADO E RESTITUI&Ccedil;&Atilde;O DA QUANTIA PAGA A MAIOR C/C DANOS MORAIS INCID&Ecirc;NCIA DO CDC. AUS&Ecirc;NCIA DOS REQUISITOS NECESS&Aacute;RIOS &Agrave; INVERS&Atilde;O DO &Ocirc;NUS DA PROVA. PEDIDO DE TRAMITA&Ccedil;&Atilde;O PRIORIT&Aacute;RIA DO FEITO. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela parte autora em face de pronunciamento que determinou a cita&ccedil;&atilde;o da parte adversa para apresentar contesta&ccedil;&atilde;o, deixando de se manifestar acerca dos pedidos de invers&atilde;o do &ocirc;nus da prova e tramita&ccedil;&atilde;o priorit&aacute;ria do feito.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) analisar se, em raz&atilde;o da natureza consumerista da demanda, seria aplic&aacute;vel a invers&atilde;o do &ocirc;nus da prova em desfavor da institui&ccedil;&atilde;o banc&aacute;ria; (ii) examinar o pedido de tramita&ccedil;&atilde;o priorit&aacute;ria do feito.
+3. Analisa-se, de of&iacute;cio, a incid&ecirc;ncia do Tema n&ordm; 1.414 do STJ.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A legisla&ccedil;&atilde;o consumerista &eacute; plenamente aplic&aacute;vel &agrave; hip&oacute;tese, uma vez que a parte agravada se enquadra no conceito de consumidor e o banco se subsome ao conceito de fornecedor, nos termos dos arts. 2&ordm; e 3&ordm; do referido diploma legal.
+4. A invers&atilde;o do &ocirc;nus da prova, prevista no art. 6&ordm;, VIII, do CDC, n&atilde;o &eacute; autom&aacute;tica e depende de decis&atilde;o judicial fundamentada, a partir da an&aacute;lise da verossimilhan&ccedil;a das alega&ccedil;&otilde;es e da hipossufici&ecirc;ncia probat&oacute;ria, inexistentes no caso concreto. N&atilde;o &eacute; poss&iacute;vel vislumbrar a hipossufici&ecirc;ncia t&eacute;cnica da parte autora para a obten&ccedil;&atilde;o do documento, tendo em vista que o instrumento contratual poderia ser facilmente obtido por esta, por meios formais dispon&iacute;veis, como plataformas digitais de acesso ao consumidor.
+6. Considerando que a parte agravante &eacute; pessoa idosa, com mais de 60 (sessenta) anos, faz jus &agrave; tramita&ccedil;&atilde;o priorit&aacute;ria do feito, conforme assegura o Estatuto do Idoso e o C&oacute;digo de Processo Civil.
+7. Determina-se que o ju&iacute;zo de origem observe a ordem de suspens&atilde;o dos feitos que tenham o mesmo objeto de discuss&atilde;o do incidente de recursos repetitivos instaurado pelo STJ, at&eacute; que ocorra o julgamento do Tema Repetitivo n&ordm; 1.414.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e parcialmente provido.
+__________
+Dispositivos relevantes citados: CDC, arts. 2&ordm;, 3&ordm;, &sect;2&ordm;, e 6&ordm;, VIII; CPC, art. 71, art. 1.015, art. 1.048;
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n. 802.832/MG, Rel. Min. Paulo de Tarso Sanseverino, Segunda Se&ccedil;&atilde;o, j. 13.4.2011 <br><br>(N&uacute;mero do Processo: 0801905-68.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Palmeira dos &Iacute;ndios; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Palmeira dos Indios
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE CONVERSÃO DE CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO EM EMPRÉSTIMO CONSIGNADO E RESTITUIÇÃO DA QUANTIA PAGA A MAIOR C/C <em>DANOS</em> <em>MORAIS</em> INCIDÊNCIA DO CDC. AUSÊNCIA DOS REQUISITOS NECESSÁRIOS À INVERSÃO DO ÔNUS DA PROVA. PEDIDO DE TRAMITAÇÃO PRIORITÁRIA DO FEITO. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE CONVERSÃO DE CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO EM EMPRÉSTIMO CONSIGNADO E RESTITUIÇÃO DA QUANTIA PAGA A MAIOR C/C <em>DANOS</em> <em>MORAIS</em> INCIDÊNCIA DO CDC. AUSÊNCIA DOS REQUISITOS NECESSÁRIOS À INVERSÃO DO ÔNUS DA PROVA. PEDIDO DE TRAMITAÇÃO PRIORITÁRIA DO FEITO. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela parte autora em face de pronunciamento que determinou a citação da parte adversa para apresentar contestação, deixando de se manifestar acerca dos pedidos de inversão do ônus da prova e tramitação prioritária do feito.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) analisar se, em razão da natureza consumerista da demanda, seria aplicável a inversão do ônus da prova em desfavor da instituição bancária; (ii) examinar o pedido de tramitação prioritária do feito.
+3. Analisa-se, de ofício, a incidência do Tema nº 1.414 do STJ.
+III. RAZÕES DE DECIDIR
+3. A legislação consumerista é plenamente aplicável à hipótese, uma vez que a parte agravada se enquadra no conceito de consumidor e o banco se subsome ao conceito de fornecedor, nos termos dos arts. 2º e 3º do referido diploma legal.
+4. A inversão do ônus da prova, prevista no art. 6º, VIII, do CDC, não é automática e depende de decisão judicial fundamentada, a partir da análise da verossimilhança das alegações e da hipossuficiência probatória, inexistentes no caso concreto. Não é possível vislumbrar a hipossuficiência técnica da parte autora para a obtenção do documento, tendo em vista que o instrumento contratual poderia ser facilmente obtido por esta, por meios formais disponíveis, como plataformas digitais de acesso ao consumidor.
+6. Considerando que a parte agravante é pessoa idosa, com mais de 60 (sessenta) anos, faz jus à tramitação prioritária do feito, conforme assegura o Estatuto do Idoso e o Código de Processo Civil.
+7. Determina-se que o juízo de origem observe a ordem de suspensão dos feitos que tenham o mesmo objeto de discussão do incidente de recursos repetitivos instaurado pelo STJ, até que ocorra o julgamento do Tema Repetitivo nº 1.414.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e parcialmente provido.
+__________
+Dispositivos relevantes citados: CDC, arts. 2º, 3º, §2º, e 6º, VIII; CPC, art. 71, art. 1.015, art. 1.048;
+Jurisprudência relevante citada: STJ, REsp n. 802.832/MG, Rel. Min. Paulo de Tarso Sanseverino, Segunda Seção, j. 13.4.2011
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>26&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811977" cdForo="0" >
+										0703194-19.2024.8.02.0058
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811977" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811977);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811977" style="display: none;" >
+	<div id="textAreaDados_811977" class="mensagemSemFormatacao" >
+		Direito processual civil. Embargos de declara&ccedil;&atilde;o em apela&ccedil;&atilde;o c&iacute;vel. Alega&ccedil;&Otilde;ES de exist&ecirc;ncia de omiss&atilde;o E OBSCURIDADE no ac&oacute;rd&atilde;o. AUS&Ecirc;NCIA DE V&Iacute;CIOS. Recurso  n&atilde;o acolhido.
+I. Caso em exame
+1. Embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que conheceu parcialmente do apelo manejado pelo r&eacute;u, para, na parte conhecida, no m&eacute;rito, negar-lhe provimento; e conheceu do recurso interposto pelas partes autoras para, no m&eacute;rito, dar-lhe parcial provimento, a fim de reformar a senten&ccedil;a atacada, a fim de majorar a indeniza&ccedil;&atilde;o por danos morais para R$ 50.000,00 (cinquenta mil reais) em favor de cada uma das demandantes e reconhecer o direito das demandantes a perceber pens&atilde;o mensal calculada sobre 2/3 (dois ter&ccedil;os) da remunera&ccedil;&atilde;o da v&iacute;tima, desde a data do &oacute;bito at&eacute; o momento em que completarem 25 (vinte e cinco) anos de idade.
+II. Quest&atilde;o em discuss&atilde;o
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) analisar eventual omiss&atilde;o quanto &agrave; alegada inexist&ecirc;ncia de culpa concorrente da v&iacute;tima; (ii) examinar supostas omiss&atilde;o e obscuridade com rela&ccedil;&atilde;o &agrave; delimita&ccedil;&atilde;o do pensionamento reconhecido no ac&oacute;rd&atilde;o; (iii) saber se h&aacute; omiss&atilde;o e obscuridade quanto &agrave; dedu&ccedil;&atilde;o do seguro obrigat&oacute;rio; e (iv) avaliar a viabilidade da pretens&atilde;o de&nbsp;prequestionamento&nbsp;da mat&eacute;ria embargada.
+iii. raz&otilde;es de decidir
+3. O ac&oacute;rd&atilde;o embargado se manifestou de maneira suficientemente clara, coerente e &iacute;ntegra quanto &agrave; discuss&atilde;o trazida a esta Corte, demonstrando, expressamente, os crit&eacute;rios utilizados (dentre eles a aus&ecirc;ncia de culpa concorrente da v&iacute;tima) para majorar o quantum indenizat&oacute;rio fixado a t&iacute;tulo de danos morais, bem como os fundamentos jur&iacute;dicos para fixar o pensionamento em favor das partes autoras  no valor correspondente a 2/3 da remunera&ccedil;&atilde;o percebida pela v&iacute;tima desde a data do &oacute;bito at&eacute; quando completarem 25 (vinte e cinco) anos de idade, acrescida dos consect&aacute;rios legais expressamente indicados no julgado. Al&eacute;m disso, ressaltou-se que n&atilde;o h&aacute; nos autos prova de que as partes autoras tenham recebido a indeniza&ccedil;&atilde;o do seguro DPVAT, de modo que n&atilde;o seria devida a dedu&ccedil;&atilde;o do valor da indeniza&ccedil;&atilde;o na forma da s&uacute;mula 246 do Superior Tribunal de Justi&ccedil;a.
+4. Ac&oacute;rd&atilde;o embargado que enfrentou todos os argumentos capazes&nbsp;de, em tese, infirmar suas pr&oacute;prias conclus&otilde;es. Mera irresigna&ccedil;&atilde;o da parte recorrente.
+5. O Tribunal n&atilde;o est&aacute; obrigado a se manifestar sobre a mat&eacute;ria suscitada pela parte apenas para fins de prequestionamento, consoante art. 1.025 do CPC.
+iv. Dispositivo e tese
+6. Recurso conhecido e n&atilde;o acolhido.
+_________
+Dispositivo relevante citado:  CPC, arts. 1.022 e 1.025.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min.  Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017; STJ, EDcl no MS n. 21315/DF, Rel. Min. Diva Malerbi &ndash; Convocada, Primeira Se&ccedil;&atilde;o, j. 08.06.2016. <br><br>(N&uacute;mero do Processo: 0703194-19.2024.8.02.0058; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Arapiraca; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(75 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Arapiraca
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									703194192024802005850000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. AlegaçÕES de existência de omissão E OBSCURIDADE no acórdão. AUSÊNCIA DE VÍCIOS. Recurso  não acolhido.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que conheceu parcialmente do apelo manejado pelo réu, para, na parte conhecida, no mérito, negar-lhe provimento; e conheceu do recurso interposto pelas
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito processual civil. Embargos de declaração em apelação cível. AlegaçÕES de existência de omissão E OBSCURIDADE no acórdão. AUSÊNCIA DE VÍCIOS. Recurso  não acolhido.
+I. Caso em exame
+1. Embargos de declaração opostos em face de acórdão que conheceu parcialmente do apelo manejado pelo réu, para, na parte conhecida, no mérito, negar-lhe provimento; e conheceu do recurso interposto pelas partes autoras para, no mérito, dar-lhe parcial provimento, a fim de reformar a sentença atacada, a fim de majorar a indenização por <em>danos</em> <em>morais</em> para R$ 50.000,00 (cinquenta mil reais) em favor de cada uma das demandantes e reconhecer o direito das demandantes a perceber pensão mensal calculada sobre 2/3 (dois terços) da remuneração da vítima, desde a data do óbito até o momento em que completarem 25 (vinte e cinco) anos de idade.
+II. Questão em discussão
+2. As questões em discussão consistem em: (i) analisar eventual omissão quanto à alegada inexistência de culpa concorrente da vítima; (ii) examinar supostas omissão e obscuridade com relação à delimitação do pensionamento reconhecido no acórdão; (iii) saber se há omissão e obscuridade quanto à dedução do seguro obrigatório; e (iv) avaliar a viabilidade da pretensão de prequestionamento da matéria embargada.
+iii. razões de decidir
+3. O acórdão embargado se manifestou de maneira suficientemente clara, coerente e íntegra quanto à discussão trazida a esta Corte, demonstrando, expressamente, os critérios utilizados (dentre eles a ausência de culpa concorrente da vítima) para majorar o quantum indenizatório fixado a título de <em>danos</em> <em>morais</em>, bem como os fundamentos jurídicos para fixar o pensionamento em favor das partes autoras  no valor correspondente a 2/3 da remuneração percebida pela vítima desde a data do óbito até quando completarem 25 (vinte e cinco) anos de idade, acrescida dos consectários legais expressamente indicados no julgado. Além disso, ressaltou-se que não há nos autos prova de que as partes autoras tenham recebido a indenização do seguro DPVAT, de modo que não seria devida a dedução do valor da indenização na forma da súmula 246 do Superior Tribunal de Justiça.
+4. Acórdão embargado que enfrentou todos os argumentos capazes de, em tese, infirmar suas próprias conclusões. Mera irresignação da parte recorrente.
+5. O Tribunal não está obrigado a se manifestar sobre a matéria suscitada pela parte apenas para fins de prequestionamento, consoante art. 1.025 do CPC.
+iv. Dispositivo e tese
+6. Recurso conhecido e não acolhido.
+_________
+Dispositivo relevante citado:  CPC, arts. 1.022 e 1.025.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min.  Jorge Mussi, Terceira Seção, j. 08.11.2017; STJ, EDcl no MS n. 21315/DF, Rel. Min. Diva Malerbi – Convocada, Primeira Seção, j. 08.06.2016.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>27&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811923" cdForo="0" >
+										0727100-49.2023.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811923" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811923);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811923" style="display: none;" >
+	<div id="textAreaDados_811923" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE COBRAN&Ccedil;A INDEVIDA C/C REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO C/C DANO MORAL. FATURAS COBRADAS EM DUPLICIDADE. REPETI&Ccedil;&Atilde;O EM DOBRO DO IND&Eacute;BITO. QUANTUM INDENIZAT&Oacute;RIO ARBITRADO NA COMPENSA&Ccedil;&Atilde;O POR DANO MORAL MANTIDO. DELIMITA&Ccedil;&Atilde;O DA MAT&Eacute;RIA PELO EFEITO DEVOLUTIVO. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pela concession&aacute;ria de energia contra senten&ccedil;a que julgou parcialmente procedentes os pedidos autorais, para declarar inexig&iacute;veis as cobran&ccedil;as relativas &agrave;s faturas impugnadas nos autos, bem como para condenar a empresa ao pagamento de indeniza&ccedil;&atilde;o por danos morais no montante de R$ 1.000,00 (mil reais). Ademais, condenou a recorrente ao pagamento das despesas processuais e honor&aacute;rios advocat&iacute;cios, estes arbitrados em 10% (dez por cento) sobre o valor da condena&ccedil;&atilde;o, nos termos do art. 85, &sect;2&ordm;, do CPC.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) analisar o pleito de condena&ccedil;&atilde;o da concession&aacute;ria &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito em dobro; (ii) examinar a possibilidade de majora&ccedil;&atilde;o do quantum arbitrado na compensa&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3.  De acordo com o teor do artigo 42, par&aacute;grafo &uacute;nico, do CDC, bem como com a jurisprud&ecirc;ncia da Corte Superior, a devolu&ccedil;&atilde;o em dobro dos valores pagos pelo consumidor pressup&otilde;e a exist&ecirc;ncia de pagamento indevido. Restou comprovado que a parte demandante efetuou pagamentos em duplicidade relativos &agrave;s faturas de fevereiro e abril de 2023, o que imp&otilde;e a repeti&ccedil;&atilde;o do ind&eacute;bito em dobro.
+4. O quantum arbitrado na compensa&ccedil;&atilde;o por danos morais atende &agrave;s peculiaridades do caso concreto, n&atilde;o comportando modifica&ccedil;&atilde;o.
+IV. DISPOSITIVO
+5. Recurso conhecido e parcialmente provido.
+_____________
+Dispositivos relevantes citados: CPC, art. 1.013; CDC, art. 6&ordm;, VIII, art. 42, par&aacute;grafo &uacute;nico; CC, art. 944.
+Jurisprud&ecirc;ncia relevante citada: STJ, EREsp n. 1.413.542/RS, Rel, Min. Maria Thereza de Assis Moura, Rel. para ac&oacute;rd&atilde;o Min. Herman Benjamin, Corte Especial, j. 21.10.2020; STJ, AgInt nos EDcl no AREsp n. 1.759.883/PR, Rel. Min. Raul Ara&uacute;jo, Quarta Turma, j. 3.10.2022; STJ, REsp n. 665.425/AM, Rel. Min. Nancy Andrighi, Terceira Turma, j. 26.4.2005.  <br><br>(N&uacute;mero do Processo: 0727100-49.2023.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(41 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Liminar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL EM AÇÃO DE COBRANÇA INDEVIDA C/C REPETIÇÃO DO INDÉBITO C/C <em>DANO</em> <em>MORAL</em>. FATURAS COBRADAS EM DUPLICIDADE. REPETIÇÃO EM DOBRO DO INDÉBITO. QUANTUM INDENIZATÓRIO ARBITRADO NA COMPENSAÇÃO POR <em>DANO</em> <em>MORAL</em> MANTIDO. DELIMITAÇÃO DA MATÉRIA PELO EFEITO DEVOLUTIVO. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Apelação cível interposta
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL EM AÇÃO DE COBRANÇA INDEVIDA C/C REPETIÇÃO DO INDÉBITO C/C <em>DANO</em> <em>MORAL</em>. FATURAS COBRADAS EM DUPLICIDADE. REPETIÇÃO EM DOBRO DO INDÉBITO. QUANTUM INDENIZATÓRIO ARBITRADO NA COMPENSAÇÃO POR <em>DANO</em> <em>MORAL</em> MANTIDO. DELIMITAÇÃO DA MATÉRIA PELO EFEITO DEVOLUTIVO. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Apelação cível interposta pela concessionária de energia contra sentença que julgou parcialmente procedentes os pedidos autorais, para declarar inexigíveis as cobranças relativas às faturas impugnadas nos autos, bem como para condenar a empresa ao pagamento de indenização por <em>danos</em> <em>morais</em> no montante de R$ 1.000,00 (mil reais). Ademais, condenou a recorrente ao pagamento das despesas processuais e honorários advocatícios, estes arbitrados em 10% (dez por cento) sobre o valor da condenação, nos termos do art. 85, §2º, do CPC.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) analisar o pleito de condenação da concessionária à repetição do indébito em dobro; (ii) examinar a possibilidade de majoração do quantum arbitrado na compensação por <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3.  De acordo com o teor do artigo 42, parágrafo único, do CDC, bem como com a jurisprudência da Corte Superior, a devolução em dobro dos valores pagos pelo consumidor pressupõe a existência de pagamento indevido. Restou comprovado que a parte demandante efetuou pagamentos em duplicidade relativos às faturas de fevereiro e abril de 2023, o que impõe a repetição do indébito em dobro.
+4. O quantum arbitrado na compensação por <em>danos</em> <em>morais</em> atende às peculiaridades do caso concreto, não comportando modificação.
+IV. DISPOSITIVO
+5. Recurso conhecido e parcialmente provido.
+_____________
+Dispositivos relevantes citados: CPC, art. 1.013; CDC, art. 6º, VIII, art. 42, parágrafo único; CC, art. 944.
+Jurisprudência relevante citada: STJ, EREsp n. 1.413.542/RS, Rel, Min. Maria Thereza de Assis Moura, Rel. para acórdão Min. Herman Benjamin, Corte Especial, j. 21.10.2020; STJ, AgInt nos EDcl no AREsp n. 1.759.883/PR, Rel. Min. Raul Araújo, Quarta Turma, j. 3.10.2022; STJ, REsp n. 665.425/AM, Rel. Min. Nancy Andrighi, Terceira Turma, j. 26.4.2005.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>28&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811919" cdForo="0" >
+										0700464-22.2024.8.02.0030
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811919" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811919);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811919" style="display: none;" >
+	<div id="textAreaDados_811919" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS EM A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO DE CR&Eacute;DITO PESSOAL CONSIGNADO C/C DANOS MORAIS. ALEGA&Ccedil;&Atilde;O DE DESCUMPRIMENTO DA TAXA DE JUROS PACTUADA. TAXA EFETIVA DENTRO DO LIMITE DA TAXA M&Eacute;DIA DE MERCADO ACRESCIDA DE 50%. INEXIST&Ecirc;NCIA DE DANO MORAL. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es c&iacute;veis interpostas pelas partes visando &agrave; reforma de senten&ccedil;a que julgou parcialmente procedentes os pedidos de revis&atilde;o contratual e indeniza&ccedil;&atilde;o por danos morais, em a&ccedil;&atilde;o revisional de cr&eacute;dito consignado.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) saber se a taxa de juros aplicada configura abusividade apta a justificar revis&atilde;o contratual; (ii) examinar se deve ser a institui&ccedil;&atilde;o financeira condenada &agrave; devolu&ccedil;&atilde;o em dobro; (iii) verificar a exist&ecirc;ncia de dano moral decorrente das supostas pr&aacute;ticas abusivas.
+III. RAZ&Otilde;ES DE DECIDIR
+3. As institui&ccedil;&otilde;es financeiras n&atilde;o se submetem &agrave; limita&ccedil;&atilde;o da Lei da Usura (Decreto n&ordm; 22.626/33), conforme S&uacute;mula 596/STF, sendo l&iacute;cita a estipula&ccedil;&atilde;o de juros remunerat&oacute;rios superiores a 12% ao ano, por si s&oacute;, nos termos da S&uacute;mula 382/STJ.
+4. A jurisprud&ecirc;ncia do STJ estabelece que a estipula&ccedil;&atilde;o de juros remunerat&oacute;rios superiores &agrave; taxa m&eacute;dia de mercado n&atilde;o configura, por si s&oacute;, abusividade, salvo se demonstrada excessiva onerosidade no caso concreto.
+5. A simples compara&ccedil;&atilde;o com a taxa m&eacute;dia de mercado n&atilde;o &eacute; suficiente para limitar os juros, devendo haver demonstra&ccedil;&atilde;o da abusividade com base nas peculiaridades da opera&ccedil;&atilde;o e no risco de cr&eacute;dito.
+6. Reconhecida a abusividade da taxa de juros anual contratada, superando em 50% a m&eacute;dia de mercado, justifica-se a limita&ccedil;&atilde;o ao patamar m&aacute;ximo aceit&aacute;vel.
+7. O dano moral n&atilde;o se configura em casos de revis&atilde;o contratual quando n&atilde;o demonstrado efetivo abalo psicol&oacute;gico ou viola&ccedil;&atilde;o a direitos da personalidade.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e provido em parte.
+_________
+Dispositivos relevantes citados: CPC/2015, arts. 85, &sect; 11, 98, &sect; 3&ordm;, 487, I; CC, arts. 22, 421, 478, 480; CDC, arts. 2&ordm;, 3&ordm;, 6&ordm;, V, 51, IV, 54-B, &sect; 2&ordm;; Decreto n&ordm; 22.626/33; Lei n&ordm; 4.595/64; Resolu&ccedil;&atilde;o CMN n&ordm; 3.517/2007; Lei n. 5.143/66; Decreto n&ordm; 6.306/2007.
+Jurisprud&ecirc;ncia relevante citada: STF, S&uacute;mula 596; STJ, S&uacute;mula 382, S&uacute;mula 297, S&uacute;mula Vinculante 7; STJ, REsp 1.061.530/RS, Rel. Min. Nancy Andrighi, 2&ordf; Se&ccedil;&atilde;o, j. 22.10.2008; STJ, REsp 1.821.182/RS, Rel. Min. Maria Isabel Gallotti, 4&ordf; Turma, j. 23.06.2022; STJ, AgInt no AREsp 1.506.600/RJ, Rel. Min. Marco Buzzi, 4&ordf; Turma, j. 09.12.2019; STJ, AgInt no REsp 2.138.867/SC, Rel. Min. Antonio Carlos Ferreira, 4&ordf; Turma, j. 04.11.2024; STJ, REsp 1251331/RS, Rel. Min. Maria Isabel Gallotti, 2&ordf; Se&ccedil;&atilde;o, j. 28.08.2013.
+ <br><br>(N&uacute;mero do Processo: 0700464-22.2024.8.02.0030; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Piranhas; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(39 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição de indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Piranhas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS EM AÇÃO REVISIONAL DE CONTRATO DE CRÉDITO PESSOAL CONSIGNADO C/C <em>DANOS</em> <em>MORAIS</em>. ALEGAÇÃO DE DESCUMPRIMENTO DA TAXA DE JUROS PACTUADA. TAXA EFETIVA DENTRO DO LIMITE DA TAXA MÉDIA DE MERCADO ACRESCIDA DE 50%. INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em>. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Apelações cíveis interpostas pelas partes
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS EM AÇÃO REVISIONAL DE CONTRATO DE CRÉDITO PESSOAL CONSIGNADO C/C <em>DANOS</em> <em>MORAIS</em>. ALEGAÇÃO DE DESCUMPRIMENTO DA TAXA DE JUROS PACTUADA. TAXA EFETIVA DENTRO DO LIMITE DA TAXA MÉDIA DE MERCADO ACRESCIDA DE 50%. INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em>. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Apelações cíveis interpostas pelas partes visando à reforma de sentença que julgou parcialmente procedentes os pedidos de revisão contratual e indenização por <em>danos</em> <em>morais</em>, em ação revisional de crédito consignado.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) saber se a taxa de juros aplicada configura abusividade apta a justificar revisão contratual; (ii) examinar se deve ser a instituição financeira condenada à devolução em dobro; (iii) verificar a existência de <em>dano</em> <em>moral</em> decorrente das supostas práticas abusivas.
+III. RAZÕES DE DECIDIR
+3. As instituições financeiras não se submetem à limitação da Lei da Usura (Decreto nº 22.626/33), conforme Súmula 596/STF, sendo lícita a estipulação de juros remuneratórios superiores a 12% ao ano, por si só, nos termos da Súmula 382/STJ.
+4. A jurisprudência do STJ estabelece que a estipulação de juros remuneratórios superiores à taxa média de mercado não configura, por si só, abusividade, salvo se demonstrada excessiva onerosidade no caso concreto.
+5. A simples comparação com a taxa média de mercado não é suficiente para limitar os juros, devendo haver demonstração da abusividade com base nas peculiaridades da operação e no risco de crédito.
+6. Reconhecida a abusividade da taxa de juros anual contratada, superando em 50% a média de mercado, justifica-se a limitação ao patamar máximo aceitável.
+7. O <em>dano</em> <em>moral</em> não se configura em casos de revisão contratual quando não demonstrado efetivo abalo psicológico ou violação a direitos da personalidade.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e provido em parte.
+_________
+Dispositivos relevantes citados: CPC/2015, arts. 85, § 11, 98, § 3º, 487, I; CC, arts. 22, 421, 478, 480; CDC, arts. 2º, 3º, 6º, V, 51, IV, 54-B, § 2º; Decreto nº 22.626/33; Lei nº 4.595/64; Resolução CMN nº 3.517/2007; Lei n. 5.143/66; Decreto nº 6.306/2007.
+Jurisprudência relevante citada: STF, Súmula 596; STJ, Súmula 382, Súmula 297, Súmula Vinculante 7; STJ, REsp 1.061.530/RS, Rel. Min. Nancy Andrighi, 2ª Seção, j. 22.10.2008; STJ, REsp 1.821.182/RS, Rel. Min. Maria Isabel Gallotti, 4ª Turma, j. 23.06.2022; STJ, AgInt no AREsp 1.506.600/RJ, Rel. Min. Marco Buzzi, 4ª Turma, j. 09.12.2019; STJ, AgInt no REsp 2.138.867/SC, Rel. Min. Antonio Carlos Ferreira, 4ª Turma, j. 04.11.2024; STJ, REsp 1251331/RS, Rel. Min. Maria Isabel Gallotti, 2ª Seção, j. 28.08.2013.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>29&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811895" cdForo="0" >
+										0801472-64.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811895" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811895);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811895" style="display: none;" >
+	<div id="textAreaDados_811895" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE NEG&Oacute;CIO JUR&Iacute;DICO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. DEMANDA DE ORIGEM AJUIZADA CONTRA DIVERSAS INSTITUI&Ccedil;&Otilde;ES FINANCEIRAS. INEXIST&Ecirc;NCIA DE COMUNH&Atilde;O DE INTERESSES, CONEX&Atilde;O OU AFINIDADE ENTRE AS DEMANDAS QUE JUSTIFIQUE A FORMA&Ccedil;&Atilde;O DE LITISCONS&Oacute;RCIO PASSIVO. AUS&Ecirc;NCIA DE PRESSUPOSTO DE CONSTITUI&Ccedil;&Atilde;O E DE DESENVOLVIMENTO V&Aacute;LIDO E REGULAR DO PROCESSO. EXTIN&Ccedil;&Atilde;O DO FEITO SEM RESOLU&Ccedil;&Atilde;O DO M&Eacute;RITO DE OF&Iacute;CIO. AN&Aacute;LISE DAS RAZ&Otilde;ES RECURSAIS PREJUDICADA.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto em face de  decis&atilde;o que indeferiu o pedido de tutela de urg&ecirc;ncia, ante a falta de comprova&ccedil;&atilde;o da probabilidade do direito.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) verificar se a recorrente faz jus ao benef&iacute;cio da justi&ccedil;a gratuita; e (ii) aferir se &eacute; devida a concess&atilde;o de tutela provis&oacute;ria de urg&ecirc;ncia, para determinar a suspens&atilde;o dos descontos efetivados no benef&iacute;cio da parte agravante em decorr&ecirc;ncia dos empr&eacute;stimos questionados no processo.
+3. An&aacute;lise, de of&iacute;cio, do preenchimento do pressuposto de constitui&ccedil;&atilde;o e de desenvolvimento v&aacute;lido e regular do processo de origem.
+III. RAZ&Otilde;ES DE DECIDIR
+4. N&atilde;o&nbsp;conhecimento&nbsp;do recurso, por aus&ecirc;ncia de&nbsp;interesse&nbsp;recursal, quanto &agrave; concess&atilde;o do benef&iacute;cio de&nbsp;justi&ccedil;a&nbsp;gratuita, tendo em vista que a gratuidade de&nbsp;justi&ccedil;a&nbsp;j&aacute; havia sido deferida na origem.
+5. A agravante ajuizou a&ccedil;&atilde;o contra diversas institui&ccedil;&otilde;es financeiras, questionando a exist&ecirc;ncia e/ou validade de diferentes contratos envolvendo a concess&atilde;o de empr&eacute;stimos. Inexist&ecirc;ncia de litiscons&oacute;rcio por comunh&atilde;o de interesses, por conex&atilde;o ou por afinidade.
+6. Irregularidade formal desde o in&iacute;cio do processo, diante da impossibilidade de cumula&ccedil;&atilde;o subjetiva levada a efeito pela parte autora. Aus&ecirc;ncia de pressuposto de constitui&ccedil;&atilde;o e de desenvolvimento v&aacute;lido e regular do processo. V&iacute;cio insan&aacute;vel.
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido em parte para, de&nbsp;of&iacute;cio, por for&ccedil;a do efeito translativo, extinguir o feito sem resolu&ccedil;&atilde;o de m&eacute;rito.
+_________
+Dispositivos relevantes citados: CPC, art. 17, art. 113, art. 485, IV e art. 780.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n. 802.497/MG, Rel. Nancy Andrighi, Terceira Turma, j. 15.05.2008; STJ, AgInt no AREsp n. 1.695.235/MG, Rel. Min. Raul Ara&uacute;jo, Quarta Turma, j. 23.11.2020. <br><br>(N&uacute;mero do Processo: 0801472-64.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Porto Calvo; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Inexequibilidade do Título / Inexigibilidade da Obrigação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Porto Calvo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DECLARATÓRIA DE NULIDADE DE NEGÓCIO JURÍDICO E INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. DEMANDA DE ORIGEM AJUIZADA CONTRA DIVERSAS INSTITUIÇÕES FINANCEIRAS. INEXISTÊNCIA DE COMUNHÃO DE INTERESSES, CONEXÃO OU AFINIDADE ENTRE AS DEMANDAS QUE JUSTIFIQUE A FORMAÇÃO DE LITISCONSÓRCIO PASSIVO. AUSÊNCIA DE PRESSUPOSTO DE CONSTITUIÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DECLARATÓRIA DE NULIDADE DE NEGÓCIO JURÍDICO E INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. DEMANDA DE ORIGEM AJUIZADA CONTRA DIVERSAS INSTITUIÇÕES FINANCEIRAS. INEXISTÊNCIA DE COMUNHÃO DE INTERESSES, CONEXÃO OU AFINIDADE ENTRE AS DEMANDAS QUE JUSTIFIQUE A FORMAÇÃO DE LITISCONSÓRCIO PASSIVO. AUSÊNCIA DE PRESSUPOSTO DE CONSTITUIÇÃO E DE DESENVOLVIMENTO VÁLIDO E REGULAR DO PROCESSO. EXTINÇÃO DO FEITO SEM RESOLUÇÃO DO MÉRITO DE OFÍCIO. ANÁLISE DAS RAZÕES RECURSAIS PREJUDICADA.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto em face de  decisão que indeferiu o pedido de tutela de urgência, ante a falta de comprovação da probabilidade do direito.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) verificar se a recorrente faz jus ao benefício da justiça gratuita; e (ii) aferir se é devida a concessão de tutela provisória de urgência, para determinar a suspensão dos descontos efetivados no benefício da parte agravante em decorrência dos empréstimos questionados no processo.
+3. Análise, de ofício, do preenchimento do pressuposto de constituição e de desenvolvimento válido e regular do processo de origem.
+III. RAZÕES DE DECIDIR
+4. Não conhecimento do recurso, por ausência de interesse recursal, quanto à concessão do benefício de justiça gratuita, tendo em vista que a gratuidade de justiça já havia sido deferida na origem.
+5. A agravante ajuizou ação contra diversas instituições financeiras, questionando a existência e/ou validade de diferentes contratos envolvendo a concessão de empréstimos. Inexistência de litisconsórcio por comunhão de interesses, por conexão ou por afinidade.
+6. Irregularidade formal desde o início do processo, diante da impossibilidade de cumulação subjetiva levada a efeito pela parte autora. Ausência de pressuposto de constituição e de desenvolvimento válido e regular do processo. Vício insanável.
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido em parte para, de ofício, por força do efeito translativo, extinguir o feito sem resolução de mérito.
+_________
+Dispositivos relevantes citados: CPC, art. 17, art. 113, art. 485, IV e art. 780.
+Jurisprudência relevante citada: STJ, REsp n. 802.497/MG, Rel. Nancy Andrighi, Terceira Turma, j. 15.05.2008; STJ, AgInt no AREsp n. 1.695.235/MG, Rel. Min. Raul Araújo, Quarta Turma, j. 23.11.2020.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>30&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812004" cdForo="0" >
+										0801977-55.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812004" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812004);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812004" style="display: none;" >
+	<div id="textAreaDados_812004" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O ORDIN&Aacute;RIA DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO COM PEDIDO DE TUTELA ANTECEDENTE E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E MATERIAIS. SUSPENS&Atilde;O DAS COBRAN&Ccedil;AS E ABSTEN&Ccedil;&Atilde;O DE NEGATIVA&Ccedil;&Atilde;O. EXIST&Ecirc;NCIA DE ELEMENTOS SUFICIENTES PARA A CONCESS&Atilde;O DA TUTELA PROVIS&Oacute;RIA NA ORIGEM. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto em face de decis&atilde;o que  deferiu o pedido de tutela provis&oacute;ria de urg&ecirc;ncia, determinando que os r&eacute;us, no prazo de 5 (cinco) dias, suspendam as cobran&ccedil;as, direta ou indiretamente, inclusive envio de boletos, liga&ccedil;&otilde;es, e-mails, WhatsApp ou correspond&ecirc;ncia, bem como se abstenham de inserir o nome dos autores nos cadastros de prote&ccedil;&atilde;o ao cr&eacute;dito, e, se assim j&aacute; tenham procedido, que no mesmo prazo seja retirada tal anota&ccedil;&atilde;o.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consiste em: (i) examinar se &eacute; devida a suspens&atilde;o das cobran&ccedil;as relativas a despesas hospitalares supostamente n&atilde;o cobertas pelo plano de sa&uacute;de, bem como a absten&ccedil;&atilde;o de inser&ccedil;&atilde;o do nome dos autores nos cadastrados de prote&ccedil;&atilde;o ao cr&eacute;dito; e (ii) analisar se, no caso, devem ser observados os par&acirc;metros fixados pelo Supremo Tribunal Federal, na ADI 7265, para fornecimento de tratamento fora do rol da ANS.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Aos contratos de seguro de sa&uacute;de aplicam-se o C&oacute;digo de Defesa do Consumidor, e por conseguinte, as cl&aacute;usulas dever&atilde;o observar o referido diploma normativo, respeitando-se as formas de interpreta&ccedil;&atilde;o e elabora&ccedil;&atilde;o contratuais, especialmente diante da evidenciada hipossufici&ecirc;ncia do consumidor em rela&ccedil;&atilde;o ao fornecedor.
+4. Os agravados comprovaram que sua filha, portadora de &quot;taquiarritmia de dif&iacute;cil controle (fibrila&ccedil;&atilde;o atrial com condu&ccedil;&atilde;o aberrante)&quot;, precisou ser transferida de nosoc&ocirc;mio localizado na cidade de Macei&oacute;/AL para o Hospital Sabar&aacute; em S&atilde;o Paulo/SP, em decorr&ecirc;ncia da gravidade extrema. No referido hospital, a genitora da crian&ccedil;a assinou termo de declara&ccedil;&atilde;o, no qual consta que a interna&ccedil;&atilde;o hospitalar da infante estava integralmente compreendida pela cobertura assistencial da operadora de sa&uacute;de agravante, a qual seria a respons&aacute;vel pelos custos e despesas decorrentes da referida interna&ccedil;&atilde;o.
+5. Inexist&ecirc;ncia de qualquer documento que demonstre que os demandantes foram cientificados, previamente, da negativa de autoriza&ccedil;&atilde;o de qualquer procedimento pela operadora de sa&uacute;de e que, mesmo assim, assumiram a responsabilidade pelo pagamento de quaisquer despesas eventualmente n&atilde;o cobertas pelo plano. Comunica&ccedil;&atilde;o a respeito de que a operadora de sa&uacute;de n&atilde;o teria coberto alguns custos associados ao internamento que somente ocorreu ap&oacute;s o falecimento da crian&ccedil;a.
+6. Par&acirc;metros estabelecidos pelo STF, na ADI 7265, para fornecimento de tratamento fora do rol da ANS. Julgamento que ocorreu no m&ecirc;s de setembro de 2025, de modo que n&atilde;o &eacute; razo&aacute;vel exigir que sejam observados todos os requisitos fixados pela Suprema Corte quando a interna&ccedil;&atilde;o da filha das partes agravadas se deu no final do ano de 2024 e, naquela &eacute;poca, n&atilde;o havia qualquer ind&iacute;cio de que houve negativa de cobertura pela operadora de sa&uacute;de.
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido e desprovido.
+_________________
+Dispositivos relevantes citados: CF, art. 6&ordm;, art. 196; CDC, art. 4&ordm;, art. 6&ordm;.
+Jurisprud&ecirc;ncia relevante citada:  STF, ARE 685230 AgR, Rel. Min. Celso de Mello, Segunda Turma, j. 05.03.2013; STF, ADI 7265, Rel. Lu&iacute;s Roberto Barroso, Tribunal Pleno, j. 18.09.2025. <br><br>(N&uacute;mero do Processo: 0801977-55.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Efeito Suspensivo / Impugnação / Embargos à Execução
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO ORDINÁRIA DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO COM PEDIDO DE TUTELA ANTECEDENTE E INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS. SUSPENSÃO DAS COBRANÇAS E ABSTENÇÃO DE NEGATIVAÇÃO. EXISTÊNCIA DE ELEMENTOS SUFICIENTES PARA A CONCESSÃO DA TUTELA PROVISÓRIA NA ORIGEM. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO ORDINÁRIA DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO COM PEDIDO DE TUTELA ANTECEDENTE E INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS. SUSPENSÃO DAS COBRANÇAS E ABSTENÇÃO DE NEGATIVAÇÃO. EXISTÊNCIA DE ELEMENTOS SUFICIENTES PARA A CONCESSÃO DA TUTELA PROVISÓRIA NA ORIGEM. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto em face de decisão que  deferiu o pedido de tutela provisória de urgência, determinando que os réus, no prazo de 5 (cinco) dias, suspendam as cobranças, direta ou indiretamente, inclusive envio de boletos, ligações, e-mails, WhatsApp ou correspondência, bem como se abstenham de inserir o nome dos autores nos cadastros de proteção ao crédito, e, se assim já tenham procedido, que no mesmo prazo seja retirada tal anotação.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consiste em: (i) examinar se é devida a suspensão das cobranças relativas a despesas hospitalares supostamente não cobertas pelo plano de saúde, bem como a abstenção de inserção do nome dos autores nos cadastrados de proteção ao crédito; e (ii) analisar se, no caso, devem ser observados os parâmetros fixados pelo Supremo Tribunal Federal, na ADI 7265, para fornecimento de tratamento fora do rol da ANS.
+III. RAZÕES DE DECIDIR
+3. Aos contratos de seguro de saúde aplicam-se o Código de Defesa do Consumidor, e por conseguinte, as cláusulas deverão observar o referido diploma normativo, respeitando-se as formas de interpretação e elaboração contratuais, especialmente diante da evidenciada hipossuficiência do consumidor em relação ao fornecedor.
+4. Os agravados comprovaram que sua filha, portadora de "taquiarritmia de difícil controle (fibrilação atrial com condução aberrante)", precisou ser transferida de nosocômio localizado na cidade de Maceió/AL para o Hospital Sabará em São Paulo/SP, em decorrência da gravidade extrema. No referido hospital, a genitora da criança assinou termo de declaração, no qual consta que a internação hospitalar da infante estava integralmente compreendida pela cobertura assistencial da operadora de saúde agravante, a qual seria a responsável pelos custos e despesas decorrentes da referida internação.
+5. Inexistência de qualquer documento que demonstre que os demandantes foram cientificados, previamente, da negativa de autorização de qualquer procedimento pela operadora de saúde e que, mesmo assim, assumiram a responsabilidade pelo pagamento de quaisquer despesas eventualmente não cobertas pelo plano. Comunicação a respeito de que a operadora de saúde não teria coberto alguns custos associados ao internamento que somente ocorreu após o falecimento da criança.
+6. Parâmetros estabelecidos pelo STF, na ADI 7265, para fornecimento de tratamento fora do rol da ANS. Julgamento que ocorreu no mês de setembro de 2025, de modo que não é razoável exigir que sejam observados todos os requisitos fixados pela Suprema Corte quando a internação da filha das partes agravadas se deu no final do ano de 2024 e, naquela época, não havia qualquer indício de que houve negativa de cobertura pela operadora de saúde.
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido e desprovido.
+_________________
+Dispositivos relevantes citados: CF, art. 6º, art. 196; CDC, art. 4º, art. 6º.
+Jurisprudência relevante citada:  STF, ARE 685230 AgR, Rel. Min. Celso de Mello, Segunda Turma, j. 05.03.2013; STF, ADI 7265, Rel. Luís Roberto Barroso, Tribunal Pleno, j. 18.09.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>31&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811958" cdForo="0" >
+										0801253-51.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811958" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811958);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811958" style="display: none;" >
+	<div id="textAreaDados_811958" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIGIBILIDADE PARCIAL DE OBRIGA&Ccedil;&Atilde;O C/C OBRIGA&Ccedil;&Atilde;O DE FAZER E PEDIDO DE TUTELA DE URG&Ecirc;NCIA. PRESTA&Ccedil;&Atilde;O DE SERVI&Ccedil;OS EDUCACIONAIS. RENOVA&Ccedil;&Atilde;O DE MATR&Iacute;CULA DE ALUNO INADIMPLENTE EM CURSO SUPERIOR.  ATRASO NO PAGAMENTO DAS MENSALIDADES SUPERIOR A 90 (NOVENTA DIAS). IMPOSSIBILIDADE. PROVIMENTO EM PARTE.
+I. CASO EM EXAME
+Agravo de instrumento interposto com o intuito de reformar decis&otilde;es interlocut&oacute;rias que  concederam a tutela de urg&ecirc;ncia requestada pela parte agravada, no sentido de determinar que a institui&ccedil;&atilde;o de ensino a) realize a rematr&iacute;cula da parte autora no semestre letivo 2026.1, no prazo improrrog&aacute;vel de 24 (vinte e quatro) horas, sob pena de multa di&aacute;ria no valor de R$ 1.000,00 (um mil reais), limitada a R$ 50.000,00, ou, alternativamente, em caso de escolha exclusiva do agravado, possibilite a transfer&ecirc;ncia externa do aluno, abstendo-se de qualquer reten&ccedil;&atilde;o por motivo de inadimpl&ecirc;ncia, sob pena da mesma multa fixada e de busca e apreens&atilde;o; b) proceda a an&aacute;lise do pedido de readequa&ccedil;&atilde;o da grade curricular do autor e efetive a realoca&ccedil;&atilde;o do aluno nas turmas e hor&aacute;rios solicitados, desde que haja disponibilidade de vagas; c)  proceda, no prazo de 48 (quarenta e oitro) horas, a matr&iacute;cula do autor nas disciplinas SOI IV (Turma G.01) e HAM IV (Turma G.01), devendo, se necess&aacute;rio, abrir vaga extra (administrativa), majorando, ainda, a multa di&aacute;ria para R$2.000,00 (dois mil reais) por dia de descumprimento, at&eacute; o limite m&aacute;ximo de R$200.000,00 (duzentos mil reais).
+2.  A quest&atilde;o em discuss&atilde;o cinge-se &agrave; verificar a possibilidade de compelir a institui&ccedil;&atilde;o de ensino a proceder a rematr&iacute;cula de aluno inadimplente no semestre letivo de 2026.1.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O aluno regularmente matriculado tem direito &agrave; renova&ccedil;&atilde;o da matr&iacute;cula, conforme calend&aacute;rio, regimento e contrato,&nbsp;exceto&nbsp;se estiver inadimplente, nos termos do art. 5&ordm; da Lei n&ordm; 9.870/1999. Jurisprud&ecirc;ncia do STJ firmada no sentido de que &eacute; l&iacute;cita a recusa de renova&ccedil;&atilde;o do contrato quando caracterizada inadimpl&ecirc;ncia superior a 90 (noventa) dias. No caso em an&aacute;lise, havendo atraso de mensalidade por tempo muito superior ao referido prazo, n&atilde;o se verifica qualquer ilegalidade perpetrada pela agravante.
+4. Impossibilidade de manter o v&iacute;nculo acad&ecirc;mico ativo, em raz&atilde;o da institui&ccedil;&atilde;o de ensino ter recusado as propostas de acordo efetuadas pelo aluno. O contrato de presta&ccedil;&atilde;o de servi&ccedil;os educacionais se caracteriza como sinalagm&aacute;tico, cujas condi&ccedil;&otilde;es foram previamente pactuadas, n&atilde;o sendo l&iacute;cito exigir da credora que receba as presta&ccedil;&otilde;es de modo diverso do convencionado, conforme disp&otilde;em os arts. 313 e 314 do C&oacute;digo Civil.
+5. Inexist&ecirc;ncia de onerosidade excessiva, nos moldes do art. 317 do C&oacute;digo Civil. Aus&ecirc;ncia de fundamento legal para que se determine que a institui&ccedil;&atilde;o de ensino agravante preste o servi&ccedil;o educacional de forma gratuita ou receba presta&ccedil;&atilde;o nos moldes diversos daquele pactuado, como quer o aluno agravado.
+6. A mera exist&ecirc;ncia de a&ccedil;&atilde;o judicial, em tr&acirc;mite perante a Justi&ccedil;a Federal, que visa a obten&ccedil;&atilde;o de financiamento estudantil (FIES), n&atilde;o enseja o direito do aluno inadimplente &agrave; rematr&iacute;cula, especialmente quando h&aacute; senten&ccedil;a de improced&ecirc;ncia, confirmada pelo TRF-5, naqueles autos.
+7. Reforma das decis&otilde;es para reconhecer a regularidade da recusa da renova&ccedil;&atilde;o de matr&iacute;cula para o semestre de 2026.1. Manuten&ccedil;&atilde;o das decis&otilde;es apenas no que concerne ao dever de emiss&atilde;o e entrega de toda a documenta&ccedil;&atilde;o necess&aacute;ria &agrave; transfer&ecirc;ncia externa, caso essa seja a op&ccedil;&atilde;o expressamente manifestada pelo autor junto &agrave; institui&ccedil;&atilde;o de ensino.
+V. DISPOSITIVO
+8. Recurso conhecido e parcialmente provido.
+______________
+Dispositivos relevantes citados: CF, arts. 205, 206 e 209; Lei n&ordm; 9.870/1999; arts. 5&ordm; e 6&ordm;; CC, arts. 313, 314, 317.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt nos EDcl no AREsp n. 1.988.919/SP, Rel. Min. Raul Ara&uacute;jo, Quarta Turma, j. 2/5/2022; STJ, REsp n. 712.313/DF, Rel. Min. Herman Benjamin, Segunda Turma, j. 12/12/2006; STJ, REsp n. 725.955/SP, Rel. Min. Eliana Calmon, Segunda Turma, j. 8/5/2007.  <br><br>(N&uacute;mero do Processo: 0801253-51.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Ensino Superior
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE PARCIAL DE OBRIGAÇÃO C/C OBRIGAÇÃO DE FAZER E PEDIDO DE TUTELA DE URGÊNCIA. PRESTAÇÃO DE SERVIÇOS EDUCACIONAIS. RENOVAÇÃO DE MATRÍCULA DE ALUNO INADIMPLENTE EM CURSO SUPERIOR.  ATRASO NO PAGAMENTO DAS MENSALIDADES SUPERIOR A 90 (NOVENTA DIAS). IMPOSSIBILIDADE. PROVIMENTO EM PARTE.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. AGRAVO DE INSTRUMENTO EM AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE PARCIAL DE OBRIGAÇÃO C/C OBRIGAÇÃO DE FAZER E PEDIDO DE TUTELA DE URGÊNCIA. PRESTAÇÃO DE SERVIÇOS EDUCACIONAIS. RENOVAÇÃO DE MATRÍCULA DE ALUNO INADIMPLENTE EM CURSO SUPERIOR.  ATRASO NO PAGAMENTO DAS MENSALIDADES SUPERIOR A 90 (NOVENTA DIAS). IMPOSSIBILIDADE. PROVIMENTO EM PARTE.
+I. CASO EM EXAME
+Agravo de instrumento interposto com o intuito de reformar decisões interlocutórias que  concederam a tutela de urgência requestada pela parte agravada, no sentido de determinar que a instituição de ensino a) realize a rematrícula da parte autora no semestre letivo 2026.1, no prazo improrrogável de 24 (vinte e quatro) horas, sob pena de multa diária no valor de R$ 1.000,00 (um mil reais), limitada a R$ 50.000,00, ou, alternativamente, em caso de escolha exclusiva do agravado, possibilite a transferência externa do aluno, abstendo-se de qualquer retenção por motivo de inadimplência, sob pena da mesma multa fixada e de busca e apreensão; b) proceda a análise do pedido de readequação da grade curricular do autor e efetive a realocação do aluno nas turmas e horários solicitados, desde que haja disponibilidade de vagas; c)  proceda, no prazo de 48 (quarenta e oitro) horas, a matrícula do autor nas disciplinas SOI IV (Turma G.01) e HAM IV (Turma G.01), devendo, se necessário, abrir vaga extra (administrativa), majorando, ainda, a multa diária para R$2.000,00 (dois mil reais) por dia de descumprimento, até o limite máximo de R$200.000,00 (duzentos mil reais).
+2.  A questão em discussão cinge-se à verificar a possibilidade de compelir a instituição de ensino a proceder a rematrícula de aluno inadimplente no semestre letivo de 2026.1.
+III. RAZÕES DE DECIDIR
+3. O aluno regularmente matriculado tem direito à renovação da matrícula, conforme calendário, regimento e contrato, exceto se estiver inadimplente, nos termos do art. 5º da Lei nº 9.870/1999. Jurisprudência do STJ firmada no sentido de que é lícita a recusa de renovação do contrato quando caracterizada inadimplência superior a 90 (noventa) dias. No caso em análise, havendo atraso de mensalidade por tempo muito superior ao referido prazo, não se verifica qualquer ilegalidade perpetrada pela agravante.
+4. Impossibilidade de manter o vínculo acadêmico ativo, em razão da instituição de ensino ter recusado as propostas de acordo efetuadas pelo aluno. O contrato de prestação de serviços educacionais se caracteriza como sinalagmático, cujas condições foram previamente pactuadas, não sendo lícito exigir da credora que receba as prestações de modo diverso do convencionado, conforme dispõem os arts. 313 e 314 do Código Civil.
+5. Inexistência de onerosidade excessiva, nos moldes do art. 317 do Código Civil. Ausência de fundamento legal para que se determine que a instituição de ensino agravante preste o serviço educacional de forma gratuita ou receba prestação nos moldes diversos daquele pactuado, como quer o aluno agravado.
+6. A mera existência de ação judicial, em trâmite perante a Justiça Federal, que visa a obtenção de financiamento estudantil (FIES), não enseja o direito do aluno inadimplente à rematrícula, especialmente quando há sentença de improcedência, confirmada pelo TRF-5, naqueles autos.
+7. Reforma das decisões para reconhecer a regularidade da recusa da renovação de matrícula para o semestre de 2026.1. Manutenção das decisões apenas no que concerne ao dever de emissão e entrega de toda a documentação necessária à transferência externa, caso essa seja a opção expressamente manifestada pelo autor junto à instituição de ensino.
+V. DISPOSITIVO
+8. Recurso conhecido e parcialmente provido.
+______________
+Dispositivos relevantes citados: CF, arts. 205, 206 e 209; Lei nº 9.870/1999; arts. 5º e 6º; CC, arts. 313, 314, 317.
+Jurisprudência relevante citada: STJ, AgInt nos EDcl no AREsp n. 1.988.919/SP, Rel. Min. Raul Araújo, Quarta Turma, j. 2/5/2022; STJ, REsp n. 712.313/DF, Rel. Min. Herman Benjamin, Segunda Turma, j. 12/12/2006; STJ, REsp n. 725.955/SP, Rel. Min. Eliana Calmon, Segunda Turma, j. 8/5/2007.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>32&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811916" cdForo="0" >
+										0800041-92.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811916" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811916);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811916" style="display: none;" >
+	<div id="textAreaDados_811916" class="mensagemSemFormatacao" >
+		DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E &Agrave; SA&Uacute;DE. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS, MATERIAIS E TUTELA DE URG&Ecirc;NCIA. REAJUSTE DE MENSALIDADE DE PLANO DE SA&Uacute;DE &quot;FALSO COLETIVO&quot;. POSSIBILIDADE DE APLICA&Ccedil;&Atilde;O APENAS DOS REAJUSTES POR FAIXA ET&Aacute;RIA E DOS REAJUSTES ANUAIS SEGUNDO OS &Iacute;NDICES DA ANS. PROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento interposto pela parte autora em face de decis&atilde;o proferida na origem, que indeferiu a tutela de urg&ecirc;ncia pleiteada pela parte autora.
+ii. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em verificar a regularidade dos reajustes aplicados sobre a mensalidade do plano de sa&uacute;de da parte autora.
+iii. raz&otilde;es de decidir
+3. O plano de sa&uacute;de contratado pela parte autora tem menos de trinta benefici&aacute;rios integrantes do mesmo n&uacute;cleo familiar, o que permite que lhe sejam aplicados apenas os reajustes por faixa et&aacute;ria e os reajustes anuais segundo os &iacute;ndices da ANS, tendo em vista a hipossufici&ecirc;ncia da empresa contratante perante as operadoras de plano de sa&uacute;de em tais hip&oacute;teses, consoante posi&ccedil;&atilde;o jurisprudencial do STJ.
+4. O c&aacute;lculo dos valores devidos deve ser realizado com base nos &iacute;ndices de reajuste estabelecidos pela ANS.
+iv. Dispositivo e tese
+5. Recurso conhecido e provido.
+_________
+Dispositivos relevantes citados: CDC, art. 2&ordm;, art. 3&ordm;; Resolu&ccedil;&atilde;o Normativa n&ordm; 309/2012 ANS, art. 9&ordm;; CPC, art. 237, art. 932, III.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl no REsp 1568244 RJ 2015/0297278-0, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 2&ordf;Se&ccedil;&atilde;o, j. 22.02.2018; STJ, AgRg nos EDcl no AREsp 235.553/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 3&ordf; Turma, j. 02.06.2015; STJ, AgInt no AREsp: 2366300 SP 2023/0175392-1, Rel. Min. Antonio Carlos Ferreira, 4&ordf; Turma, j. 30.10.2023; STJ, AgInt no AREsp 2285008 SP 2023/0020654-2, Rel. Min. Humberto Martins, 3&ordf; Turma, j. 08.04.2024; STJ, REM 56.333/BA, Rel. Min. Mauro Campbell Marques, 2&ordf; Turma, j. 01.03.2018; STJ, AgInt no AREsp 1170544/MG, Rel. Min. Luis Felipe Salom&atilde;o, 4&ordf; Turma, j. 06.02.2018. <br><br>(N&uacute;mero do Processo: 0800041-92.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Reajuste de Prestações
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E À SAÚDE. AGRAVO DE INSTRUMENTO EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>, MATERIAIS E TUTELA DE URGÊNCIA. REAJUSTE DE MENSALIDADE DE PLANO DE SAÚDE "FALSO COLETIVO". POSSIBILIDADE DE APLICAÇÃO APENAS DOS REAJUSTES POR FAIXA ETÁRIA E DOS REAJUSTES ANUAIS SEGUNDO OS ÍNDICES DA ANS. PROVIMENTO.
+I. Caso em
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL, CONSTITUCIONAL E À SAÚDE. AGRAVO DE INSTRUMENTO EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>, MATERIAIS E TUTELA DE URGÊNCIA. REAJUSTE DE MENSALIDADE DE PLANO DE SAÚDE "FALSO COLETIVO". POSSIBILIDADE DE APLICAÇÃO APENAS DOS REAJUSTES POR FAIXA ETÁRIA E DOS REAJUSTES ANUAIS SEGUNDO OS ÍNDICES DA ANS. PROVIMENTO.
+I. Caso em exame
+1. Agravo de instrumento interposto pela parte autora em face de decisão proferida na origem, que indeferiu a tutela de urgência pleiteada pela parte autora.
+ii. Questão em discussão
+2. A questão em discussão consiste em verificar a regularidade dos reajustes aplicados sobre a mensalidade do plano de saúde da parte autora.
+iii. razões de decidir
+3. O plano de saúde contratado pela parte autora tem menos de trinta beneficiários integrantes do mesmo núcleo familiar, o que permite que lhe sejam aplicados apenas os reajustes por faixa etária e os reajustes anuais segundo os índices da ANS, tendo em vista a hipossuficiência da empresa contratante perante as operadoras de plano de saúde em tais hipóteses, consoante posição jurisprudencial do STJ.
+4. O cálculo dos valores devidos deve ser realizado com base nos índices de reajuste estabelecidos pela ANS.
+iv. Dispositivo e tese
+5. Recurso conhecido e provido.
+_________
+Dispositivos relevantes citados: CDC, art. 2º, art. 3º; Resolução Normativa nº 309/2012 ANS, art. 9º; CPC, art. 237, art. 932, III.
+Jurisprudência relevante citada: STJ, EDcl no REsp 1568244 RJ 2015/0297278-0, Rel. Min. Ricardo Villas Bôas Cueva, 2ªSeção, j. 22.02.2018; STJ, AgRg nos EDcl no AREsp 235.553/SP, Rel. Min. Ricardo Villas Bôas Cueva, 3ª Turma, j. 02.06.2015; STJ, AgInt no AREsp: 2366300 SP 2023/0175392-1, Rel. Min. Antonio Carlos Ferreira, 4ª Turma, j. 30.10.2023; STJ, AgInt no AREsp 2285008 SP 2023/0020654-2, Rel. Min. Humberto Martins, 3ª Turma, j. 08.04.2024; STJ, REM 56.333/BA, Rel. Min. Mauro Campbell Marques, 2ª Turma, j. 01.03.2018; STJ, AgInt no AREsp 1170544/MG, Rel. Min. Luis Felipe Salomão, 4ª Turma, j. 06.02.2018.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>33&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812082" cdForo="0" >
+										0747476-56.2023.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812082" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812082);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812082" style="display: none;" >
+	<div id="textAreaDados_812082" class="mensagemSemFormatacao" >
+		Direito do consumidor. APELA&Ccedil;&atilde;o C&Iacute;VEl EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C PEDIDOS DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E MATERIAIS. MAT&Eacute;RIA DELIMITADA PELO EFEITO DEVOLUTIVO. MAJORA&Ccedil;&Atilde;O DO Quantum COMPENSAT&Oacute;RIO. MANUTEN&Ccedil;&Atilde;O DOS HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS. PROVIMENTO PARCIAL.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pela parte autora em face da senten&ccedil;a que julgou procedentes os pedidos autorais, para declarar a inexist&ecirc;ncia e a nulidade de qualquer d&eacute;bito remanescente relativo ao financiamento unilateral &quot;FINANCIAM FAT&quot; e aos juros morat&oacute;rios lan&ccedil;ados na fatura de agosto de 2023, decorrentes da falha no c&oacute;digo de barras da fatura anterior, bem como para condenar a parte r&eacute; &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, em dobro, do valor pago indevidamente pela autora e n&atilde;o estornado administrativamente e, ainda, ao pagamento de compensa&ccedil;&atilde;o por danos morais no valor de R$ 2.000,00 (dois mil reais).
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em analisar a possibilidade de majora&ccedil;&atilde;o do quantum indenizat&oacute;rio arbitrado na compensa&ccedil;&atilde;o por danos morais, bem como do percentual fixado a t&iacute;tulo de honor&aacute;rios advocat&iacute;cios.
+III. Raz&otilde;es de decidir
+3. O efeito devolutivo do recurso impede a discuss&atilde;o acerca da exist&ecirc;ncia dos danos morais. Quantum compensat&oacute;rio majorado para R$ 3.000,00 (tr&ecirc;s mil reais), em observ&acirc;ncia aos par&acirc;metros fixados por jurisprud&ecirc;ncia an&aacute;loga.
+4. Percentual de honor&aacute;rios que atende aos requisitos do art. 85 do CPC.
+IV. Dispositivo e tese
+5. Recurso conhecido e parcialmente provido.
+_______________
+Dispositivos relevantes citados: CPC, art. 1.013; CC, art. 944;
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n. 1.152.541/RS, Rel. Min. Paulo de Tarso Sanseverino, Terceira Turma, j. 13.9.2011 <br><br>(N&uacute;mero do Processo: 0747476-56.2023.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(56 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito do consumidor. APELAÇão CÍVEl EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C PEDIDOS DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS. MATÉRIA DELIMITADA PELO EFEITO DEVOLUTIVO. MAJORAÇÃO DO Quantum COMPENSATÓRIO. MANUTENÇÃO DOS HONORÁRIOS ADVOCATÍCIOS. PROVIMENTO PARCIAL.
+I. Caso em exame
+1. Apelação cível interposta pela parte autora em face da sentença que julgou
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito do consumidor. APELAÇão CÍVEl EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C PEDIDOS DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em> E MATERIAIS. MATÉRIA DELIMITADA PELO EFEITO DEVOLUTIVO. MAJORAÇÃO DO Quantum COMPENSATÓRIO. MANUTENÇÃO DOS HONORÁRIOS ADVOCATÍCIOS. PROVIMENTO PARCIAL.
+I. Caso em exame
+1. Apelação cível interposta pela parte autora em face da sentença que julgou procedentes os pedidos autorais, para declarar a inexistência e a nulidade de qualquer débito remanescente relativo ao financiamento unilateral "FINANCIAM FAT" e aos juros moratórios lançados na fatura de agosto de 2023, decorrentes da falha no código de barras da fatura anterior, bem como para condenar a parte ré à repetição do indébito, em dobro, do valor pago indevidamente pela autora e não estornado administrativamente e, ainda, ao pagamento de compensação por <em>danos</em> <em>morais</em> no valor de R$ 2.000,00 (dois mil reais).
+II. Questão em discussão
+2. A questão em discussão consiste em analisar a possibilidade de majoração do quantum indenizatório arbitrado na compensação por <em>danos</em> <em>morais</em>, bem como do percentual fixado a título de honorários advocatícios.
+III. Razões de decidir
+3. O efeito devolutivo do recurso impede a discussão acerca da existência dos <em>danos</em> <em>morais</em>. Quantum compensatório majorado para R$ 3.000,00 (três mil reais), em observância aos parâmetros fixados por jurisprudência análoga.
+4. Percentual de honorários que atende aos requisitos do art. 85 do CPC.
+IV. Dispositivo e tese
+5. Recurso conhecido e parcialmente provido.
+_______________
+Dispositivos relevantes citados: CPC, art. 1.013; CC, art. 944;
+Jurisprudência relevante citada: STJ, REsp n. 1.152.541/RS, Rel. Min. Paulo de Tarso Sanseverino, Terceira Turma, j. 13.9.2011
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>34&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812030" cdForo="0" >
+										0700274-81.2019.8.02.0047
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812030" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812030);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812030" style="display: none;" >
+	<div id="textAreaDados_812030" class="mensagemSemFormatacao" >
+		DIREITO ADMINISTRATIVO. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O DE DANOS MATERIAIS E MORAIS. DEMOLI&Ccedil;&Atilde;O DE IM&Oacute;VEL EM CONJUNTO HABITACIONAL. FRAGILIDADE DO CONJUNTO PROBAT&Oacute;RIO. CONDUTA DA PREFEITURA DE PILAR N&Atilde;O VERIFICADA. DESPROVIMENTO.
+CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pela parte autora contra a senten&ccedil;a que julgou improcedente a&ccedil;&atilde;o de repara&ccedil;&atilde;o de danos materiais e morais. Houve condena&ccedil;&atilde;o em custas e honor&aacute;rios, estes na ordem de 10% (dez por cento) sobre o valor da causa, cuja exigibilidade foi suspensa, na forma do art. 98, &sect;3&ordm;, do CPC.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o cinge-se a examinar a configura&ccedil;&atilde;o dos elementos da indeniza&ccedil;&atilde;o por danos morais e materiais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A responsabiliza&ccedil;&atilde;o objetiva do ente p&uacute;blico pelo ato comissivo depende do preenchimento dos seguintes requisitos: a) exist&ecirc;ncia de um dano; b) a&ccedil;&atilde;o ou omiss&atilde;o administrativa; c) ocorr&ecirc;ncia de nexo causal entre o dano e a a&ccedil;&atilde;o ou omiss&atilde;o administrativa; e d) aus&ecirc;ncia de causa excludente da responsabilidade estatal.
+4. Em rela&ccedil;&atilde;o &agrave; a&ccedil;&atilde;o administrativa, n&atilde;o se vislumbram nos autos outras provas para refor&ccedil;ar a afirma&ccedil;&atilde;o das testemunhas, que permitam concluir, com seguran&ccedil;a, que houve a efetiva demoli&ccedil;&atilde;o da casa da autora pelo Munic&iacute;pio e n&atilde;o uma mera retirada/mudan&ccedil;a para outro local, a exemplo de fotos, m&iacute;dias ou at&eacute; mesmo a comprova&ccedil;&atilde;o de alguma obra ou benfeitoria efetivada na regi&atilde;o possivelmente demolida pelo poder p&uacute;blico e ocupada pela autora, n&atilde;o se podendo atribuir aos depoimentos a for&ccedil;a probante de ocasionar o reconhecimento do ato il&iacute;cito. Por n&atilde;o ter sido realizada qualquer avalia&ccedil;&atilde;o t&eacute;cnica sobre o bem, inexistem crit&eacute;rios/par&acirc;metros que permitam aferir o seu valor com razoabilidade.
+5. Pelo ordenamento jur&iacute;dico p&aacute;trio, o destinat&aacute;rio final das provas produzidas &eacute; o julgador, a quem cabe valor&aacute;-las, consoante disposto no art. 371 do CPC, em aten&ccedil;&atilde;o ao livre convencimento motivado do juiz.
+6. A apelante n&atilde;o logrou &ecirc;xito em comprovar os fatos constitutivos do seu direito, tendo em vista n&atilde;o se verificar elementos probat&oacute;rios que atestem minimamente a alegada atua&ccedil;&atilde;o administrativa geradora do dano, o que obstaculiza a responsabiliza&ccedil;&atilde;o do ente p&uacute;blico demandado em indenizar os danos morais e materiais vindicados e, por consequ&ecirc;ncia, deve ser mantida a senten&ccedil;a.
+IV. DISPOSITIVO
+7. Recurso conhecido e desprovido.
+__________
+Dispositivos relevantes citados: CF, arts. 5&ordm;, X, 37, &sect;6&ordm;; CC, arts. 402, 927; CPC, arts. 371 e 373.
+Jurisprud&ecirc;ncia relevante citada: STF, RE 1290437, Rel. Min. Ricardo Lewandowski, Segunda Turma, j. 30/11/2020, RE 136861 (Tema 366), Rel. Min. Edson Fachin, Tribunal Pleno, j. 11/03/2020. <br><br>(N&uacute;mero do Processo: 0700274-81.2019.8.02.0047; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Pilar; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(47 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Dano
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Pilar
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO. APELAÇÃO CÍVEL EM AÇÃO DE REPARAÇÃO DE <em>DANOS</em> MATERIAIS E <em>MORAIS</em>. DEMOLIÇÃO DE IMÓVEL EM CONJUNTO HABITACIONAL. FRAGILIDADE DO CONJUNTO PROBATÓRIO. CONDUTA DA PREFEITURA DE PILAR NÃO VERIFICADA. DESPROVIMENTO.
+CASO EM EXAME
+1. Apelação cível interposta pela parte autora contra a sentença que julgou improcedente ação de reparação de <em>danos</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO. APELAÇÃO CÍVEL EM AÇÃO DE REPARAÇÃO DE <em>DANOS</em> MATERIAIS E <em>MORAIS</em>. DEMOLIÇÃO DE IMÓVEL EM CONJUNTO HABITACIONAL. FRAGILIDADE DO CONJUNTO PROBATÓRIO. CONDUTA DA PREFEITURA DE PILAR NÃO VERIFICADA. DESPROVIMENTO.
+CASO EM EXAME
+1. Apelação cível interposta pela parte autora contra a sentença que julgou improcedente ação de reparação de <em>danos</em> materiais e <em>morais</em>. Houve condenação em custas e honorários, estes na ordem de 10% (dez por cento) sobre o valor da causa, cuja exigibilidade foi suspensa, na forma do art. 98, §3º, do CPC.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão cinge-se a examinar a configuração dos elementos da indenização por <em>danos</em> <em>morais</em> e materiais.
+III. RAZÕES DE DECIDIR
+3. A responsabilização objetiva do ente público pelo ato comissivo depende do preenchimento dos seguintes requisitos: a) existência de um <em>dano</em>; b) ação ou omissão administrativa; c) ocorrência de nexo causal entre o <em>dano</em> e a ação ou omissão administrativa; e d) ausência de causa excludente da responsabilidade estatal.
+4. Em relação à ação administrativa, não se vislumbram nos autos outras provas para reforçar a afirmação das testemunhas, que permitam concluir, com segurança, que houve a efetiva demolição da casa da autora pelo Município e não uma mera retirada/mudança para outro local, a exemplo de fotos, mídias ou até mesmo a comprovação de alguma obra ou benfeitoria efetivada na região possivelmente demolida pelo poder público e ocupada pela autora, não se podendo atribuir aos depoimentos a força probante de ocasionar o reconhecimento do ato ilícito. Por não ter sido realizada qualquer avaliação técnica sobre o bem, inexistem critérios/parâmetros que permitam aferir o seu valor com razoabilidade.
+5. Pelo ordenamento jurídico pátrio, o destinatário final das provas produzidas é o julgador, a quem cabe valorá-las, consoante disposto no art. 371 do CPC, em atenção ao livre convencimento motivado do juiz.
+6. A apelante não logrou êxito em comprovar os fatos constitutivos do seu direito, tendo em vista não se verificar elementos probatórios que atestem minimamente a alegada atuação administrativa geradora do <em>dano</em>, o que obstaculiza a responsabilização do ente público demandado em indenizar os <em>danos</em> <em>morais</em> e materiais vindicados e, por consequência, deve ser mantida a sentença.
+IV. DISPOSITIVO
+7. Recurso conhecido e desprovido.
+__________
+Dispositivos relevantes citados: CF, arts. 5º, X, 37, §6º; CC, arts. 402, 927; CPC, arts. 371 e 373.
+Jurisprudência relevante citada: STF, RE 1290437, Rel. Min. Ricardo Lewandowski, Segunda Turma, j. 30/11/2020, RE 136861 (Tema 366), Rel. Min. Edson Fachin, Tribunal Pleno, j. 11/03/2020.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>35&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811918" cdForo="0" >
+										0802945-85.2026.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811918" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811918);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811918" style="display: none;" >
+	<div id="textAreaDados_811918" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS C/C DANOS MORAIS E REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO EM DOBRO. PLEITO DE CONCESS&Atilde;O DE JUSTI&Ccedil;A GRATUITA. AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DA HIPOSSUFICI&Ecirc;NCIA ECON&Ocirc;MICA. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela parte autora contra decis&atilde;o interlocut&oacute;ria que indeferiu a concess&atilde;o do benef&iacute;cio da justi&ccedil;a gratuita.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; somente uma quest&atilde;o em discuss&atilde;o: analisar se a parte faz jus &agrave; gratuidade da justi&ccedil;a, &agrave; luz dos requisitos previstos no C&oacute;digo de Processo Civil.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A concess&atilde;o da gratuidade&nbsp;de&nbsp;justi&ccedil;a&nbsp;deve ser deferida quando demonstrada a hipossufici&ecirc;ncia financeira, conforme previs&atilde;o do art. 98 do CPC, e na aus&ecirc;ncia&nbsp;de&nbsp;elementos que indiquem m&aacute;-f&eacute; ou abuso&nbsp;de&nbsp;direito.
+4. A parte recorrente n&atilde;o logrou &ecirc;xito em comprovar sua situa&ccedil;&atilde;o de hipervulnerabilidade financeira. Indeferimento da benesse.
+IV. Dispositivo e tese
+4. Recurso conhecido e desprovido.
+________
+Dispositivos relevantes citados: CPC/2015, arts. 98 e 99, art. 101, &sect;1&ordm;
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no REsp: 1900902 DF, Rel. Min. Herman Benjamin, Segunda Turma, j. 08.03.2021; STJ, AgInt nos EDcl no REsp n. 1.949.298/SP, Rel. Min. Francisco Falc&atilde;o, Segunda Turma, j. 27.6.2022 <br><br>(N&uacute;mero do Processo: 0802945-85.2026.8.02.0000; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Coruripe; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Assistência Judiciária Gratuita
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Coruripe
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE INDENIZAÇÃO POR <em>DANOS</em> MATERIAIS C/C <em>DANOS</em> <em>MORAIS</em> E REPETIÇÃO DO INDÉBITO EM DOBRO. PLEITO DE CONCESSÃO DE JUSTIÇA GRATUITA. AUSÊNCIA DE COMPROVAÇÃO DA HIPOSSUFICIÊNCIA ECONÔMICA. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela parte autora contra decisão interlocutória que indeferiu a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO EM AÇÃO DE INDENIZAÇÃO POR <em>DANOS</em> MATERIAIS C/C <em>DANOS</em> <em>MORAIS</em> E REPETIÇÃO DO INDÉBITO EM DOBRO. PLEITO DE CONCESSÃO DE JUSTIÇA GRATUITA. AUSÊNCIA DE COMPROVAÇÃO DA HIPOSSUFICIÊNCIA ECONÔMICA. DESPROVIMENTO.
+I. CASO EM EXAME
+1. Agravo de instrumento interposto pela parte autora contra decisão interlocutória que indeferiu a concessão do benefício da justiça gratuita.
+II. QUESTÃO EM DISCUSSÃO
+2. Há somente uma questão em discussão: analisar se a parte faz jus à gratuidade da justiça, à luz dos requisitos previstos no Código de Processo Civil.
+III. RAZÕES DE DECIDIR
+3. A concessão da gratuidade de justiça deve ser deferida quando demonstrada a hipossuficiência financeira, conforme previsão do art. 98 do CPC, e na ausência de elementos que indiquem má-fé ou abuso de direito.
+4. A parte recorrente não logrou êxito em comprovar sua situação de hipervulnerabilidade financeira. Indeferimento da benesse.
+IV. Dispositivo e tese
+4. Recurso conhecido e desprovido.
+________
+Dispositivos relevantes citados: CPC/2015, arts. 98 e 99, art. 101, §1º
+Jurisprudência relevante citada: STJ, AgInt no REsp: 1900902 DF, Rel. Min. Herman Benjamin, Segunda Turma, j. 08.03.2021; STJ, AgInt nos EDcl no REsp n. 1.949.298/SP, Rel. Min. Francisco Falcão, Segunda Turma, j. 27.6.2022
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>36&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811892" cdForo="0" >
+										0700117-19.2025.8.02.0041
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811892" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811892);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811892" style="display: none;" >
+	<div id="textAreaDados_811892" class="mensagemSemFormatacao" >
+		DIREITO CIVIL, PROCESSUAL CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO E DEVOLU&Ccedil;&Atilde;O DOS VALORES EXIGIDOS EM DOBRO (MATERIAIS) C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS.  AUS&Ecirc;NCIA DE OBSERV&Acirc;NCIA &Agrave; RESOLU&Ccedil;&Atilde;O ARSAL N&ordm; 137/2014. PROCEDIMENTO UNILATERAL. NULIDADE DO D&Eacute;BITO. AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DO PAGAMENTO INDEVIDO. MERA COBRAN&Ccedil;A. DANO MORAL N&Atilde;O CONFIGURADO. DESPROVIMENTO DO RECURSO DA AUTORA. PARCIAL PROVIMENTO DO RECURSO DA R&Eacute;.
+I. CASO EM EXAME
+1. Recursos de apela&ccedil;&otilde;es c&iacute;veis interpostos por ambas as partes visando &agrave; reforma da senten&ccedil;a que julgou parcialmente procedentes os pedidos da autora, para declarar a inexist&ecirc;ncia do d&eacute;bito referente &agrave; multa por viola&ccedil;&atilde;o do hidr&ocirc;metro, determinar a revis&atilde;o da fatura do m&ecirc;s de janeiro de 2025, bem como condenar a concession&aacute;ria ao pagamento de indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) saber se a concession&aacute;ria de fornecimento de &aacute;gua agiu de forma leg&iacute;tima e legal quando da inspe&ccedil;&atilde;o realizada na unidade consumidora da parte autora e, por conseguinte, avaliar a regularidade da penalidade aplicada; (ii) verificar se a parte autora faz jus &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito em dobro; e (iii) aferir se h&aacute; dano moral pela cobran&ccedil;a indevida de d&eacute;bito declarado inexistente.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Aplica-se o C&oacute;digo de Defesa do Consumidor, por se tratar de rela&ccedil;&atilde;o jur&iacute;dica de consumo entre fornecedora de &aacute;gua e consumidor final, nos termos dos arts. 2&ordm; e 3&ordm; do CDC.
+4. A invers&atilde;o do &ocirc;nus da prova &eacute; admitida, nos termos do art. 6&ordm;, VIII, do CDC, em raz&atilde;o da verossimilhan&ccedil;a das alega&ccedil;&otilde;es do consumidor e sua hipossufici&ecirc;ncia t&eacute;cnica frente &agrave; concession&aacute;ria.
+5. A Resolu&ccedil;&atilde;o n&ordm; 137/2014 da ARSAL imp&otilde;e &agrave; concession&aacute;ria o dever de seguir rigoroso procedimento t&eacute;cnico para caracteriza&ccedil;&atilde;o de irregularidade, incluindo a elabora&ccedil;&atilde;o de TOI e notifica&ccedil;&atilde;o, garantindo contradit&oacute;rio e ampla defesa, o que n&atilde;o foi observado no caso.
+6. A jurisprud&ecirc;ncia do STJ &eacute; pac&iacute;fica no sentido de que a apura&ccedil;&atilde;o unilateral da suposta fraude, desacompanhada de outros elementos de prova, n&atilde;o legitima a cobran&ccedil;a de valores ao consumidor. Manuten&ccedil;&atilde;o da declara&ccedil;&atilde;o da inexist&ecirc;ncia do d&eacute;bito.
+7. A aus&ecirc;ncia de pagamento do valor indevido impede a devolu&ccedil;&atilde;o em dobro, nos termos do art. 42, par&aacute;grafo &uacute;nico, do CDC.
+8. N&atilde;o restou comprovada a ocorr&ecirc;ncia de negativa&ccedil;&atilde;o do nome da parte consumidora ou a suspens&atilde;o do servi&ccedil;o. Mera cobran&ccedil;a indevida que n&atilde;o configura dano moral.
+IV. DISPOSITIVO E TESE
+9. Recurso da r&eacute; conhecido e parcialmente provido. Recurso da autora conhecido e desprovido.
+______________
+Dispositivos relevantes citados: CDC, arts. 2&ordm;, 3&ordm;, 6&ordm;, VIII e 42, par&aacute;grafo &uacute;nico; CC, art. 927; Lei n&ordm; 7.081/2009, art. 26; Resolu&ccedil;&atilde;o ARSAL n&ordm; 137/2014, art. 17, art. 103.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no AREsp n. 857.257/SP, Rel. Min. Assusete Magalh&atilde;es, Segunda Turma, j.  2.6.2016; STJ, AgRg no AREsp n. 369.114/RJ, Rel. Min. Assusete Magalh&atilde;es, Segunda Turma, j. 18.11.2014;  STJ, REsp n. 1.645.589/MS, Rel. Min. Ricardo Villas B&ocirc;as Cueva, Terceira Turma, j. 4.2.2020; STJ, AgInt no AREsp n. 2.110.525/SP, Rel. Min. Antonio Carlos Ferreira, Quarta Turma, j. 29.8.2022. <br><br>(N&uacute;mero do Processo: 0700117-19.2025.8.02.0041; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Capela; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(49 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Fornecimento de Água
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Capela
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO E DEVOLUÇÃO DOS VALORES EXIGIDOS EM DOBRO (MATERIAIS) C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>.  AUSÊNCIA DE OBSERVÂNCIA À RESOLUÇÃO ARSAL Nº 137/2014. PROCEDIMENTO UNILATERAL. NULIDADE DO DÉBITO. AUSÊNCIA DE COMPROVAÇÃO DO PAGAMENTO INDEVIDO. MERA COBRANÇA. <em>DANO</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL, PROCESSUAL CIVIL E DO CONSUMIDOR. APELAÇÕES CÍVEIS EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO E DEVOLUÇÃO DOS VALORES EXIGIDOS EM DOBRO (MATERIAIS) C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>.  AUSÊNCIA DE OBSERVÂNCIA À RESOLUÇÃO ARSAL Nº 137/2014. PROCEDIMENTO UNILATERAL. NULIDADE DO DÉBITO. AUSÊNCIA DE COMPROVAÇÃO DO PAGAMENTO INDEVIDO. MERA COBRANÇA. <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO. DESPROVIMENTO DO RECURSO DA AUTORA. PARCIAL PROVIMENTO DO RECURSO DA RÉ.
+I. CASO EM EXAME
+1. Recursos de apelações cíveis interpostos por ambas as partes visando à reforma da sentença que julgou parcialmente procedentes os pedidos da autora, para declarar a inexistência do débito referente à multa por violação do hidrômetro, determinar a revisão da fatura do mês de janeiro de 2025, bem como condenar a concessionária ao pagamento de indenização por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) saber se a concessionária de fornecimento de água agiu de forma legítima e legal quando da inspeção realizada na unidade consumidora da parte autora e, por conseguinte, avaliar a regularidade da penalidade aplicada; (ii) verificar se a parte autora faz jus à repetição do indébito em dobro; e (iii) aferir se há <em>dano</em> <em>moral</em> pela cobrança indevida de débito declarado inexistente.
+III. RAZÕES DE DECIDIR
+3. Aplica-se o Código de Defesa do Consumidor, por se tratar de relação jurídica de consumo entre fornecedora de água e consumidor final, nos termos dos arts. 2º e 3º do CDC.
+4. A inversão do ônus da prova é admitida, nos termos do art. 6º, VIII, do CDC, em razão da verossimilhança das alegações do consumidor e sua hipossuficiência técnica frente à concessionária.
+5. A Resolução nº 137/2014 da ARSAL impõe à concessionária o dever de seguir rigoroso procedimento técnico para caracterização de irregularidade, incluindo a elaboração de TOI e notificação, garantindo contraditório e ampla defesa, o que não foi observado no caso.
+6. A jurisprudência do STJ é pacífica no sentido de que a apuração unilateral da suposta fraude, desacompanhada de outros elementos de prova, não legitima a cobrança de valores ao consumidor. Manutenção da declaração da inexistência do débito.
+7. A ausência de pagamento do valor indevido impede a devolução em dobro, nos termos do art. 42, parágrafo único, do CDC.
+8. Não restou comprovada a ocorrência de negativação do nome da parte consumidora ou a suspensão do serviço. Mera cobrança indevida que não configura <em>dano</em> <em>moral</em>.
+IV. DISPOSITIVO E TESE
+9. Recurso da ré conhecido e parcialmente provido. Recurso da autora conhecido e desprovido.
+______________
+Dispositivos relevantes citados: CDC, arts. 2º, 3º, 6º, VIII e 42, parágrafo único; CC, art. 927; Lei nº 7.081/2009, art. 26; Resolução ARSAL nº 137/2014, art. 17, art. 103.
+Jurisprudência relevante citada: STJ, AgInt no AREsp n. 857.257/SP, Rel. Min. Assusete Magalhães, Segunda Turma, j.  2.6.2016; STJ, AgRg no AREsp n. 369.114/RJ, Rel. Min. Assusete Magalhães, Segunda Turma, j. 18.11.2014;  STJ, REsp n. 1.645.589/MS, Rel. Min. Ricardo Villas Bôas Cueva, Terceira Turma, j. 4.2.2020; STJ, AgInt no AREsp n. 2.110.525/SP, Rel. Min. Antonio Carlos Ferreira, Quarta Turma, j. 29.8.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>37&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811863" cdForo="0" >
+										0712401-53.2023.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811863" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811863);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811863" style="display: none;" >
+	<div id="textAreaDados_811863" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM  A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZAT&Oacute;RIA POR DANOS MATERIAIS E MORAIS C/C LUCROS CESSANTES. SUPOSTA AUS&Ecirc;NCIA DE REPASSE DE VALORES RELACIONADOS A COMPRAS REALIZADAS COM MAQUINETA DE CART&Atilde;O DE CR&Eacute;DITO. APLICA&Ccedil;&Atilde;O INDEVIDA DOS EFEITOS MATERIAIS DA REVELIA. INAPLICABILIDADE DO CDC. NECESSIDADE DE INSTRU&Ccedil;&Atilde;O PROBAT&Oacute;RIA. SENTEN&Ccedil;A ANULADA DE OF&Iacute;CIO. AN&Aacute;LISE DAS RAZ&Otilde;ES RECURSAIS PREJUDICADA.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por uma das r&eacute;s contra senten&ccedil;a que julgou que aplicou os efeitos materiais da revelia, acolhendo como verdadeiras todas as alega&ccedil;&otilde;es da inicial, e julgou parcialmente procedentes os pedidos autorais, para condenar as r&eacute;s, solidariamente, ao pagamento de indeniza&ccedil;&atilde;o por danos materiais, no valor de R$ 19.440,00 (dezenove mil, quatrocentos e quarenta reais), bem como compensa&ccedil;&atilde;o por danos morais, no montante de R$ 10.000,00 (dez mil reis). Houve, ainda, condena&ccedil;&atilde;o das r&eacute;s ao pagamento das custas processuais e honor&aacute;rios advocat&iacute;cios.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) analisar o pedido de anula&ccedil;&atilde;o da senten&ccedil;a diante da indevida aplica&ccedil;&atilde;o dos efeitos da revelia; (ii) aferir se o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel ao caso; (iii) analisar se est&atilde;o preenchidos os requisitos da responsabilidade civil e se existe o direito da parte autora em receber compensa&ccedil;&atilde;o por danos materiais e morais; (iv) fixar o quantum devido a t&iacute;tulo de compensa&ccedil;&atilde;o pelos danos morais sofridos.
+3. Analisar, de of&iacute;cio, a necessidade de anula&ccedil;&atilde;o da senten&ccedil;a, para que seja determinada a instru&ccedil;&atilde;o probat&oacute;ria.
+III. RAZ&Otilde;ES DE DECIDIR
+4. Ainda que indevida a aplica&ccedil;&atilde;o dos efeitos materiais da revelia, pois a parte demandada apresentou contesta&ccedil;&atilde;o, n&atilde;o se vislumbra qualquer preju&iacute;zo. A parte foi devidamente intimada de todos os atos processuais, inclusive para indicar as provas que desejava produzir.
+5. A regra do art. 2&ordm; revela que o CDC adotou a chamada Teoria Finalista ao definir o consumidor como aquele que adquire bens e servi&ccedil;os no mercado de consumo como destinat&aacute;rio final. De acordo com essa teoria, o consumidor, al&eacute;m de destinat&aacute;rio final, deve ser tamb&eacute;m o destinat&aacute;rio econ&ocirc;mico dos produtos e servi&ccedil;os, ou seja, o destinat&aacute;rio f&aacute;tico, no qual se exaurem as finalidades do produto, conferindo contornos mais precisos &agrave; express&atilde;o consumidor.
+6. A autora n&atilde;o se caracteriza como destinat&aacute;ria final dos servi&ccedil;os fornecidos pelo r&eacute;u, mas, em verdade, exaure fun&ccedil;&atilde;o econ&ocirc;mica desse servi&ccedil;o. A par disso, afasta-se a incid&ecirc;ncia das normas e princ&iacute;pios do C&oacute;digo de Defesa do Consumidor e, por conseguinte, a invers&atilde;o do &ocirc;nus da prova com base no art. 6&ordm;, VIII, do CDC revela-se indevida.
+7. Necessidade de retorno dos autos &agrave; origem, para permitir que a parte autora comprove os fatos constitutivos do seu direito de acordo com a regra ordin&aacute;ria do art. 373, I, do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido para, de of&iacute;cio, anular a senten&ccedil;a, julgando prejudicadas as raz&otilde;es recursais.
+________________
+Dispositivos relevantes citados: CPC, arts. 307 e 344, art. 345, I, art. 373; CDC, arts. 2&ordm;, 3&ordm;, art. 6&ordm;, VIII;
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n. 2.180.780/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, Terceira Turma, j. 11.2.2025; STJ, REsp n. 1.990.962/RS, Rel. Min. Humberto Martins, Rel. para ac&oacute;rd&atilde;o Min. Nancy Andrighi, Terceira Turma, j. 14.5.2024. <br><br>(N&uacute;mero do Processo: 0712401-53.2023.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Material
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL EM  AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZATÓRIA POR <em>DANOS</em> MATERIAIS E <em>MORAIS</em> C/C LUCROS CESSANTES. SUPOSTA AUSÊNCIA DE REPASSE DE VALORES RELACIONADOS A COMPRAS REALIZADAS COM MAQUINETA DE CARTÃO DE CRÉDITO. APLICAÇÃO INDEVIDA DOS EFEITOS MATERIAIS DA REVELIA. INAPLICABILIDADE DO CDC. NECESSIDADE DE INSTRUÇÃO PROBATÓRIA. SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL EM  AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZATÓRIA POR <em>DANOS</em> MATERIAIS E <em>MORAIS</em> C/C LUCROS CESSANTES. SUPOSTA AUSÊNCIA DE REPASSE DE VALORES RELACIONADOS A COMPRAS REALIZADAS COM MAQUINETA DE CARTÃO DE CRÉDITO. APLICAÇÃO INDEVIDA DOS EFEITOS MATERIAIS DA REVELIA. INAPLICABILIDADE DO CDC. NECESSIDADE DE INSTRUÇÃO PROBATÓRIA. SENTENÇA ANULADA DE OFÍCIO. ANÁLISE DAS RAZÕES RECURSAIS PREJUDICADA.
+I. CASO EM EXAME
+1. Apelação cível interposta por uma das rés contra sentença que julgou que aplicou os efeitos materiais da revelia, acolhendo como verdadeiras todas as alegações da inicial, e julgou parcialmente procedentes os pedidos autorais, para condenar as rés, solidariamente, ao pagamento de indenização por <em>danos</em> materiais, no valor de R$ 19.440,00 (dezenove mil, quatrocentos e quarenta reais), bem como compensação por <em>danos</em> <em>morais</em>, no montante de R$ 10.000,00 (dez mil reis). Houve, ainda, condenação das rés ao pagamento das custas processuais e honorários advocatícios.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) analisar o pedido de anulação da sentença diante da indevida aplicação dos efeitos da revelia; (ii) aferir se o Código de Defesa do Consumidor é aplicável ao caso; (iii) analisar se estão preenchidos os requisitos da responsabilidade civil e se existe o direito da parte autora em receber compensação por <em>danos</em> materiais e <em>morais</em>; (iv) fixar o quantum devido a título de compensação pelos <em>danos</em> <em>morais</em> sofridos.
+3. Analisar, de ofício, a necessidade de anulação da sentença, para que seja determinada a instrução probatória.
+III. RAZÕES DE DECIDIR
+4. Ainda que indevida a aplicação dos efeitos materiais da revelia, pois a parte demandada apresentou contestação, não se vislumbra qualquer prejuízo. A parte foi devidamente intimada de todos os atos processuais, inclusive para indicar as provas que desejava produzir.
+5. A regra do art. 2º revela que o CDC adotou a chamada Teoria Finalista ao definir o consumidor como aquele que adquire bens e serviços no mercado de consumo como destinatário final. De acordo com essa teoria, o consumidor, além de destinatário final, deve ser também o destinatário econômico dos produtos e serviços, ou seja, o destinatário fático, no qual se exaurem as finalidades do produto, conferindo contornos mais precisos à expressão consumidor.
+6. A autora não se caracteriza como destinatária final dos serviços fornecidos pelo réu, mas, em verdade, exaure função econômica desse serviço. A par disso, afasta-se a incidência das normas e princípios do Código de Defesa do Consumidor e, por conseguinte, a inversão do ônus da prova com base no art. 6º, VIII, do CDC revela-se indevida.
+7. Necessidade de retorno dos autos à origem, para permitir que a parte autora comprove os fatos constitutivos do seu direito de acordo com a regra ordinária do art. 373, I, do CPC.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido para, de ofício, anular a sentença, julgando prejudicadas as razões recursais.
+________________
+Dispositivos relevantes citados: CPC, arts. 307 e 344, art. 345, I, art. 373; CDC, arts. 2º, 3º, art. 6º, VIII;
+Jurisprudência relevante citada: STJ, REsp n. 2.180.780/SP, Rel. Min. Ricardo Villas Bôas Cueva, Terceira Turma, j. 11.2.2025; STJ, REsp n. 1.990.962/RS, Rel. Min. Humberto Martins, Rel. para acórdão Min. Nancy Andrighi, Terceira Turma, j. 14.5.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>38&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812041" cdForo="0" >
+										0729355-77.2023.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812041" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812041);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812041" style="display: none;" >
+	<div id="textAreaDados_812041" class="mensagemSemFormatacao" >
+		direito processual civil. embargos de declara&ccedil;&atilde;o em apela&ccedil;&Atilde;O C&Iacute;VEL. Alega&ccedil;&atilde;o de exist&ecirc;ncia de omiss&atilde;o no ac&oacute;rd&atilde;o. AUS&Ecirc;NCIA DE V&Iacute;CIO. Recurso  n&atilde;o acolhido.
+i. caso em exame
+1. Embargos de declara&ccedil;&atilde;o opostos em face de ac&oacute;rd&atilde;o que conheceu do recurso de apela&ccedil;&atilde;o outrora interposto pela parte embargada, para, no m&eacute;rito, dar-lhe parcial provimento, reformando a senten&ccedil;a para julgar parcialmente procedentes os pedidos formulados na exordial, no sentido de declarar a nulidade do parcelamento autom&aacute;tico, no valor mensal de R$ 308,02 trezentos e oito reais e dois centavos), a ser pago em 24 (vinte e quatro) parcelas, bem como condenar o demandado ao ressarcimento, em dobro, dos valores descontados indevidamente, acrescidos de juros de mora e corre&ccedil;&atilde;o monet&aacute;ria a partir do evento danoso que, no caso do pagamento indevido, constituem a mesma data, conforme as S&uacute;mulas n&ordm; 54 e n&ordm; 43 do Superior Tribunal de Justi&ccedil;a. Al&eacute;m disso, determinou-se a aplica&ccedil;&atilde;o da taxa Selic, desde o evento danoso at&eacute; 29.08.2024, em raz&atilde;o da coincid&ecirc;ncia do termo inicial de ambos; e a partir de 30.08.2024 &ndash; in&iacute;cio da vig&ecirc;ncia da Lei n&ordm; 14.905/2024 &ndash;, a corre&ccedil;&atilde;o monet&aacute;ria dever&aacute; ser calculada com base no &Iacute;ndice de Pre&ccedil;os ao Consumidor Amplo (IPCA), conforme art. 389, par&aacute;grafo &uacute;nico, do C&oacute;digo Civil, e os juros morat&oacute;rios corresponder&atilde;o &agrave; subtra&ccedil;&atilde;o entre a Selic e o IPCA (Selic menos o IPCA = juros morat&oacute;rios), apurada mensalmente; sendo o resultado da diminui&ccedil;&atilde;o inferior a zero, os juros corresponder&atilde;o a zero, consoante art. 406, &sect; 1&ordm; e &sect; 3&ordm;, do C&oacute;digo Civil. Em raz&atilde;o da sucumb&ecirc;ncia rec&iacute;proca entre as partes, determinou-se a distribui&ccedil;&atilde;o proporcional das despesas, no percentual de 50% para cada umas das partes, observado o deferimento da gratuidade da justi&ccedil;a para a parte apelante. Ademais, condenou-se a parte autora ao pagamento da verba honor&aacute;ria arbitrada em 10% (dez por cento) sobre o valor do proveito econ&ocirc;mico obtido pela institui&ccedil;&atilde;o financeira, ficando a cobran&ccedil;a sob condi&ccedil;&atilde;o suspensiva de exigibilidade, visto que &eacute; benefici&aacute;ria da justi&ccedil;a gratuita, nos termos do art. 98, &sect;3&ordm; do CPC. Por sua vez, a institui&ccedil;&atilde;o financeira apelante fora condenada a arcar com honor&aacute;rios sucumbenciais fixados em 10% (dez por cento) sobre o valor da condena&ccedil;&atilde;o, com fulcro no art. 85, &sect;2&ordm;, do C&oacute;digo de Processo Civil.
+ii. quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; omiss&atilde;o no julgado sob alega&ccedil;&atilde;o de este n&atilde;o ter observado o Tema 929 do STJ e a exist&ecirc;ncia de engano justific&aacute;vel apto a afastar a restitui&ccedil;&atilde;o em dobro.
+iii. raz&otilde;es de decidir
+3. A omiss&atilde;o capaz de ensejar a oposi&ccedil;&atilde;o de embargos de declara&ccedil;&atilde;o consiste na aus&ecirc;ncia de manifesta&ccedil;&atilde;o acerca de pedido ou argumento relevante da parte no decisum, n&atilde;o sendo par&acirc;metro v&aacute;lido o mero n&atilde;o acolhimento de tese ou aus&ecirc;ncia de men&ccedil;&atilde;o expressa acerca de todos os dispositivos legais invocados.
+4. O julgado recorrido se manifestou de maneira suficientemente clara, coerente e &iacute;ntegra quanto &agrave; discuss&atilde;o trazida a esta Corte, demonstrando, expressamente, os motivos pelos quais se entendeu  pelo cabimento da repeti&ccedil;&atilde;o do ind&eacute;bito em dobro no caso. Mera irresigna&ccedil;&atilde;o da parte recorrente.
+5. O Tribunal n&atilde;o precisa enfrentar as mat&eacute;rias apenas para fins de&nbsp;prequestionamento, nos termos do art. 1.025 do C&oacute;digo de Processo Civil.
+iv. dispositivo e tese
+6. Recurso conhecido e n&atilde;o acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022 e art. 1.025.
+Jurisprud&ecirc;ncia relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Se&ccedil;&atilde;o, j. 08.11.2017; STJ, EDcl no MS 21315/DF, Rel. Min. Diva Malerbi, Primeira Se&ccedil;&atilde;o, j.  15.06.2016.  <br><br>(N&uacute;mero do Processo: 0729355-77.2023.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									729355772023802000150000
+								</td>
+							</tr>
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>direito processual civil. embargos de declaração em apelaçÃO CÍVEL. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIO. Recurso  não acolhido.
+i. caso em exame
+1. Embargos de declaração opostos em face de acórdão que conheceu do recurso de apelação outrora interposto pela parte embargada, para, no mérito, dar-lhe parcial provimento, reformando a sentença para julgar parcialmente
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>direito processual civil. embargos de declaração em apelaçÃO CÍVEL. Alegação de existência de omissão no acórdão. AUSÊNCIA DE VÍCIO. Recurso  não acolhido.
+i. caso em exame
+1. Embargos de declaração opostos em face de acórdão que conheceu do recurso de apelação outrora interposto pela parte embargada, para, no mérito, dar-lhe parcial provimento, reformando a sentença para julgar parcialmente procedentes os pedidos formulados na exordial, no sentido de declarar a nulidade do parcelamento automático, no valor mensal de R$ 308,02 trezentos e oito reais e dois centavos), a ser pago em 24 (vinte e quatro) parcelas, bem como condenar o demandado ao ressarcimento, em dobro, dos valores descontados indevidamente, acrescidos de juros de mora e correção monetária a partir do evento danoso que, no caso do pagamento indevido, constituem a mesma data, conforme as Súmulas nº 54 e nº 43 do Superior Tribunal de Justiça. Além disso, determinou-se a aplicação da taxa Selic, desde o evento danoso até 29.08.2024, em razão da coincidência do termo inicial de ambos; e a partir de 30.08.2024 – início da vigência da Lei nº 14.905/2024 –, a correção monetária deverá ser calculada com base no Índice de Preços ao Consumidor Amplo (IPCA), conforme art. 389, parágrafo único, do Código Civil, e os juros moratórios corresponderão à subtração entre a Selic e o IPCA (Selic menos o IPCA = juros moratórios), apurada mensalmente; sendo o resultado da diminuição inferior a zero, os juros corresponderão a zero, consoante art. 406, § 1º e § 3º, do Código Civil. Em razão da sucumbência recíproca entre as partes, determinou-se a distribuição proporcional das despesas, no percentual de 50% para cada umas das partes, observado o deferimento da gratuidade da justiça para a parte apelante. Ademais, condenou-se a parte autora ao pagamento da verba honorária arbitrada em 10% (dez por cento) sobre o valor do proveito econômico obtido pela instituição financeira, ficando a cobrança sob condição suspensiva de exigibilidade, visto que é beneficiária da justiça gratuita, nos termos do art. 98, §3º do CPC. Por sua vez, a instituição financeira apelante fora condenada a arcar com honorários sucumbenciais fixados em 10% (dez por cento) sobre o valor da condenação, com fulcro no art. 85, §2º, do Código de Processo Civil.
+ii. questão em discussão
+2. A questão em discussão consiste em saber se há omissão no julgado sob alegação de este não ter observado o Tema 929 do STJ e a existência de engano justificável apto a afastar a restituição em dobro.
+iii. razões de decidir
+3. A omissão capaz de ensejar a oposição de embargos de declaração consiste na ausência de manifestação acerca de pedido ou argumento relevante da parte no decisum, não sendo parâmetro válido o mero não acolhimento de tese ou ausência de menção expressa acerca de todos os dispositivos legais invocados.
+4. O julgado recorrido se manifestou de maneira suficientemente clara, coerente e íntegra quanto à discussão trazida a esta Corte, demonstrando, expressamente, os motivos pelos quais se entendeu  pelo cabimento da repetição do indébito em dobro no caso. Mera irresignação da parte recorrente.
+5. O Tribunal não precisa enfrentar as matérias apenas para fins de prequestionamento, nos termos do art. 1.025 do Código de Processo Civil.
+iv. dispositivo e tese
+6. Recurso conhecido e não acolhido.
+_________
+Dispositivo relevante citado: CPC, art. 1.022 e art. 1.025.
+Jurisprudência relevante citada: STJ, EDcl na Rcl 3.487/DF, Rel. Min. Jorge Mussi, Terceira Seção, j. 08.11.2017; STJ, EDcl no MS 21315/DF, Rel. Min. Diva Malerbi, Primeira Seção, j.  15.06.2016.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>39&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="812013" cdForo="0" >
+										0754310-07.2025.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="812013" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(812013);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_812013" style="display: none;" >
+	<div id="textAreaDados_812013" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E PEDIDO DE TUTELA PROVIS&Oacute;RIA DE URG&Ecirc;NCIA. INEXIST&Ecirc;NCIA DE CONTRATO. REGISTRO DE D&Iacute;VIDAS ANTERIORES. INCID&Ecirc;NCIA DA S&Uacute;MULA 385 DO STJ. DANOS MORAIS N&Atilde;O CONFIGURADOS. PROVIMENTO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta pela parte r&eacute; contra senten&ccedil;a que julgou parcialmente procedentes os pleitos autorais, para declarar a inexist&ecirc;ncia do d&eacute;bito objeto da a&ccedil;&atilde;o e, por conseguinte, condenar a recorrente ao pagamento de compensa&ccedil;&atilde;o por danos morais no valor de R$ 3.000,00 (tr&ecirc;s mil reais).
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) analisar a ocorr&ecirc;ncia de danos morais; (ii) avaliar a aplicabilidade da S&uacute;mula n&ordm; 385 do STJ ao caso em quest&atilde;o, considerando a alega&ccedil;&atilde;o de preexist&ecirc;ncia de d&iacute;vidas inscritas nos cadastros de restri&ccedil;&atilde;o ao cr&eacute;dito; (iii) analisar, subsidiariamente, a adequa&ccedil;&atilde;o do quantum indenizat&oacute;rio arbitrado na compensa&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A s&uacute;mula n&ordm; 385 do STJ disciplina que  n&atilde;o cabe compensa&ccedil;&atilde;o por danos morais em face de negativa&ccedil;&atilde;o indevida quando preexistente leg&iacute;tima inscri&ccedil;&atilde;o.
+4. No momento do registro negativo do d&eacute;bito ora discutido, a parte apelante possu&iacute;a inscri&ccedil;&otilde;es preexistentes ativas. Imp&otilde;e-se, portanto, a aplica&ccedil;&atilde;o da s&uacute;mula 385 do STJ e a improced&ecirc;ncia do pedido de compensa&ccedil;&atilde;o por danos morais.
+5. Redistribui&ccedil;&atilde;o dos &ocirc;nus sucumbenciais.
+IV. DISPOSITIVO E TESE
+6. Recurso conhecido e provido.
+_________
+Dispositivos relevantes citados: CDC, art. 2&ordm;, art. 3&ordm;, art. 14; CC, art. 927, art. 186; CPC, art. 373, II;
+Jurisprud&ecirc;ncia relevante citada: STJ. AgRg no AREsp 618.821/SP, Rel. Min. Antonio Carlos Ferreira, Quarta Turma, j. 05.05.2015;  S&uacute;mula  385 do STJ. <br><br>(N&uacute;mero do Processo: 0754310-07.2025.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(67 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em> E PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA. INEXISTÊNCIA DE CONTRATO. REGISTRO DE DÍVIDAS ANTERIORES. INCIDÊNCIA DA SÚMULA 385 DO STJ. <em>DANOS</em> <em>MORAIS</em> NÃO CONFIGURADOS. PROVIMENTO.
+I. CASO EM EXAME
+1. Apelação cível interposta pela parte
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em> E PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA. INEXISTÊNCIA DE CONTRATO. REGISTRO DE DÍVIDAS ANTERIORES. INCIDÊNCIA DA SÚMULA 385 DO STJ. <em>DANOS</em> <em>MORAIS</em> NÃO CONFIGURADOS. PROVIMENTO.
+I. CASO EM EXAME
+1. Apelação cível interposta pela parte ré contra sentença que julgou parcialmente procedentes os pleitos autorais, para declarar a inexistência do débito objeto da ação e, por conseguinte, condenar a recorrente ao pagamento de compensação por <em>danos</em> <em>morais</em> no valor de R$ 3.000,00 (três mil reais).
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) analisar a ocorrência de <em>danos</em> <em>morais</em>; (ii) avaliar a aplicabilidade da Súmula nº 385 do STJ ao caso em questão, considerando a alegação de preexistência de dívidas inscritas nos cadastros de restrição ao crédito; (iii) analisar, subsidiariamente, a adequação do quantum indenizatório arbitrado na compensação por <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3. A súmula nº 385 do STJ disciplina que  não cabe compensação por <em>danos</em> <em>morais</em> em face de negativação indevida quando preexistente legítima inscrição.
+4. No momento do registro negativo do débito ora discutido, a parte apelante possuía inscrições preexistentes ativas. Impõe-se, portanto, a aplicação da súmula 385 do STJ e a improcedência do pedido de compensação por <em>danos</em> <em>morais</em>.
+5. Redistribuição dos ônus sucumbenciais.
+IV. DISPOSITIVO E TESE
+6. Recurso conhecido e provido.
+_________
+Dispositivos relevantes citados: CDC, art. 2º, art. 3º, art. 14; CC, art. 927, art. 186; CPC, art. 373, II;
+Jurisprudência relevante citada: STJ. AgRg no AREsp 618.821/SP, Rel. Min. Antonio Carlos Ferreira, Quarta Turma, j. 05.05.2015;  Súmula  385 do STJ.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>40&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="811946" cdForo="0" >
+										0735155-23.2022.8.02.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="811946" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(811946);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_811946" style="display: none;" >
+	<div id="textAreaDados_811946" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL, DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER COM PEDIDO DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. LEGITIMIDADE RECURSAL. AUS&Ecirc;NCIA DE PREJU&Iacute;ZO AO TERCEIRO QUE INTERP&Ocirc;S O RECURSO. N&Atilde;O CONHECIMENTO. RECURSO ADESIVO PREJUDICADO. N&Atilde;O CONHECIMENTO DE AMBOS OS RECURSOS.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es c&iacute;veis contra a senten&ccedil;a que julgou parcialmente procedentes a demanda para determinar que a operadora de sa&uacute;de autorize e custeie o tratamento cir&uacute;rgico pleiteado pela parte autor, bem como pague compensa&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es em discuss&atilde;o consistem em: (i) saber se o tratamento m&eacute;dico pleiteado tem car&aacute;ter reparador ou meramente est&eacute;tico; (ii) apurar a ocorr&ecirc;ncia de danos morais a serem compensados no caso; (iii) analisar, de of&iacute;cio, a admissibilidade recursal.
+III. RAZ&Otilde;ES DE DECIDIR
+3. De acordo com o art. 996 do C&oacute;digo de Processo Civil, o recurso pode ser interposto pela parte vencida, pelo terceiro prejudicado e pelo Minist&eacute;rio P&uacute;blico. No caso do terceiro prejudicado, o par&aacute;grafo &uacute;nico do citado artigo esclarece que para que o recurso seja admitido, &eacute; imprescind&iacute;vel que ele demonstre possibilidade de a decis&atilde;o atingir direito de que se afirme titular ou que possa discutir em ju&iacute;zo como substituto processual.
+4. N&atilde;o ficou demonstrado o interesse da recorrente no deslinde da controv&eacute;rsia, ou, ao menos, qualquer esp&eacute;cie de repercuss&atilde;o que a senten&ccedil;a impugnada poderia causar-lhe. Recurso principal n&atilde;o conhecido.
+5. A inadmissibilidade do recurso principal implica o n&atilde;o conhecimento do recurso adesivo.
+IV. DISPOSITIVO
+6. Recursos n&atilde;o conhecidos.
+_______________
+Dispositivos relevantes citados: CPC, art. 18, art. 996, par&aacute;grafo &uacute;nico, art. 997, III.
+Jurisprud&ecirc;ncias relevantes citadas: STJ, AgInt no AREsp n. 2.137.302/MG, Rel. Min. Nancy Andrighi, Terceira Turma, j. 17.10.2022. <br><br>(N&uacute;mero do Processo: 0735155-23.2022.8.02.0001; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 13/04/2026; Data de registro: 13/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(16 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Assistência à Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL, DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS EM AÇÃO DE OBRIGAÇÃO DE FAZER COM PEDIDO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. LEGITIMIDADE RECURSAL. AUSÊNCIA DE PREJUÍZO AO TERCEIRO QUE INTERPÔS O RECURSO. NÃO CONHECIMENTO. RECURSO ADESIVO PREJUDICADO. NÃO CONHECIMENTO DE AMBOS OS RECURSOS.
+I. CASO EM EXAME
+1. Apelações cíveis contra a sentença que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL, DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS EM AÇÃO DE OBRIGAÇÃO DE FAZER COM PEDIDO DE INDENIZAÇÃO POR <em>DANOS</em> <em>MORAIS</em>. LEGITIMIDADE RECURSAL. AUSÊNCIA DE PREJUÍZO AO TERCEIRO QUE INTERPÔS O RECURSO. NÃO CONHECIMENTO. RECURSO ADESIVO PREJUDICADO. NÃO CONHECIMENTO DE AMBOS OS RECURSOS.
+I. CASO EM EXAME
+1. Apelações cíveis contra a sentença que julgou parcialmente procedentes a demanda para determinar que a operadora de saúde autorize e custeie o tratamento cirúrgico pleiteado pela parte autor, bem como pague compensação por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões em discussão consistem em: (i) saber se o tratamento médico pleiteado tem caráter reparador ou meramente estético; (ii) apurar a ocorrência de <em>danos</em> <em>morais</em> a serem compensados no caso; (iii) analisar, de ofício, a admissibilidade recursal.
+III. RAZÕES DE DECIDIR
+3. De acordo com o art. 996 do Código de Processo Civil, o recurso pode ser interposto pela parte vencida, pelo terceiro prejudicado e pelo Ministério Público. No caso do terceiro prejudicado, o parágrafo único do citado artigo esclarece que para que o recurso seja admitido, é imprescindível que ele demonstre possibilidade de a decisão atingir direito de que se afirme titular ou que possa discutir em juízo como substituto processual.
+4. Não ficou demonstrado o interesse da recorrente no deslinde da controvérsia, ou, ao menos, qualquer espécie de repercussão que a sentença impugnada poderia causar-lhe. Recurso principal não conhecido.
+5. A inadmissibilidade do recurso principal implica o não conhecimento do recurso adesivo.
+IV. DISPOSITIVO
+6. Recursos não conhecidos.
+_______________
+Dispositivos relevantes citados: CPC, art. 18, art. 996, parágrafo único, art. 997, III.
+Jurisprudências relevantes citadas: STJ, AgInt no AREsp n. 2.137.302/MG, Rel. Min. Nancy Andrighi, Terceira Turma, j. 17.10.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="RECURSO">
+									<label for="ckTermo1">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="CONHECIDO">
+									<label for="ckTermo2">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="APELAÇÃO">
+									<label for="ckTermo3">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="PROVIDO">
+									<label for="ckTermo4">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="DIREITO">
+									<label for="ckTermo5">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="CÍVEL">
+									<label for="ckTermo6">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="AÇÃO">
+									<label for="ckTermo7">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="CIVIL">
+									<label for="ckTermo8">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="DANOS">
+									<label for="ckTermo9">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="CONSUMIDOR">
+									<label for="ckTermo10">
+										CONSUMIDOR
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="MORAIS">
+									<label for="ckTermo11">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="SENTENÇA">
+									<label for="ckTermo12">
+										SENTENÇA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="INDENIZAÇÃO">
+									<label for="ckTermo13">
+										INDENIZAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="INEXISTÊNCIA">
+									<label for="ckTermo14">
+										INEXISTÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="DECISÃO">
+									<label for="ckTermo15">
+										DECISÃO
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				21 a 40
+			</strong>
+			de 136804
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+			<a name="A1" title="Página anterior">
+				&lt;
+			</a>
+
+
+
+
+
+
+
+
+
+
+
+					<a name="A1" style="padding-left:4px" >
+						1
+					</a>
+
+
+
+
+
+					<span class="paginaAtual" >
+						2
+					</span>
+
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A3" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjal/samples/cjsg/single_page.html
+++ b/tests/tjal/samples/cjsg/single_page.html
@@ -1,0 +1,1298 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(7)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="7" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="786839" cdForo="0" >
+										0700507-57.2023.8.02.0041
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="786839" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(786839);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_786839" style="display: none;" >
+	<div id="textAreaDados_786839" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE SERVID&Atilde;O. USUCAPI&Atilde;O DE SERVID&Atilde;O DE PASSAGEM. UTILIDADE DO PR&Eacute;DIO DOMINANTE. EXIST&Ecirc;NCIA DE VIA ALTERNATIVA QUE N&Atilde;O AFASTA O DIREITO. INOVA&Ccedil;&Atilde;O RECURSAL. PEDIDO INDENIZAT&Oacute;RIO FORMULADO APENAS EM APELA&Ccedil;&Atilde;O. RECURSO CONHECIDO EM PARTE E DESPROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apela&ccedil;&atilde;o C&iacute;vel interposta contra senten&ccedil;a proferida em A&ccedil;&atilde;o Ordin&aacute;ria c/c Pedido Declarat&oacute;rio de Servid&atilde;o c/c Tutela de Urg&ecirc;ncia, que julgou procedente a pretens&atilde;o autoral de reconhecimento de servid&atilde;o de passagem sobre im&oacute;vel rural, com fundamento na usucapi&atilde;o de servid&atilde;o aparente. A senten&ccedil;a determinou o registro da servid&atilde;o em cart&oacute;rio e imp&ocirc;s condena&ccedil;&atilde;o em custas e honor&aacute;rios ao r&eacute;u, com observ&acirc;ncia da gratuidade da justi&ccedil;a. O recurso impugna a imposi&ccedil;&atilde;o da servid&atilde;o, alega a exist&ecirc;ncia de via alternativa de acesso e requer, subsidiariamente, indeniza&ccedil;&atilde;o pelo uso da &aacute;rea ou pagamento mensal pelo uso da terra.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) verificar se h&aacute; provas suficientes para o reconhecimento da servid&atilde;o de passagem por usucapi&atilde;o; (ii) definir se a exist&ecirc;ncia de rota alternativa afasta a necessidade de imposi&ccedil;&atilde;o da servid&atilde;o; (iii) determinar a possibilidade de conhecimento do pedido indenizat&oacute;rio formulado apenas na apela&ccedil;&atilde;o.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O pedido indenizat&oacute;rio apresentado no recurso configura inova&ccedil;&atilde;o recursal, pois n&atilde;o foi deduzido formalmente na inst&acirc;ncia de origem, tampouco por meio de reconven&ccedil;&atilde;o, conforme exige o art. 343 do CPC. A men&ccedil;&atilde;o a valores e danos em sede de contesta&ccedil;&atilde;o ocorreu em contexto de tentativa conciliat&oacute;ria e n&atilde;o configura pedido contraposto impl&iacute;cito, sob pena de viola&ccedil;&atilde;o aos arts. 141 e 492 do CPC.
+4. A exist&ecirc;ncia de via alternativa n&atilde;o afasta o reconhecimento da servid&atilde;o de passagem, uma vez que o instituto n&atilde;o se confunde com a passagem for&ccedil;ada, exigindo apenas que proporcione utilidade ao pr&eacute;dio dominante.
+5. A servid&atilde;o pode ser adquirida por usucapi&atilde;o, desde que exercida de forma aparente, cont&iacute;nua, incontestada e prolongada. O prazo aplic&aacute;vel, &agrave; luz da interpreta&ccedil;&atilde;o sistem&aacute;tica do C&oacute;digo Civil e do Enunciado 251 do CJF, &eacute; de 15 anos, ainda que o art. 1.379, par&aacute;grafo &uacute;nico, mencione 20 anos.
+6. Demonstrado o uso pac&iacute;fico da via por mais de 17 anos, com comprova&ccedil;&atilde;o documental e aus&ecirc;ncia de oposi&ccedil;&atilde;o, restam preenchidos os requisitos legais para o reconhecimento da servid&atilde;o de passagem por usucapi&atilde;o.
+7. A senten&ccedil;a observou corretamente os pressupostos legais e probat&oacute;rios, sendo de rigor sua manuten&ccedil;&atilde;o. Procede-se, de of&iacute;cio, &agrave; retifica&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios fixados, com base em crit&eacute;rios objetivos e valor atribu&iacute;do &agrave; causa.
+IV. DISPOSITIVO E TESE
+4. Recurso conhecido, em parte, e desprovido.
+_________
+Dispositivos relevantes citados: CC, arts. 1.238, 1.378 e 1.379, par&aacute;grafo &uacute;nico; CPC/2015, arts. 98, &sect;3&ordm;, 141, 343, 492 e 1.013, &sect;1&ordm;; Lei n&ordm; 6.015/73, art. 167, I, item 6, e II, item 5.
+Jurisprud&ecirc;ncia relevante citada: TJPR, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0003529-90.2015.8.16.0095, Rel. Des. Fernando Paulino da Silva Wolff Filho, 17&ordf; C&acirc;mara C&iacute;vel, j. 18.05.2018.
+Enunciado relevante citado: Enunciado CJF n&ordm; 251. <br><br>(N&uacute;mero do Processo: 0700507-57.2023.8.02.0041; Relator (a):&nbsp;Des. Alcides Gusm&atilde;o da Silva; Comarca:&nbsp;Foro de Capela; &Oacute;rg&atilde;o julgador: 3&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 05/02/2026; Data de registro: 09/02/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(31 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Servidão
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alcides Gusmão da Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Capela
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									05/02/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									09/02/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE SERVIDÃO. <em>USUCAPIÃO</em> DE SERVIDÃO DE PASSAGEM. UTILIDADE DO <em>PRÉDIO</em> DOMINANTE. EXISTÊNCIA DE VIA ALTERNATIVA QUE NÃO AFASTA O DIREITO. INOVAÇÃO RECURSAL. PEDIDO INDENIZATÓRIO FORMULADO APENAS EM APELAÇÃO. RECURSO CONHECIDO EM PARTE E DESPROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apelação Cível interposta contra sentença proferida
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE SERVIDÃO. <em>USUCAPIÃO</em> DE SERVIDÃO DE PASSAGEM. UTILIDADE DO <em>PRÉDIO</em> DOMINANTE. EXISTÊNCIA DE VIA ALTERNATIVA QUE NÃO AFASTA O DIREITO. INOVAÇÃO RECURSAL. PEDIDO INDENIZATÓRIO FORMULADO APENAS EM APELAÇÃO. RECURSO CONHECIDO EM PARTE E DESPROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apelação Cível interposta contra sentença proferida em Ação Ordinária c/c Pedido Declaratório de Servidão c/c Tutela de Urgência, que julgou procedente a pretensão autoral de reconhecimento de servidão de passagem sobre imóvel <em>rural</em>, com fundamento na <em>usucapião</em> de servidão aparente. A sentença determinou o registro da servidão em cartório e impôs condenação em custas e honorários ao réu, com observância da gratuidade da justiça. O recurso impugna a imposição da servidão, alega a existência de via alternativa de acesso e requer, subsidiariamente, indenização pelo uso da área ou pagamento mensal pelo uso da terra.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) verificar se há provas suficientes para o reconhecimento da servidão de passagem por <em>usucapião</em>; (ii) definir se a existência de rota alternativa afasta a necessidade de imposição da servidão; (iii) determinar a possibilidade de conhecimento do pedido indenizatório formulado apenas na apelação.
+III. RAZÕES DE DECIDIR
+3. O pedido indenizatório apresentado no recurso configura inovação recursal, pois não foi deduzido formalmente na instância de origem, tampouco por meio de reconvenção, conforme exige o art. 343 do CPC. A menção a valores e danos em sede de contestação ocorreu em contexto de tentativa conciliatória e não configura pedido contraposto implícito, sob pena de violação aos arts. 141 e 492 do CPC.
+4. A existência de via alternativa não afasta o reconhecimento da servidão de passagem, uma vez que o instituto não se confunde com a passagem forçada, exigindo apenas que proporcione utilidade ao <em>prédio</em> dominante.
+5. A servidão pode ser adquirida por <em>usucapião</em>, desde que exercida de forma aparente, contínua, incontestada e prolongada. O prazo aplicável, à luz da interpretação sistemática do Código Civil e do Enunciado 251 do CJF, é de 15 anos, ainda que o art. 1.379, parágrafo único, mencione 20 anos.
+6. Demonstrado o uso pacífico da via por mais de 17 anos, com comprovação documental e ausência de oposição, restam preenchidos os requisitos legais para o reconhecimento da servidão de passagem por <em>usucapião</em>.
+7. A sentença observou corretamente os pressupostos legais e probatórios, sendo de rigor sua manutenção. Procede-se, de ofício, à retificação dos honorários advocatícios fixados, com base em critérios objetivos e valor atribuído à causa.
+IV. DISPOSITIVO E TESE
+4. Recurso conhecido, em parte, e desprovido.
+_________
+Dispositivos relevantes citados: CC, arts. 1.238, 1.378 e 1.379, parágrafo único; CPC/2015, arts. 98, §3º, 141, 343, 492 e 1.013, §1º; Lei nº 6.015/73, art. 167, I, item 6, e II, item 5.
+Jurisprudência relevante citada: TJPR, Apelação Cível nº 0003529-90.2015.8.16.0095, Rel. Des. Fernando Paulino da Silva Wolff Filho, 17ª Câmara Cível, j. 18.05.2018.
+Enunciado relevante citado: Enunciado CJF nº 251.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="486534" cdForo="0" >
+										0700164-16.2018.8.02.0048
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="486534" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(486534);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_486534" style="display: none;" >
+	<div id="textAreaDados_486534" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO CIVIL. A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIA. SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. TESE CONTRARRECURSAL DE VIOLA&Ccedil;&Atilde;O AO PRINC&Iacute;PIO DA DIALETICIDADE RECURSAL. N&Atilde;O VERIFICA&Ccedil;&Atilde;O. IMPUGNA&Ccedil;&Atilde;O SUFICIENTE DA SENTEN&Ccedil;A. ALEGA&Ccedil;&Atilde;O DE IN&Eacute;PCIA DA INICIAL. N&Atilde;O ACOLHIDA. ATENDIMENTO DOS REQUISITOS DO C&Oacute;DIGO DE PROCESSO CIVIL E JUNTADA DOS DOCUMENTOS NECESS&Aacute;RIOS AO REGULAR ANDAMENTO DO FEITO. ALEGA&Ccedil;&Atilde;O RECURSAL DE QUE O BEM &Eacute; P&Uacute;BLICO. N&Atilde;O ACOLHIMENTO. AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O. INEXIST&Ecirc;NCIA DE REGISTRO IMOBILI&Aacute;RIO DO BEM OBJETO DE A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O QUE N&Atilde;O INDUZ PRESUN&Ccedil;&Atilde;O DE QUE O IM&Oacute;VEL &Eacute; P&Uacute;BLICO, CABENDO &Agrave; FAZENDA P&Uacute;BLICA PROVAR A TITULARIDADE DO TERRENO COMO &Oacute;BICE AO RECONHECIMENTO DA PRESCRI&Ccedil;&Atilde;O AQUISITIVA. ENTENDIMENTO DO SUPERIOR TRIBUNAL DE JUSTI&Ccedil;A. MUNIC&Iacute;PIO RECORRENTE QUE N&Atilde;O SE DESINCUMBIU DO &Ocirc;NUS QUE LHE CABIA. SENTEN&Ccedil;A MANTIDA EM SEU CERNE. FIXA&Ccedil;&Atilde;O DE HONOR&Aacute;RIOS DE SUCUMB&Ecirc;NCIA. RECURSO CONHECIDO E N&Atilde;O PROVIDO. <br><br>(N&uacute;mero do Processo: 0700164-16.2018.8.02.0048; Relator (a):&nbsp;Des. F&aacute;bio Costa de Almeida Ferrario; Comarca:&nbsp;Foro de P&atilde;o de A&ccedil;&uacute;car; &Oacute;rg&atilde;o julgador: 4&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 02/10/2023; Data de registro: 02/10/2023)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(39 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Extraordinária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio Costa de Almeida Ferrario
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Pão de Açúcar
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									02/10/2023
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									02/10/2023
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. SENTENÇA DE PROCEDÊNCIA. TESE CONTRARRECURSAL DE VIOLAÇÃO AO PRINCÍPIO DA DIALETICIDADE RECURSAL. NÃO VERIFICAÇÃO. IMPUGNAÇÃO SUFICIENTE DA SENTENÇA. ALEGAÇÃO DE INÉPCIA DA INICIAL. NÃO ACOLHIDA. ATENDIMENTO DOS REQUISITOS DO CÓDIGO DE PROCESSO CIVIL E JUNTADA DOS DOCUMENTOS NECESSÁRIOS AO REGULAR ANDAMENTO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. SENTENÇA DE PROCEDÊNCIA. TESE CONTRARRECURSAL DE VIOLAÇÃO AO PRINCÍPIO DA DIALETICIDADE RECURSAL. NÃO VERIFICAÇÃO. IMPUGNAÇÃO SUFICIENTE DA SENTENÇA. ALEGAÇÃO DE INÉPCIA DA INICIAL. NÃO ACOLHIDA. ATENDIMENTO DOS REQUISITOS DO CÓDIGO DE PROCESSO CIVIL E JUNTADA DOS DOCUMENTOS NECESSÁRIOS AO REGULAR ANDAMENTO DO FEITO. ALEGAÇÃO RECURSAL DE QUE O BEM É PÚBLICO. NÃO ACOLHIMENTO. AUSÊNCIA DE COMPROVAÇÃO. INEXISTÊNCIA DE REGISTRO IMOBILIÁRIO DO BEM OBJETO DE AÇÃO DE <em>USUCAPIÃO</em> QUE NÃO INDUZ PRESUNÇÃO DE QUE O IMÓVEL É PÚBLICO, CABENDO À FAZENDA PÚBLICA PROVAR A TITULARIDADE DO TERRENO COMO ÓBICE AO RECONHECIMENTO DA PRESCRIÇÃO AQUISITIVA. ENTENDIMENTO DO SUPERIOR TRIBUNAL DE JUSTIÇA. MUNICÍPIO RECORRENTE QUE NÃO SE DESINCUMBIU DO ÔNUS QUE LHE CABIA. SENTENÇA MANTIDA EM SEU CERNE. FIXAÇÃO DE HONORÁRIOS DE SUCUMBÊNCIA. RECURSO CONHECIDO E NÃO PROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="467214" cdForo="0" >
+										0803410-41.2019.8.02.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="467214" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(467214);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_467214" style="display: none;" >
+	<div id="textAreaDados_467214" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O RESCIS&Oacute;RIA. PROCESSO CIVIL E DIREITO REAL. A&Ccedil;&Atilde;O RESCINDENDA DE USUCAPI&Atilde;O. SENTEN&Ccedil;A TRANSITADA EM JULGADO QUE CONCEDEU A PROPRIEDADE DO IM&Oacute;VEL AO R&Eacute;U. AUTORA TERCEIRA PREJUDICADA. PRELIMINAR EM CONTESTA&Ccedil;&Atilde;O DE DECAD&Ecirc;NCIA DO DIREITO RESCIS&Oacute;RIO. N&Atilde;O ACOLHIDA. ALEGA&Ccedil;&Atilde;O DE DOLO NA A&Ccedil;&Atilde;O RESCINDENDA. AFASTADA. ALEGA&Ccedil;&Atilde;O DE VIOLA&Ccedil;&Atilde;O MANIFESTA A NORMA JUR&Iacute;DICA. N&Atilde;O VERIFICADA. ALEGA&Ccedil;&Atilde;O DE ERRO DE FATO VERIFIC&Aacute;VEL AOS AUTOS. N&Atilde;O DEMONSTRADO. PROVAS NOVAS QUE PODERIAM MODIFICAR A DECIS&Atilde;O. INEXISTENTES. DOCUMENTOS SEM FOR&Ccedil;A PROBANTE SUFICIENTE. A&Ccedil;&Atilde;O JULGADA IMPROCEDENTE.
+1. O tr&acirc;nsito em julgado que marca o in&iacute;cio do prazo decadencial para a propositura da a&ccedil;&atilde;o rescis&oacute;ria, no caso das a&ccedil;&otilde;es em que o Minist&eacute;rio P&uacute;blico atue como fiscal da lei, apenas ocorre ap&oacute;s o fim do prazo para que este interponha recursos. Intelig&ecirc;ncia dos arts. 502 e 996 do CPC/15.
+2. A fundamenta&ccedil;&atilde;o de a&ccedil;&atilde;o rescis&oacute;ria com base em dolo do r&eacute;u demanda a demonstra&ccedil;&atilde;o de que a conduta apontada como dolosa tenha, necessariamente, implicado no resultado do julgamento. Jurisprud&ecirc;ncia do STJ.
+3. A rescis&atilde;o com base em viola&ccedil;&atilde;o manifesta a norma jur&iacute;dica demanda a comprova&ccedil;&atilde;o de que o julgado combatido conferiu interpreta&ccedil;&atilde;o manifestamente descabida ao dispositivo legal indicado, contrariando-o em sua ess&ecirc;ncia. N&atilde;o basta mera men&ccedil;&atilde;o a suposta viola&ccedil;&atilde;o em abstrato. Jurisprud&ecirc;ncia do STJ.
+4. O erro de fato estar&aacute; configurado quando seja fundamento essencial da decis&atilde;o rescindenda, mediante apura&ccedil;&atilde;o do equ&iacute;voco factual realizado com as provas produzidas no processo origin&aacute;rio e aus&ecirc;ncia de pronunciamento judicial a respeito do fato, haja vista que a m&aacute; aprecia&ccedil;&atilde;o da prova n&atilde;o implica rescis&atilde;o do julgado. Jurisprud&ecirc;ncia do STJ.
+5. O documento novo apto a aparelhar a a&ccedil;&atilde;o rescis&oacute;ria &eacute; aquele que, j&aacute; existente &agrave; &eacute;poca da decis&atilde;o rescindenda, era ignorado pelo autor ou do qual n&atilde;o p&ocirc;de fazer uso, capaz de assegurar, por si s&oacute;, a proced&ecirc;ncia do pedido. Jurisprud&ecirc;ncia do STJ.
+6. A&ccedil;&atilde;o rescis&oacute;ria improcedente. <br><br>(N&uacute;mero do Processo: 0803410-41.2019.8.02.0000; Relator (a):&nbsp;Des. Paulo Zacarias da Silva; Comarca:&nbsp;Foro de &Aacute;gua Branca; &Oacute;rg&atilde;o julgador: Se&ccedil;&atilde;o Especializada C&iacute;vel; Data do julgamento: 24/07/2023; Data de registro: 26/07/2023)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(24 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Ação Rescisória / Aquisição
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Zacarias da Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Agua Branca
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Especializada Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									24/07/2023
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									26/07/2023
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO RESCISÓRIA. PROCESSO CIVIL E DIREITO REAL. AÇÃO RESCINDENDA DE <em>USUCAPIÃO</em>. SENTENÇA TRANSITADA EM JULGADO QUE CONCEDEU A PROPRIEDADE DO IMÓVEL AO RÉU. AUTORA TERCEIRA PREJUDICADA. PRELIMINAR EM CONTESTAÇÃO DE DECADÊNCIA DO DIREITO RESCISÓRIO. NÃO ACOLHIDA. ALEGAÇÃO DE DOLO NA AÇÃO RESCINDENDA. AFASTADA. ALEGAÇÃO DE VIOLAÇÃO MANIFESTA A NORMA JURÍDICA. NÃO VERIFICADA. ALEGAÇÃO DE ERRO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO RESCISÓRIA. PROCESSO CIVIL E DIREITO REAL. AÇÃO RESCINDENDA DE <em>USUCAPIÃO</em>. SENTENÇA TRANSITADA EM JULGADO QUE CONCEDEU A PROPRIEDADE DO IMÓVEL AO RÉU. AUTORA TERCEIRA PREJUDICADA. PRELIMINAR EM CONTESTAÇÃO DE DECADÊNCIA DO DIREITO RESCISÓRIO. NÃO ACOLHIDA. ALEGAÇÃO DE DOLO NA AÇÃO RESCINDENDA. AFASTADA. ALEGAÇÃO DE VIOLAÇÃO MANIFESTA A NORMA JURÍDICA. NÃO VERIFICADA. ALEGAÇÃO DE ERRO DE FATO VERIFICÁVEL AOS AUTOS. NÃO DEMONSTRADO. PROVAS NOVAS QUE PODERIAM MODIFICAR A DECISÃO. INEXISTENTES. DOCUMENTOS SEM FORÇA PROBANTE SUFICIENTE. AÇÃO JULGADA IMPROCEDENTE.
+1. O trânsito em julgado que marca o início do prazo decadencial para a propositura da ação rescisória, no caso das ações em que o Ministério Público atue como fiscal da lei, apenas ocorre após o fim do prazo para que este interponha recursos. Inteligência dos arts. 502 e 996 do CPC/15.
+2. A fundamentação de ação rescisória com base em dolo do réu demanda a demonstração de que a conduta apontada como dolosa tenha, necessariamente, implicado no resultado do julgamento. Jurisprudência do STJ.
+3. A rescisão com base em violação manifesta a norma jurídica demanda a comprovação de que o julgado combatido conferiu interpretação manifestamente descabida ao dispositivo legal indicado, contrariando-o em sua essência. Não basta mera menção a suposta violação em abstrato. Jurisprudência do STJ.
+4. O erro de fato estará configurado quando seja fundamento essencial da decisão rescindenda, mediante apuração do equívoco factual realizado com as provas produzidas no processo originário e ausência de pronunciamento judicial a respeito do fato, haja vista que a má apreciação da prova não implica rescisão do julgado. Jurisprudência do STJ.
+5. O documento novo apto a aparelhar a ação rescisória é aquele que, já existente à época da decisão rescindenda, era ignorado pelo autor ou do qual não pôde fazer uso, capaz de assegurar, por si só, a procedência do pedido. Jurisprudência do STJ.
+6. Ação rescisória improcedente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="382625" cdForo="0" >
+										0700206-74.2019.8.02.0066
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="382625" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(382625);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_382625" style="display: none;" >
+	<div id="textAreaDados_382625" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE MANUTEN&Ccedil;&Atilde;O DE POSSE, COM PEDIDO DE LIMINAR. SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. 1. PEDIDO DE GRATUIDADE DA JUSTI&Ccedil;A FORMULADO NESTA INST&Acirc;NCIA. DEFERIDO. HIP&Oacute;TESE DE PRESUN&Ccedil;&Atilde;O RELATIVA DE POBREZA QUE MILITA EM FAVOR DAQUELE QUE PEDE A GRATUIDADE - CPC/2015, ART. 99, &sect; 3&ordm; -, SEM, CONTUDO, ATRIBUIR-LHE EFEITOS RETROATIVOS. 2. PEDIDO DE ATRIBUI&Ccedil;&Atilde;O DE EFEITO SUSPENSIVO &Agrave; APELA&Ccedil;&Atilde;O. N&Atilde;O CONHECIDO. PRETENS&Atilde;O QUE DEVE SER DEDUZIDA EM PE&Ccedil;A APARTADA. INADEQUA&Ccedil;&Atilde;O DA VIA ELEITA, POR FOR&Ccedil;A DO ART. 1.012, &sect; 3&ordm;, DO CPC/2015. 3. INCOMPET&Ecirc;NCIA ABSOLUTA DO JU&Iacute;ZO SENTENCIANTE DECLARADA DE OF&Iacute;CIO. MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA. OBSERV&Acirc;NCIA DO PRINC&Iacute;PIO DA N&Atilde;O SURPRESA. DEMANDA DE NATUREZA POSSESS&Oacute;RIA DE IM&Oacute;VEL SITUADO NA COMARCA DA MACEI&Oacute; ATRAI A COMPET&Ecirc;NCIA ABSOLUTA DO JU&Iacute;ZO ESPECIALIZADO DA 29&ordf; VARA C&Iacute;VEL DA CAPITAL, EX VI DO ART. 47, &sect; 2&ordm;, DO CPC/2015; E, DO ART. 1&ordm; DA LEI ESTADUAL N.&ordm; 6.895/2007, COM REDA&Ccedil;&Atilde;O DADA PELAS LEIS N.&ordm; 7.907/2017; E, N.&ordm; 8.176/2019. 4. PRELIMINAR DE CONEX&Atilde;O COM A A&Ccedil;&Atilde;O DE ADJUDICA&Ccedil;&Atilde;O COMPULS&Oacute;RIA N.&ordm; 0718824-68.2019.8.02.0001. REJEITADA. AUS&Ecirc;NCIA DE IDENTIDADE ENTRE A&Ccedil;&Atilde;O PETIT&Oacute;RIA E POSSESS&Oacute;RIA, SEJA QUANTO AO PEDIDO OU A CAUSA DE PEDIR. DE TODO MODO, &Eacute; INCAB&Iacute;VEL A ALTERA&Ccedil;&Atilde;O DA COMPET&Ecirc;NCIA ABSOLUTA, POR EVENTUAL CONEX&Atilde;O - CPC/2015, ARTS. 54 E 62 -. 5. REMESSA DOS AUTOS AO JU&Iacute;ZO DE DIREITO ORIGINARIAMENTE COMPETENTE PARA AN&Aacute;LISE DA EFIC&Aacute;CIA DOS ATOS DECIS&Oacute;RIOS, A TEOR DO ART. 64, &sect; 4&ordm;, DO CPC/2015. 6. RECURSO CONHECIDO, EM PARTE, RESTANDO O M&Eacute;RITO PREJUDICADO. UNANIMIDADE.  <br><br>(N&uacute;mero do Processo: 0700206-74.2019.8.02.0066; Relator (a):&nbsp;Juiz Convocado Manoel Cavalcante de Lima Neto; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 1&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 23/05/2022; Data de registro: 27/05/2022)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Esbulho / Turbação / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Convocado Manoel Cavalcante de Lima Neto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									23/05/2022
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									27/05/2022
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE MANUTENÇÃO DE POSSE, COM PEDIDO DE LIMINAR. SENTENÇA DE PROCEDÊNCIA. 1. PEDIDO DE GRATUIDADE DA JUSTIÇA FORMULADO NESTA INSTÂNCIA. DEFERIDO. HIPÓTESE DE PRESUNÇÃO RELATIVA DE POBREZA QUE MILITA EM FAVOR DAQUELE QUE PEDE A GRATUIDADE - CPC/2015, ART. 99, § 3º -, SEM, CONTUDO, ATRIBUIR-LHE EFEITOS RETROATIVOS. 2. PEDIDO DE ATRIBUIÇÃO DE EFEITO SUSPENSIVO À APELAÇÃO. NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE MANUTENÇÃO DE POSSE, COM PEDIDO DE LIMINAR. SENTENÇA DE PROCEDÊNCIA. 1. PEDIDO DE GRATUIDADE DA JUSTIÇA FORMULADO NESTA INSTÂNCIA. DEFERIDO. HIPÓTESE DE PRESUNÇÃO RELATIVA DE POBREZA QUE MILITA EM FAVOR DAQUELE QUE PEDE A GRATUIDADE - CPC/2015, ART. 99, § 3º -, SEM, CONTUDO, ATRIBUIR-LHE EFEITOS RETROATIVOS. 2. PEDIDO DE ATRIBUIÇÃO DE EFEITO SUSPENSIVO À APELAÇÃO. NÃO CONHECIDO. PRETENSÃO QUE DEVE SER DEDUZIDA EM PEÇA APARTADA. INADEQUAÇÃO DA VIA ELEITA, POR FORÇA DO ART. 1.012, § 3º, DO CPC/2015. 3. INCOMPETÊNCIA ABSOLUTA DO JUÍZO SENTENCIANTE DECLARADA DE OFÍCIO. MATÉRIA DE ORDEM PÚBLICA. OBSERVÂNCIA DO PRINCÍPIO DA NÃO SURPRESA. DEMANDA DE NATUREZA POSSESSÓRIA DE IMÓVEL SITUADO NA COMARCA DA MACEIÓ ATRAI A COMPETÊNCIA ABSOLUTA DO JUÍZO ESPECIALIZADO DA 29ª VARA CÍVEL DA CAPITAL, EX VI DO ART. 47, § 2º, DO CPC/2015; E, DO ART. 1º DA LEI ESTADUAL N.º 6.895/2007, COM REDAÇÃO DADA PELAS LEIS N.º 7.907/2017; E, N.º 8.176/2019. 4. PRELIMINAR DE CONEXÃO COM A AÇÃO DE ADJUDICAÇÃO COMPULSÓRIA N.º 0718824-68.2019.8.02.0001. REJEITADA. AUSÊNCIA DE IDENTIDADE ENTRE AÇÃO PETITÓRIA E POSSESSÓRIA, SEJA QUANTO AO PEDIDO OU A CAUSA DE PEDIR. DE TODO MODO, É INCABÍVEL A ALTERAÇÃO DA COMPETÊNCIA ABSOLUTA, POR EVENTUAL CONEXÃO - CPC/2015, ARTS. 54 E 62 -. 5. REMESSA DOS AUTOS AO JUÍZO DE DIREITO ORIGINARIAMENTE COMPETENTE PARA ANÁLISE DA EFICÁCIA DOS ATOS DECISÓRIOS, A TEOR DO ART. 64, § 4º, DO CPC/2015. 6. RECURSO CONHECIDO, EM PARTE, RESTANDO O MÉRITO PREJUDICADO. UNANIMIDADE.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="322303" cdForo="0" >
+										0700024-69.2017.8.02.0095
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="322303" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(322303);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_322303" style="display: none;" >
+	<div id="textAreaDados_322303" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DE INTERDITO PROIBIT&Oacute;RIO. NATUREZA POSSESS&Oacute;RIA. BEM IM&Oacute;VEL. SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. PEDIDO DE CONCESS&Atilde;O/MANUTEN&Ccedil;&Atilde;O DA ASSIST&Ecirc;NCIA JUDICI&Aacute;RIA GRATUITA. N&Atilde;O CONHECIMENTO DOS APELOS NESTE PONTO. AUS&Ecirc;NCIA DE INTERESSE RECURSAL. BENESSE QUE SE PERPETUA NA INST&Acirc;NCIA POSTERIOR, SALVO REVOGA&Ccedil;&Atilde;O EXPRESSA DO JULGADOR. PRELIMINAR DE CONEX&Atilde;O. N&Atilde;O CONHECIMENTO. INOVA&Ccedil;&Atilde;O RECURSAL. PRELIMINARES DE INCOMPET&Ecirc;NCIA MATERIAL, INCOMPET&Ecirc;NCIA TERRITORIAL, ILEGITIMIDADE AD CAUSAM. N&Atilde;O ACOLHIMENTO.  PRELIMINAR DE CERCEAMENTO DE DEFESA EM RAZ&Atilde;O DA N&Atilde;O REALIZA&Ccedil;&Atilde;O DO PEDIDO DE PER&Iacute;CIA GRAFOT&Eacute;CNICA. N&Atilde;O ACOLHIMENTO. DEMANDA QUE J&Aacute; SE ENCONTRAVA APTA PARA JULGAMENTO &Agrave; &Eacute;POCA DA PROLA&Ccedil;&Atilde;O DA SENTEN&Ccedil;A, COM A REALIZA&Ccedil;&Atilde;O DE 05 (CINCO) AUDI&Ecirc;NCIAS CONCILIAT&Oacute;RIAS E/OU INSTRUT&Oacute;RIAS. A&Ccedil;&Atilde;O POSSESS&Oacute;RIA. IMPOSSIBILIDADE, IN CASU, DE DISCUSS&Atilde;O BASEADA EM EXCE&Ccedil;&Atilde;O DE DOM&Iacute;NIO. R&Eacute;US/RECORRENTES COM MERA PERMISS&Atilde;O CONDICIONADA AO CUMPRIMENTO DE REQUISITOS PARA MORADIA. CARACTERIZADA A AMEA&Ccedil;A DA POSSE EM DESFAVOR DO AUTOR/RECORRIDO. MANUTEN&Ccedil;&Atilde;O DO COMANDO PARA ABSTEN&Ccedil;&Atilde;O DA PR&Aacute;TICA DE ATOS QUE AMEACEM O ANIMUS POSSIDENDI. MAJORA&Ccedil;&Atilde;O DOS HONOR&Aacute;RIOS RECURSAIS. INTELIG&Ecirc;NCIA DO &sect; 11&ordm; DO ART. 85 DO CPC/15. CUSTAS E VERBAS HONOR&Aacute;RIAS SOB CONDI&Ccedil;&Atilde;O SUSPENSIVA EM RAZ&Atilde;O DA SITUA&Ccedil;&Atilde;O DE HIPOSSUFICI&Ecirc;NCIA FINANCEIRA DOS RECORRENTES. RECURSOS DE APELA&Ccedil;&Atilde;O CONHECIDOS EM PARTE E IMPR&Oacute;VIDOS. UNANIMIDADE.  <br><br>(N&uacute;mero do Processo: 0700024-69.2017.8.02.0095; Relator (a):&nbsp;Des. Celyrio Adamastor Ten&oacute;rio Accioly; Comarca:&nbsp;Foro de Macei&oacute;; &Oacute;rg&atilde;o julgador: 3&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 11/03/2021; Data de registro: 27/04/2021)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(18 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Esbulho / Turbação / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Celyrio Adamastor Tenório Accioly
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Maceió
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									11/03/2021
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									27/04/2021
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. AÇÃO DE INTERDITO PROIBITÓRIO. NATUREZA POSSESSÓRIA. BEM IMÓVEL. SENTENÇA DE PROCEDÊNCIA. PEDIDO DE CONCESSÃO/MANUTENÇÃO DA ASSISTÊNCIA JUDICIÁRIA GRATUITA. NÃO CONHECIMENTO DOS APELOS NESTE PONTO. AUSÊNCIA DE INTERESSE RECURSAL. BENESSE QUE SE PERPETUA NA INSTÂNCIA POSTERIOR, SALVO REVOGAÇÃO EXPRESSA DO JULGADOR. PRELIMINAR DE CONEXÃO. NÃO CONHECIMENTO. INOVAÇÃO RECURSAL.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. AÇÃO DE INTERDITO PROIBITÓRIO. NATUREZA POSSESSÓRIA. BEM IMÓVEL. SENTENÇA DE PROCEDÊNCIA. PEDIDO DE CONCESSÃO/MANUTENÇÃO DA ASSISTÊNCIA JUDICIÁRIA GRATUITA. NÃO CONHECIMENTO DOS APELOS NESTE PONTO. AUSÊNCIA DE INTERESSE RECURSAL. BENESSE QUE SE PERPETUA NA INSTÂNCIA POSTERIOR, SALVO REVOGAÇÃO EXPRESSA DO JULGADOR. PRELIMINAR DE CONEXÃO. NÃO CONHECIMENTO. INOVAÇÃO RECURSAL. PRELIMINARES DE INCOMPETÊNCIA MATERIAL, INCOMPETÊNCIA TERRITORIAL, ILEGITIMIDADE AD CAUSAM. NÃO ACOLHIMENTO.  PRELIMINAR DE CERCEAMENTO DE DEFESA EM RAZÃO DA NÃO REALIZAÇÃO DO PEDIDO DE PERÍCIA GRAFOTÉCNICA. NÃO ACOLHIMENTO. DEMANDA QUE JÁ SE ENCONTRAVA APTA PARA JULGAMENTO À ÉPOCA DA PROLAÇÃO DA SENTENÇA, COM A REALIZAÇÃO DE 05 (CINCO) AUDIÊNCIAS CONCILIATÓRIAS E/OU INSTRUTÓRIAS. AÇÃO POSSESSÓRIA. IMPOSSIBILIDADE, IN CASU, DE DISCUSSÃO BASEADA EM EXCEÇÃO DE DOMÍNIO. RÉUS/RECORRENTES COM MERA PERMISSÃO CONDICIONADA AO CUMPRIMENTO DE REQUISITOS PARA MORADIA. CARACTERIZADA A AMEAÇA DA POSSE EM DESFAVOR DO AUTOR/RECORRIDO. MANUTENÇÃO DO COMANDO PARA ABSTENÇÃO DA PRÁTICA DE ATOS QUE AMEACEM O ANIMUS POSSIDENDI. MAJORAÇÃO DOS HONORÁRIOS RECURSAIS. INTELIGÊNCIA DO § 11º DO ART. 85 DO CPC/15. CUSTAS E VERBAS HONORÁRIAS SOB CONDIÇÃO SUSPENSIVA EM RAZÃO DA SITUAÇÃO DE HIPOSSUFICIÊNCIA FINANCEIRA DOS RECORRENTES. RECURSOS DE APELAÇÃO CONHECIDOS EM PARTE E IMPRÓVIDOS. UNANIMIDADE.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="267931" cdForo="0" >
+										0700806-82.2015.8.02.0051
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="267931" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(267931);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_267931" style="display: none;" >
+	<div id="textAreaDados_267931" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O ESPECIAL URBANA. PROCESSO EXTINTO SEM RESOLU&Ccedil;&Atilde;O DO M&Eacute;RITO. APLICA&Ccedil;&Atilde;O DA TEORIA DA CAUSA MADURA. ENFITEUSE. POSSIBILIDADE DE TRANSFER&Ecirc;NCIA DO DOM&Iacute;NIO &Uacute;TIL. REQUISITOS DA USUCAPI&Atilde;O N&Atilde;O CONFIGURADOS. AUS&Ecirc;NCIA DE ANIMUS DOMINI. POSSE MANSA E PAC&Iacute;FICA N&Atilde;O CARACTERIZADA. DEMANDA REINTEGRAT&Oacute;RIA DE POSSE ANTERIOR QUE DISCUTE O DOM&Iacute;NIO SOBRE O MESMO IM&Oacute;VEL. POSS&Iacute;VEL COMODATO VERBAL. REQUISITOS PARA PRESCRI&Ccedil;&Atilde;O AQUISITIVA N&Atilde;O PREENCHIDOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO. REFORMA DA SENTEN&Ccedil;A EMPREENDIDA COM FUNDAMENTO NO ART. 1.013, &sect;3&ordm;, I, DO CPC. IMPROCED&Ecirc;NCIA DO PLEITO AUTORAL. FEITO ORIGIN&Aacute;RIO EXTINTO COM RESOLU&Ccedil;&Atilde;O DO M&Eacute;RITO. <br><br>(N&uacute;mero do Processo: 0700806-82.2015.8.02.0051; Relator (a):&nbsp;Des. Alcides Gusm&atilde;o da Silva; Comarca:&nbsp;Foro de Rio Largo; &Oacute;rg&atilde;o julgador: 3&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 30/03/2020; Data de registro: 31/03/2020)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Especial (Constitucional)
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alcides Gusmão da Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Largo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									30/03/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									31/03/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> ESPECIAL URBANA. PROCESSO EXTINTO SEM RESOLUÇÃO DO MÉRITO. APLICAÇÃO DA TEORIA DA CAUSA MADURA. ENFITEUSE. POSSIBILIDADE DE TRANSFERÊNCIA DO DOMÍNIO ÚTIL. REQUISITOS DA <em>USUCAPIÃO</em> NÃO CONFIGURADOS. AUSÊNCIA DE ANIMUS DOMINI. POSSE MANSA E PACÍFICA NÃO CARACTERIZADA. DEMANDA REINTEGRATÓRIA DE POSSE ANTERIOR QUE DISCUTE O DOMÍNIO SOBRE O MESMO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> ESPECIAL URBANA. PROCESSO EXTINTO SEM RESOLUÇÃO DO MÉRITO. APLICAÇÃO DA TEORIA DA CAUSA MADURA. ENFITEUSE. POSSIBILIDADE DE TRANSFERÊNCIA DO DOMÍNIO ÚTIL. REQUISITOS DA <em>USUCAPIÃO</em> NÃO CONFIGURADOS. AUSÊNCIA DE ANIMUS DOMINI. POSSE MANSA E PACÍFICA NÃO CARACTERIZADA. DEMANDA REINTEGRATÓRIA DE POSSE ANTERIOR QUE DISCUTE O DOMÍNIO SOBRE O MESMO IMÓVEL. POSSÍVEL COMODATO VERBAL. REQUISITOS PARA PRESCRIÇÃO AQUISITIVA NÃO PREENCHIDOS. RECURSO CONHECIDO E PARCIALMENTE PROVIDO. REFORMA DA SENTENÇA EMPREENDIDA COM FUNDAMENTO NO ART. 1.013, §3º, I, DO CPC. IMPROCEDÊNCIA DO PLEITO AUTORAL. FEITO ORIGINÁRIO EXTINTO COM RESOLUÇÃO DO MÉRITO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="231230" cdForo="0" >
+										0000386-71.2013.8.02.0057
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="231230" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(231230);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_231230" style="display: none;" >
+	<div id="textAreaDados_231230" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE REINTEGRA&Ccedil;&Atilde;O DE POSSE. SENTEN&Ccedil;A QUE JULGOU PROCEDENTE O PEDIDO INICIAL, DETERMINANDO A REINTEGRA&Ccedil;&Atilde;O DEFINITIVA DA AUTORA, ORA APELADA, NA POSSE DO IM&Oacute;VEL EM DEBATE, IMPONDO AO R&Eacute;U A OBRIGA&Ccedil;&Atilde;O DE N&Atilde;O ESBULHAR NOVAMENTE O IM&Oacute;VEL, SOB PENA DE IMPOSI&Ccedil;&Atilde;O DE MULTA DI&Aacute;RIA NO IMPORTE DE R$ 200,00 (DUZENTOS REAIS) POR ESBULHO PRATICADO. CONDENA&Ccedil;&Atilde;O DO DEMANDADO AO PAGAMENTO DE CUSTAS PROCESSUAIS E HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS ARBITRADOS EM 10% (DEZ POR CENTO) SOBRE O VALOR ATRIBU&Iacute;DO &Agrave; CAUSA, NA FORMA DO ART. 85, &sect;2&ordm;, I A IV DO CPC/15. PARTE R&Eacute;/APELANTE QUE PRETENDE A REFORMA DA SENTEN&Ccedil;A HOSTILIZADA PARA QUE SEJAM JULGADOS TOTALMENTE IMPROCEDENTES OS PEDIDOS INICIAIS. ALEGA&Ccedil;&Atilde;O DE QUE A AUTORA N&Atilde;O TERIA INTERESSE DE AGIR, COM BASE NA SUPOSTA FALTA DE PROVA DO ESBULHO, DA SUA DATA E DA CONTINUA&Ccedil;&Atilde;O DA POSSE. AFASTADA. REQUERIMENTO DE APLICA&Ccedil;&Atilde;O DO INSTITUTO DA ACCESSIO POSSESSIONIS, COM A FINALIDADE DE PERFAZER O TEMPO EXIGIDO PARA O RECONHECIMENTO DO DIREITO DO R&Eacute;U EM USUCAPIR O BEM OBJETO DA LIDE. N&Atilde;O ACOLHIDO. AUS&Ecirc;NCIA COMPROVA&Ccedil;&Atilde;O QUANTO &Agrave; EXIST&Ecirc;NCIA DE ANIMUS DOMINI DA POSSE ANTERIOR, EXERCIDA EM RAZ&Atilde;O DE CONTRATO VERBAL DE LOCA&Ccedil;&Atilde;O. IMPOSSIBILIDADE DE USUCAPI&Atilde;O URBANA PELO R&Eacute;U ANTE A AUS&Ecirc;NCIA DE TRANSCURSO DO PRAZO PRESCRICIONAL AQUISITIVO. DIREITO &Agrave; REINTEGRA&Ccedil;&Atilde;O DE POSSE PELA AUTORA CONFIGURADO. PREENCHIMENTO DOS REQUISITOS PREVISTOS NO ARTIGO 561 DO C&Oacute;DIGO DE PROCESSO CIVIL DE 2015. SENTEN&Ccedil;A MANTIDA. MAJORA&Ccedil;&Atilde;O DA VERBA HONOR&Aacute;RIA RECURSAL EM FAVOR DO CAUS&Iacute;DICO DA PARTE APELADA, NA FORMA DO ART. 85, &sect;&sect; 1&ordm;, 2&ordm; E 11, DO CPC/15, DE 10% (DEZ POR CENTO) PARA 12% (DOZE POR CENTO) SOBRE O VALOR ATUALIZADO DA CAUSA. RECURSO CONHECIDO E N&Atilde;O PROVIDO. DECIS&Atilde;O UN&Acirc;NIME. <br><br>(N&uacute;mero do Processo: 0000386-71.2013.8.02.0057; Relator (a):&nbsp;Des. F&aacute;bio Jos&eacute; Bittencourt Ara&uacute;jo; Comarca:&nbsp;Foro de Vi&ccedil;osa; &Oacute;rg&atilde;o julgador: 1&ordf; C&acirc;mara C&iacute;vel; Data do julgamento: 23/05/2019; Data de registro: 23/05/2019)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Esbulho / Turbação / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Fábio José Bittencourt Araújo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Viçosa
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									23/05/2019
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									23/05/2019
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DE REINTEGRAÇÃO DE POSSE. SENTENÇA QUE JULGOU PROCEDENTE O PEDIDO INICIAL, DETERMINANDO A REINTEGRAÇÃO DEFINITIVA DA AUTORA, ORA APELADA, NA POSSE DO IMÓVEL EM DEBATE, IMPONDO AO RÉU A OBRIGAÇÃO DE NÃO ESBULHAR NOVAMENTE O IMÓVEL, SOB PENA DE IMPOSIÇÃO DE MULTA DIÁRIA NO IMPORTE DE R$ 200,00 (DUZENTOS REAIS) POR ESBULHO PRATICADO. CONDENAÇÃO DO DEMANDADO AO PAGAMENTO DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DE REINTEGRAÇÃO DE POSSE. SENTENÇA QUE JULGOU PROCEDENTE O PEDIDO INICIAL, DETERMINANDO A REINTEGRAÇÃO DEFINITIVA DA AUTORA, ORA APELADA, NA POSSE DO IMÓVEL EM DEBATE, IMPONDO AO RÉU A OBRIGAÇÃO DE NÃO ESBULHAR NOVAMENTE O IMÓVEL, SOB PENA DE IMPOSIÇÃO DE MULTA DIÁRIA NO IMPORTE DE R$ 200,00 (DUZENTOS REAIS) POR ESBULHO PRATICADO. CONDENAÇÃO DO DEMANDADO AO PAGAMENTO DE CUSTAS PROCESSUAIS E HONORÁRIOS ADVOCATÍCIOS ARBITRADOS EM 10% (DEZ POR CENTO) SOBRE O VALOR ATRIBUÍDO À CAUSA, NA FORMA DO ART. 85, §2º, I A IV DO CPC/15. PARTE RÉ/APELANTE QUE PRETENDE A REFORMA DA SENTENÇA HOSTILIZADA PARA QUE SEJAM JULGADOS TOTALMENTE IMPROCEDENTES OS PEDIDOS INICIAIS. ALEGAÇÃO DE QUE A AUTORA NÃO TERIA INTERESSE DE AGIR, COM BASE NA SUPOSTA FALTA DE PROVA DO ESBULHO, DA SUA DATA E DA CONTINUAÇÃO DA POSSE. AFASTADA. REQUERIMENTO DE APLICAÇÃO DO INSTITUTO DA ACCESSIO POSSESSIONIS, COM A FINALIDADE DE PERFAZER O TEMPO EXIGIDO PARA O RECONHECIMENTO DO DIREITO DO RÉU EM USUCAPIR O BEM OBJETO DA LIDE. NÃO ACOLHIDO. AUSÊNCIA COMPROVAÇÃO QUANTO À EXISTÊNCIA DE ANIMUS DOMINI DA POSSE ANTERIOR, EXERCIDA EM RAZÃO DE CONTRATO VERBAL DE LOCAÇÃO. IMPOSSIBILIDADE DE <em>USUCAPIÃO</em> URBANA PELO RÉU ANTE A AUSÊNCIA DE TRANSCURSO DO PRAZO PRESCRICIONAL AQUISITIVO. DIREITO À REINTEGRAÇÃO DE POSSE PELA AUTORA CONFIGURADO. PREENCHIMENTO DOS REQUISITOS PREVISTOS NO ARTIGO 561 DO CÓDIGO DE PROCESSO CIVIL DE 2015. SENTENÇA MANTIDA. MAJORAÇÃO DA VERBA HONORÁRIA RECURSAL EM FAVOR DO CAUSÍDICO DA PARTE APELADA, NA FORMA DO ART. 85, §§ 1º, 2º E 11, DO CPC/15, DE 10% (DEZ POR CENTO) PARA 12% (DOZE POR CENTO) SOBRE O VALOR ATUALIZADO DA CAUSA. RECURSO CONHECIDO E NÃO PROVIDO. DECISÃO UNÂNIME.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="AÇÃO">
+									<label for="ckTermo1">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="APELAÇÃO">
+									<label for="ckTermo2">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="IMÓVEL">
+									<label for="ckTermo3">
+										IMÓVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="SENTENÇA">
+									<label for="ckTermo4">
+										SENTENÇA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="AUSÊNCIA">
+									<label for="ckTermo5">
+										AUSÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="CONHECIDO">
+									<label for="ckTermo6">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="CÍVEL">
+									<label for="ckTermo7">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="DIREITO">
+									<label for="ckTermo8">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="RECURSO">
+									<label for="ckTermo9">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="USUCAPIÃO">
+									<label for="ckTermo10">
+										USUCAPIÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="CIVIL">
+									<label for="ckTermo11">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="PARTE">
+									<label for="ckTermo12">
+										PARTE
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="PEDIDO">
+									<label for="ckTermo13">
+										PEDIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="POSSE">
+									<label for="ckTermo14">
+										POSSE
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="PROCESSO">
+									<label for="ckTermo15">
+										PROCESSO
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 7
+			</strong>
+			de 7
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjal/test_cjsg_contract.py
+++ b/tests/tjal/test_cjsg_contract.py
@@ -1,0 +1,86 @@
+"""Offline contract tests for TJAL cjsg.
+
+Mocks ``resultadoCompleta.do`` + ``trocaDePagina.do`` with captured samples
+(see ``tests/fixtures/capture/tjal.py``) and asserts the public DataFrame
+contract. Covers typical multi-page, single-page, and zero-result scenarios.
+"""
+import pandas as pd
+import responses
+from responses.matchers import query_param_matcher, urlencoded_params_matcher
+
+import juscraper as jus
+from tests._helpers import load_sample_bytes
+from tests.fixtures.capture._util import make_esaj_body
+
+BASE = "https://www2.tjal.jus.br/cjsg"
+CJSG_MIN_COLUMNS = {"processo", "cd_acordao", "cd_foro", "ementa"}
+
+
+def _add_post(pesquisa: str) -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjal", "cjsg/post_initial.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(make_esaj_body(pesquisa), allow_blank=True)],
+    )
+
+
+def _add_get(pagina: int, sample_path: str) -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjal", sample_path),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": str(pagina)})],
+    )
+
+
+@responses.activate
+def test_cjsg_typical_com_paginacao(tmp_path, mocker):
+    """Typical multi-page query returns a DataFrame with the minimum schema."""
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+    _add_get(2, "cjsg/results_normal_page_02.html")
+
+    df = jus.scraper("tjal", download_path=str(tmp_path)).cjsg(
+        "dano moral", paginas=range(1, 3)
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_single_page(tmp_path, mocker):
+    """Query whose hits fit in one page skips the per-page loop."""
+    mocker.patch("time.sleep")
+    _add_post("usucapiao extraordinario predio rural familia")
+    _add_get(1, "cjsg/single_page.html")
+
+    df = jus.scraper("tjal", download_path=str(tmp_path)).cjsg(
+        "usucapiao extraordinario predio rural familia", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_no_results(tmp_path, mocker):
+    """Zero-result query returns an empty DataFrame instead of raising."""
+    mocker.patch("time.sleep")
+    _add_post("juscraper_probe_zero_hits_xyzqwe")
+    _add_get(1, "cjsg/no_results.html")
+
+    df = jus.scraper("tjal", download_path=str(tmp_path)).cjsg(
+        "juscraper_probe_zero_hits_xyzqwe", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty

--- a/tests/tjam/samples/cjsg/no_results.html
+++ b/tests/tjam/samples/cjsg/no_results.html
@@ -1,0 +1,18 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(0)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="0" />
+
+
+
+			<div align="center" class="ementaClass" style="padding: 80px;">
+				<strong>
+					Não foi encontrado nenhum resultado correspondente à busca realizada.
+				</strong>
+			</div>

--- a/tests/tjam/samples/cjsg/post_initial.html
+++ b/tests/tjam/samples/cjsg/post_initial.html
@@ -1,0 +1,6543 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Nodo 6 -->
+
+<html>
+	<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+
+
+
+
+
+
+
+
+
+
+
+	<script language="javascript" type="text/JavaScript" src="https://consultasaj.tjam.jus.br/sajcas/verificarLogin.js?script=1776718196006"></script>
+
+	<script language="javascript">
+		if(window.sajcas && window.sajcas.usuarioLogadoNoCasServer) {
+			var urlRetornoSistema = 'https://consultasaj.tjam.jus.br/cjsg/consultaCompleta.do';
+			if(urlRetornoSistema === '') {
+				urlRetornoSistema = window.location.href;
+			}
+
+			if(urlRetornoSistema.lastIndexOf('?') != -1) {
+				urlRetornoSistema += '&';
+			} else {
+				urlRetornoSistema += '?';
+			}
+			urlRetornoSistema+= 'gateway=true';
+			window.location.href = urlRetornoSistema;
+		}
+	</script>
+
+
+
+
+
+
+
+
+
+
+	<title>Consulta de Jurisprudência do Segundo Grau</title>
+	<script>
+		window.saj = window.saj || {};
+		window.saj.env = window.saj.env || {};
+		window.saj.env.root = '/cjsg';
+		window.saj.env.css = '/cjsg/css';
+		window.saj.env.js = '/cjsg/js';
+		window.saj.env.imagens = '/cjsg/imagens';
+		window.saj.env.cliente = 'AM';
+	</script>
+ 	<script src="/cjsg/js/jquery/jquery.min.js?n=b5d78a2c-2a08-468c-99ae-3769404dce38"></script>
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/saj/saj-web-2.2.41-4.js?n=6951c1f3-a82b-4673-9bb6-d52002a59308"></script>
+
+
+ 	<script>var localeJS = "pt_BR"; </script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMsg.js"></script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMap_pt.js"></script>
+	<script src="/cjsg/js/jquery/jquery.browser.min.js?n=74a8f43c-7969-44ab-8fbf-ca28740913d2"></script>
+ 	<script src="/cjsg/js/spw/spwConcatenado.js?n=27c52ebe-9241-4c43-a21b-3ddbc0b7d1df"></script>
+ 	<link href="/cjsg/css/spw/spwConcatenado.css" rel="stylesheet" type="text/css" />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+<meta http-equiv="pragma" content="no-cache"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<meta http-equiv="expires" content="0"/>
+
+<link href="https://consultasaj.tjam.jus.br/esaj/tema/padrao/css/esajComum.css" rel="stylesheet" type="text/css" />
+<link href="https://consultasaj.tjam.jus.br/esaj/tema/padrao/css/esajLayout.css" rel="stylesheet" type="text/css" />
+<link href="https://consultasaj.tjam.jus.br/esaj/tema/padrao/clientes/AM/css/esajLayoutAM.css" rel="stylesheet" type="text/css" />
+
+<style type="text/css">
+<!--
+/* botao default means o mais claro, que seria o "botï¿½o principal" */
+.spwBotaoDefault, .spwBotaoDefault-o {
+	background-image: url(https://consultasaj.tjam.jus.br/esaj/tema/padrao/clientes/AM/imagens/layout/fundoBotaoDefault.gif);
+}
+/* o botao secundario, menos provavel de ser clicado, mais escuro */
+.spwBotao, .spwBotao-o {
+	background-image: url(https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/fundoBotao.gif);
+}
+-->
+</style>
+
+
+<script language="javascript" type="text/JavaScript" src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/js/menu.js?n=2553626853"></script>
+
+<link rel="shortcut icon" href="https://consultasaj.tjam.jus.br/esaj/tema/padrao/clientes/AM/imagens/favicon.ico" type="image/x-icon" />
+
+
+
+
+<script>
+    var dict = {
+        'certificado.tituloCertificadoDigital': 'Certificado digital',
+        'certificado.msgCarregandoCertificado': 'Carregando certificados...',
+        'certificado.msgNenhumCertificadoEncontrado': 'Nenhum certificado encontrado',
+        'certificado.msgErroCarregarCertificado': 'Erro ao carregar certificados',
+        'certificado.msgCertificadoExpirado': '[Expirado]',
+        'certificado.msgCertificadoNaoValido': '[Ainda não válido]',
+        'certificado.msgCertificadoNaoIcpBrasil': '[Não ICP-Brasil]',
+        'certificado.tituloProblemasAoAssinar': 'Falha de comunicação com o dispositivo de assinatura digital',
+
+        'label.contato': 'Contato',
+        'label.identificarSe': 'Identificar-se ',
+
+        'mensagem.aguarde': 'Por favor, aguarde.',
+        'mensagem.paginaNaoCarregada': 'Não foi possível carregar a página.',
+        'mensagem.marcarLido': 'Marcar como lido',
+        'mensagem.registrosSelecionados': 'Registros selecionados',
+        'mensagem.registroJaSelecionado': 'Este registro já está selecionado',
+
+        'mensagem.data.invalida': 'A data digitada é inválida.',
+        'mensagem.data.anoInvalido': 'O ano informado deve ser maior que',
+        'mensagem.data.mesInvalido': 'O mês não pode ser maior que 12.',
+        'mensagem.data.mes': 'O mês',
+        'mensagem.data.mesMaior29dias': 'não pode ter mais que 29 dias.',
+        'mensagem.data.mesMaior28dias': 'não pode ter mais que 28 dias.',
+        'mensagem.data.mesMaior31dias': 'não pode ter mais que 31 dias.',
+        'mensagem.data.mesMaior30dias': 'não pode ter mais que 30 dias.',
+
+        'mensagem.email.invalido': 'O formato do endereço de e-mail não é válido. Verifique se ele tem o formato "usuario@dominio".',
+        'mensagem.email.caracteresInvalidos': 'O endereço de e-mail possui caracteres inválidos',
+        'mensagem.email.usuarioInvalido': 'O formato do usuário informado no endereço de e-mail não é válido.',
+        'mensagem.email.ipInvalido': 'O endereço IP informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioInvalido': 'O formato do domínio informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioIncompleto': 'O domínio informado no endereço de e-mail deve possuir pelo menos duas partes. Por exemplo: "usuario@empresa.com.br".',
+
+        'mensagem.texto.tamanhoInvalido': 'O tamanho do texto digitado é maior do que o tamanho permitido. Tamanho permitido:',
+        'mensagem.texto.caracter': 'O caracter',
+        'mensagem.texto.caracterPosicaoInvalida': 'não está permitido na posição',
+
+        'mensagem.numero.numeroInvalido': 'O valor digitado não é um número válido.',
+        'mensagem.numero.numeroNaoPodeCasasDecimais': 'O número não pode conter casas decimais',
+        'mensagem.numero.numeroCasaDecimaisInvalidas': 'O número de casas decimais é inválido. O número pode conter apenas',
+        'mensagem.numero.casaDecimais': 'casas decimais',
+        'mensagem.numero.numeroInteiroInvalido': 'O número de dígitos inteiros é inválido. O número pode conter apenas',
+        'mensagem.numero.digitosInteiros': 'dígitos inteiros',
+        'mensagem.numero.numeroTamanhoInvalido': 'O número digitado não pode ser maior que',
+        'mensagem.numero.numeroZeroInvalido': 'O número digitado deve ser diferente de zero.'
+    }
+</script>
+
+
+
+
+
+
+
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/cjsg-2.2.5-0.js?n=260410155"></script>
+ 	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/AM/cjsg.css" />
+	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/AM/link.css" />
+
+
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/spw/spwTab.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-popup-modal.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-tree.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/cjsg.css" />
+
+
+		<script type="text/JavaScript" src="/cjsg/js/jquery/jquery.blockUI.min.js?n=c5ffc7ba-4326-4414-b73c-417e0a6d4191"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tooltip.js?n=df275a5c-c641-4c60-a60c-034d4d36a519"></script>
+		<script type="text/JavaScript" src="/cjsg/js/spw/spwTab.js?n=2803951349"></script>
+		<script type="text/javascript" src="/cjsg/js/saj/saj-popup-modal-1.0.0-1.js?n=ad7b132a-be56-48a3-a7dc-68ed4400000d"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-popup.js?n=2538966893"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tree-2.5.1-1.js?n=13698285-becd-4e70-9ec7-27800642f308"></script>
+
+		<!-- remover valor da versao na proxima versao do sistema -->
+		<script type="text/JavaScript" src="/cjsg/js/filtrosLaterais.js?n=2874483102?c=123"></script>
+		<script type="text/JavaScript" src="/cjsg/jsp/completa/consultaCompleta.js?n=769933514"></script>
+	</head>
+
+	<body style="margin: 0px;">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoCliente" summary=" ">
+	<tr>
+		<td><a href="http://www.tjam.jus.br"><img src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/clientes/AM/imagens/layout/cabecalhoLogo.jpg" width="271" height="57" alt="Tribunal de Justiça do Estados do Amazonas" /></a></td>
+		<td align="right" valign="top"><img src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/clientes/AM/imagens/layout/cabecalhoImagem.jpg" alt=" " width="449" height="57" /></td>
+	</tr>
+</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- cabecalho e-Saj -->
+<table width="100%" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoServico" summary=" ">
+	<tr>
+		<td class="esajCelulaCabecalhoServicoLogo">
+
+
+
+
+<a href="https://consultasaj.tjam.jus.br/esaj/redirecionarNovoEsaj.do"><img src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/eSajServico.gif" title="Voltar para página inicial do e-SAJ" alt="Voltar para página inicial do e-SAJ" width="255" height="53" border="0" /></a><img src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/eSajServicoInf.gif" alt=" " width="255" height="28" border="0" />
+</td>
+		<td class="esajCelulaCabecalhoServicoMenu">
+		    <table width="100%" border="0" cellpadding="0" cellspacing="0" summary=" ">
+				<tr>
+					<td align="right">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Devido ao alinhamento inline das imagens, elas nÃ£o podem ter nenhum tipo de espaÃ§amento entre elas, portanto Ã© necessÃ¡rio finalizar a linha iniciando um comentÃ¡rio e fechar o comentÃ¡rio imediatamente antes da abertura da nova tag-->
+<img height="24" width="47" alt=" " src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/inicioMenuSup.jpg"/><a href="https://consultasaj.tjam.jus.br/caixapostal"><!--
+
+    --><img height="24" width="83" border="0" alt="Caixa Postal" src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/caixaPostal.gif"/></a><!--
+    --><img height="24" width="4" alt=" " src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/menuSeparador.jpg"/><a href="https://consultasaj.tjam.jus.br/esaj/cadastro.do"><!--
+
+--><img src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/cadastro.gif" alt="Cadastro" width="81" height="24" border="0" /></a><!--
+
+    --><img height="24" width="4" alt=" " src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/menuSeparador.jpg"/><a id="linkContato" href="#"><!--
+    --><img height="24" width="68" border="0" alt="Contato" src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/contato.gif"/></a><!--
+
+
+    --><img height="24" width="4" alt=" " src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/menuSeparador.jpg"/><a target="blank" href="https://consultasaj.tjam.jus.br/WebHelp/"><!--
+    --><img height="24" width="61" border="0" alt="Ajuda do e-Saj" src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/ajuda.gif"/></a><!--
+
+
+-->
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaIdentificacaoServico" >
+
+
+
+
+<style>
+
+    td.esajCelulaIdentificacao, td.esajCelulaIdentificacaoServico {
+        position: relative;
+    }
+
+    button.escolhaBeta {
+        border: 0;
+        background: #0078D7;
+        color: #fff;
+        margin-right: 5px;
+        font-family: verdana;
+        font-size: 12px;
+        height: 27px;
+        line-height: 14px;
+        border-radius: 0;
+        text-shadow: 1px 1px 1px #797979;
+        position: absolute;
+        top: 30px;
+        right: 3px;
+        padding: 7px 12px;
+        cursor: pointer;
+    }
+
+    button.escolhaBeta:hover {
+        background-color: #0b5c9c;
+    }
+</style>
+
+<span id="identificacao"></span>
+
+<button style="display: none" class="escolhaBeta"></button>
+
+
+
+
+
+
+        <script language="javascript" type="text/JavaScript" src="https://consultasaj.tjam.jus.br/sajcas/conteudoIdentificacao?script=1776674477795"></script>
+
+
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaCabecalhoServicoCaminho" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<a href="" class="esajCaminhoLink"></a>
+
+ &gt;
+
+
+<a href="https://consultasaj.tjam.jus.br/esaj/portal.do?servico=740000" class="esajCaminhoLink">Bem-vindo</a>
+
+ &gt;
+
+
+<a href="https://consultasaj.tjam.jus.br/esaj/portal.do?servico=190090" class="esajCaminhoLink">Consultas</a>
+
+ &gt;
+
+
+<a href="https://consultasaj.tjam.jus.br/esaj/portal.do?servico=789900" class="esajCaminhoLink">Jurisprudência</a>
+
+ &gt;
+
+
+<a href="https://consultasaj.tjam.jus.br/esaj/portal.do?servico=780000" class="esajCaminhoLink">Consulta de Jurisprudências do TJ, T.Recursais,J.Especiais e Conselho da Magistratura - Digital</a>
+
+ &gt;
+
+
+
+Consulta Completa
+</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+<!-- CONTEUDO -->
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaTitulo">
+	<tr>
+		<td class="esajCelulaMenuSuspenso">
+		<a href="#" onclick="return showMenuSuspenso()"><img src="https://consultasaj.tjam.jus.br/esaj/tema/padrao/imagens/layout/menuSuspenso.gif" alt="Menu de servi&ccedil;os" width="243" height="21" style="display:block" /></a>
+		<div id="layerMenu" style="display:none">
+
+
+<!-- MENU -->
+<ul id="esajMenuArea">
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Consultas</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/cpopg/">Consulta de Processos do 1ºGrau</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/cposgcr/">Consulta de Processos do 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/esaj/portal.do?servico=190500">Consulta de Ordem de Processos</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/pauta-julgamento/consulta">Consulta da Pauta de Julgamento 2º Grau - Digital</a></li>
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Jurisprudência</a>
+<ul>
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Consulta de Jurisprudências do TJ, T.Recursais,J.Especiais e Conselho da Magistratura - Digital</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/cjsg/consultaSimples.do">Consulta Simples</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/cjsg/consultaCompleta.do">Consulta Completa</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/cdje">Diário da Justiça Eletrônico</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/temas/consulta">Consulta de Temas de Repercussão Geral e Casos Repetitivos</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Recolhimento de Custas</a>
+<ul>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas Processuais, Despesas e Fianças de Primeiro Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/ccpweb/abrirConsultaCustas.do">Consulta de Custas</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas Processuais, Despesas e Fianças de Segundo Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/ccpweb/abrirConsultaCustasSg.do">Consulta de Custas</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/petpg/abrirConsultaPeticoes.do">Consulta de Petições de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/petcr/abrirConsultaPeticoes.do">Consulta de Petições de 2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Push - Acompanhar Processo Judicial</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/push">Push - Primeiro Grau</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/pushsg5">Push - Segundo Grau Digital</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Intimação e Citação Eletrônica</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/intimacoesweb/abrirConsultaAtosNaoRecebidos.do">Recebimento de Intimações Eletrônicas</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/intimacoesweb/abrirConsultaAtosRecebidos.do">Consulta de Intimações Recebidas</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Certidões</a>
+<ul>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Certidões de 1ºgrau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/sco/abrirDownload.do">Download de Certidão</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/sco/abrirConferencia.do">Conferência de Certidão</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Certidões de 2º grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/scosg/abrirDownload.do">Download de Certidão de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/scosg/abrirConferencia.do">Conferência de Certidão de 2º Grau</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Conferência de Documento</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/pastadigital/pg/abrirConferenciaDocumento.do">Conferência de Documento Digital do 1ºGrau</a></li>
+  <li class="esajMenuItem"><a href="https://consultasaj.tjam.jus.br/pastadigital/sg/abrirConferenciaDocumento.do">Conferência de Documento Digital do 2ºGrau - Digital</a></li>
+</ul>
+  </li>
+</ul>
+
+		</div>
+		</td>
+		<td class="esajCelulaTituloServico"><h1 class="esajTituloPagina">Consulta Completa</h1></td>
+	</tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" summary=" ">
+	<tr>
+		<td class="esajCelulaConteudoServico" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <span class="esajTituloOrientacoes">Orientações</span>
+
+
+
+
+            <ul class="esajUlOrientacoes" id="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<li>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Para detalhes sobre cada campo de busca, selecione o campo específico.
+
+
+
+	</li>
+
+
+
+
+            </ul>
+
+
+
+
+    <br>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<form name="consultaCompletaForm" method="post" action="/cjsg/resultadoCompleta.do;jsessionid=2E9BDB066F4E0F604380F84B395550B1.cjsg3" autocomplete="off" enctype="" onsubmit="return applySubmit(this, eval('function spwSubmit(t, e){decodificaInputMulSelOnSubmit();if (!IS_enableSubmit) return false; return BENV_isCamposValidos(t); } spwSubmit(this, event);'));" id="" target="">
+	<input type="hidden" name="conversationId" value="">
+
+
+
+
+
+<div style="display: none;">
+
+	<div id="inteiroTeor">
+		<b>"Pesquisa Livre"</b> <br />Busca acórdãos que contenham as <br /> palavras/expressões desejadas no seu inteiro teor.
+	</div>
+
+	<div id="ementa">
+		<b>"Ementa"</b><br>Busca acórdaos que contenham as palavras/express&otilde;es<br />desejadas na ementa do acórdão.
+	</div>
+
+	<div id="classesTooltip">
+		<b>"Classe"</b><br />Busca decisões que sejam de uma determinada classe processual.<br> Exemplo: Ação Penal.
+	</div>
+
+	<div id="assuntosTooltip">
+		<b>"Assuntos"</b><br />Busca acórdãos que sejam de um determinado assunto.
+	</div>
+
+	<div id="secoesTooltip">
+		<b>"Orgão julgadores"</b><br /> Busca acórdãos que sejam de uma determinado orgão julgador.
+	</div>
+
+	<div id="dtJulgamentoInicioTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtJulgamentoFimTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoInicioTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoFimTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroInicioTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroFimTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="orgaoJulgador">
+		<b>"Órgão Julgador"</b><br />Busca acórdãos que sejam de um determinado órgão julgador.<br />Exemplo: 10ª Câmara de Direito Público.
+	</div>
+
+	<div id="comarcaTooltip">
+		<b>"Comarca"</b><br>Busca acórdãos que sejam de uma determinada comarca de origem.<br> Exemplo: São Paulo.
+	</div>
+
+	<div id="agenteTooltip">
+		<b>"Relator"</b><br>Busca acórdãos que sejam de um determinado relator.
+	</div>
+
+	<div id="juizProlatorTooltip">
+		<b>"Juiz prolator"</b><br>Busca acórdãos para o juiz prolator selecionado.<br />
+	</div>
+
+	<div id="nuRegistro">
+		<b>&quot;N&uacute;mero do Registro&quot;</b><br>Busca acórdãos que tenham sido registrados<br />com o número informado.
+	</div>
+
+	<div id="nuProcOrigem">
+		<b>"Número do recurso"</b><br/>Busca acórdãos que se referem ao<br/>número de recurso informado.
+	</div>
+
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Consulta Completa
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaInteiroTeor';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="top">
+
+
+
+
+				<label for="iddados.buscaInteiroTeor" class="" style="float:left;font-weight:bold;margin-top:3px;">Pesquisa livre</label><div style="text-align:right;font-weight:bold;margin-top:3px;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="top">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaInteiroTeor" size="100" value="dano moral" formatType="TEXT" formato="120" obrigatorio="" rotulo="Pesquisa livre" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaInteiroTeor" title="" alt="">
+
+
+
+
+
+
+
+						<div class="botoesOperadores" style="margin-top: 3px;">
+							<input type="button" value=" E " name="E" />
+							<input type="button" value=" OU " name="OU" />
+							<input type="button" value=" N&Atilde;O " name="NAO" />
+							<input type="button" value='"&nbsp;&nbsp;"' name="ASP" />
+							<a style="font-size: 11px; font-weight: bold; padding-left: 10px; padding-right: 2px;" href="https://consultasaj.tjam.jus.br/WebHelp//#id_operadores_logicos.htm" target="_blank">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="">
+
+
+
+	<span id="">Como utilizar os filtros</span>
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+							</a>
+							<input type="checkbox" name="dados.pesquisarComSinonimos" value="S" checked="checked" uncheckedValue="N"  onclick="CH_updateHiddenValue(this);" style="width: 10px" id="checkBoxSinonimos"><input type="hidden" value="S" name="dados.pesquisarComSinonimos" inputCheckBox="true">
+							<label for="checkBoxSinonimos" >
+								Pesquisar por sinônimos
+							</label>
+							&nbsp;&nbsp;&nbsp;
+						</div>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Pesquisa por campos específicos
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaEmenta';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.buscaEmenta" class="" style="float:left;font-weight:bold;">Ementa</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaEmenta" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Ementa" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaEmenta" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuProcOrigem';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.nuProcOrigem" class="" style="float:left;font-weight:bold;">Número do recurso</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuProcOrigem" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do recurso" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuProcOrigem" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuRegistro';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="iddados.nuRegistro" class="" style="float:left;font-weight:bold;">Número do registro</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuRegistro" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do registro" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuRegistro" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.relator" class="" style="float:left;font-weight:bold;">Relator(a)</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var agenteNomeCamposArray = new Array();
+ agenteNomeCamposArray[0] = 'codigoCr';
+ agenteNomeCamposArray[1] = 'codigoTr';
+ agenteNomeCamposArray[2] = 'nmAgente';
+ var codigoCrNomeCamposArray = agenteNomeCamposArray;
+ var codigoTrNomeCamposArray = agenteNomeCamposArray;
+ var nmAgenteNomeCamposArray = agenteNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="agente" idPai="null" filtroPai="null" url="jsp/search/searchAgente.jsp" input-select="agente" property="dados.agentes" name="codigoCr" title="Relatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="agenteSelectedEntitiesList"  value="" id="agenteSelectedEntitiesList" />
+<input type="hidden" name="contadoragente"  value="0" id="contadoragente" />
+<input type="hidden" name="contadorMaioragente"  value="0" id="contadorMaioragente" />
+    <tr>
+								<td >
+            <input type="text" name="codigoCr" id="codigoCr" bindingReference="codigoCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoTr" id="codigoTr" bindingReference="codigoTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoTr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="nmAgente" id="nmAgente" bindingReference="nmAgente" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'nmAgente', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="agente" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr','','/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('agente');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="agenteLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.juizProlator" class="" style="float:left;font-weight:bold;">Magistrado prolator</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var juizProlatorNomeCamposArray = new Array();
+ juizProlatorNomeCamposArray[0] = 'codigoJuizCr';
+ juizProlatorNomeCamposArray[1] = 'codigoJuizTr';
+ juizProlatorNomeCamposArray[2] = 'nmJuiz';
+ var codigoJuizCrNomeCamposArray = juizProlatorNomeCamposArray;
+ var codigoJuizTrNomeCamposArray = juizProlatorNomeCamposArray;
+ var nmJuizNomeCamposArray = juizProlatorNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="juizProlator" idPai="null" filtroPai="null" url="jsp/search/searchJuizProlator.jsp" input-select="juizProlator" property="dados.juizesProlatores" name="codigoJuizCr" title="Juizes prolatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="juizProlatorSelectedEntitiesList"  value="" id="juizProlatorSelectedEntitiesList" />
+<input type="hidden" name="contadorjuizProlator"  value="0" id="contadorjuizProlator" />
+<input type="hidden" name="contadorMaiorjuizProlator"  value="0" id="contadorMaiorjuizProlator" />
+    <tr>
+								<td >
+            <input type="text" name="codigoJuizCr" id="codigoJuizCr" bindingReference="codigoJuizCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoJuizTr" id="codigoJuizTr" bindingReference="codigoJuizTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizTr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="nmJuiz" id="nmJuiz" bindingReference="nmJuiz" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'nmJuiz', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="juizProlator" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr','','/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('juizProlator');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="juizLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="classes_selectionText" class="" style="float:left;font-weight:bold;">Classe</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="classesId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="classesTreeSelection.values" value="" id="classes">
+						<span id="classes_action" value="/cjsg/classesTreeSelect.do" />
+
+						<input type="text" name="classesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'classes',
+								treeSelectId: 'classesId',
+								url: '/cjsg/classesTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="classes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_classes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_classes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'classes',
+				treeSelectId: 'classesId',
+				url: '/cjsg/classesTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_classes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_classes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="assuntos_selectionText" class="" style="float:left;font-weight:bold;">Assunto</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="assuntosId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="assuntosTreeSelection.values" value="" id="assuntos">
+						<span id="assuntos_action" value="/cjsg/assuntosTreeSelect.do" />
+
+						<input type="text" name="assuntosTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'assuntos',
+								treeSelectId: 'assuntosId',
+								url: '/cjsg/assuntosTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="assuntos_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_assuntos"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_assuntos"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'assuntos',
+				treeSelectId: 'assuntosId',
+				url: '/cjsg/assuntosTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_assuntos').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_assuntos').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="secoes_selectionText" class="" style="float:left;font-weight:bold;">Órgão julgador</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="secaoId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="secoesTreeSelection.values" value="" id="secoes">
+						<span id="secoes_action" value="/cjsg/secaoTreeSelect.do" />
+
+						<input type="text" name="secoesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'secoes',
+								treeSelectId: 'secaoId',
+								url: '/cjsg/secaoTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="secoes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_secoes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_secoes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'secoes',
+				treeSelectId: 'secaoId',
+				url: '/cjsg/secaoTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_secoes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_secoes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtJulgamento" class="" style="float:left;font-weight:bold;">Data do julgamento</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoInicio">
+
+
+
+	<input type="text" name="dados.dtJulgamentoInicio" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoFim">
+
+
+
+	<input type="text" name="dados.dtJulgamentoFim" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							<span id="dtJulgamentoFormato">
+								(dd/mm/aaaa)
+							</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtPublicacao" class="" style="float:left;font-weight:bold;">Data de publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoInicio">
+
+
+
+	<input type="text" name="dados.dtPublicacaoInicio" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoFim">
+
+
+
+	<input type="text" name="dados.dtPublicacaoFim" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						<span id="dtPublicacaoFormato">
+							(dd/mm/aaaa)
+						</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.origem" class="" style="float:left;font-weight:bold;">Origem</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<input type="checkbox" name="dados.origensSelecionadas" value="T" checked="checked" id="origem2grau">
+						<label for="origem2grau">
+							2° grau
+						</label>
+						<input type="checkbox" name="dados.origensSelecionadas" value="R" id="origemRecursal">
+						<label for="origemRecursal">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Colégios Recursais
+
+
+						</label>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.tpDecisao" class="" style="float:left;font-weight:bold;">Tipo de Publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<div id="linhaTipoDecisao">
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="A" checked="checked" id="Acheckbox">
+								<label for="Acheckbox">
+									Acórdãos
+								</label>
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="H" id="Hcheckbox">
+								<label for="Hcheckbox">
+									Homologações de Acordo
+								</label>
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="D" id="Dcheckbox">
+								<label for="Dcheckbox">
+									Decisões Monocráticas
+								</label>
+
+						</div>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="150" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.ordenar" class="" style="float:left;font-weight:bold;">Ordenar por</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenardtPublicacao">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenardtPublicacao" value="dtPublicacao" style="vertical-align:middle;" onclick="" class="" title=""  checked/>
+			Data de publicação
+		</label>
+
+	</span>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenarRelevancia">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenarRelevancia" value="relevancia" style="vertical-align:middle;" onclick="" class="" title=""  />
+			Relevância
+		</label>
+
+	</span>
+
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<table id="" class="secaoBotoesBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+		<tr>
+
+ 				<td width="150">&nbsp;</td>
+
+			<td align="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="submit" name="pbSubmit" value="Pesquisar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotaoDefault " id="pbSubmit">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="button" name="pbLimpar" value="Limpar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotao " id="pbLimpar">
+
+
+
+			</td>
+		</tr>
+	</table>
+
+
+
+
+
+
+</form>
+
+
+
+
+			<!-- Resultado consulta -->
+
+				<!-- Tabs -->
+				<div id="tabs">
+					<ul>
+
+							<li tipo="A" >
+								<a href="A">
+									<span  id="nomeAba-A" >Acórdãos(54334)</span>
+									<input id="totalResultadoAba-A" type="hidden" value="54334" />
+								</a>
+							</li>
+
+					</ul>
+
+						<div id="tabs-A">
+
+
+
+
+
+
+
+
+
+
+<div id="paginacaoSuperior-A" style="padding-bottom: 15px;" >
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 10
+			</strong>
+			de 54334
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr>
+		<td height="1" valign="top" id="tdResultados" width="*" >
+			<div id="divDadosResultado-A" >
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363939" cdForo="0" >
+										0708349-62.2020.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363939" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363939);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363939" style="display: none;" >
+	<div id="textAreaDados_3363939" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. DIREITO CIVIL. DIREITO CONSUMERISTA. PLANO DE SA&Uacute;DE. RECUSA DE ATENDIMENTO NA REDE CREDENCIADA. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. DANO MORAL ARBITRADO EM FAVOR DO MENOR AUTOR-APELANTE E DE SUA GENITORA. RECURSO DE APELA&Ccedil;&Atilde;O MANEJADO APENAS PELO MENOR. MAJORA&Ccedil;&Atilde;O. POSSIBILIDADE. PRIMEIRO RECURSO CONHECIDO E N&Atilde;O PROVIDO. SEGUNDO RECURSO CONHECIDO E PROVIDO. SENTEN&Ccedil;A REFORMADA. 1. O cerne da controv&eacute;rsia cinge-se em apurar se houve falha na presta&ccedil;&atilde;o de servi&ccedil;os em raz&atilde;o da negativa de atendimento aos autores-apelantes na rede credenciada da operadora r&eacute; no  dia 22/11/2019 e, em caso positivo, a exist&ecirc;ncia da obriga&ccedil;&atilde;o em compensa-los a t&iacute;tulo de danos morais; 2.  A rela&ccedil;&atilde;o entre as partes enquadra-se perfeitamente em uma t&iacute;pica rela&ccedil;&atilde;o de consumo, devendo ser aplicado o C&oacute;digo de Prote&ccedil;&atilde;o e Defesa do Consumidor - CDC e o seu regramento, pois tanto o conceito de consumidor, quanto de fornecedor est&atilde;o presentes; 3.  Muito embora a r&eacute;-apelante negue os fatos narrados ao longo da peti&ccedil;&atilde;o inicial, &eacute; certo que o contexto probat&oacute;rio existente nos autos com eles corrobora, tendo em vista que os autores-apelantes a eles aportaram o registro de conversa via Whatsapp tendo como interlocutor preposto da operadora r&eacute;. Nesse di&aacute;logo est&aacute; suficientemente claro que o nome do autor-apelante Pedro Rafael da Silva Sales ainda n&atilde;o constava do sistema de benefici&aacute;rios no dia 23/11/2019, isto &eacute;, um dia ap&oacute;s os fatos narrados na inicial; 4. H&aacute; nos autos, ainda, ficha de atendimento do autor-apelante no Pronto Socorro da Crian&ccedil;a da Zona Sul de Manaus, unidade integrante do SUS, indicando justamente a data de 22/11/2019, quando teria havido a recusa de atendimento do paciente na rede credenciada &agrave; operadora r&eacute;; 5. A recusa de atendimento na rede credenciada, a um s&oacute; tempo, prolongou o estado do sofrimento do paciente e a ang&uacute;stia de sua m&atilde;e por se ver incapaz de adotar medidas para cura-lo, caracterizando o dano moral; 6. Considerando que o paciente cujo atendimento foi negado trata-se de crian&ccedil;a, deve-se majorar o valor dos danos morais de R$ 5.000,00 (cinco mil reais) para R$ 6.000,00 (seis mil reais); 7. Primeiro recurso conhecido e n&atilde;o provido. Segundo recurso conhecido e provido. Senten&ccedil;a reformada. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0708349-62.2020.8.04.0001; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 25/11/2024; Data de registro: 18/09/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(42 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Material
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									25/11/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									18/09/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. DIREITO CIVIL. DIREITO CONSUMERISTA. PLANO DE SAÚDE. RECUSA DE ATENDIMENTO NA REDE CREDENCIADA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> ARBITRADO EM FAVOR DO MENOR AUTOR-APELANTE E DE SUA GENITORA. RECURSO DE APELAÇÃO MANEJADO APENAS PELO MENOR. MAJORAÇÃO. POSSIBILIDADE. PRIMEIRO RECURSO CONHECIDO E NÃO PROVIDO. SEGUNDO RECURSO CONHECIDO E PROVIDO. SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. DIREITO CIVIL. DIREITO CONSUMERISTA. PLANO DE SAÚDE. RECUSA DE ATENDIMENTO NA REDE CREDENCIADA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> ARBITRADO EM FAVOR DO MENOR AUTOR-APELANTE E DE SUA GENITORA. RECURSO DE APELAÇÃO MANEJADO APENAS PELO MENOR. MAJORAÇÃO. POSSIBILIDADE. PRIMEIRO RECURSO CONHECIDO E NÃO PROVIDO. SEGUNDO RECURSO CONHECIDO E PROVIDO. SENTENÇA REFORMADA. 1. O cerne da controvérsia cinge-se em apurar se houve falha na prestação de serviços em razão da negativa de atendimento aos autores-apelantes na rede credenciada da operadora ré no  dia 22/11/2019 e, em caso positivo, a existência da obrigação em compensa-los a título de <em>danos</em> <em>morais</em>; 2.  A relação entre as partes enquadra-se perfeitamente em uma típica relação de consumo, devendo ser aplicado o Código de Proteção e Defesa do Consumidor - CDC e o seu regramento, pois tanto o conceito de consumidor, quanto de fornecedor estão presentes; 3.  Muito embora a ré-apelante negue os fatos narrados ao longo da petição inicial, é certo que o contexto probatório existente nos autos com eles corrobora, tendo em vista que os autores-apelantes a eles aportaram o registro de conversa via Whatsapp tendo como interlocutor preposto da operadora ré. Nesse diálogo está suficientemente claro que o nome do autor-apelante Pedro Rafael da Silva Sales ainda não constava do sistema de beneficiários no dia 23/11/2019, isto é, um dia após os fatos narrados na inicial; 4. Há nos autos, ainda, ficha de atendimento do autor-apelante no Pronto Socorro da Criança da Zona Sul de Manaus, unidade integrante do SUS, indicando justamente a data de 22/11/2019, quando teria havido a recusa de atendimento do paciente na rede credenciada à operadora ré; 5. A recusa de atendimento na rede credenciada, a um só tempo, prolongou o estado do sofrimento do paciente e a angústia de sua mãe por se ver incapaz de adotar medidas para cura-lo, caracterizando o <em>dano</em> <em>moral</em>; 6. Considerando que o paciente cujo atendimento foi negado trata-se de criança, deve-se majorar o valor dos <em>danos</em> <em>morais</em> de R$ 5.000,00 (cinco mil reais) para R$ 6.000,00 (seis mil reais); 7. Primeiro recurso conhecido e não provido. Segundo recurso conhecido e provido. Sentença reformada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363938" cdForo="0" >
+										0515824-48.2023.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363938" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363938);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363938" style="display: none;" >
+	<div id="textAreaDados_3363938" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL &ndash; TAXA DE JUROS REGULAR &ndash; M&Eacute;DIA DO MERCADO &ndash; CET - ABUSIVIDADE N&Atilde;O CONFIGURADA &ndash; SENTEN&Ccedil;A MANTIDA:
+- Nota-se que o Autor, ora Apelante, teve ci&ecirc;ncia dos valores que estavam sendo cobrados, sendo-lhe informado claramente o valor de cada uma das presta&ccedil;&otilde;es a serem pagas e os seus respectivos vencimentos, levando-se em considera&ccedil;&atilde;o o valor contratado, ao que aderiu livremente e de forma volunt&aacute;ria, sem que houvesse demonstra&ccedil;&atilde;o de qualquer v&iacute;cio de consentimento.
+- Pela natureza do contrato banc&aacute;rio, diversos elementos s&atilde;o inseridos na cobran&ccedil;a e no seu c&aacute;lculo, sendo poss&iacute;vel destacar do contrato de fls. 20/21 que foi previsto a cobran&ccedil;a de juros remunerat&oacute;rios em 2,35% ao m&ecirc;s com capitaliza&ccedil;&atilde;o mensal, somado ao Imposto sobre Opera&ccedil;&otilde;es Financeiras (IOF). O Custo Efetivo Total (CET) restou configurado em 2,92% ao m&ecirc;s, sendo que ele diz respeito ao valor total a opera&ccedil;&atilde;o, com todos os valores agregados e n&atilde;o somente os juros mensais.
+- Assim, entendo que a limita&ccedil;&atilde;o da taxa de juros em face da suposta abusividade somente teria raz&atilde;o diante de uma demonstra&ccedil;&atilde;o cabal da excessividade do lucro da institui&ccedil;&atilde;o financeira, o que n&atilde;o ocorreu. Destarte, n&atilde;o havendo ato il&iacute;cito, inexiste a obriga&ccedil;&atilde;o de repara&ccedil;&atilde;o material ou moral, devendo portanto ser mantida a senten&ccedil;a de piso.
+RECURSO CONHECIDO E DESPROVIDO.  <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0515824-48.2023.8.04.0001; Relator (a): Domingos Jorge Chalub Pereira; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Terceira C&acirc;mara C&iacute;vel; Data do julgamento: 29/07/2025; Data de registro: 29/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Limitação de Juros
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Domingos Jorge Chalub Pereira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Terceira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									29/07/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									29/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL – TAXA DE JUROS REGULAR – MÉDIA DO MERCADO – CET - ABUSIVIDADE NÃO CONFIGURADA – SENTENÇA MANTIDA:
+- Nota-se que o Autor, ora Apelante, teve ciência dos valores que estavam sendo cobrados, sendo-lhe informado claramente o valor de cada uma das prestações a serem pagas e os seus respectivos vencimentos, levando-se em consideração o valor contratado, ao que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL – TAXA DE JUROS REGULAR – MÉDIA DO MERCADO – CET - ABUSIVIDADE NÃO CONFIGURADA – SENTENÇA MANTIDA:
+- Nota-se que o Autor, ora Apelante, teve ciência dos valores que estavam sendo cobrados, sendo-lhe informado claramente o valor de cada uma das prestações a serem pagas e os seus respectivos vencimentos, levando-se em consideração o valor contratado, ao que aderiu livremente e de forma voluntária, sem que houvesse demonstração de qualquer vício de consentimento.
+- Pela natureza do contrato bancário, diversos elementos são inseridos na cobrança e no seu cálculo, sendo possível destacar do contrato de fls. 20/21 que foi previsto a cobrança de juros remuneratórios em 2,35% ao mês com capitalização mensal, somado ao Imposto sobre Operações Financeiras (IOF). O Custo Efetivo Total (CET) restou configurado em 2,92% ao mês, sendo que ele diz respeito ao valor total a operação, com todos os valores agregados e não somente os juros mensais.
+- Assim, entendo que a limitação da taxa de juros em face da suposta abusividade somente teria razão diante de uma demonstração cabal da excessividade do lucro da instituição financeira, o que não ocorreu. Destarte, não havendo ato ilícito, inexiste a obrigação de reparação material ou <em>moral</em>, devendo portanto ser mantida a sentença de piso.
+RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363937" cdForo="0" >
+										0006912-88.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363937" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363937);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363937" style="display: none;" >
+	<div id="textAreaDados_3363937" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. VIOLA&Ccedil;&Atilde;O AO DEVER DE INFORMA&Ccedil;&Atilde;O. CONVERS&Atilde;O DO CONTRATO. DANO MORAL. RESTITUI&Ccedil;&Atilde;O EM DOBRO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que negou provimento ao recurso da agravante, em Apela&ccedil;&atilde;o C&iacute;vel envolvendo discuss&atilde;o sobre contrato banc&aacute;rio. A agravante sustenta a inexist&ecirc;ncia de contrata&ccedil;&atilde;o v&aacute;lida de cart&atilde;o de cr&eacute;dito consignado, afirmando que contratou t&atilde;o somente empr&eacute;stimo consignado. Argumenta que houve viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o, com aus&ecirc;ncia de clareza sobre os termos contratuais e aus&ecirc;ncia de entrega de c&oacute;pia contratual. Pleiteia a convers&atilde;o do contrato, indeniza&ccedil;&atilde;o por danos morais e restitui&ccedil;&atilde;o em dobro dos valores descontados. O agravado n&atilde;o apresentou contrarraz&otilde;es.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o:
+(i) verificar se houve viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o na contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado;
+(ii) definir se &eacute; poss&iacute;vel a convers&atilde;o do contrato banc&aacute;rio em empr&eacute;stimo consignado comum com base no entendimento firmado em IRDR;
+(iii) estabelecer se s&atilde;o devidos danos morais e restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados.
+III. RAZ&Otilde;ES DE DECIDIR
+1. A validade do contrato de cart&atilde;o de cr&eacute;dito consignado depende da comprova&ccedil;&atilde;o de que o consumidor foi claramente informado sobre as condi&ccedil;&otilde;es espec&iacute;ficas da contrata&ccedil;&atilde;o, conforme entendimento firmado no IRDR n&ordm; 0005217-75.2019.8.04.0000.
+2. O contrato juntado aos autos n&atilde;o apresenta, de forma clara, objetiva e acess&iacute;vel, os elementos essenciais da contrata&ccedil;&atilde;o, como a forma de pagamento e a din&acirc;mica do d&eacute;bito m&iacute;nimo com incid&ecirc;ncia de encargos rotativos, impossibilitando a compreens&atilde;o plena do consumidor.
+3. A aus&ecirc;ncia de informa&ccedil;&otilde;es claras e a inexist&ecirc;ncia de comprova&ccedil;&atilde;o de que o consumidor recebeu c&oacute;pia do contrato comprometem a validade da contrata&ccedil;&atilde;o, configurando v&iacute;cio de consentimento.
+4. A constata&ccedil;&atilde;o da falha no dever de informa&ccedil;&atilde;o autoriza a convers&atilde;o do contrato de cart&atilde;o de cr&eacute;dito consignado em contrato de empr&eacute;stimo consignado simples, com a incid&ecirc;ncia da taxa m&eacute;dia de mercado &agrave; &eacute;poca da contrata&ccedil;&atilde;o.
+5. A devolu&ccedil;&atilde;o em dobro dos valores descontados indevidamente &eacute; devida, independentemente da comprova&ccedil;&atilde;o de m&aacute;-f&eacute;, diante da contrariedade &agrave; boa-f&eacute; objetiva.
+6. O dano moral &eacute; configurado, considerando o abalo psicol&oacute;gico decorrente da perpetua&ccedil;&atilde;o de d&iacute;vida n&atilde;o compreendida pelo consumidor, sendo fixado valor indenizat&oacute;rio proporcional ao preju&iacute;zo experimentado.
+IV. DISPOSITIVO E TESE
+Recurso provido.
+Tese de julgamento:
+1. A validade do contrato de cart&atilde;o de cr&eacute;dito consignado exige comprova&ccedil;&atilde;o inequ&iacute;voca de que o consumidor foi claramente informado sobre todos os seus termos.
+2. A aus&ecirc;ncia de informa&ccedil;&otilde;es claras e a n&atilde;o entrega de c&oacute;pia do contrato autorizam a convers&atilde;o do contrato em empr&eacute;stimo consignado simples.
+3. A devolu&ccedil;&atilde;o em dobro de valores descontados indevidamente prescinde da comprova&ccedil;&atilde;o de m&aacute;-f&eacute;, bastando a viola&ccedil;&atilde;o &agrave; boa-f&eacute; objetiva.
+4. A contrata&ccedil;&atilde;o banc&aacute;ria em desconformidade com a vontade real do consumidor configura dano moral indeniz&aacute;vel.
+Dispositivos relevantes citados: CPC, art. 85, &sect;2&ordm;; CC, art. 405.
+Jurisprud&ecirc;ncia relevante citada: TJAM, IRDR n&ordm; 0005217-75.2019.8.04.0000 &ndash; Tema 05; AC n&ordm; 0628064-77.2023.8.04.0001; AC n&ordm; 0619765-58.2016.8.04.0001; AC n&ordm; 0603988-96.2017.8.04.0001. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0006912-88.2024.8.04.0000; Relator (a): Socorro Guedes Moura; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 16/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(52 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Socorro Guedes Moura
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO DO CONTRATO. <em>DANO</em> <em>MORAL</em>. RESTITUIÇÃO EM DOBRO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo Interno interposto contra decisão monocrática que negou provimento ao recurso da agravante, em Apelação Cível envolvendo discussão sobre contrato bancário. A agravante
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO DO CONTRATO. <em>DANO</em> <em>MORAL</em>. RESTITUIÇÃO EM DOBRO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo Interno interposto contra decisão monocrática que negou provimento ao recurso da agravante, em Apelação Cível envolvendo discussão sobre contrato bancário. A agravante sustenta a inexistência de contratação válida de cartão de crédito consignado, afirmando que contratou tão somente empréstimo consignado. Argumenta que houve violação ao dever de informação, com ausência de clareza sobre os termos contratuais e ausência de entrega de cópia contratual. Pleiteia a conversão do contrato, indenização por <em>danos</em> <em>morais</em> e restituição em dobro dos valores descontados. O agravado não apresentou contrarrazões.
+II. QUESTÃO EM DISCUSSÃO
+Há três questões em discussão:
+(i) verificar se houve violação ao dever de informação na contratação do cartão de crédito consignado;
+(ii) definir se é possível a conversão do contrato bancário em empréstimo consignado comum com base no entendimento firmado em IRDR;
+(iii) estabelecer se são devidos <em>danos</em> <em>morais</em> e restituição em dobro dos valores indevidamente descontados.
+III. RAZÕES DE DECIDIR
+1. A validade do contrato de cartão de crédito consignado depende da comprovação de que o consumidor foi claramente informado sobre as condições específicas da contratação, conforme entendimento firmado no IRDR nº 0005217-75.2019.8.04.0000.
+2. O contrato juntado aos autos não apresenta, de forma clara, objetiva e acessível, os elementos essenciais da contratação, como a forma de pagamento e a dinâmica do débito mínimo com incidência de encargos rotativos, impossibilitando a compreensão plena do consumidor.
+3. A ausência de informações claras e a inexistência de comprovação de que o consumidor recebeu cópia do contrato comprometem a validade da contratação, configurando vício de consentimento.
+4. A constatação da falha no dever de informação autoriza a conversão do contrato de cartão de crédito consignado em contrato de empréstimo consignado simples, com a incidência da taxa média de mercado à época da contratação.
+5. A devolução em dobro dos valores descontados indevidamente é devida, independentemente da comprovação de má-fé, diante da contrariedade à boa-fé objetiva.
+6. O <em>dano</em> <em>moral</em> é configurado, considerando o abalo psicológico decorrente da perpetuação de dívida não compreendida pelo consumidor, sendo fixado valor indenizatório proporcional ao prejuízo experimentado.
+IV. DISPOSITIVO E TESE
+Recurso provido.
+Tese de julgamento:
+1. A validade do contrato de cartão de crédito consignado exige comprovação inequívoca de que o consumidor foi claramente informado sobre todos os seus termos.
+2. A ausência de informações claras e a não entrega de cópia do contrato autorizam a conversão do contrato em empréstimo consignado simples.
+3. A devolução em dobro de valores descontados indevidamente prescinde da comprovação de má-fé, bastando a violação à boa-fé objetiva.
+4. A contratação bancária em desconformidade com a vontade real do consumidor configura <em>dano</em> <em>moral</em> indenizável.
+Dispositivos relevantes citados: CPC, art. 85, §2º; CC, art. 405.
+Jurisprudência relevante citada: TJAM, IRDR nº 0005217-75.2019.8.04.0000 – Tema 05; AC nº 0628064-77.2023.8.04.0001; AC nº 0619765-58.2016.8.04.0001; AC nº 0603988-96.2017.8.04.0001.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363936" cdForo="0" >
+										0627605-27.2013.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363936" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363936);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363936" style="display: none;" >
+	<div id="textAreaDados_3363936" class="mensagemSemFormatacao" >
+		Ementa: Direito Civil e do Consumidor. Apela&ccedil;&otilde;es C&iacute;veis. Rescis&atilde;o Contratual. Promessa de Compra e Venda de Im&oacute;vel. Atraso na Entrega. Culpa Exclusiva da Incorporadora. Restitui&ccedil;&atilde;o Integral dos Valores Pagos. Taxa de Corretagem. Aus&ecirc;ncia de Informa&ccedil;&atilde;o Pr&eacute;via. Devolu&ccedil;&atilde;o. Lucros Cessantes. Incid&ecirc;ncia. Juros Morat&oacute;rios. Termo Inicial. Cita&ccedil;&atilde;o. Parcial Provimento da Apela&ccedil;&atilde;o do Recurso aviado pela Incorporada e Provimento do Apelo Interposto pela Autora.
+I. Caso em exame
+1. Apela&ccedil;&otilde;es c&iacute;veis interpostas por Rozana Nunes Batista e Direcional Rubi Empreendimentos Imobili&aacute;rios Ltda. contra senten&ccedil;a que declarou a rescis&atilde;o de contrato de compra e venda de im&oacute;vel, determinou a restitui&ccedil;&atilde;o integral dos valores pagos pela adquirente, reconheceu a nulidade de cl&aacute;usulas contratuais abusivas e condenou a incorporadora ao pagamento de lucros cessantes.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; 4 (quatro) quest&otilde;es em discuss&atilde;o: (i) definir se a incorporadora deve devolver a taxa de corretagem paga pela adquirente; (ii) estabelecer se os lucros cessantes devem ser limitados ao valor efetivamente pago; (iii) determinar se a reten&ccedil;&atilde;o de percentual sobre os valores pagos pelo comprador &eacute; cab&iacute;vel e qual seria seu limite; e (iv) fixar o &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria e o termo inicial dos juros morat&oacute;rios sobre a devolu&ccedil;&atilde;o dos valores pagos.
+III. Raz&otilde;es de decidir
+3. A cl&aacute;usula contratual que transfere &agrave; autora a obriga&ccedil;&atilde;o de pagar a taxa de corretagem &eacute; inv&aacute;lida, pois n&atilde;o houve o cumprimento do dever de informa&ccedil;&atilde;o pr&eacute;via, nos termos do Tema n.&ordm; 938 do STJ.
+4. Os lucros cessantes, decorrentes do atraso na entrega do im&oacute;vel, devem ser fixados com base no valor venal do im&oacute;vel, aplicando-se o percentual de 0,5% (cinco d&eacute;cimos por cento) ao m&ecirc;s, conforme a Tese 1.2 do Tema n.&ordm; 966 do STJ.
+5. Diante da culpa exclusiva da incorporadora pelo descumprimento do contrato, a restitui&ccedil;&atilde;o integral dos valores pagos pela autora &eacute; devida, afastando-se qualquer hip&oacute;tese de reten&ccedil;&atilde;o, nos termos da S&uacute;mula n.&ordm; 543 do STJ.
+6. O &iacute;ndice de atualiza&ccedil;&atilde;o monet&aacute;ria deve ser o INPC-IBGE at&eacute; o tr&acirc;nsito em julgado, e, a partir deste marco, a Taxa SELIC deve ser utilizada, englobando juros e corre&ccedil;&atilde;o monet&aacute;ria, conforme jurisprud&ecirc;ncia consolidada do STJ e entendimento desta Corte.
+7. Os juros morat&oacute;rios incidem a partir da cita&ccedil;&atilde;o, pois se trata de responsabilidade contratual decorrente da inadimpl&ecirc;ncia da incorporadora.
+IV. Dispositivo e tese
+8. Recurso da Direcional Rubi Empreendimentos Imobili&aacute;rios Ltda. parcialmente provido para ajustar os &iacute;ndices de atualiza&ccedil;&atilde;o e juros morat&oacute;rios &agrave; jurisprud&ecirc;ncia e recurso de Rozana Nunes Batista provido, com a fixa&ccedil;&atilde;o do termo inicial dos juros de mora da condena&ccedil;&atilde;o na data da cita&ccedil;&atilde;o da parte r&eacute;, Direcional Rubi Empreendimentos Imobili&aacute;rios Ltda.
+Tese de julgamento: &quot;1. O dever de informa&ccedil;&atilde;o quanto &agrave; transfer&ecirc;ncia da obriga&ccedil;&atilde;o de pagar a taxa de corretagem ao consumidor deve ser cumprido com destaque e anteced&ecirc;ncia, sob pena de nulidade da cl&aacute;usula contratual; 2. O descumprimento do prazo para entrega de im&oacute;vel, inclu&iacute;do o per&iacute;odo de toler&acirc;ncia, enseja indeniza&ccedil;&atilde;o a t&iacute;tulo de lucros cessantes, calculados com base no valor venal do im&oacute;vel, em percentual de 0,5% (cinco d&eacute;cimos por cento) ao m&ecirc;s; 3. Na resolu&ccedil;&atilde;o de contrato de promessa de compra e venda por culpa do promitente-vendedor, a restitui&ccedil;&atilde;o das parcelas pagas pelo comprador deve ser integral e imediata; 4. Nas rescis&otilde;es contratuais, o INPC-IBGE &eacute; aplic&aacute;vel como &iacute;ndice de atualiza&ccedil;&atilde;o at&eacute; o tr&acirc;nsito em julgado, sendo a Taxa SELIC utilizada a partir deste marco para juros e corre&ccedil;&atilde;o monet&aacute;ria; 5. Os juros morat&oacute;rios sobre a devolu&ccedil;&atilde;o dos valores pagos pelo comprador incidem a partir da cita&ccedil;&atilde;o, nos termos do art. 405 do C&oacute;digo Civil&quot;.
+___________
+Dispositivos relevantes citados: CC, arts. 406, 421 e 884; CDC, art. 6.&ordm;, III; CPC, art. 487, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n.&ordm; 1.599.511/SP (Tema n.&ordm; 938); STJ, REsp n.&ordm; 1.729.593/SP (Tema n.&ordm; 966); STJ, REsp n.&ordm; 1.740.911/DF (Tema n.&ordm; 970); STJ, S&uacute;mula 543; TJAM, Apela&ccedil;&atilde;o C&iacute;vel n.&ordm; 0627495-91.2014.8.04.0001; TJAM, Apela&ccedil;&atilde;o C&iacute;vel n.&ordm; 0610225-88.2013.8.04.0001.  <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0627605-27.2013.8.04.0001; Relator (a): Yedo Sim&otilde;es de Oliveira; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 15/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(43 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Rescisão do contrato e devolução do dinheiro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Yedo Simões de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito Civil e do Consumidor. Apelações Cíveis. Rescisão Contratual. Promessa de Compra e Venda de Imóvel. Atraso na Entrega. Culpa Exclusiva da Incorporadora. Restituição Integral dos Valores Pagos. Taxa de Corretagem. Ausência de Informação Prévia. Devolução. Lucros Cessantes. Incidência. Juros Moratórios. Termo Inicial. Citação. Parcial Provimento da Apelação do Recurso aviado pela
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito Civil e do Consumidor. Apelações Cíveis. Rescisão Contratual. Promessa de Compra e Venda de Imóvel. Atraso na Entrega. Culpa Exclusiva da Incorporadora. Restituição Integral dos Valores Pagos. Taxa de Corretagem. Ausência de Informação Prévia. Devolução. Lucros Cessantes. Incidência. Juros Moratórios. Termo Inicial. Citação. Parcial Provimento da Apelação do Recurso aviado pela Incorporada e Provimento do Apelo Interposto pela Autora.
+I. Caso em exame
+1. Apelações cíveis interpostas por Rozana Nunes Batista e Direcional Rubi Empreendimentos Imobiliários Ltda. contra sentença que declarou a rescisão de contrato de compra e venda de imóvel, determinou a restituição integral dos valores pagos pela adquirente, reconheceu a nulidade de cláusulas contratuais abusivas e condenou a incorporadora ao pagamento de lucros cessantes.
+II. Questão em discussão
+2. Há 4 (quatro) questões em discussão: (i) definir se a incorporadora deve devolver a taxa de corretagem paga pela adquirente; (ii) estabelecer se os lucros cessantes devem ser limitados ao valor efetivamente pago; (iii) determinar se a retenção de percentual sobre os valores pagos pelo comprador é cabível e qual seria seu limite; e (iv) fixar o índice de correção monetária e o termo inicial dos juros moratórios sobre a devolução dos valores pagos.
+III. Razões de decidir
+3. A cláusula contratual que transfere à autora a obrigação de pagar a taxa de corretagem é inválida, pois não houve o cumprimento do dever de informação prévia, nos termos do Tema n.º 938 do STJ.
+4. Os lucros cessantes, decorrentes do atraso na entrega do imóvel, devem ser fixados com base no valor venal do imóvel, aplicando-se o percentual de 0,5% (cinco décimos por cento) ao mês, conforme a Tese 1.2 do Tema n.º 966 do STJ.
+5. Diante da culpa exclusiva da incorporadora pelo descumprimento do contrato, a restituição integral dos valores pagos pela autora é devida, afastando-se qualquer hipótese de retenção, nos termos da Súmula n.º 543 do STJ.
+6. O índice de atualização monetária deve ser o INPC-IBGE até o trânsito em julgado, e, a partir deste marco, a Taxa SELIC deve ser utilizada, englobando juros e correção monetária, conforme jurisprudência consolidada do STJ e entendimento desta Corte.
+7. Os juros moratórios incidem a partir da citação, pois se trata de responsabilidade contratual decorrente da inadimplência da incorporadora.
+IV. Dispositivo e tese
+8. Recurso da Direcional Rubi Empreendimentos Imobiliários Ltda. parcialmente provido para ajustar os índices de atualização e juros moratórios à jurisprudência e recurso de Rozana Nunes Batista provido, com a fixação do termo inicial dos juros de mora da condenação na data da citação da parte ré, Direcional Rubi Empreendimentos Imobiliários Ltda.
+Tese de julgamento: "1. O dever de informação quanto à transferência da obrigação de pagar a taxa de corretagem ao consumidor deve ser cumprido com destaque e antecedência, sob pena de nulidade da cláusula contratual; 2. O descumprimento do prazo para entrega de imóvel, incluído o período de tolerância, enseja indenização a título de lucros cessantes, calculados com base no valor venal do imóvel, em percentual de 0,5% (cinco décimos por cento) ao mês; 3. Na resolução de contrato de promessa de compra e venda por culpa do promitente-vendedor, a restituição das parcelas pagas pelo comprador deve ser integral e imediata; 4. Nas rescisões contratuais, o INPC-IBGE é aplicável como índice de atualização até o trânsito em julgado, sendo a Taxa SELIC utilizada a partir deste marco para juros e correção monetária; 5. Os juros moratórios sobre a devolução dos valores pagos pelo comprador incidem a partir da citação, nos termos do art. 405 do Código Civil".
+___________
+Dispositivos relevantes citados: CC, arts. 406, 421 e 884; CDC, art. 6.º, III; CPC, art. 487, I.
+Jurisprudência relevante citada: STJ, REsp n.º 1.599.511/SP (Tema n.º 938); STJ, REsp n.º 1.729.593/SP (Tema n.º 966); STJ, REsp n.º 1.740.911/DF (Tema n.º 970); STJ, Súmula 543; TJAM, Apelação Cível n.º 0627495-91.2014.8.04.0001; TJAM, Apelação Cível n.º 0610225-88.2013.8.04.0001.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363935" cdForo="0" >
+										0677200-48.2020.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363935" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363935);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363935" style="display: none;" >
+	<div id="textAreaDados_3363935" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO CIVIL E ADMINISTRATIVO. FISCALIZA&Ccedil;&Atilde;O. &Oacute;RG&Atilde;O INCOMPETENTE. DIVULGA&Ccedil;&Atilde;O. DEVER GERAL DE CUIDADO. INOBSERV&Acirc;NCIA. DANO MORAL CONFIGURADO. SENTEN&Ccedil;A PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO EM PARTE.
+1. Gera dano moral indeniz&aacute;vel a divulga&ccedil;&atilde;o oficial, por &oacute;rg&atilde;o p&uacute;blico, de ato de fiscaliza&ccedil;&atilde;o feito por autoridade incompetente para faz&ecirc;-lo e que n&atilde;o observa o dever geral de cuidado quanto &agrave;s especificidades do evento relatado;
+2. Recurso conhecido e provido em parte;
+3. Senten&ccedil;a parcialmente reformada. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0677200-48.2020.8.04.0001; Relator (a): Yedo Sim&otilde;es de Oliveira; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 15/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inspeção Sanitária de Origem Animal
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Yedo Simões de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL E ADMINISTRATIVO. FISCALIZAÇÃO. ÓRGÃO INCOMPETENTE. DIVULGAÇÃO. DEVER GERAL DE CUIDADO. INOBSERVÂNCIA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO EM PARTE.
+1. Gera <em>dano</em> <em>moral</em> indenizável a divulgação oficial, por órgão público, de ato de fiscalização feito por autoridade incompetente para
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL E ADMINISTRATIVO. FISCALIZAÇÃO. ÓRGÃO INCOMPETENTE. DIVULGAÇÃO. DEVER GERAL DE CUIDADO. INOBSERVÂNCIA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO EM PARTE.
+1. Gera <em>dano</em> <em>moral</em> indenizável a divulgação oficial, por órgão público, de ato de fiscalização feito por autoridade incompetente para fazê-lo e que não observa o dever geral de cuidado quanto às especificidades do evento relatado;
+2. Recurso conhecido e provido em parte;
+3. Sentença parcialmente reformada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363934" cdForo="0" >
+										0635055-50.2015.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363934" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363934);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363934" style="display: none;" >
+	<div id="textAreaDados_3363934" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO CIVIL. DIREITO PROCESSUAL CIVIL. PRELIMINARES RECURSAIS. PRINC&Iacute;PIO DA DIALETICIDADE. INEXIST&Ecirc;NCIA DE VIOLA&Ccedil;&Atilde;O.  M&Eacute;RITO. ACIDENTE DE TR&Acirc;NSITO. V&Iacute;TIMAS FATAIS. ILEGITIMIDADE ATIVA. CONSTATA&Ccedil;&Atilde;O. SENTEN&Ccedil;A TRANSITADA EM JULGADO RECHA&Ccedil;ANDO PRETENS&Atilde;O AO RECONHECIMENTO DE UNI&Atilde;O EST&Aacute;VEL POST MORTEM. RESPONSABILIDADE CIVIL. ARTS. 186 E 927, DO C&Oacute;DIGO CIVIL. DISCUSS&Atilde;O RELATIVA AO ELEMENTO CULPA. DIVERG&Ecirc;NCIA ENTRE NARRATIVAS DAS PARTES. ARQUIVAMENTO DE INQU&Eacute;RITO INSTAURADO PARA APURA&Ccedil;&Atilde;O DOS FATOS. INDEPEND&Ecirc;NCIA DAS INST&Acirc;NCIAS. ART. 935, DO C&Oacute;DIGO CIVIL. ART. 67, I, DO C&Oacute;DIGO DE PROCESSO PENAL &ndash; CPP. AUS&Ecirc;NCIA DE ELEMENTOS SUFICIENTES PARA FORMA&Ccedil;&Atilde;O DE JU&Iacute;ZO DE CERTEZA SOBRE A TESE AUTORAL. ART. 373, I, DO C&Oacute;DIGO DE PROCESSO CIVIL &ndash; CPC. RECURSO CONHECIDO E N&Atilde;O PROVIDO. 1. O princ&iacute;pio da dialeticidade aparece como norte do requisito da regularidade formal, tendo em vista que o recorrente precisa elucidar de modo claro as raz&otilde;es pelas quais a decis&atilde;o impugnada encontra-se eivada de erros, apontando em que aspectos o Ju&iacute;zo de 1&ordm; Grau incorreu em equ&iacute;vocos jur&iacute;dicos. No caso, fazendo um cotejo entre a senten&ccedil;a impugnada e as raz&otilde;es expostas por ocasi&atilde;o da presente apela&ccedil;&atilde;o, verifica-se que o recorrente impugnou de forma adequada os fundamentos da senten&ccedil;a; 2. O cerne da controv&eacute;rsia cinge-se em apurar a responsabilidade civil dos r&eacute;us-apelados pelo acidente de tr&acirc;nsito que teria vitimado companheiro e filha da autora-apelante, levando-os a &oacute;bito; 3. A autora-apelante ajuizou a a&ccedil;&atilde;o declarat&oacute;ria de uni&atilde;o est&aacute;vel post mortem n.&ordm; 0605680-38.2014.8.04.0001, a qual foi julgada improcedente pelo Ju&iacute;zo da 6.&ordf; Vara de Fam&iacute;lia e Sucess&otilde;es, tendo a senten&ccedil;a transitada em julgado desde 2015, e, sendo assim, considerando a aus&ecirc;ncia de demonstra&ccedil;&atilde;o de v&iacute;nculos familiares entre a autora-apelante e aquele que, alegadamente, era seu companheiro, conclui-se pela ilegitimidade ativa da parte nesse particular; 4. A responsabilidade civil &eacute; o dever secund&aacute;rio de reparar a outrem como decorr&ecirc;ncia da causa&ccedil;&atilde;o de danos, caracterizando a partir dos requisitos estabelecidos pelos arts. 186 e 927, do C&oacute;digo Civil, quais sejam, a conduta, a culpa, o nexo causal e o dano; 5.  Em sua pe&ccedil;a de contesta&ccedil;&atilde;o, os r&eacute;us-apelados n&atilde;o impugnam o fato de que foram os autores do atropelamento, evento que foi a causa da morte, conforme atestado pela certid&atilde;o de &oacute;bito de ambas as v&iacute;timas, limitando-se a discuss&atilde;o ao elemento culpa, necess&aacute;rio para a caracteriza&ccedil;&atilde;o da responsabilidade civil, havendo diverg&ecirc;ncia entre narrativas apresentadas pelas partes; 6. Nos autos do inqu&eacute;rito n.&ordm; 0000398-45.2014.8.04.4600, o Minist&eacute;rio P&uacute;blico do Estado do Amazonas - MP/AM, analisando o laudo pericial e a reprodu&ccedil;&atilde;o simulada dos fatos, concluiu pela aus&ecirc;ncia de elementos informativos suficientes para a forma&ccedil;&atilde;o da culpa, promovendo o &oacute;rg&atilde;o ministerial pelo arquivamento do feito; 7. Embora o art. 935, do C&oacute;digo Civil, e art.67, I, do C&oacute;digo de Processo Penal &ndash; CPP, estabele&ccedil;am a regra da independ&ecirc;ncia das inst&acirc;ncias, os elementos probat&oacute;rios destes autos conduzem &agrave; mesma conclus&atilde;o j&aacute; atingida pelo parquet na seara penal. &Eacute; dizer, a autora-apelante n&atilde;o se desincumbiu do &ocirc;nus probat&oacute;rio fixado pelo art. 373, I, do C&oacute;digo de Processo Civil &ndash; CPC, no sentido de aportar elementos probat&oacute;rios suficientes para a forma&ccedil;&atilde;o de um ju&iacute;zo de certeza sobre a vers&atilde;o apresentada, destacadamente sobre a exist&ecirc;ncia de culpa do primeiro r&eacute;u-apelado na causa&ccedil;&atilde;o do acidente fatal; 8. Os fatos apurados na a&ccedil;&atilde;o penal n.&ordm; 0225067-70.2015.8.04.0001 n&atilde;o t&ecirc;m relev&acirc;ncia para o deslinde da controv&eacute;rsia tratada nos presentes autos; 9. Recurso conhecido e n&atilde;o provido. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0635055-50.2015.8.04.0001; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 07/07/2025; Data de registro: 11/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/07/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									11/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. DIREITO PROCESSUAL CIVIL. PRELIMINARES RECURSAIS. PRINCÍPIO DA DIALETICIDADE. INEXISTÊNCIA DE VIOLAÇÃO.  MÉRITO. ACIDENTE DE TRÂNSITO. VÍTIMAS FATAIS. ILEGITIMIDADE ATIVA. CONSTATAÇÃO. SENTENÇA TRANSITADA EM JULGADO RECHAÇANDO PRETENSÃO AO RECONHECIMENTO DE UNIÃO ESTÁVEL POST MORTEM. RESPONSABILIDADE CIVIL. ARTS. 186 E 927, DO CÓDIGO CIVIL. DISCUSSÃO RELATIVA AO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. DIREITO PROCESSUAL CIVIL. PRELIMINARES RECURSAIS. PRINCÍPIO DA DIALETICIDADE. INEXISTÊNCIA DE VIOLAÇÃO.  MÉRITO. ACIDENTE DE TRÂNSITO. VÍTIMAS FATAIS. ILEGITIMIDADE ATIVA. CONSTATAÇÃO. SENTENÇA TRANSITADA EM JULGADO RECHAÇANDO PRETENSÃO AO RECONHECIMENTO DE UNIÃO ESTÁVEL POST MORTEM. RESPONSABILIDADE CIVIL. ARTS. 186 E 927, DO CÓDIGO CIVIL. DISCUSSÃO RELATIVA AO ELEMENTO CULPA. DIVERGÊNCIA ENTRE NARRATIVAS DAS PARTES. ARQUIVAMENTO DE INQUÉRITO INSTAURADO PARA APURAÇÃO DOS FATOS. INDEPENDÊNCIA DAS INSTÂNCIAS. ART. 935, DO CÓDIGO CIVIL. ART. 67, I, DO CÓDIGO DE PROCESSO PENAL – CPP. AUSÊNCIA DE ELEMENTOS SUFICIENTES PARA FORMAÇÃO DE JUÍZO DE CERTEZA SOBRE A TESE AUTORAL. ART. 373, I, DO CÓDIGO DE PROCESSO CIVIL – CPC. RECURSO CONHECIDO E NÃO PROVIDO. 1. O princípio da dialeticidade aparece como norte do requisito da regularidade formal, tendo em vista que o recorrente precisa elucidar de modo claro as razões pelas quais a decisão impugnada encontra-se eivada de erros, apontando em que aspectos o Juízo de 1º Grau incorreu em equívocos jurídicos. No caso, fazendo um cotejo entre a sentença impugnada e as razões expostas por ocasião da presente apelação, verifica-se que o recorrente impugnou de forma adequada os fundamentos da sentença; 2. O cerne da controvérsia cinge-se em apurar a responsabilidade civil dos réus-apelados pelo acidente de trânsito que teria vitimado companheiro e filha da autora-apelante, levando-os a óbito; 3. A autora-apelante ajuizou a ação declaratória de união estável post mortem n.º 0605680-38.2014.8.04.0001, a qual foi julgada improcedente pelo Juízo da 6.ª Vara de Família e Sucessões, tendo a sentença transitada em julgado desde 2015, e, sendo assim, considerando a ausência de demonstração de vínculos familiares entre a autora-apelante e aquele que, alegadamente, era seu companheiro, conclui-se pela ilegitimidade ativa da parte nesse particular; 4. A responsabilidade civil é o dever secundário de reparar a outrem como decorrência da causação de <em>danos</em>, caracterizando a partir dos requisitos estabelecidos pelos arts. 186 e 927, do Código Civil, quais sejam, a conduta, a culpa, o nexo causal e o <em>dano</em>; 5.  Em sua peça de contestação, os réus-apelados não impugnam o fato de que foram os autores do atropelamento, evento que foi a causa da morte, conforme atestado pela certidão de óbito de ambas as vítimas, limitando-se a discussão ao elemento culpa, necessário para a caracterização da responsabilidade civil, havendo divergência entre narrativas apresentadas pelas partes; 6. Nos autos do inquérito n.º 0000398-45.2014.8.04.4600, o Ministério Público do Estado do Amazonas - MP/AM, analisando o laudo pericial e a reprodução simulada dos fatos, concluiu pela ausência de elementos informativos suficientes para a formação da culpa, promovendo o órgão ministerial pelo arquivamento do feito; 7. Embora o art. 935, do Código Civil, e art.67, I, do Código de Processo Penal – CPP, estabeleçam a regra da independência das instâncias, os elementos probatórios destes autos conduzem à mesma conclusão já atingida pelo parquet na seara penal. É dizer, a autora-apelante não se desincumbiu do ônus probatório fixado pelo art. 373, I, do Código de Processo Civil – CPC, no sentido de aportar elementos probatórios suficientes para a formação de um juízo de certeza sobre a versão apresentada, destacadamente sobre a existência de culpa do primeiro réu-apelado na causação do acidente fatal; 8. Os fatos apurados na ação penal n.º 0225067-70.2015.8.04.0001 não têm relevância para o deslinde da controvérsia tratada nos presentes autos; 9. Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363933" cdForo="0" >
+										0001087-08.2020.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363933" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363933);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363933" style="display: none;" >
+	<div id="textAreaDados_3363933" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL E REMESSA NECESS&Aacute;RIA. IMPROBIDADE ADMINISTRATIVA. ART. 19 DA LEI N.&ordm; 4.717/65. REGIME APLIC&Aacute;VEL &Agrave; A&Ccedil;&Atilde;O DE IMPROBIDADE JULGADA IMPROCEDENTE ANTES DA ENTRADA EM VIGOR DA LEI N.&ordm; 14.230/21. CONTRATA&Ccedil;&Atilde;O DE SERVIDORES P&Uacute;BLICOS &Agrave; REVELIA DO CONCURSO P&Uacute;BLICO. MALFERIMENTO AOS PRINC&Iacute;PIOS DA ADMINISTRA&Ccedil;&Atilde;O P&Uacute;BLICA. ART. 37, CAPUT E II, DA CF. SUPERVENI&Ecirc;NCIA DA LEI N.&ordm; 14.230/21. REVOGA&Ccedil;&Atilde;O DO ART. 11, I, DA LEI N.&ordm; 8.429/92. CONDUTA ATRIBU&Iacute;DA AO AGENTE P&Uacute;BLICO QUE N&Atilde;O SE AMOLDA AO TIPO DO ART. 11, V, DA LEI N.&ordm; 8.429/92. PREJU&Iacute;ZO AO ER&Aacute;RIO P&Uacute;BLICO. ART. 10, I E XII, DA LEI N.&ordm; 8.429/92. CONTRATA&Ccedil;&Atilde;O DE SERVIDOR N&Atilde;O BASEADA EM LEGISLA&Ccedil;&Atilde;O LOCAL E N&Atilde;O ANTECEDIDA POR QUALQUER PROCESSO DE SELE&Ccedil;&Atilde;O. PRORROGA&Ccedil;&Atilde;O SUCESSIVA &Agrave; MARGEM DA URG&Ecirc;NCIA OU NECESSIDADE EXCEPCIONAL. MEDIDA DE INTERRUP&Ccedil;&Atilde;O DOS CONTRATOS PARA FURTAR-SE AO PAGAMENTO DE VERBAS DEVIDAS AO SERVIDORES CONTRATADOS. ABUSO DO M&Uacute;NUS P&Uacute;BLICO. RESTRI&Ccedil;&Atilde;O IL&Iacute;CITA E MALICIOSA DE DIREITOS DOS ADMINISTRADOS. VIOLA&Ccedil;&Atilde;O AOS INTERESSES P&Uacute;BLICOS PRIM&Aacute;RIO E SECUND&Aacute;RIO DO MUNIC&Iacute;PIO. CONDUTAS DISTANCIADAS DA MORALIDADE E HONESTIDADE ADMINISTRATIVAS. DOLO ESPEC&Iacute;FICO. CONSCI&Ecirc;NCIA E VONTADE NA PR&Aacute;TICA DO ATO &Iacute;MPROBO. SITUA&Ccedil;&Atilde;O QUE SE AMOLDA &Agrave; RESSALVA DO TEMA REPETITIVO N.&ordm; 1108. DANO AO ER&Aacute;RIO DEVIDAMENTE COMPROVADO. IRRETROATIVIDADE DO REGIME SANCIONAT&Oacute;RIO DA LEI N.&ordm; 14.230/21. RECURSO E REEXAME OFICIAL CONHECIDOS E PARCIALMENTE PROVIDOS. 1. Na origem, o parquet prop&ocirc;s a&ccedil;&atilde;o civil de improbidade administrativa contra o ex-prefeito do Munic&iacute;pio de Coari em raz&atilde;o do suposto cometimento das condutas previstas nos arts. 10, caput, e 11, I e V, ambos da Lei n.&ordm; 8.429/92, consubstanciado na contrata&ccedil;&atilde;o de servidores entre os anos de 2001 e 2007 para compor os quadros da Administra&ccedil;&atilde;o P&uacute;blica sem a pr&eacute;via realiza&ccedil;&atilde;o de concurso p&uacute;blico, ocasi&atilde;o em que seus pedidos foram julgados improcedentes pelo MM. Ju&iacute;zo da 1&ordf; Vara da Comarca de Coari; 2. Em raz&atilde;o da entrada em vigor da Lei n.&ordm; 14.230/21, o STJ desafetou o Tema Repetitivo n.&ordm; 1042 e firmou entendimento sobre a aplica&ccedil;&atilde;o do regime do duplo grau obrigat&oacute;rio de jurisdi&ccedil;&atilde;o do art. 19 da Lei n.&ordm; 4.717/65 para as a&ccedil;&otilde;es de improbidade julgadas improcedentes anteriormente &agrave; entrada em vigor daquele ato normativo, mantida sua inaplicabilidade para as senten&ccedil;as de improced&ecirc;ncia ou extin&ccedil;&atilde;o sem resolu&ccedil;&atilde;o do m&eacute;rito posteriores &agrave; sobredita Lei n.&ordm; 14.230/21; 3. Com rela&ccedil;&atilde;o &agrave; acusa&ccedil;&atilde;o de viola&ccedil;&atilde;o aos princ&iacute;pios da administra&ccedil;&atilde;o, sabe-se que o entendimento firmado pelo STJ em precedentes vinculantes orienta-se no sentido de que a contrata&ccedil;&atilde;o de servidores p&uacute;blicos tempor&aacute;rios sem concurso p&uacute;blico n&atilde;o &eacute; per si causa precursora de ato &iacute;mprobo atentat&oacute;rio aos princ&iacute;pios administrativos, desde que tais v&iacute;nculos tempor&aacute;rios encontrem-se respaldados por legisla&ccedil;&atilde;o local (Tema Repetitivo n.&ordm; 1108); 4. In casu, por for&ccedil;a das altera&ccedil;&otilde;es introduzidas pela Lei n.&ordm; 14.230/21 e considerando a revoga&ccedil;&atilde;o do art. 11, I, da Lei n.&ordm; 8.429/91, revela-se invi&aacute;vel examinar a subsun&ccedil;&atilde;o da conduta atribu&iacute;da ao apelado precisamente no que diz respeito a tal il&iacute;cito, sob pena de viola&ccedil;&atilde;o das regras constitucionais atinentes &agrave; legalidade e &agrave; retroatividade da lei penal benigna (art. 1&ordm;, &sect;4&ordm;, da Lei n.&ordm; 8.429/91 e art. 5&ordm;, XL e XLI, da CF); 5. Outrossim, ainda que subsista a tipifica&ccedil;&atilde;o do art. 11, V, da Lei n.&ordm; 8.429/91, infere-se dos autos que a conduta atribu&iacute;da pelo parquet ao apelado n&atilde;o se amolda ao tipo previsto na norma, dado que o referido dispositivo se destina aos casos em que se verifica a viola&ccedil;&atilde;o ao car&aacute;ter concorrencial do concurso p&uacute;blico e n&atilde;o para as situa&ccedil;&otilde;es em que sua realiza&ccedil;&atilde;o &eacute; ignorada pelo agente p&uacute;blico respons&aacute;vel; 6. Com rela&ccedil;&atilde;o &agrave; acusa&ccedil;&atilde;o de danos ao er&aacute;rio, tal modalidade de improbidade revela-se nas situa&ccedil;&otilde;es em que o agente p&uacute;blico, aproveitando-se dos poderes e facilidades decorrentes de seu m&uacute;nus, pratica dolosamente ato omissivo ou comissivo contr&aacute;rio &agrave; moralidade administrativa e que ocasione preju&iacute;zo ao patrim&ocirc;nio p&uacute;blico, sendo pertinentes ao caso concreto as condutas dos incisos I e XII do rol exemplificativo do art. 10 da Lei n.&ordm; 8.429/92; 7. De acordo com o conjunto probat&oacute;rio agregado aos f&oacute;lios, em especial o Of&iacute;cio n.&ordm; 154/2011-CMC-GP encaminhado pela C&acirc;mara Municipal de Coari, do Of&iacute;cio n.&ordm; 12/2010-GAB e da Representa&ccedil;&atilde;o n.&ordm; 965/2009.11.000/8-04 ambos remetido pela Procuradoria Regional do Trabalho da 11&ordf; Regi&atilde;o, conclui-se que: (i) a contrata&ccedil;&atilde;o dos servidores n&atilde;o foi antecedida por concurso ou por qualquer processo simplificado de sele&ccedil;&atilde;o; bem como (ii) n&atilde;o se fundou em lei local permissiva de contrata&ccedil;&atilde;o tempor&aacute;ria; (iii) o gestor p&uacute;blico promoveu a sucessiva prorroga&ccedil;&atilde;o dos contratos &agrave; margem de qualquer urg&ecirc;ncia ou necessidade excepcional; bem como (iv) implementou medidas para interrup&ccedil;&atilde;o das contrata&ccedil;&otilde;es em meses estrat&eacute;gicos, no claro intuito de furtar-se ao pagamento das verbas devidas aos prestadores de servi&ccedil;o; (v) tal cen&aacute;rio ensejou a condena&ccedil;&atilde;o da municipalidade perante o Tribunal Regional do Trabalho da 11&ordf; Regi&atilde;o em diversas a&ccedil;&otilde;es ajuizadas pelos servidores irregularmente contratados; 8. A conduta praticada pelo apelado n&atilde;o apenas se distanciou das regras pertinentes &agrave; boa administra&ccedil;&atilde;o, como tamb&eacute;m incorreu abuso de direito, dado que este procedeu de forma il&iacute;cita e maliciosa restringindo e dificultando o exerc&iacute;cio dos direitos pelos seus administrados, bem como causando preju&iacute;zo ao patrim&ocirc;nio p&uacute;blico, circunst&acirc;ncia que representa a um s&oacute; tempo malferimento intencional aos interesses p&uacute;blicos prim&aacute;rio e secund&aacute;rio daquela municipalidade; 9. Em que pese a contrata&ccedil;&atilde;o irregular de servidor p&uacute;blico n&atilde;o seja per si sin&ocirc;nimo de ato &iacute;mprobo, a situa&ccedil;&atilde;o retratada nos autos recai exatamente sobre a ressalva firmada no Tema Repetitivo n.&ordm; 1108, visto que n&atilde;o se trata de simples ilicitude e dano ocasionados ao Poder P&uacute;blico em raz&atilde;o de incompet&ecirc;ncia ou do mau exerc&iacute;cio do m&uacute;nus p&uacute;blico (dolo gen&eacute;rico), mas sim em raz&atilde;o de uma gest&atilde;o permeada por atos distanciados da moralidade e da honestidade administrativas que, ao final, lesaram de forma consecutiva e irrevers&iacute;vel o patrim&ocirc;nio do Munic&iacute;pio de Coari (dolo espec&iacute;fico); 10. For&ccedil;osa a conclus&atilde;o pela presen&ccedil;a dos elementos subjetivo e objetivo da conduta imputada pelo parquet ao apelado, notadamente porque restou demonstrada a contrata&ccedil;&atilde;o irregular de servidores p&uacute;blicos que ocasionou danos irrevers&iacute;veis ao patrim&ocirc;nio p&uacute;blico do Munic&iacute;pio de Coari, bem como a consci&ecirc;ncia e vontade do apelado para a pr&aacute;tica do ato &iacute;mprobo; 11. Tendo em vista a natureza sancionat&oacute;ria do regime de improbidade e fazendo um cotejo entre a reda&ccedil;&atilde;o origin&aacute;ria da Lei n.&ordm; 8.429/92 e a atualmente vigente, alcan&ccedil;a-se a conclus&atilde;o de que as san&ccedil;&otilde;es vigentes &agrave; &eacute;poca dos fatos s&atilde;o menos gravosas, raz&atilde;o pela qual n&atilde;o se pode cogitar da retroatividade das penalidades da Lei n.&ordm; 14.230/21 para atingir a situa&ccedil;&atilde;o do apelado; 12. Considerando as peculiaridades do agente, as circunst&acirc;ncias f&aacute;ticas do caso e a extens&atilde;o do dano causado, conclui-se que as penalidades de recomposi&ccedil;&atilde;o do dano e multa revelam-se suficientemente adequadas para reprimir o ato &iacute;mprobo, mormente porque a aplica&ccedil;&atilde;o conjunta das demais comina&ccedil;&otilde;es dos incisos do art. 12 da Lei n.&ordm; 8.429/92 deve destinar-se aos casos extremos, em observ&acirc;ncia os princ&iacute;pios da proporcionalidade e da razoabilidade; 13. Senten&ccedil;a parcialmente reformada para julgar procedente o pedido de condena&ccedil;&atilde;o do apelado pela pr&aacute;tica do ato de improbidade do art. 10, I e XII, da Lei n.&ordm; 8.429/92, com a comina&ccedil;&atilde;o das penas do art. 12, II, da Lei n.&ordm; 8.429/91, quais sejam: (a) a recomposi&ccedil;&atilde;o do dano causado ao er&aacute;rio do Munic&iacute;pio de Coari, nos moldes delimitados pelo parquet em sua inicial e (b) o pagamento de multa correspondente ao valor do dano provocado ao er&aacute;rio p&uacute;blico, ambos devidamente atualizados, e, por fim, julgar improcedente o pedido de condena&ccedil;&atilde;o do apelado nas condutas do art. 11, I e V, da Lei n.&ordm; 8.429/91; 14. Recurso de apela&ccedil;&atilde;o e reexame oficial conhecidos e parcialmente providos, em harmonia com o parecer ministerial. <br><br>(Remessa Necess&aacute;ria C&iacute;vel N&ordm; 0001087-08.2020.8.04.0000; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 07/07/2025; Data de registro: 11/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Remessa Necessária Cível / Efeitos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Coari
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/07/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									11/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E REMESSA NECESSÁRIA. IMPROBIDADE ADMINISTRATIVA. ART. 19 DA LEI N.º 4.717/65. REGIME APLICÁVEL À AÇÃO DE IMPROBIDADE JULGADA IMPROCEDENTE ANTES DA ENTRADA EM VIGOR DA LEI N.º 14.230/21. CONTRATAÇÃO DE SERVIDORES PÚBLICOS À REVELIA DO CONCURSO PÚBLICO. MALFERIMENTO AOS PRINCÍPIOS DA ADMINISTRAÇÃO PÚBLICA. ART. 37, CAPUT E II, DA CF. SUPERVENIÊNCIA DA LEI N.º 14.230/21. REVOGAÇÃO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E REMESSA NECESSÁRIA. IMPROBIDADE ADMINISTRATIVA. ART. 19 DA LEI N.º 4.717/65. REGIME APLICÁVEL À AÇÃO DE IMPROBIDADE JULGADA IMPROCEDENTE ANTES DA ENTRADA EM VIGOR DA LEI N.º 14.230/21. CONTRATAÇÃO DE SERVIDORES PÚBLICOS À REVELIA DO CONCURSO PÚBLICO. MALFERIMENTO AOS PRINCÍPIOS DA ADMINISTRAÇÃO PÚBLICA. ART. 37, CAPUT E II, DA CF. SUPERVENIÊNCIA DA LEI N.º 14.230/21. REVOGAÇÃO DO ART. 11, I, DA LEI N.º 8.429/92. CONDUTA ATRIBUÍDA AO AGENTE PÚBLICO QUE NÃO SE AMOLDA AO TIPO DO ART. 11, V, DA LEI N.º 8.429/92. PREJUÍZO AO ERÁRIO PÚBLICO. ART. 10, I E XII, DA LEI N.º 8.429/92. CONTRATAÇÃO DE SERVIDOR NÃO BASEADA EM LEGISLAÇÃO LOCAL E NÃO ANTECEDIDA POR QUALQUER PROCESSO DE SELEÇÃO. PRORROGAÇÃO SUCESSIVA À MARGEM DA URGÊNCIA OU NECESSIDADE EXCEPCIONAL. MEDIDA DE INTERRUPÇÃO DOS CONTRATOS PARA FURTAR-SE AO PAGAMENTO DE VERBAS DEVIDAS AO SERVIDORES CONTRATADOS. ABUSO DO MÚNUS PÚBLICO. RESTRIÇÃO ILÍCITA E MALICIOSA DE DIREITOS DOS ADMINISTRADOS. VIOLAÇÃO AOS INTERESSES PÚBLICOS PRIMÁRIO E SECUNDÁRIO DO MUNICÍPIO. CONDUTAS DISTANCIADAS DA MORALIDADE E HONESTIDADE ADMINISTRATIVAS. DOLO ESPECÍFICO. CONSCIÊNCIA E VONTADE NA PRÁTICA DO ATO ÍMPROBO. SITUAÇÃO QUE SE AMOLDA À RESSALVA DO TEMA REPETITIVO N.º 1108. <em>DANO</em> AO ERÁRIO DEVIDAMENTE COMPROVADO. IRRETROATIVIDADE DO REGIME SANCIONATÓRIO DA LEI N.º 14.230/21. RECURSO E REEXAME OFICIAL CONHECIDOS E PARCIALMENTE PROVIDOS. 1. Na origem, o parquet propôs ação civil de improbidade administrativa contra o ex-prefeito do Município de Coari em razão do suposto cometimento das condutas previstas nos arts. 10, caput, e 11, I e V, ambos da Lei n.º 8.429/92, consubstanciado na contratação de servidores entre os anos de 2001 e 2007 para compor os quadros da Administração Pública sem a prévia realização de concurso público, ocasião em que seus pedidos foram julgados improcedentes pelo MM. Juízo da 1ª Vara da Comarca de Coari; 2. Em razão da entrada em vigor da Lei n.º 14.230/21, o STJ desafetou o Tema Repetitivo n.º 1042 e firmou entendimento sobre a aplicação do regime do duplo grau obrigatório de jurisdição do art. 19 da Lei n.º 4.717/65 para as ações de improbidade julgadas improcedentes anteriormente à entrada em vigor daquele ato normativo, mantida sua inaplicabilidade para as sentenças de improcedência ou extinção sem resolução do mérito posteriores à sobredita Lei n.º 14.230/21; 3. Com relação à acusação de violação aos princípios da administração, sabe-se que o entendimento firmado pelo STJ em precedentes vinculantes orienta-se no sentido de que a contratação de servidores públicos temporários sem concurso público não é per si causa precursora de ato ímprobo atentatório aos princípios administrativos, desde que tais vínculos temporários encontrem-se respaldados por legislação local (Tema Repetitivo n.º 1108); 4. In casu, por força das alterações introduzidas pela Lei n.º 14.230/21 e considerando a revogação do art. 11, I, da Lei n.º 8.429/91, revela-se inviável examinar a subsunção da conduta atribuída ao apelado precisamente no que diz respeito a tal ilícito, sob pena de violação das regras constitucionais atinentes à legalidade e à retroatividade da lei penal benigna (art. 1º, §4º, da Lei n.º 8.429/91 e art. 5º, XL e XLI, da CF); 5. Outrossim, ainda que subsista a tipificação do art. 11, V, da Lei n.º 8.429/91, infere-se dos autos que a conduta atribuída pelo parquet ao apelado não se amolda ao tipo previsto na norma, dado que o referido dispositivo se destina aos casos em que se verifica a violação ao caráter concorrencial do concurso público e não para as situações em que sua realização é ignorada pelo agente público responsável; 6. Com relação à acusação de <em>danos</em> ao erário, tal modalidade de improbidade revela-se nas situações em que o agente público, aproveitando-se dos poderes e facilidades decorrentes de seu múnus, pratica dolosamente ato omissivo ou comissivo contrário à moralidade administrativa e que ocasione prejuízo ao patrimônio público, sendo pertinentes ao caso concreto as condutas dos incisos I e XII do rol exemplificativo do art. 10 da Lei n.º 8.429/92; 7. De acordo com o conjunto probatório agregado aos fólios, em especial o Ofício n.º 154/2011-CMC-GP encaminhado pela Câmara Municipal de Coari, do Ofício n.º 12/2010-GAB e da Representação n.º 965/2009.11.000/8-04 ambos remetido pela Procuradoria Regional do Trabalho da 11ª Região, conclui-se que: (i) a contratação dos servidores não foi antecedida por concurso ou por qualquer processo simplificado de seleção; bem como (ii) não se fundou em lei local permissiva de contratação temporária; (iii) o gestor público promoveu a sucessiva prorrogação dos contratos à margem de qualquer urgência ou necessidade excepcional; bem como (iv) implementou medidas para interrupção das contratações em meses estratégicos, no claro intuito de furtar-se ao pagamento das verbas devidas aos prestadores de serviço; (v) tal cenário ensejou a condenação da municipalidade perante o Tribunal Regional do Trabalho da 11ª Região em diversas ações ajuizadas pelos servidores irregularmente contratados; 8. A conduta praticada pelo apelado não apenas se distanciou das regras pertinentes à boa administração, como também incorreu abuso de direito, dado que este procedeu de forma ilícita e maliciosa restringindo e dificultando o exercício dos direitos pelos seus administrados, bem como causando prejuízo ao patrimônio público, circunstância que representa a um só tempo malferimento intencional aos interesses públicos primário e secundário daquela municipalidade; 9. Em que pese a contratação irregular de servidor público não seja per si sinônimo de ato ímprobo, a situação retratada nos autos recai exatamente sobre a ressalva firmada no Tema Repetitivo n.º 1108, visto que não se trata de simples ilicitude e <em>dano</em> ocasionados ao Poder Público em razão de incompetência ou do mau exercício do múnus público (dolo genérico), mas sim em razão de uma gestão permeada por atos distanciados da moralidade e da honestidade administrativas que, ao final, lesaram de forma consecutiva e irreversível o patrimônio do Município de Coari (dolo específico); 10. Forçosa a conclusão pela presença dos elementos subjetivo e objetivo da conduta imputada pelo parquet ao apelado, notadamente porque restou demonstrada a contratação irregular de servidores públicos que ocasionou <em>danos</em> irreversíveis ao patrimônio público do Município de Coari, bem como a consciência e vontade do apelado para a prática do ato ímprobo; 11. Tendo em vista a natureza sancionatória do regime de improbidade e fazendo um cotejo entre a redação originária da Lei n.º 8.429/92 e a atualmente vigente, alcança-se a conclusão de que as sanções vigentes à época dos fatos são menos gravosas, razão pela qual não se pode cogitar da retroatividade das penalidades da Lei n.º 14.230/21 para atingir a situação do apelado; 12. Considerando as peculiaridades do agente, as circunstâncias fáticas do caso e a extensão do <em>dano</em> causado, conclui-se que as penalidades de recomposição do <em>dano</em> e multa revelam-se suficientemente adequadas para reprimir o ato ímprobo, mormente porque a aplicação conjunta das demais cominações dos incisos do art. 12 da Lei n.º 8.429/92 deve destinar-se aos casos extremos, em observância os princípios da proporcionalidade e da razoabilidade; 13. Sentença parcialmente reformada para julgar procedente o pedido de condenação do apelado pela prática do ato de improbidade do art. 10, I e XII, da Lei n.º 8.429/92, com a cominação das penas do art. 12, II, da Lei n.º 8.429/91, quais sejam: (a) a recomposição do <em>dano</em> causado ao erário do Município de Coari, nos moldes delimitados pelo parquet em sua inicial e (b) o pagamento de multa correspondente ao valor do <em>dano</em> provocado ao erário público, ambos devidamente atualizados, e, por fim, julgar improcedente o pedido de condenação do apelado nas condutas do art. 11, I e V, da Lei n.º 8.429/91; 14. Recurso de apelação e reexame oficial conhecidos e parcialmente providos, em harmonia com o parecer ministerial.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363931" cdForo="0" >
+										0008015-33.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363931" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363931);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363931" style="display: none;" >
+	<div id="textAreaDados_3363931" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. V&Iacute;CIO DE CONSENTIMENTO. VIOLA&Ccedil;&Atilde;O AO DEVER DE INFORMA&Ccedil;&Atilde;O. CONVERS&Atilde;O EM EMPR&Eacute;STIMO CONSIGNADO. REPETI&Ccedil;&Atilde;O EM DOBRO. DANOS MORAIS. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que deu provimento &agrave; apela&ccedil;&atilde;o do banco agravado, em a&ccedil;&atilde;o na qual a consumidora alegou ter contratado empr&eacute;stimo consignado, mas sofreu descontos mensais decorrentes de cart&atilde;o de cr&eacute;dito consignado n&atilde;o solicitado ou compreendido. Sustentou n&atilde;o ter recebido o cart&atilde;o, nem ter ci&ecirc;ncia de que os descontos seriam feitos a t&iacute;tulo de pagamento m&iacute;nimo da fatura, em sistema de juros rotativos que tornou a d&iacute;vida infind&aacute;vel. Pleiteou a declara&ccedil;&atilde;o de nulidade do contrato, convers&atilde;o da contrata&ccedil;&atilde;o para empr&eacute;stimo consignado, devolu&ccedil;&atilde;o em dobro dos valores pagos indevidamente e indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) verificar se houve v&iacute;cio de consentimento na contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado, por viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o; (ii) determinar se &eacute; cab&iacute;vel a convers&atilde;o do contrato para a modalidade de empr&eacute;stimo consignado, com devolu&ccedil;&atilde;o em dobro dos valores pagos indevidamente; (iii) estabelecer se est&atilde;o presentes os requisitos para a condena&ccedil;&atilde;o em danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A institui&ccedil;&atilde;o financeira viola o dever de informa&ccedil;&atilde;o ao n&atilde;o apresentar, de forma clara e acess&iacute;vel, elementos essenciais do contrato de cart&atilde;o de cr&eacute;dito consignado, como meios de quita&ccedil;&atilde;o da d&iacute;vida, cobran&ccedil;a integral do valor sacado, mecanismo de incid&ecirc;ncia de juros e acesso &agrave;s faturas.
+4. A aus&ecirc;ncia de preenchimento de campos essenciais no contrato, como o &quot;Quadro IV&quot;, que indicaria a forma de pagamento, revela nulidade contratual por falta de clareza e transpar&ecirc;ncia, contrariando as teses firmadas no IRDR n&ordm; 0005217-75.2019.8.04.0000.
+5. A repeti&ccedil;&atilde;o em dobro do ind&eacute;bito &eacute; cab&iacute;vel, independentemente de demonstra&ccedil;&atilde;o de m&aacute;-f&eacute;, bastando a conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva da institui&ccedil;&atilde;o financeira, conforme tese 4 do IRDR.
+6. Os saques e compras comprovadamente realizados pela consumidora com o cart&atilde;o devem ser compensados na fase de liquida&ccedil;&atilde;o, sob pena de enriquecimento il&iacute;cito, conforme tese 5 do IRDR.
+7. A configura&ccedil;&atilde;o do dano moral decorre da frustra&ccedil;&atilde;o leg&iacute;tima de expectativas do consumidor, da viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o e do prolongamento indevido da d&iacute;vida, justificando indeniza&ccedil;&atilde;o pecuni&aacute;ria nos termos da tese 3 do IRDR.
+IV. DISPOSITIVO E TESE
+8. Recurso parcialmente provido.
+Tese de julgamento:
+1) A contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado sem a inequ&iacute;voca ci&ecirc;ncia dos termos contratuais viola o dever de informa&ccedil;&atilde;o e configura v&iacute;cio de consentimento.
+2) A invalidade do contrato por aus&ecirc;ncia de informa&ccedil;&atilde;o autoriza sua convers&atilde;o para empr&eacute;stimo consignado, com aplica&ccedil;&atilde;o da taxa de juros correspondente &agrave; modalidade.
+3) A repeti&ccedil;&atilde;o em dobro dos valores pagos indevidamente &eacute; cab&iacute;vel sem necessidade de prova de m&aacute;-f&eacute;, bastando a viola&ccedil;&atilde;o &agrave; boa-f&eacute; objetiva.
+4) A configura&ccedil;&atilde;o de dano moral decorre da conduta abusiva da institui&ccedil;&atilde;o financeira, sendo devida a indeniza&ccedil;&atilde;o, ainda que n&atilde;o haja utiliza&ccedil;&atilde;o do cart&atilde;o pelo consumidor.
+5) Os valores efetivamente utilizados pelo consumidor por meio do cart&atilde;o de cr&eacute;dito devem ser compensados na fase de liquida&ccedil;&atilde;o, para evitar enriquecimento il&iacute;cito.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, X; CC, arts. 170, 186, 927, 944; CDC, arts. 14, 42, par&aacute;grafo &uacute;nico, 51, IV e XV; CPC, art. 932, V, &quot;c&quot;.
+Jurisprud&ecirc;ncia relevante citada: TJAM, IRDR n&ordm; 0005217-75.2019.8.04.0000, Rel. Des. Jos&eacute; Hamilton Saraiva dos Santos, Tribunal Pleno, j. 01.02.2022. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0008015-33.2024.8.04.0000; Relator (a): Cezar Luiz Bandiera; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 10/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Cezar Luiz Bandiera
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									10/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO EM EMPRÉSTIMO CONSIGNADO. REPETIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em>. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento à apelação do banco agravado, em ação na qual a consumidora
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO EM EMPRÉSTIMO CONSIGNADO. REPETIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em>. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento à apelação do banco agravado, em ação na qual a consumidora alegou ter contratado empréstimo consignado, mas sofreu descontos mensais decorrentes de cartão de crédito consignado não solicitado ou compreendido. Sustentou não ter recebido o cartão, nem ter ciência de que os descontos seriam feitos a título de pagamento mínimo da fatura, em sistema de juros rotativos que tornou a dívida infindável. Pleiteou a declaração de nulidade do contrato, conversão da contratação para empréstimo consignado, devolução em dobro dos valores pagos indevidamente e indenização por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) verificar se houve vício de consentimento na contratação de cartão de crédito consignado, por violação ao dever de informação; (ii) determinar se é cabível a conversão do contrato para a modalidade de empréstimo consignado, com devolução em dobro dos valores pagos indevidamente; (iii) estabelecer se estão presentes os requisitos para a condenação em <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3. A instituição financeira viola o dever de informação ao não apresentar, de forma clara e acessível, elementos essenciais do contrato de cartão de crédito consignado, como meios de quitação da dívida, cobrança integral do valor sacado, mecanismo de incidência de juros e acesso às faturas.
+4. A ausência de preenchimento de campos essenciais no contrato, como o "Quadro IV", que indicaria a forma de pagamento, revela nulidade contratual por falta de clareza e transparência, contrariando as teses firmadas no IRDR nº 0005217-75.2019.8.04.0000.
+5. A repetição em dobro do indébito é cabível, independentemente de demonstração de má-fé, bastando a conduta contrária à boa-fé objetiva da instituição financeira, conforme tese 4 do IRDR.
+6. Os saques e compras comprovadamente realizados pela consumidora com o cartão devem ser compensados na fase de liquidação, sob pena de enriquecimento ilícito, conforme tese 5 do IRDR.
+7. A configuração do <em>dano</em> <em>moral</em> decorre da frustração legítima de expectativas do consumidor, da violação ao dever de informação e do prolongamento indevido da dívida, justificando indenização pecuniária nos termos da tese 3 do IRDR.
+IV. DISPOSITIVO E TESE
+8. Recurso parcialmente provido.
+Tese de julgamento:
+1) A contratação de cartão de crédito consignado sem a inequívoca ciência dos termos contratuais viola o dever de informação e configura vício de consentimento.
+2) A invalidade do contrato por ausência de informação autoriza sua conversão para empréstimo consignado, com aplicação da taxa de juros correspondente à modalidade.
+3) A repetição em dobro dos valores pagos indevidamente é cabível sem necessidade de prova de má-fé, bastando a violação à boa-fé objetiva.
+4) A configuração de <em>dano</em> <em>moral</em> decorre da conduta abusiva da instituição financeira, sendo devida a indenização, ainda que não haja utilização do cartão pelo consumidor.
+5) Os valores efetivamente utilizados pelo consumidor por meio do cartão de crédito devem ser compensados na fase de liquidação, para evitar enriquecimento ilícito.
+Dispositivos relevantes citados: CF/1988, art. 5º, X; CC, arts. 170, 186, 927, 944; CDC, arts. 14, 42, parágrafo único, 51, IV e XV; CPC, art. 932, V, "c".
+Jurisprudência relevante citada: TJAM, IRDR nº 0005217-75.2019.8.04.0000, Rel. Des. José Hamilton Saraiva dos Santos, Tribunal Pleno, j. 01.02.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363747" cdForo="0" >
+										0628624-87.2021.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363747" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363747);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363747" style="display: none;" >
+	<div id="textAreaDados_3363747" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. RESPONSABILIDADE CIVIL. V&Iacute;CIO DO PRODUTO. RESTITUI&Ccedil;&Atilde;O DO VALOR PAGO PELO VE&Iacute;CULO. DANO MORAL. REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO PROVIDO EM PARTE.
+I. CASO EM EXAME
+Apela&ccedil;&otilde;es c&iacute;veis interpostas pelos requeridos contra senten&ccedil;a que julgou procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos materiais e morais, determinando, solidariamente, a substitui&ccedil;&atilde;o de ve&iacute;culo automotor com v&iacute;cio oculto por outro zero quil&ocirc;metro ou, alternativamente, a restitui&ccedil;&atilde;o integral da quantia paga, acrescida de juros e corre&ccedil;&atilde;o monet&aacute;ria, al&eacute;m de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 20.000,00. O voto vencido diverge parcialmente do entendimento da relatora, entendendo excessiva a substitui&ccedil;&atilde;o do ve&iacute;culo usado por um novo e desproporcional o montante indenizat&oacute;rio, votando pela restitui&ccedil;&atilde;o do valor conforme Tabela FIPE, com descontos legais, e redu&ccedil;&atilde;o dos danos morais para R$ 10.000,00.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; devida a substitui&ccedil;&atilde;o do ve&iacute;culo com v&iacute;cio oculto por outro zero quil&ocirc;metro ou apenas a restitui&ccedil;&atilde;o proporcional do valor pago; (ii) estabelecer o valor adequado da indeniza&ccedil;&atilde;o por danos morais diante do caso concreto.
+III. RAZ&Otilde;ES DE DECIDIR
+1) A responsabilidade solid&aacute;ria entre fabricante e concession&aacute;ria por v&iacute;cio no produto &eacute; aplic&aacute;vel nos moldes do C&oacute;digo de Defesa do Consumidor, especialmente quando o v&iacute;cio reduz o valor do bem ou o torna impr&oacute;prio ao uso.
+2) A substitui&ccedil;&atilde;o do ve&iacute;culo usado por outro novo mostra-se desproporcional quando n&atilde;o h&aacute; demonstra&ccedil;&atilde;o de inutilidade do bem nem de impossibilidade de reparo dentro do prazo legal.
+3) O reparo do ve&iacute;culo foi realizado em tempo h&aacute;bil e a consumidora permaneceu em posse do bem, sem novas reclama&ccedil;&otilde;es, indicando que a concession&aacute;ria n&atilde;o foi privada da chance de sanar o defeito.
+4) A restitui&ccedil;&atilde;o do valor do ve&iacute;culo com base na Tabela FIPE, com dedu&ccedil;&atilde;o de d&eacute;bitos existentes, atende &agrave; repara&ccedil;&atilde;o integral sem configurar enriquecimento sem causa.
+5) O valor de R$ 10.000,00 por danos morais mostra-se razo&aacute;vel e proporcional ao preju&iacute;zo extrapatrimonial experimentado pela parte autora.
+IV. DISPOSITIVO E TESE
+Recursos providos em parte.
+Pedidos procedentes em parte.
+Tese de julgamento:
+1) A substitui&ccedil;&atilde;o de ve&iacute;culo usado por outro zero quil&ocirc;metro exige prova de inutilidade ou irreparabilidade do bem, n&atilde;o sendo cab&iacute;vel apenas por exist&ecirc;ncia de v&iacute;cio san&aacute;vel.
+2) A restitui&ccedil;&atilde;o do valor do ve&iacute;culo com base na Tabela FIPE, com descontos legais, &eacute; medida adequada quando constatado v&iacute;cio no produto e j&aacute; transcorrido tempo razo&aacute;vel desde a aquisi&ccedil;&atilde;o.
+3) A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, podendo ser reduzida quando excessiva em rela&ccedil;&atilde;o &agrave;s circunst&acirc;ncias do caso concreto.
+Dispositivos relevantes citados: CDC, art. 6&ordm;, VI; art. 18 e &sect;1&ordm;. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0628624-87.2021.8.04.0001; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 05/06/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Rescisão do contrato e devolução do dinheiro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									05/06/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÕES CÍVEIS. RESPONSABILIDADE CIVIL. VÍCIO DO PRODUTO. RESTITUIÇÃO DO VALOR PAGO PELO VEÍCULO. <em>DANO</em> <em>MORAL</em>. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PROVIDO EM PARTE.
+I. CASO EM EXAME
+Apelações cíveis interpostas pelos requeridos contra sentença que julgou procedente ação de indenização por <em>danos</em> materiais e <em>morais</em>, determinando,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÕES CÍVEIS. RESPONSABILIDADE CIVIL. VÍCIO DO PRODUTO. RESTITUIÇÃO DO VALOR PAGO PELO VEÍCULO. <em>DANO</em> <em>MORAL</em>. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PROVIDO EM PARTE.
+I. CASO EM EXAME
+Apelações cíveis interpostas pelos requeridos contra sentença que julgou procedente ação de indenização por <em>danos</em> materiais e <em>morais</em>, determinando, solidariamente, a substituição de veículo automotor com vício oculto por outro zero quilômetro ou, alternativamente, a restituição integral da quantia paga, acrescida de juros e correção monetária, além de indenização por <em>danos</em> <em>morais</em> no valor de R$ 20.000,00. O voto vencido diverge parcialmente do entendimento da relatora, entendendo excessiva a substituição do veículo usado por um novo e desproporcional o montante indenizatório, votando pela restituição do valor conforme Tabela FIPE, com descontos legais, e redução dos <em>danos</em> <em>morais</em> para R$ 10.000,00.
+II. QUESTÃO EM DISCUSSÃO
+Há duas questões em discussão: (i) definir se é devida a substituição do veículo com vício oculto por outro zero quilômetro ou apenas a restituição proporcional do valor pago; (ii) estabelecer o valor adequado da indenização por <em>danos</em> <em>morais</em> diante do caso concreto.
+III. RAZÕES DE DECIDIR
+1) A responsabilidade solidária entre fabricante e concessionária por vício no produto é aplicável nos moldes do Código de Defesa do Consumidor, especialmente quando o vício reduz o valor do bem ou o torna impróprio ao uso.
+2) A substituição do veículo usado por outro novo mostra-se desproporcional quando não há demonstração de inutilidade do bem nem de impossibilidade de reparo dentro do prazo legal.
+3) O reparo do veículo foi realizado em tempo hábil e a consumidora permaneceu em posse do bem, sem novas reclamações, indicando que a concessionária não foi privada da chance de sanar o defeito.
+4) A restituição do valor do veículo com base na Tabela FIPE, com dedução de débitos existentes, atende à reparação integral sem configurar enriquecimento sem causa.
+5) O valor de R$ 10.000,00 por <em>danos</em> <em>morais</em> mostra-se razoável e proporcional ao prejuízo extrapatrimonial experimentado pela parte autora.
+IV. DISPOSITIVO E TESE
+Recursos providos em parte.
+Pedidos procedentes em parte.
+Tese de julgamento:
+1) A substituição de veículo usado por outro zero quilômetro exige prova de inutilidade ou irreparabilidade do bem, não sendo cabível apenas por existência de vício sanável.
+2) A restituição do valor do veículo com base na Tabela FIPE, com descontos legais, é medida adequada quando constatado vício no produto e já transcorrido tempo razoável desde a aquisição.
+3) A fixação de indenização por <em>danos</em> <em>morais</em> deve observar os princípios da razoabilidade e proporcionalidade, podendo ser reduzida quando excessiva em relação às circunstâncias do caso concreto.
+Dispositivos relevantes citados: CDC, art. 6º, VI; art. 18 e §1º.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363745" cdForo="0" >
+										4013261-73.2023.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363745" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363745);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363745" style="display: none;" >
+	<div id="textAreaDados_3363745" class="mensagemSemFormatacao" >
+		Ementa: AGRAVO DE INSTRUMENTO. GRATUIDADE DA JUSTI&Ccedil;A. PESSOA F&Iacute;SICA. DECLARA&Ccedil;&Atilde;O DE HIPOSSUFICI&Ecirc;NCIA ECON&Ocirc;MICA. PRESUN&Ccedil;&Atilde;O RELATIVA DE VERACIDADE. DEMAIS DOCUMENTOS QUE CORROBORAM A ALEGA&Ccedil;&Atilde;O. PREENCHIMENTO DOS PRESSUPOSTOS NECESS&Aacute;RIOS &Agrave; CONCESS&Atilde;O DA GRATUIDADE. RECURSO CONHECIDO E PROVIDO. DECIS&Atilde;O REFORMADA PARA CONCEDER A GRATUIDADE DA JUSTI&Ccedil;A AO AUTOR. 1. O art. 99, &sect; 3&ordm; do CPC disp&otilde;e que a afirma&ccedil;&atilde;o de hipossufici&ecirc;ncia econ&ocirc;mica deduzida por pessoa natural possui presun&ccedil;&atilde;o relativa de veracidade e, justamente em raz&atilde;o deste car&aacute;ter relativo, &eacute; que o mesmo diploma autoriza que o magistrado, verificando a exist&ecirc;ncia de elementos que evidenciem a falta dos pressupostos legais para a concess&atilde;o do benef&iacute;cio, indefira o pleito, devendo antes oportunizar &agrave; parte que comprove a presen&ccedil;a de tais pressupostos. 2. No caso concreto, o Ju&iacute;zo a quo, observando o procedimento previsto pelo art. 99, &sect; 2&ordm;, do CPC, determinou &agrave; agravante que apresentasse documentos comprobat&oacute;rios da alegada insufici&ecirc;ncia de recursos, a fim de avaliar a possibilidade de concess&atilde;o do benef&iacute;cio da gratuidade de justi&ccedil;a e, ap&oacute;s cumprida tal determina&ccedil;&atilde;o, decidiu indeferir o pedido. 3. Sucede que os documentos juntados aos autos corroboram a alega&ccedil;&atilde;o de hipossufici&ecirc;ncia econ&ocirc;mica deduzida pela agravante, devendo ser concedida em seu favor a gratuidade de justi&ccedil;a, na forma do art. 98, caput e &sect; 1&ordm;, do C&oacute;digo de Processo Civil, garantindo-lhe o direito fundamental ao acesso &agrave; justi&ccedil;a (art. 5&ordm;, XXXV, CF). 4. Recurso conhecido e provido. Decis&atilde;o reformada para conceder a gratuidade da justi&ccedil;a ao autor.  <br><br>(Agravo de Instrumento N&ordm; 4013261-73.2023.8.04.0000; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 05/06/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Assistência Judiciária Gratuita
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									05/06/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. GRATUIDADE DA JUSTIÇA. PESSOA FÍSICA. DECLARAÇÃO DE HIPOSSUFICIÊNCIA ECONÔMICA. PRESUNÇÃO RELATIVA DE VERACIDADE. DEMAIS DOCUMENTOS QUE CORROBORAM A ALEGAÇÃO. PREENCHIMENTO DOS PRESSUPOSTOS NECESSÁRIOS À CONCESSÃO DA GRATUIDADE. RECURSO CONHECIDO E PROVIDO. DECISÃO REFORMADA PARA CONCEDER A GRATUIDADE DA JUSTIÇA AO AUTOR. 1. O art. 99, § 3º do CPC dispõe que a afirmação de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. GRATUIDADE DA JUSTIÇA. PESSOA FÍSICA. DECLARAÇÃO DE HIPOSSUFICIÊNCIA ECONÔMICA. PRESUNÇÃO RELATIVA DE VERACIDADE. DEMAIS DOCUMENTOS QUE CORROBORAM A ALEGAÇÃO. PREENCHIMENTO DOS PRESSUPOSTOS NECESSÁRIOS À CONCESSÃO DA GRATUIDADE. RECURSO CONHECIDO E PROVIDO. DECISÃO REFORMADA PARA CONCEDER A GRATUIDADE DA JUSTIÇA AO AUTOR. 1. O art. 99, § 3º do CPC dispõe que a afirmação de hipossuficiência econômica deduzida por pessoa natural possui presunção relativa de veracidade e, justamente em razão deste caráter relativo, é que o mesmo diploma autoriza que o magistrado, verificando a existência de elementos que evidenciem a falta dos pressupostos legais para a concessão do benefício, indefira o pleito, devendo antes oportunizar à parte que comprove a presença de tais pressupostos. 2. No caso concreto, o Juízo a quo, observando o procedimento previsto pelo art. 99, § 2º, do CPC, determinou à agravante que apresentasse documentos comprobatórios da alegada insuficiência de recursos, a fim de avaliar a possibilidade de concessão do benefício da gratuidade de justiça e, após cumprida tal determinação, decidiu indeferir o pedido. 3. Sucede que os documentos juntados aos autos corroboram a alegação de hipossuficiência econômica deduzida pela agravante, devendo ser concedida em seu favor a gratuidade de justiça, na forma do art. 98, caput e § 1º, do Código de Processo Civil, garantindo-lhe o direito fundamental ao acesso à justiça (art. 5º, XXXV, CF). 4. Recurso conhecido e provido. Decisão reformada para conceder a gratuidade da justiça ao autor.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			</div>
+		</td>
+		<td width="20px">
+			&nbsp;
+		</td>
+		<td valign="top" width="230px">
+			<div id="adicionarPesquisa-A">
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="EMENTA">
+									<label for="ckTermo1">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="RECURSO">
+									<label for="ckTermo2">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="APELAÇÃO">
+									<label for="ckTermo3">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="CONHECIDO">
+									<label for="ckTermo4">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="CÍVEL">
+									<label for="ckTermo5">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="PROVIDO">
+									<label for="ckTermo6">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="AÇÃO">
+									<label for="ckTermo7">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="Recurso">
+									<label for="ckTermo8">
+										Recurso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="conhecido">
+									<label for="ckTermo9">
+										conhecido
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="SENTENÇA">
+									<label for="ckTermo10">
+										SENTENÇA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="DIREITO">
+									<label for="ckTermo11">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="CIVIL">
+									<label for="ckTermo12">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="DANOS">
+									<label for="ckTermo13">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="MORAIS">
+									<label for="ckTermo14">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="provido">
+									<label for="ckTermo15">
+										provido
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			</div>
+
+		</td>
+	</tr>
+</table>
+<div id="paginacaoInferior-A">
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 10
+			</strong>
+			de 54334
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+							<script>
+							$(function(){
+								$.saj.cjsg.bindsAbaInicial('A');
+							});
+							</script>
+
+
+
+						</div>
+
+				</div>
+
+			<!-- Resultado consulta -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</td>
+</tr>
+</table>
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaRodape" summary=" ">
+    <tr>
+        <td class="esajCelulaRodapeCentro">
+            Desenvolvido pela Softplan em parceria com o Tribunal de Justiça do Estado do Amazonas
+
+        </td>
+    </tr>
+</table>
+<link href="https://consultasaj.tjam.jus.br/esaj/tema/padrao/css/saj-popup-modal.css" rel="stylesheet" type="text/css">
+<link href="https://consultasaj.tjam.jus.br/esaj/tema/padrao/css/popup-beta.css" rel="stylesheet" type="text/css">
+
+
+<script>
+    var appEsajLayout = appEsajLayout || {};
+    appEsajLayout.tituloCertificadoDigital = 'Certificado digital';
+    appEsajLayout.cliente = 'AM';
+    appEsajLayout.emailParaContato = 'suporte.capital@tjam.jus.br';
+    appEsajLayout.utilizarBotaoContato = 'false';
+    appEsajLayout.contexto = 'https://consultasaj.tjam.jus.br/esaj';
+
+    if(window.jQuery) {
+        jQuery.saj = jQuery.saj || {};
+        jQuery.saj.certificado = jQuery.saj.certificado || {};
+        jQuery.saj.certificado.cliente = 'AM';
+        jQuery.saj.certificado.urlConteudoAjudaWebSigner = appEsajLayout.contexto + '/ajudaWebSigner.do';
+        jQuery.saj.certificado.licenca = 'AWcBKi50amFtLmp1cy5iciwxMC40Ny42MC4xMDYsMTAuNDcuNjAuMTA3LDEwLjQ3LjYwLjEzNSwxMC40Ny42MC4xMzYsMTAuNDcuNjAuMTQxLDEwLjQ3LjYwLjE0MiwxMC40Ny42MC4yMDYsMTAuNDcuNjAuMjExLDEwLjQ3LjYwLjIyMywxMC40Ny43MC4xOSwxMC40Ny43MC4yMiwxMC40Ny43MC4zNSwxMC40Ny43MC4zNiwxMC40Ny43MC4zNywxMC40Ny43MC4zOCwxMC40Ny43MC4zOSwxMC40Ny43MC40MCwxMC40Ny43MC40MSwxMC40Ny43MC40MiwxMC40Ny43MC40MywxMC40Ny43MC40NCwxMC40Ny43MC40NSwxMC40Ny43MC40NiwxMC40Ny43MC40OCwxMC40Ny43MC40OSwxMC40Ny43MC41MCwxMC40Ny43MC41MSwxNzIuMjMuMjAuODEAAAABPOQA8kW3k6PK2jr+5q1X8ZKxJq7cCX+9KudTXFHgOmcHdaGBp13/P+be/0iqBLfeTcd040IbsE8nxc6aNhGuAbM5YoAJoNwr7Gpcp2LiYB205hxgkMQAIBkTPUsfq6D84juBWB1/B4cjZDLbTP/bsMY0Zwbj1Bw8RE2N5qGCQkUXH1z6Yj4rKK0OPPqVv0j9+BfolMP4+1Bg23pzzvSz+mmipbs0t+PsGCJdzyc56yHurBWLagvUEnxBawsAgY4Eh0ow2kahv+eadwtLDCb3BQMpEHDIVofVJ6PV3ptgTWsreTSxSE1YpDqb32uLNqrLUhu8tV3tKsA2lwFgLD/nCA==';
+        jQuery.saj.certificado.cofreDigital = jQuery.saj.certificado.cofreDigital || {};
+        jQuery.saj.certificado.cofreDigital.habilitado = 'false' === 'true';
+        jQuery.saj.certificado.cofreDigital.enderecoBase = 'https://consultasaj.tjam.jus.br/esaj';
+    }
+
+</script>
+<script src="https://consultasaj.tjam.jus.br/esaj/js/app-bundle.js?n=2978165087"></script>
+<script src="https://consultasaj.tjam.jus.br/sajcas/seletorVersaoBeta.js?n=e27d1c0d-17ea-46ca-9db5-f150aaeb8f01&versao=1"></script>
+<script language="javascript" type="text/JavaScript" src="https://consultasaj.tjam.jus.br/esaj/js/softplan-websigner-2.5.1.js?n=736057767"></script>
+
+<script language="javascript" type="text/JavaScript" src="https://consultasaj.tjam.jus.br/esaj/js/saj-certificado.js?n=1326929064"></script>
+
+
+
+<div id="webSignerNaoInstalado" style="display: none;">
+    <p>Para utilização do certificado digital no Portal e-SAJ é necessário a instalação do plug-in Web Signer. Por favor, realize a instalação antes de continuar.</p>
+    <div class="footer_certificado">
+        <button id="redirecionarParaPaginaInstalacao" class="actionPrincipal spwBotaoDefault">Instalar</button>
+        <button class="fecharModalInstalacao spwBotao">Cancelar</button>
+        <button class="spwBotao" onclick="window.open('https://consultasaj.tjam.jus.br/WebHelp//#id_instalacao_lacuna.htm','_blank')">Ajuda</button>
+    </div>
+</div>
+
+<div id="webSignerNaoSuportado" style="display: none;">
+    <p>O navegador utilizado não é compatível com a tecnologia (Web Signer) necessária para utilização do certificado digital. Por favor, utilize um dos navegadores homologados. Em caso de dúvidas, efetue a validação de requisitos <a href="https://consultasaj.tjam.jus.br/petpg/abrirVerificacaoRequisitosPet.do" target="_blank">aqui</a>.</p>
+    <div class="footer_certificado">
+        <button class="fecharModalInstalacao spwBotaoDefault actionPrincipal">OK</button>
+    </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+	</body>
+</html>

--- a/tests/tjam/samples/cjsg/results_normal_page_01.html
+++ b/tests/tjam/samples/cjsg/results_normal_page_01.html
@@ -1,0 +1,1889 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(54334)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="54334" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363939" cdForo="0" >
+										0708349-62.2020.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363939" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363939);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363939" style="display: none;" >
+	<div id="textAreaDados_3363939" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. DIREITO CIVIL. DIREITO CONSUMERISTA. PLANO DE SA&Uacute;DE. RECUSA DE ATENDIMENTO NA REDE CREDENCIADA. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. DANO MORAL ARBITRADO EM FAVOR DO MENOR AUTOR-APELANTE E DE SUA GENITORA. RECURSO DE APELA&Ccedil;&Atilde;O MANEJADO APENAS PELO MENOR. MAJORA&Ccedil;&Atilde;O. POSSIBILIDADE. PRIMEIRO RECURSO CONHECIDO E N&Atilde;O PROVIDO. SEGUNDO RECURSO CONHECIDO E PROVIDO. SENTEN&Ccedil;A REFORMADA. 1. O cerne da controv&eacute;rsia cinge-se em apurar se houve falha na presta&ccedil;&atilde;o de servi&ccedil;os em raz&atilde;o da negativa de atendimento aos autores-apelantes na rede credenciada da operadora r&eacute; no  dia 22/11/2019 e, em caso positivo, a exist&ecirc;ncia da obriga&ccedil;&atilde;o em compensa-los a t&iacute;tulo de danos morais; 2.  A rela&ccedil;&atilde;o entre as partes enquadra-se perfeitamente em uma t&iacute;pica rela&ccedil;&atilde;o de consumo, devendo ser aplicado o C&oacute;digo de Prote&ccedil;&atilde;o e Defesa do Consumidor - CDC e o seu regramento, pois tanto o conceito de consumidor, quanto de fornecedor est&atilde;o presentes; 3.  Muito embora a r&eacute;-apelante negue os fatos narrados ao longo da peti&ccedil;&atilde;o inicial, &eacute; certo que o contexto probat&oacute;rio existente nos autos com eles corrobora, tendo em vista que os autores-apelantes a eles aportaram o registro de conversa via Whatsapp tendo como interlocutor preposto da operadora r&eacute;. Nesse di&aacute;logo est&aacute; suficientemente claro que o nome do autor-apelante Pedro Rafael da Silva Sales ainda n&atilde;o constava do sistema de benefici&aacute;rios no dia 23/11/2019, isto &eacute;, um dia ap&oacute;s os fatos narrados na inicial; 4. H&aacute; nos autos, ainda, ficha de atendimento do autor-apelante no Pronto Socorro da Crian&ccedil;a da Zona Sul de Manaus, unidade integrante do SUS, indicando justamente a data de 22/11/2019, quando teria havido a recusa de atendimento do paciente na rede credenciada &agrave; operadora r&eacute;; 5. A recusa de atendimento na rede credenciada, a um s&oacute; tempo, prolongou o estado do sofrimento do paciente e a ang&uacute;stia de sua m&atilde;e por se ver incapaz de adotar medidas para cura-lo, caracterizando o dano moral; 6. Considerando que o paciente cujo atendimento foi negado trata-se de crian&ccedil;a, deve-se majorar o valor dos danos morais de R$ 5.000,00 (cinco mil reais) para R$ 6.000,00 (seis mil reais); 7. Primeiro recurso conhecido e n&atilde;o provido. Segundo recurso conhecido e provido. Senten&ccedil;a reformada. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0708349-62.2020.8.04.0001; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 25/11/2024; Data de registro: 18/09/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(42 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Material
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									25/11/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									18/09/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. DIREITO CIVIL. DIREITO CONSUMERISTA. PLANO DE SAÚDE. RECUSA DE ATENDIMENTO NA REDE CREDENCIADA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> ARBITRADO EM FAVOR DO MENOR AUTOR-APELANTE E DE SUA GENITORA. RECURSO DE APELAÇÃO MANEJADO APENAS PELO MENOR. MAJORAÇÃO. POSSIBILIDADE. PRIMEIRO RECURSO CONHECIDO E NÃO PROVIDO. SEGUNDO RECURSO CONHECIDO E PROVIDO. SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. DIREITO CIVIL. DIREITO CONSUMERISTA. PLANO DE SAÚDE. RECUSA DE ATENDIMENTO NA REDE CREDENCIADA. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> ARBITRADO EM FAVOR DO MENOR AUTOR-APELANTE E DE SUA GENITORA. RECURSO DE APELAÇÃO MANEJADO APENAS PELO MENOR. MAJORAÇÃO. POSSIBILIDADE. PRIMEIRO RECURSO CONHECIDO E NÃO PROVIDO. SEGUNDO RECURSO CONHECIDO E PROVIDO. SENTENÇA REFORMADA. 1. O cerne da controvérsia cinge-se em apurar se houve falha na prestação de serviços em razão da negativa de atendimento aos autores-apelantes na rede credenciada da operadora ré no  dia 22/11/2019 e, em caso positivo, a existência da obrigação em compensa-los a título de <em>danos</em> <em>morais</em>; 2.  A relação entre as partes enquadra-se perfeitamente em uma típica relação de consumo, devendo ser aplicado o Código de Proteção e Defesa do Consumidor - CDC e o seu regramento, pois tanto o conceito de consumidor, quanto de fornecedor estão presentes; 3.  Muito embora a ré-apelante negue os fatos narrados ao longo da petição inicial, é certo que o contexto probatório existente nos autos com eles corrobora, tendo em vista que os autores-apelantes a eles aportaram o registro de conversa via Whatsapp tendo como interlocutor preposto da operadora ré. Nesse diálogo está suficientemente claro que o nome do autor-apelante Pedro Rafael da Silva Sales ainda não constava do sistema de beneficiários no dia 23/11/2019, isto é, um dia após os fatos narrados na inicial; 4. Há nos autos, ainda, ficha de atendimento do autor-apelante no Pronto Socorro da Criança da Zona Sul de Manaus, unidade integrante do SUS, indicando justamente a data de 22/11/2019, quando teria havido a recusa de atendimento do paciente na rede credenciada à operadora ré; 5. A recusa de atendimento na rede credenciada, a um só tempo, prolongou o estado do sofrimento do paciente e a angústia de sua mãe por se ver incapaz de adotar medidas para cura-lo, caracterizando o <em>dano</em> <em>moral</em>; 6. Considerando que o paciente cujo atendimento foi negado trata-se de criança, deve-se majorar o valor dos <em>danos</em> <em>morais</em> de R$ 5.000,00 (cinco mil reais) para R$ 6.000,00 (seis mil reais); 7. Primeiro recurso conhecido e não provido. Segundo recurso conhecido e provido. Sentença reformada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363938" cdForo="0" >
+										0515824-48.2023.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363938" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363938);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363938" style="display: none;" >
+	<div id="textAreaDados_3363938" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL &ndash; TAXA DE JUROS REGULAR &ndash; M&Eacute;DIA DO MERCADO &ndash; CET - ABUSIVIDADE N&Atilde;O CONFIGURADA &ndash; SENTEN&Ccedil;A MANTIDA:
+- Nota-se que o Autor, ora Apelante, teve ci&ecirc;ncia dos valores que estavam sendo cobrados, sendo-lhe informado claramente o valor de cada uma das presta&ccedil;&otilde;es a serem pagas e os seus respectivos vencimentos, levando-se em considera&ccedil;&atilde;o o valor contratado, ao que aderiu livremente e de forma volunt&aacute;ria, sem que houvesse demonstra&ccedil;&atilde;o de qualquer v&iacute;cio de consentimento.
+- Pela natureza do contrato banc&aacute;rio, diversos elementos s&atilde;o inseridos na cobran&ccedil;a e no seu c&aacute;lculo, sendo poss&iacute;vel destacar do contrato de fls. 20/21 que foi previsto a cobran&ccedil;a de juros remunerat&oacute;rios em 2,35% ao m&ecirc;s com capitaliza&ccedil;&atilde;o mensal, somado ao Imposto sobre Opera&ccedil;&otilde;es Financeiras (IOF). O Custo Efetivo Total (CET) restou configurado em 2,92% ao m&ecirc;s, sendo que ele diz respeito ao valor total a opera&ccedil;&atilde;o, com todos os valores agregados e n&atilde;o somente os juros mensais.
+- Assim, entendo que a limita&ccedil;&atilde;o da taxa de juros em face da suposta abusividade somente teria raz&atilde;o diante de uma demonstra&ccedil;&atilde;o cabal da excessividade do lucro da institui&ccedil;&atilde;o financeira, o que n&atilde;o ocorreu. Destarte, n&atilde;o havendo ato il&iacute;cito, inexiste a obriga&ccedil;&atilde;o de repara&ccedil;&atilde;o material ou moral, devendo portanto ser mantida a senten&ccedil;a de piso.
+RECURSO CONHECIDO E DESPROVIDO.  <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0515824-48.2023.8.04.0001; Relator (a): Domingos Jorge Chalub Pereira; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Terceira C&acirc;mara C&iacute;vel; Data do julgamento: 29/07/2025; Data de registro: 29/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Limitação de Juros
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Domingos Jorge Chalub Pereira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Terceira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									29/07/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									29/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL – TAXA DE JUROS REGULAR – MÉDIA DO MERCADO – CET - ABUSIVIDADE NÃO CONFIGURADA – SENTENÇA MANTIDA:
+- Nota-se que o Autor, ora Apelante, teve ciência dos valores que estavam sendo cobrados, sendo-lhe informado claramente o valor de cada uma das prestações a serem pagas e os seus respectivos vencimentos, levando-se em consideração o valor contratado, ao que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL – TAXA DE JUROS REGULAR – MÉDIA DO MERCADO – CET - ABUSIVIDADE NÃO CONFIGURADA – SENTENÇA MANTIDA:
+- Nota-se que o Autor, ora Apelante, teve ciência dos valores que estavam sendo cobrados, sendo-lhe informado claramente o valor de cada uma das prestações a serem pagas e os seus respectivos vencimentos, levando-se em consideração o valor contratado, ao que aderiu livremente e de forma voluntária, sem que houvesse demonstração de qualquer vício de consentimento.
+- Pela natureza do contrato bancário, diversos elementos são inseridos na cobrança e no seu cálculo, sendo possível destacar do contrato de fls. 20/21 que foi previsto a cobrança de juros remuneratórios em 2,35% ao mês com capitalização mensal, somado ao Imposto sobre Operações Financeiras (IOF). O Custo Efetivo Total (CET) restou configurado em 2,92% ao mês, sendo que ele diz respeito ao valor total a operação, com todos os valores agregados e não somente os juros mensais.
+- Assim, entendo que a limitação da taxa de juros em face da suposta abusividade somente teria razão diante de uma demonstração cabal da excessividade do lucro da instituição financeira, o que não ocorreu. Destarte, não havendo ato ilícito, inexiste a obrigação de reparação material ou <em>moral</em>, devendo portanto ser mantida a sentença de piso.
+RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363937" cdForo="0" >
+										0006912-88.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363937" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363937);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363937" style="display: none;" >
+	<div id="textAreaDados_3363937" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. VIOLA&Ccedil;&Atilde;O AO DEVER DE INFORMA&Ccedil;&Atilde;O. CONVERS&Atilde;O DO CONTRATO. DANO MORAL. RESTITUI&Ccedil;&Atilde;O EM DOBRO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que negou provimento ao recurso da agravante, em Apela&ccedil;&atilde;o C&iacute;vel envolvendo discuss&atilde;o sobre contrato banc&aacute;rio. A agravante sustenta a inexist&ecirc;ncia de contrata&ccedil;&atilde;o v&aacute;lida de cart&atilde;o de cr&eacute;dito consignado, afirmando que contratou t&atilde;o somente empr&eacute;stimo consignado. Argumenta que houve viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o, com aus&ecirc;ncia de clareza sobre os termos contratuais e aus&ecirc;ncia de entrega de c&oacute;pia contratual. Pleiteia a convers&atilde;o do contrato, indeniza&ccedil;&atilde;o por danos morais e restitui&ccedil;&atilde;o em dobro dos valores descontados. O agravado n&atilde;o apresentou contrarraz&otilde;es.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o:
+(i) verificar se houve viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o na contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado;
+(ii) definir se &eacute; poss&iacute;vel a convers&atilde;o do contrato banc&aacute;rio em empr&eacute;stimo consignado comum com base no entendimento firmado em IRDR;
+(iii) estabelecer se s&atilde;o devidos danos morais e restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados.
+III. RAZ&Otilde;ES DE DECIDIR
+1. A validade do contrato de cart&atilde;o de cr&eacute;dito consignado depende da comprova&ccedil;&atilde;o de que o consumidor foi claramente informado sobre as condi&ccedil;&otilde;es espec&iacute;ficas da contrata&ccedil;&atilde;o, conforme entendimento firmado no IRDR n&ordm; 0005217-75.2019.8.04.0000.
+2. O contrato juntado aos autos n&atilde;o apresenta, de forma clara, objetiva e acess&iacute;vel, os elementos essenciais da contrata&ccedil;&atilde;o, como a forma de pagamento e a din&acirc;mica do d&eacute;bito m&iacute;nimo com incid&ecirc;ncia de encargos rotativos, impossibilitando a compreens&atilde;o plena do consumidor.
+3. A aus&ecirc;ncia de informa&ccedil;&otilde;es claras e a inexist&ecirc;ncia de comprova&ccedil;&atilde;o de que o consumidor recebeu c&oacute;pia do contrato comprometem a validade da contrata&ccedil;&atilde;o, configurando v&iacute;cio de consentimento.
+4. A constata&ccedil;&atilde;o da falha no dever de informa&ccedil;&atilde;o autoriza a convers&atilde;o do contrato de cart&atilde;o de cr&eacute;dito consignado em contrato de empr&eacute;stimo consignado simples, com a incid&ecirc;ncia da taxa m&eacute;dia de mercado &agrave; &eacute;poca da contrata&ccedil;&atilde;o.
+5. A devolu&ccedil;&atilde;o em dobro dos valores descontados indevidamente &eacute; devida, independentemente da comprova&ccedil;&atilde;o de m&aacute;-f&eacute;, diante da contrariedade &agrave; boa-f&eacute; objetiva.
+6. O dano moral &eacute; configurado, considerando o abalo psicol&oacute;gico decorrente da perpetua&ccedil;&atilde;o de d&iacute;vida n&atilde;o compreendida pelo consumidor, sendo fixado valor indenizat&oacute;rio proporcional ao preju&iacute;zo experimentado.
+IV. DISPOSITIVO E TESE
+Recurso provido.
+Tese de julgamento:
+1. A validade do contrato de cart&atilde;o de cr&eacute;dito consignado exige comprova&ccedil;&atilde;o inequ&iacute;voca de que o consumidor foi claramente informado sobre todos os seus termos.
+2. A aus&ecirc;ncia de informa&ccedil;&otilde;es claras e a n&atilde;o entrega de c&oacute;pia do contrato autorizam a convers&atilde;o do contrato em empr&eacute;stimo consignado simples.
+3. A devolu&ccedil;&atilde;o em dobro de valores descontados indevidamente prescinde da comprova&ccedil;&atilde;o de m&aacute;-f&eacute;, bastando a viola&ccedil;&atilde;o &agrave; boa-f&eacute; objetiva.
+4. A contrata&ccedil;&atilde;o banc&aacute;ria em desconformidade com a vontade real do consumidor configura dano moral indeniz&aacute;vel.
+Dispositivos relevantes citados: CPC, art. 85, &sect;2&ordm;; CC, art. 405.
+Jurisprud&ecirc;ncia relevante citada: TJAM, IRDR n&ordm; 0005217-75.2019.8.04.0000 &ndash; Tema 05; AC n&ordm; 0628064-77.2023.8.04.0001; AC n&ordm; 0619765-58.2016.8.04.0001; AC n&ordm; 0603988-96.2017.8.04.0001. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0006912-88.2024.8.04.0000; Relator (a): Socorro Guedes Moura; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 16/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(52 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Socorro Guedes Moura
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO DO CONTRATO. <em>DANO</em> <em>MORAL</em>. RESTITUIÇÃO EM DOBRO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo Interno interposto contra decisão monocrática que negou provimento ao recurso da agravante, em Apelação Cível envolvendo discussão sobre contrato bancário. A agravante
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO DO CONTRATO. <em>DANO</em> <em>MORAL</em>. RESTITUIÇÃO EM DOBRO. RECURSO PROVIDO.
+I. CASO EM EXAME
+Agravo Interno interposto contra decisão monocrática que negou provimento ao recurso da agravante, em Apelação Cível envolvendo discussão sobre contrato bancário. A agravante sustenta a inexistência de contratação válida de cartão de crédito consignado, afirmando que contratou tão somente empréstimo consignado. Argumenta que houve violação ao dever de informação, com ausência de clareza sobre os termos contratuais e ausência de entrega de cópia contratual. Pleiteia a conversão do contrato, indenização por <em>danos</em> <em>morais</em> e restituição em dobro dos valores descontados. O agravado não apresentou contrarrazões.
+II. QUESTÃO EM DISCUSSÃO
+Há três questões em discussão:
+(i) verificar se houve violação ao dever de informação na contratação do cartão de crédito consignado;
+(ii) definir se é possível a conversão do contrato bancário em empréstimo consignado comum com base no entendimento firmado em IRDR;
+(iii) estabelecer se são devidos <em>danos</em> <em>morais</em> e restituição em dobro dos valores indevidamente descontados.
+III. RAZÕES DE DECIDIR
+1. A validade do contrato de cartão de crédito consignado depende da comprovação de que o consumidor foi claramente informado sobre as condições específicas da contratação, conforme entendimento firmado no IRDR nº 0005217-75.2019.8.04.0000.
+2. O contrato juntado aos autos não apresenta, de forma clara, objetiva e acessível, os elementos essenciais da contratação, como a forma de pagamento e a dinâmica do débito mínimo com incidência de encargos rotativos, impossibilitando a compreensão plena do consumidor.
+3. A ausência de informações claras e a inexistência de comprovação de que o consumidor recebeu cópia do contrato comprometem a validade da contratação, configurando vício de consentimento.
+4. A constatação da falha no dever de informação autoriza a conversão do contrato de cartão de crédito consignado em contrato de empréstimo consignado simples, com a incidência da taxa média de mercado à época da contratação.
+5. A devolução em dobro dos valores descontados indevidamente é devida, independentemente da comprovação de má-fé, diante da contrariedade à boa-fé objetiva.
+6. O <em>dano</em> <em>moral</em> é configurado, considerando o abalo psicológico decorrente da perpetuação de dívida não compreendida pelo consumidor, sendo fixado valor indenizatório proporcional ao prejuízo experimentado.
+IV. DISPOSITIVO E TESE
+Recurso provido.
+Tese de julgamento:
+1. A validade do contrato de cartão de crédito consignado exige comprovação inequívoca de que o consumidor foi claramente informado sobre todos os seus termos.
+2. A ausência de informações claras e a não entrega de cópia do contrato autorizam a conversão do contrato em empréstimo consignado simples.
+3. A devolução em dobro de valores descontados indevidamente prescinde da comprovação de má-fé, bastando a violação à boa-fé objetiva.
+4. A contratação bancária em desconformidade com a vontade real do consumidor configura <em>dano</em> <em>moral</em> indenizável.
+Dispositivos relevantes citados: CPC, art. 85, §2º; CC, art. 405.
+Jurisprudência relevante citada: TJAM, IRDR nº 0005217-75.2019.8.04.0000 – Tema 05; AC nº 0628064-77.2023.8.04.0001; AC nº 0619765-58.2016.8.04.0001; AC nº 0603988-96.2017.8.04.0001.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363936" cdForo="0" >
+										0627605-27.2013.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363936" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363936);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363936" style="display: none;" >
+	<div id="textAreaDados_3363936" class="mensagemSemFormatacao" >
+		Ementa: Direito Civil e do Consumidor. Apela&ccedil;&otilde;es C&iacute;veis. Rescis&atilde;o Contratual. Promessa de Compra e Venda de Im&oacute;vel. Atraso na Entrega. Culpa Exclusiva da Incorporadora. Restitui&ccedil;&atilde;o Integral dos Valores Pagos. Taxa de Corretagem. Aus&ecirc;ncia de Informa&ccedil;&atilde;o Pr&eacute;via. Devolu&ccedil;&atilde;o. Lucros Cessantes. Incid&ecirc;ncia. Juros Morat&oacute;rios. Termo Inicial. Cita&ccedil;&atilde;o. Parcial Provimento da Apela&ccedil;&atilde;o do Recurso aviado pela Incorporada e Provimento do Apelo Interposto pela Autora.
+I. Caso em exame
+1. Apela&ccedil;&otilde;es c&iacute;veis interpostas por Rozana Nunes Batista e Direcional Rubi Empreendimentos Imobili&aacute;rios Ltda. contra senten&ccedil;a que declarou a rescis&atilde;o de contrato de compra e venda de im&oacute;vel, determinou a restitui&ccedil;&atilde;o integral dos valores pagos pela adquirente, reconheceu a nulidade de cl&aacute;usulas contratuais abusivas e condenou a incorporadora ao pagamento de lucros cessantes.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; 4 (quatro) quest&otilde;es em discuss&atilde;o: (i) definir se a incorporadora deve devolver a taxa de corretagem paga pela adquirente; (ii) estabelecer se os lucros cessantes devem ser limitados ao valor efetivamente pago; (iii) determinar se a reten&ccedil;&atilde;o de percentual sobre os valores pagos pelo comprador &eacute; cab&iacute;vel e qual seria seu limite; e (iv) fixar o &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria e o termo inicial dos juros morat&oacute;rios sobre a devolu&ccedil;&atilde;o dos valores pagos.
+III. Raz&otilde;es de decidir
+3. A cl&aacute;usula contratual que transfere &agrave; autora a obriga&ccedil;&atilde;o de pagar a taxa de corretagem &eacute; inv&aacute;lida, pois n&atilde;o houve o cumprimento do dever de informa&ccedil;&atilde;o pr&eacute;via, nos termos do Tema n.&ordm; 938 do STJ.
+4. Os lucros cessantes, decorrentes do atraso na entrega do im&oacute;vel, devem ser fixados com base no valor venal do im&oacute;vel, aplicando-se o percentual de 0,5% (cinco d&eacute;cimos por cento) ao m&ecirc;s, conforme a Tese 1.2 do Tema n.&ordm; 966 do STJ.
+5. Diante da culpa exclusiva da incorporadora pelo descumprimento do contrato, a restitui&ccedil;&atilde;o integral dos valores pagos pela autora &eacute; devida, afastando-se qualquer hip&oacute;tese de reten&ccedil;&atilde;o, nos termos da S&uacute;mula n.&ordm; 543 do STJ.
+6. O &iacute;ndice de atualiza&ccedil;&atilde;o monet&aacute;ria deve ser o INPC-IBGE at&eacute; o tr&acirc;nsito em julgado, e, a partir deste marco, a Taxa SELIC deve ser utilizada, englobando juros e corre&ccedil;&atilde;o monet&aacute;ria, conforme jurisprud&ecirc;ncia consolidada do STJ e entendimento desta Corte.
+7. Os juros morat&oacute;rios incidem a partir da cita&ccedil;&atilde;o, pois se trata de responsabilidade contratual decorrente da inadimpl&ecirc;ncia da incorporadora.
+IV. Dispositivo e tese
+8. Recurso da Direcional Rubi Empreendimentos Imobili&aacute;rios Ltda. parcialmente provido para ajustar os &iacute;ndices de atualiza&ccedil;&atilde;o e juros morat&oacute;rios &agrave; jurisprud&ecirc;ncia e recurso de Rozana Nunes Batista provido, com a fixa&ccedil;&atilde;o do termo inicial dos juros de mora da condena&ccedil;&atilde;o na data da cita&ccedil;&atilde;o da parte r&eacute;, Direcional Rubi Empreendimentos Imobili&aacute;rios Ltda.
+Tese de julgamento: &quot;1. O dever de informa&ccedil;&atilde;o quanto &agrave; transfer&ecirc;ncia da obriga&ccedil;&atilde;o de pagar a taxa de corretagem ao consumidor deve ser cumprido com destaque e anteced&ecirc;ncia, sob pena de nulidade da cl&aacute;usula contratual; 2. O descumprimento do prazo para entrega de im&oacute;vel, inclu&iacute;do o per&iacute;odo de toler&acirc;ncia, enseja indeniza&ccedil;&atilde;o a t&iacute;tulo de lucros cessantes, calculados com base no valor venal do im&oacute;vel, em percentual de 0,5% (cinco d&eacute;cimos por cento) ao m&ecirc;s; 3. Na resolu&ccedil;&atilde;o de contrato de promessa de compra e venda por culpa do promitente-vendedor, a restitui&ccedil;&atilde;o das parcelas pagas pelo comprador deve ser integral e imediata; 4. Nas rescis&otilde;es contratuais, o INPC-IBGE &eacute; aplic&aacute;vel como &iacute;ndice de atualiza&ccedil;&atilde;o at&eacute; o tr&acirc;nsito em julgado, sendo a Taxa SELIC utilizada a partir deste marco para juros e corre&ccedil;&atilde;o monet&aacute;ria; 5. Os juros morat&oacute;rios sobre a devolu&ccedil;&atilde;o dos valores pagos pelo comprador incidem a partir da cita&ccedil;&atilde;o, nos termos do art. 405 do C&oacute;digo Civil&quot;.
+___________
+Dispositivos relevantes citados: CC, arts. 406, 421 e 884; CDC, art. 6.&ordm;, III; CPC, art. 487, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n.&ordm; 1.599.511/SP (Tema n.&ordm; 938); STJ, REsp n.&ordm; 1.729.593/SP (Tema n.&ordm; 966); STJ, REsp n.&ordm; 1.740.911/DF (Tema n.&ordm; 970); STJ, S&uacute;mula 543; TJAM, Apela&ccedil;&atilde;o C&iacute;vel n.&ordm; 0627495-91.2014.8.04.0001; TJAM, Apela&ccedil;&atilde;o C&iacute;vel n.&ordm; 0610225-88.2013.8.04.0001.  <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0627605-27.2013.8.04.0001; Relator (a): Yedo Sim&otilde;es de Oliveira; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 15/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(43 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Rescisão do contrato e devolução do dinheiro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Yedo Simões de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito Civil e do Consumidor. Apelações Cíveis. Rescisão Contratual. Promessa de Compra e Venda de Imóvel. Atraso na Entrega. Culpa Exclusiva da Incorporadora. Restituição Integral dos Valores Pagos. Taxa de Corretagem. Ausência de Informação Prévia. Devolução. Lucros Cessantes. Incidência. Juros Moratórios. Termo Inicial. Citação. Parcial Provimento da Apelação do Recurso aviado pela
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito Civil e do Consumidor. Apelações Cíveis. Rescisão Contratual. Promessa de Compra e Venda de Imóvel. Atraso na Entrega. Culpa Exclusiva da Incorporadora. Restituição Integral dos Valores Pagos. Taxa de Corretagem. Ausência de Informação Prévia. Devolução. Lucros Cessantes. Incidência. Juros Moratórios. Termo Inicial. Citação. Parcial Provimento da Apelação do Recurso aviado pela Incorporada e Provimento do Apelo Interposto pela Autora.
+I. Caso em exame
+1. Apelações cíveis interpostas por Rozana Nunes Batista e Direcional Rubi Empreendimentos Imobiliários Ltda. contra sentença que declarou a rescisão de contrato de compra e venda de imóvel, determinou a restituição integral dos valores pagos pela adquirente, reconheceu a nulidade de cláusulas contratuais abusivas e condenou a incorporadora ao pagamento de lucros cessantes.
+II. Questão em discussão
+2. Há 4 (quatro) questões em discussão: (i) definir se a incorporadora deve devolver a taxa de corretagem paga pela adquirente; (ii) estabelecer se os lucros cessantes devem ser limitados ao valor efetivamente pago; (iii) determinar se a retenção de percentual sobre os valores pagos pelo comprador é cabível e qual seria seu limite; e (iv) fixar o índice de correção monetária e o termo inicial dos juros moratórios sobre a devolução dos valores pagos.
+III. Razões de decidir
+3. A cláusula contratual que transfere à autora a obrigação de pagar a taxa de corretagem é inválida, pois não houve o cumprimento do dever de informação prévia, nos termos do Tema n.º 938 do STJ.
+4. Os lucros cessantes, decorrentes do atraso na entrega do imóvel, devem ser fixados com base no valor venal do imóvel, aplicando-se o percentual de 0,5% (cinco décimos por cento) ao mês, conforme a Tese 1.2 do Tema n.º 966 do STJ.
+5. Diante da culpa exclusiva da incorporadora pelo descumprimento do contrato, a restituição integral dos valores pagos pela autora é devida, afastando-se qualquer hipótese de retenção, nos termos da Súmula n.º 543 do STJ.
+6. O índice de atualização monetária deve ser o INPC-IBGE até o trânsito em julgado, e, a partir deste marco, a Taxa SELIC deve ser utilizada, englobando juros e correção monetária, conforme jurisprudência consolidada do STJ e entendimento desta Corte.
+7. Os juros moratórios incidem a partir da citação, pois se trata de responsabilidade contratual decorrente da inadimplência da incorporadora.
+IV. Dispositivo e tese
+8. Recurso da Direcional Rubi Empreendimentos Imobiliários Ltda. parcialmente provido para ajustar os índices de atualização e juros moratórios à jurisprudência e recurso de Rozana Nunes Batista provido, com a fixação do termo inicial dos juros de mora da condenação na data da citação da parte ré, Direcional Rubi Empreendimentos Imobiliários Ltda.
+Tese de julgamento: "1. O dever de informação quanto à transferência da obrigação de pagar a taxa de corretagem ao consumidor deve ser cumprido com destaque e antecedência, sob pena de nulidade da cláusula contratual; 2. O descumprimento do prazo para entrega de imóvel, incluído o período de tolerância, enseja indenização a título de lucros cessantes, calculados com base no valor venal do imóvel, em percentual de 0,5% (cinco décimos por cento) ao mês; 3. Na resolução de contrato de promessa de compra e venda por culpa do promitente-vendedor, a restituição das parcelas pagas pelo comprador deve ser integral e imediata; 4. Nas rescisões contratuais, o INPC-IBGE é aplicável como índice de atualização até o trânsito em julgado, sendo a Taxa SELIC utilizada a partir deste marco para juros e correção monetária; 5. Os juros moratórios sobre a devolução dos valores pagos pelo comprador incidem a partir da citação, nos termos do art. 405 do Código Civil".
+___________
+Dispositivos relevantes citados: CC, arts. 406, 421 e 884; CDC, art. 6.º, III; CPC, art. 487, I.
+Jurisprudência relevante citada: STJ, REsp n.º 1.599.511/SP (Tema n.º 938); STJ, REsp n.º 1.729.593/SP (Tema n.º 966); STJ, REsp n.º 1.740.911/DF (Tema n.º 970); STJ, Súmula 543; TJAM, Apelação Cível n.º 0627495-91.2014.8.04.0001; TJAM, Apelação Cível n.º 0610225-88.2013.8.04.0001.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363935" cdForo="0" >
+										0677200-48.2020.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363935" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363935);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363935" style="display: none;" >
+	<div id="textAreaDados_3363935" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO CIVIL E ADMINISTRATIVO. FISCALIZA&Ccedil;&Atilde;O. &Oacute;RG&Atilde;O INCOMPETENTE. DIVULGA&Ccedil;&Atilde;O. DEVER GERAL DE CUIDADO. INOBSERV&Acirc;NCIA. DANO MORAL CONFIGURADO. SENTEN&Ccedil;A PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO EM PARTE.
+1. Gera dano moral indeniz&aacute;vel a divulga&ccedil;&atilde;o oficial, por &oacute;rg&atilde;o p&uacute;blico, de ato de fiscaliza&ccedil;&atilde;o feito por autoridade incompetente para faz&ecirc;-lo e que n&atilde;o observa o dever geral de cuidado quanto &agrave;s especificidades do evento relatado;
+2. Recurso conhecido e provido em parte;
+3. Senten&ccedil;a parcialmente reformada. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0677200-48.2020.8.04.0001; Relator (a): Yedo Sim&otilde;es de Oliveira; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 15/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inspeção Sanitária de Origem Animal
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Yedo Simões de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL E ADMINISTRATIVO. FISCALIZAÇÃO. ÓRGÃO INCOMPETENTE. DIVULGAÇÃO. DEVER GERAL DE CUIDADO. INOBSERVÂNCIA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO EM PARTE.
+1. Gera <em>dano</em> <em>moral</em> indenizável a divulgação oficial, por órgão público, de ato de fiscalização feito por autoridade incompetente para
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL E ADMINISTRATIVO. FISCALIZAÇÃO. ÓRGÃO INCOMPETENTE. DIVULGAÇÃO. DEVER GERAL DE CUIDADO. INOBSERVÂNCIA. <em>DANO</em> <em>MORAL</em> CONFIGURADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO EM PARTE.
+1. Gera <em>dano</em> <em>moral</em> indenizável a divulgação oficial, por órgão público, de ato de fiscalização feito por autoridade incompetente para fazê-lo e que não observa o dever geral de cuidado quanto às especificidades do evento relatado;
+2. Recurso conhecido e provido em parte;
+3. Sentença parcialmente reformada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363934" cdForo="0" >
+										0635055-50.2015.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363934" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363934);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363934" style="display: none;" >
+	<div id="textAreaDados_3363934" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL. DIREITO CIVIL. DIREITO PROCESSUAL CIVIL. PRELIMINARES RECURSAIS. PRINC&Iacute;PIO DA DIALETICIDADE. INEXIST&Ecirc;NCIA DE VIOLA&Ccedil;&Atilde;O.  M&Eacute;RITO. ACIDENTE DE TR&Acirc;NSITO. V&Iacute;TIMAS FATAIS. ILEGITIMIDADE ATIVA. CONSTATA&Ccedil;&Atilde;O. SENTEN&Ccedil;A TRANSITADA EM JULGADO RECHA&Ccedil;ANDO PRETENS&Atilde;O AO RECONHECIMENTO DE UNI&Atilde;O EST&Aacute;VEL POST MORTEM. RESPONSABILIDADE CIVIL. ARTS. 186 E 927, DO C&Oacute;DIGO CIVIL. DISCUSS&Atilde;O RELATIVA AO ELEMENTO CULPA. DIVERG&Ecirc;NCIA ENTRE NARRATIVAS DAS PARTES. ARQUIVAMENTO DE INQU&Eacute;RITO INSTAURADO PARA APURA&Ccedil;&Atilde;O DOS FATOS. INDEPEND&Ecirc;NCIA DAS INST&Acirc;NCIAS. ART. 935, DO C&Oacute;DIGO CIVIL. ART. 67, I, DO C&Oacute;DIGO DE PROCESSO PENAL &ndash; CPP. AUS&Ecirc;NCIA DE ELEMENTOS SUFICIENTES PARA FORMA&Ccedil;&Atilde;O DE JU&Iacute;ZO DE CERTEZA SOBRE A TESE AUTORAL. ART. 373, I, DO C&Oacute;DIGO DE PROCESSO CIVIL &ndash; CPC. RECURSO CONHECIDO E N&Atilde;O PROVIDO. 1. O princ&iacute;pio da dialeticidade aparece como norte do requisito da regularidade formal, tendo em vista que o recorrente precisa elucidar de modo claro as raz&otilde;es pelas quais a decis&atilde;o impugnada encontra-se eivada de erros, apontando em que aspectos o Ju&iacute;zo de 1&ordm; Grau incorreu em equ&iacute;vocos jur&iacute;dicos. No caso, fazendo um cotejo entre a senten&ccedil;a impugnada e as raz&otilde;es expostas por ocasi&atilde;o da presente apela&ccedil;&atilde;o, verifica-se que o recorrente impugnou de forma adequada os fundamentos da senten&ccedil;a; 2. O cerne da controv&eacute;rsia cinge-se em apurar a responsabilidade civil dos r&eacute;us-apelados pelo acidente de tr&acirc;nsito que teria vitimado companheiro e filha da autora-apelante, levando-os a &oacute;bito; 3. A autora-apelante ajuizou a a&ccedil;&atilde;o declarat&oacute;ria de uni&atilde;o est&aacute;vel post mortem n.&ordm; 0605680-38.2014.8.04.0001, a qual foi julgada improcedente pelo Ju&iacute;zo da 6.&ordf; Vara de Fam&iacute;lia e Sucess&otilde;es, tendo a senten&ccedil;a transitada em julgado desde 2015, e, sendo assim, considerando a aus&ecirc;ncia de demonstra&ccedil;&atilde;o de v&iacute;nculos familiares entre a autora-apelante e aquele que, alegadamente, era seu companheiro, conclui-se pela ilegitimidade ativa da parte nesse particular; 4. A responsabilidade civil &eacute; o dever secund&aacute;rio de reparar a outrem como decorr&ecirc;ncia da causa&ccedil;&atilde;o de danos, caracterizando a partir dos requisitos estabelecidos pelos arts. 186 e 927, do C&oacute;digo Civil, quais sejam, a conduta, a culpa, o nexo causal e o dano; 5.  Em sua pe&ccedil;a de contesta&ccedil;&atilde;o, os r&eacute;us-apelados n&atilde;o impugnam o fato de que foram os autores do atropelamento, evento que foi a causa da morte, conforme atestado pela certid&atilde;o de &oacute;bito de ambas as v&iacute;timas, limitando-se a discuss&atilde;o ao elemento culpa, necess&aacute;rio para a caracteriza&ccedil;&atilde;o da responsabilidade civil, havendo diverg&ecirc;ncia entre narrativas apresentadas pelas partes; 6. Nos autos do inqu&eacute;rito n.&ordm; 0000398-45.2014.8.04.4600, o Minist&eacute;rio P&uacute;blico do Estado do Amazonas - MP/AM, analisando o laudo pericial e a reprodu&ccedil;&atilde;o simulada dos fatos, concluiu pela aus&ecirc;ncia de elementos informativos suficientes para a forma&ccedil;&atilde;o da culpa, promovendo o &oacute;rg&atilde;o ministerial pelo arquivamento do feito; 7. Embora o art. 935, do C&oacute;digo Civil, e art.67, I, do C&oacute;digo de Processo Penal &ndash; CPP, estabele&ccedil;am a regra da independ&ecirc;ncia das inst&acirc;ncias, os elementos probat&oacute;rios destes autos conduzem &agrave; mesma conclus&atilde;o j&aacute; atingida pelo parquet na seara penal. &Eacute; dizer, a autora-apelante n&atilde;o se desincumbiu do &ocirc;nus probat&oacute;rio fixado pelo art. 373, I, do C&oacute;digo de Processo Civil &ndash; CPC, no sentido de aportar elementos probat&oacute;rios suficientes para a forma&ccedil;&atilde;o de um ju&iacute;zo de certeza sobre a vers&atilde;o apresentada, destacadamente sobre a exist&ecirc;ncia de culpa do primeiro r&eacute;u-apelado na causa&ccedil;&atilde;o do acidente fatal; 8. Os fatos apurados na a&ccedil;&atilde;o penal n.&ordm; 0225067-70.2015.8.04.0001 n&atilde;o t&ecirc;m relev&acirc;ncia para o deslinde da controv&eacute;rsia tratada nos presentes autos; 9. Recurso conhecido e n&atilde;o provido. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0635055-50.2015.8.04.0001; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 07/07/2025; Data de registro: 11/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/07/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									11/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. DIREITO PROCESSUAL CIVIL. PRELIMINARES RECURSAIS. PRINCÍPIO DA DIALETICIDADE. INEXISTÊNCIA DE VIOLAÇÃO.  MÉRITO. ACIDENTE DE TRÂNSITO. VÍTIMAS FATAIS. ILEGITIMIDADE ATIVA. CONSTATAÇÃO. SENTENÇA TRANSITADA EM JULGADO RECHAÇANDO PRETENSÃO AO RECONHECIMENTO DE UNIÃO ESTÁVEL POST MORTEM. RESPONSABILIDADE CIVIL. ARTS. 186 E 927, DO CÓDIGO CIVIL. DISCUSSÃO RELATIVA AO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. DIREITO CIVIL. DIREITO PROCESSUAL CIVIL. PRELIMINARES RECURSAIS. PRINCÍPIO DA DIALETICIDADE. INEXISTÊNCIA DE VIOLAÇÃO.  MÉRITO. ACIDENTE DE TRÂNSITO. VÍTIMAS FATAIS. ILEGITIMIDADE ATIVA. CONSTATAÇÃO. SENTENÇA TRANSITADA EM JULGADO RECHAÇANDO PRETENSÃO AO RECONHECIMENTO DE UNIÃO ESTÁVEL POST MORTEM. RESPONSABILIDADE CIVIL. ARTS. 186 E 927, DO CÓDIGO CIVIL. DISCUSSÃO RELATIVA AO ELEMENTO CULPA. DIVERGÊNCIA ENTRE NARRATIVAS DAS PARTES. ARQUIVAMENTO DE INQUÉRITO INSTAURADO PARA APURAÇÃO DOS FATOS. INDEPENDÊNCIA DAS INSTÂNCIAS. ART. 935, DO CÓDIGO CIVIL. ART. 67, I, DO CÓDIGO DE PROCESSO PENAL – CPP. AUSÊNCIA DE ELEMENTOS SUFICIENTES PARA FORMAÇÃO DE JUÍZO DE CERTEZA SOBRE A TESE AUTORAL. ART. 373, I, DO CÓDIGO DE PROCESSO CIVIL – CPC. RECURSO CONHECIDO E NÃO PROVIDO. 1. O princípio da dialeticidade aparece como norte do requisito da regularidade formal, tendo em vista que o recorrente precisa elucidar de modo claro as razões pelas quais a decisão impugnada encontra-se eivada de erros, apontando em que aspectos o Juízo de 1º Grau incorreu em equívocos jurídicos. No caso, fazendo um cotejo entre a sentença impugnada e as razões expostas por ocasião da presente apelação, verifica-se que o recorrente impugnou de forma adequada os fundamentos da sentença; 2. O cerne da controvérsia cinge-se em apurar a responsabilidade civil dos réus-apelados pelo acidente de trânsito que teria vitimado companheiro e filha da autora-apelante, levando-os a óbito; 3. A autora-apelante ajuizou a ação declaratória de união estável post mortem n.º 0605680-38.2014.8.04.0001, a qual foi julgada improcedente pelo Juízo da 6.ª Vara de Família e Sucessões, tendo a sentença transitada em julgado desde 2015, e, sendo assim, considerando a ausência de demonstração de vínculos familiares entre a autora-apelante e aquele que, alegadamente, era seu companheiro, conclui-se pela ilegitimidade ativa da parte nesse particular; 4. A responsabilidade civil é o dever secundário de reparar a outrem como decorrência da causação de <em>danos</em>, caracterizando a partir dos requisitos estabelecidos pelos arts. 186 e 927, do Código Civil, quais sejam, a conduta, a culpa, o nexo causal e o <em>dano</em>; 5.  Em sua peça de contestação, os réus-apelados não impugnam o fato de que foram os autores do atropelamento, evento que foi a causa da morte, conforme atestado pela certidão de óbito de ambas as vítimas, limitando-se a discussão ao elemento culpa, necessário para a caracterização da responsabilidade civil, havendo divergência entre narrativas apresentadas pelas partes; 6. Nos autos do inquérito n.º 0000398-45.2014.8.04.4600, o Ministério Público do Estado do Amazonas - MP/AM, analisando o laudo pericial e a reprodução simulada dos fatos, concluiu pela ausência de elementos informativos suficientes para a formação da culpa, promovendo o órgão ministerial pelo arquivamento do feito; 7. Embora o art. 935, do Código Civil, e art.67, I, do Código de Processo Penal – CPP, estabeleçam a regra da independência das instâncias, os elementos probatórios destes autos conduzem à mesma conclusão já atingida pelo parquet na seara penal. É dizer, a autora-apelante não se desincumbiu do ônus probatório fixado pelo art. 373, I, do Código de Processo Civil – CPC, no sentido de aportar elementos probatórios suficientes para a formação de um juízo de certeza sobre a versão apresentada, destacadamente sobre a existência de culpa do primeiro réu-apelado na causação do acidente fatal; 8. Os fatos apurados na ação penal n.º 0225067-70.2015.8.04.0001 não têm relevância para o deslinde da controvérsia tratada nos presentes autos; 9. Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363933" cdForo="0" >
+										0001087-08.2020.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363933" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363933);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363933" style="display: none;" >
+	<div id="textAreaDados_3363933" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL E REMESSA NECESS&Aacute;RIA. IMPROBIDADE ADMINISTRATIVA. ART. 19 DA LEI N.&ordm; 4.717/65. REGIME APLIC&Aacute;VEL &Agrave; A&Ccedil;&Atilde;O DE IMPROBIDADE JULGADA IMPROCEDENTE ANTES DA ENTRADA EM VIGOR DA LEI N.&ordm; 14.230/21. CONTRATA&Ccedil;&Atilde;O DE SERVIDORES P&Uacute;BLICOS &Agrave; REVELIA DO CONCURSO P&Uacute;BLICO. MALFERIMENTO AOS PRINC&Iacute;PIOS DA ADMINISTRA&Ccedil;&Atilde;O P&Uacute;BLICA. ART. 37, CAPUT E II, DA CF. SUPERVENI&Ecirc;NCIA DA LEI N.&ordm; 14.230/21. REVOGA&Ccedil;&Atilde;O DO ART. 11, I, DA LEI N.&ordm; 8.429/92. CONDUTA ATRIBU&Iacute;DA AO AGENTE P&Uacute;BLICO QUE N&Atilde;O SE AMOLDA AO TIPO DO ART. 11, V, DA LEI N.&ordm; 8.429/92. PREJU&Iacute;ZO AO ER&Aacute;RIO P&Uacute;BLICO. ART. 10, I E XII, DA LEI N.&ordm; 8.429/92. CONTRATA&Ccedil;&Atilde;O DE SERVIDOR N&Atilde;O BASEADA EM LEGISLA&Ccedil;&Atilde;O LOCAL E N&Atilde;O ANTECEDIDA POR QUALQUER PROCESSO DE SELE&Ccedil;&Atilde;O. PRORROGA&Ccedil;&Atilde;O SUCESSIVA &Agrave; MARGEM DA URG&Ecirc;NCIA OU NECESSIDADE EXCEPCIONAL. MEDIDA DE INTERRUP&Ccedil;&Atilde;O DOS CONTRATOS PARA FURTAR-SE AO PAGAMENTO DE VERBAS DEVIDAS AO SERVIDORES CONTRATADOS. ABUSO DO M&Uacute;NUS P&Uacute;BLICO. RESTRI&Ccedil;&Atilde;O IL&Iacute;CITA E MALICIOSA DE DIREITOS DOS ADMINISTRADOS. VIOLA&Ccedil;&Atilde;O AOS INTERESSES P&Uacute;BLICOS PRIM&Aacute;RIO E SECUND&Aacute;RIO DO MUNIC&Iacute;PIO. CONDUTAS DISTANCIADAS DA MORALIDADE E HONESTIDADE ADMINISTRATIVAS. DOLO ESPEC&Iacute;FICO. CONSCI&Ecirc;NCIA E VONTADE NA PR&Aacute;TICA DO ATO &Iacute;MPROBO. SITUA&Ccedil;&Atilde;O QUE SE AMOLDA &Agrave; RESSALVA DO TEMA REPETITIVO N.&ordm; 1108. DANO AO ER&Aacute;RIO DEVIDAMENTE COMPROVADO. IRRETROATIVIDADE DO REGIME SANCIONAT&Oacute;RIO DA LEI N.&ordm; 14.230/21. RECURSO E REEXAME OFICIAL CONHECIDOS E PARCIALMENTE PROVIDOS. 1. Na origem, o parquet prop&ocirc;s a&ccedil;&atilde;o civil de improbidade administrativa contra o ex-prefeito do Munic&iacute;pio de Coari em raz&atilde;o do suposto cometimento das condutas previstas nos arts. 10, caput, e 11, I e V, ambos da Lei n.&ordm; 8.429/92, consubstanciado na contrata&ccedil;&atilde;o de servidores entre os anos de 2001 e 2007 para compor os quadros da Administra&ccedil;&atilde;o P&uacute;blica sem a pr&eacute;via realiza&ccedil;&atilde;o de concurso p&uacute;blico, ocasi&atilde;o em que seus pedidos foram julgados improcedentes pelo MM. Ju&iacute;zo da 1&ordf; Vara da Comarca de Coari; 2. Em raz&atilde;o da entrada em vigor da Lei n.&ordm; 14.230/21, o STJ desafetou o Tema Repetitivo n.&ordm; 1042 e firmou entendimento sobre a aplica&ccedil;&atilde;o do regime do duplo grau obrigat&oacute;rio de jurisdi&ccedil;&atilde;o do art. 19 da Lei n.&ordm; 4.717/65 para as a&ccedil;&otilde;es de improbidade julgadas improcedentes anteriormente &agrave; entrada em vigor daquele ato normativo, mantida sua inaplicabilidade para as senten&ccedil;as de improced&ecirc;ncia ou extin&ccedil;&atilde;o sem resolu&ccedil;&atilde;o do m&eacute;rito posteriores &agrave; sobredita Lei n.&ordm; 14.230/21; 3. Com rela&ccedil;&atilde;o &agrave; acusa&ccedil;&atilde;o de viola&ccedil;&atilde;o aos princ&iacute;pios da administra&ccedil;&atilde;o, sabe-se que o entendimento firmado pelo STJ em precedentes vinculantes orienta-se no sentido de que a contrata&ccedil;&atilde;o de servidores p&uacute;blicos tempor&aacute;rios sem concurso p&uacute;blico n&atilde;o &eacute; per si causa precursora de ato &iacute;mprobo atentat&oacute;rio aos princ&iacute;pios administrativos, desde que tais v&iacute;nculos tempor&aacute;rios encontrem-se respaldados por legisla&ccedil;&atilde;o local (Tema Repetitivo n.&ordm; 1108); 4. In casu, por for&ccedil;a das altera&ccedil;&otilde;es introduzidas pela Lei n.&ordm; 14.230/21 e considerando a revoga&ccedil;&atilde;o do art. 11, I, da Lei n.&ordm; 8.429/91, revela-se invi&aacute;vel examinar a subsun&ccedil;&atilde;o da conduta atribu&iacute;da ao apelado precisamente no que diz respeito a tal il&iacute;cito, sob pena de viola&ccedil;&atilde;o das regras constitucionais atinentes &agrave; legalidade e &agrave; retroatividade da lei penal benigna (art. 1&ordm;, &sect;4&ordm;, da Lei n.&ordm; 8.429/91 e art. 5&ordm;, XL e XLI, da CF); 5. Outrossim, ainda que subsista a tipifica&ccedil;&atilde;o do art. 11, V, da Lei n.&ordm; 8.429/91, infere-se dos autos que a conduta atribu&iacute;da pelo parquet ao apelado n&atilde;o se amolda ao tipo previsto na norma, dado que o referido dispositivo se destina aos casos em que se verifica a viola&ccedil;&atilde;o ao car&aacute;ter concorrencial do concurso p&uacute;blico e n&atilde;o para as situa&ccedil;&otilde;es em que sua realiza&ccedil;&atilde;o &eacute; ignorada pelo agente p&uacute;blico respons&aacute;vel; 6. Com rela&ccedil;&atilde;o &agrave; acusa&ccedil;&atilde;o de danos ao er&aacute;rio, tal modalidade de improbidade revela-se nas situa&ccedil;&otilde;es em que o agente p&uacute;blico, aproveitando-se dos poderes e facilidades decorrentes de seu m&uacute;nus, pratica dolosamente ato omissivo ou comissivo contr&aacute;rio &agrave; moralidade administrativa e que ocasione preju&iacute;zo ao patrim&ocirc;nio p&uacute;blico, sendo pertinentes ao caso concreto as condutas dos incisos I e XII do rol exemplificativo do art. 10 da Lei n.&ordm; 8.429/92; 7. De acordo com o conjunto probat&oacute;rio agregado aos f&oacute;lios, em especial o Of&iacute;cio n.&ordm; 154/2011-CMC-GP encaminhado pela C&acirc;mara Municipal de Coari, do Of&iacute;cio n.&ordm; 12/2010-GAB e da Representa&ccedil;&atilde;o n.&ordm; 965/2009.11.000/8-04 ambos remetido pela Procuradoria Regional do Trabalho da 11&ordf; Regi&atilde;o, conclui-se que: (i) a contrata&ccedil;&atilde;o dos servidores n&atilde;o foi antecedida por concurso ou por qualquer processo simplificado de sele&ccedil;&atilde;o; bem como (ii) n&atilde;o se fundou em lei local permissiva de contrata&ccedil;&atilde;o tempor&aacute;ria; (iii) o gestor p&uacute;blico promoveu a sucessiva prorroga&ccedil;&atilde;o dos contratos &agrave; margem de qualquer urg&ecirc;ncia ou necessidade excepcional; bem como (iv) implementou medidas para interrup&ccedil;&atilde;o das contrata&ccedil;&otilde;es em meses estrat&eacute;gicos, no claro intuito de furtar-se ao pagamento das verbas devidas aos prestadores de servi&ccedil;o; (v) tal cen&aacute;rio ensejou a condena&ccedil;&atilde;o da municipalidade perante o Tribunal Regional do Trabalho da 11&ordf; Regi&atilde;o em diversas a&ccedil;&otilde;es ajuizadas pelos servidores irregularmente contratados; 8. A conduta praticada pelo apelado n&atilde;o apenas se distanciou das regras pertinentes &agrave; boa administra&ccedil;&atilde;o, como tamb&eacute;m incorreu abuso de direito, dado que este procedeu de forma il&iacute;cita e maliciosa restringindo e dificultando o exerc&iacute;cio dos direitos pelos seus administrados, bem como causando preju&iacute;zo ao patrim&ocirc;nio p&uacute;blico, circunst&acirc;ncia que representa a um s&oacute; tempo malferimento intencional aos interesses p&uacute;blicos prim&aacute;rio e secund&aacute;rio daquela municipalidade; 9. Em que pese a contrata&ccedil;&atilde;o irregular de servidor p&uacute;blico n&atilde;o seja per si sin&ocirc;nimo de ato &iacute;mprobo, a situa&ccedil;&atilde;o retratada nos autos recai exatamente sobre a ressalva firmada no Tema Repetitivo n.&ordm; 1108, visto que n&atilde;o se trata de simples ilicitude e dano ocasionados ao Poder P&uacute;blico em raz&atilde;o de incompet&ecirc;ncia ou do mau exerc&iacute;cio do m&uacute;nus p&uacute;blico (dolo gen&eacute;rico), mas sim em raz&atilde;o de uma gest&atilde;o permeada por atos distanciados da moralidade e da honestidade administrativas que, ao final, lesaram de forma consecutiva e irrevers&iacute;vel o patrim&ocirc;nio do Munic&iacute;pio de Coari (dolo espec&iacute;fico); 10. For&ccedil;osa a conclus&atilde;o pela presen&ccedil;a dos elementos subjetivo e objetivo da conduta imputada pelo parquet ao apelado, notadamente porque restou demonstrada a contrata&ccedil;&atilde;o irregular de servidores p&uacute;blicos que ocasionou danos irrevers&iacute;veis ao patrim&ocirc;nio p&uacute;blico do Munic&iacute;pio de Coari, bem como a consci&ecirc;ncia e vontade do apelado para a pr&aacute;tica do ato &iacute;mprobo; 11. Tendo em vista a natureza sancionat&oacute;ria do regime de improbidade e fazendo um cotejo entre a reda&ccedil;&atilde;o origin&aacute;ria da Lei n.&ordm; 8.429/92 e a atualmente vigente, alcan&ccedil;a-se a conclus&atilde;o de que as san&ccedil;&otilde;es vigentes &agrave; &eacute;poca dos fatos s&atilde;o menos gravosas, raz&atilde;o pela qual n&atilde;o se pode cogitar da retroatividade das penalidades da Lei n.&ordm; 14.230/21 para atingir a situa&ccedil;&atilde;o do apelado; 12. Considerando as peculiaridades do agente, as circunst&acirc;ncias f&aacute;ticas do caso e a extens&atilde;o do dano causado, conclui-se que as penalidades de recomposi&ccedil;&atilde;o do dano e multa revelam-se suficientemente adequadas para reprimir o ato &iacute;mprobo, mormente porque a aplica&ccedil;&atilde;o conjunta das demais comina&ccedil;&otilde;es dos incisos do art. 12 da Lei n.&ordm; 8.429/92 deve destinar-se aos casos extremos, em observ&acirc;ncia os princ&iacute;pios da proporcionalidade e da razoabilidade; 13. Senten&ccedil;a parcialmente reformada para julgar procedente o pedido de condena&ccedil;&atilde;o do apelado pela pr&aacute;tica do ato de improbidade do art. 10, I e XII, da Lei n.&ordm; 8.429/92, com a comina&ccedil;&atilde;o das penas do art. 12, II, da Lei n.&ordm; 8.429/91, quais sejam: (a) a recomposi&ccedil;&atilde;o do dano causado ao er&aacute;rio do Munic&iacute;pio de Coari, nos moldes delimitados pelo parquet em sua inicial e (b) o pagamento de multa correspondente ao valor do dano provocado ao er&aacute;rio p&uacute;blico, ambos devidamente atualizados, e, por fim, julgar improcedente o pedido de condena&ccedil;&atilde;o do apelado nas condutas do art. 11, I e V, da Lei n.&ordm; 8.429/91; 14. Recurso de apela&ccedil;&atilde;o e reexame oficial conhecidos e parcialmente providos, em harmonia com o parecer ministerial. <br><br>(Remessa Necess&aacute;ria C&iacute;vel N&ordm; 0001087-08.2020.8.04.0000; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 07/07/2025; Data de registro: 11/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Remessa Necessária Cível / Efeitos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Coari
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/07/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									11/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E REMESSA NECESSÁRIA. IMPROBIDADE ADMINISTRATIVA. ART. 19 DA LEI N.º 4.717/65. REGIME APLICÁVEL À AÇÃO DE IMPROBIDADE JULGADA IMPROCEDENTE ANTES DA ENTRADA EM VIGOR DA LEI N.º 14.230/21. CONTRATAÇÃO DE SERVIDORES PÚBLICOS À REVELIA DO CONCURSO PÚBLICO. MALFERIMENTO AOS PRINCÍPIOS DA ADMINISTRAÇÃO PÚBLICA. ART. 37, CAPUT E II, DA CF. SUPERVENIÊNCIA DA LEI N.º 14.230/21. REVOGAÇÃO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E REMESSA NECESSÁRIA. IMPROBIDADE ADMINISTRATIVA. ART. 19 DA LEI N.º 4.717/65. REGIME APLICÁVEL À AÇÃO DE IMPROBIDADE JULGADA IMPROCEDENTE ANTES DA ENTRADA EM VIGOR DA LEI N.º 14.230/21. CONTRATAÇÃO DE SERVIDORES PÚBLICOS À REVELIA DO CONCURSO PÚBLICO. MALFERIMENTO AOS PRINCÍPIOS DA ADMINISTRAÇÃO PÚBLICA. ART. 37, CAPUT E II, DA CF. SUPERVENIÊNCIA DA LEI N.º 14.230/21. REVOGAÇÃO DO ART. 11, I, DA LEI N.º 8.429/92. CONDUTA ATRIBUÍDA AO AGENTE PÚBLICO QUE NÃO SE AMOLDA AO TIPO DO ART. 11, V, DA LEI N.º 8.429/92. PREJUÍZO AO ERÁRIO PÚBLICO. ART. 10, I E XII, DA LEI N.º 8.429/92. CONTRATAÇÃO DE SERVIDOR NÃO BASEADA EM LEGISLAÇÃO LOCAL E NÃO ANTECEDIDA POR QUALQUER PROCESSO DE SELEÇÃO. PRORROGAÇÃO SUCESSIVA À MARGEM DA URGÊNCIA OU NECESSIDADE EXCEPCIONAL. MEDIDA DE INTERRUPÇÃO DOS CONTRATOS PARA FURTAR-SE AO PAGAMENTO DE VERBAS DEVIDAS AO SERVIDORES CONTRATADOS. ABUSO DO MÚNUS PÚBLICO. RESTRIÇÃO ILÍCITA E MALICIOSA DE DIREITOS DOS ADMINISTRADOS. VIOLAÇÃO AOS INTERESSES PÚBLICOS PRIMÁRIO E SECUNDÁRIO DO MUNICÍPIO. CONDUTAS DISTANCIADAS DA MORALIDADE E HONESTIDADE ADMINISTRATIVAS. DOLO ESPECÍFICO. CONSCIÊNCIA E VONTADE NA PRÁTICA DO ATO ÍMPROBO. SITUAÇÃO QUE SE AMOLDA À RESSALVA DO TEMA REPETITIVO N.º 1108. <em>DANO</em> AO ERÁRIO DEVIDAMENTE COMPROVADO. IRRETROATIVIDADE DO REGIME SANCIONATÓRIO DA LEI N.º 14.230/21. RECURSO E REEXAME OFICIAL CONHECIDOS E PARCIALMENTE PROVIDOS. 1. Na origem, o parquet propôs ação civil de improbidade administrativa contra o ex-prefeito do Município de Coari em razão do suposto cometimento das condutas previstas nos arts. 10, caput, e 11, I e V, ambos da Lei n.º 8.429/92, consubstanciado na contratação de servidores entre os anos de 2001 e 2007 para compor os quadros da Administração Pública sem a prévia realização de concurso público, ocasião em que seus pedidos foram julgados improcedentes pelo MM. Juízo da 1ª Vara da Comarca de Coari; 2. Em razão da entrada em vigor da Lei n.º 14.230/21, o STJ desafetou o Tema Repetitivo n.º 1042 e firmou entendimento sobre a aplicação do regime do duplo grau obrigatório de jurisdição do art. 19 da Lei n.º 4.717/65 para as ações de improbidade julgadas improcedentes anteriormente à entrada em vigor daquele ato normativo, mantida sua inaplicabilidade para as sentenças de improcedência ou extinção sem resolução do mérito posteriores à sobredita Lei n.º 14.230/21; 3. Com relação à acusação de violação aos princípios da administração, sabe-se que o entendimento firmado pelo STJ em precedentes vinculantes orienta-se no sentido de que a contratação de servidores públicos temporários sem concurso público não é per si causa precursora de ato ímprobo atentatório aos princípios administrativos, desde que tais vínculos temporários encontrem-se respaldados por legislação local (Tema Repetitivo n.º 1108); 4. In casu, por força das alterações introduzidas pela Lei n.º 14.230/21 e considerando a revogação do art. 11, I, da Lei n.º 8.429/91, revela-se inviável examinar a subsunção da conduta atribuída ao apelado precisamente no que diz respeito a tal ilícito, sob pena de violação das regras constitucionais atinentes à legalidade e à retroatividade da lei penal benigna (art. 1º, §4º, da Lei n.º 8.429/91 e art. 5º, XL e XLI, da CF); 5. Outrossim, ainda que subsista a tipificação do art. 11, V, da Lei n.º 8.429/91, infere-se dos autos que a conduta atribuída pelo parquet ao apelado não se amolda ao tipo previsto na norma, dado que o referido dispositivo se destina aos casos em que se verifica a violação ao caráter concorrencial do concurso público e não para as situações em que sua realização é ignorada pelo agente público responsável; 6. Com relação à acusação de <em>danos</em> ao erário, tal modalidade de improbidade revela-se nas situações em que o agente público, aproveitando-se dos poderes e facilidades decorrentes de seu múnus, pratica dolosamente ato omissivo ou comissivo contrário à moralidade administrativa e que ocasione prejuízo ao patrimônio público, sendo pertinentes ao caso concreto as condutas dos incisos I e XII do rol exemplificativo do art. 10 da Lei n.º 8.429/92; 7. De acordo com o conjunto probatório agregado aos fólios, em especial o Ofício n.º 154/2011-CMC-GP encaminhado pela Câmara Municipal de Coari, do Ofício n.º 12/2010-GAB e da Representação n.º 965/2009.11.000/8-04 ambos remetido pela Procuradoria Regional do Trabalho da 11ª Região, conclui-se que: (i) a contratação dos servidores não foi antecedida por concurso ou por qualquer processo simplificado de seleção; bem como (ii) não se fundou em lei local permissiva de contratação temporária; (iii) o gestor público promoveu a sucessiva prorrogação dos contratos à margem de qualquer urgência ou necessidade excepcional; bem como (iv) implementou medidas para interrupção das contratações em meses estratégicos, no claro intuito de furtar-se ao pagamento das verbas devidas aos prestadores de serviço; (v) tal cenário ensejou a condenação da municipalidade perante o Tribunal Regional do Trabalho da 11ª Região em diversas ações ajuizadas pelos servidores irregularmente contratados; 8. A conduta praticada pelo apelado não apenas se distanciou das regras pertinentes à boa administração, como também incorreu abuso de direito, dado que este procedeu de forma ilícita e maliciosa restringindo e dificultando o exercício dos direitos pelos seus administrados, bem como causando prejuízo ao patrimônio público, circunstância que representa a um só tempo malferimento intencional aos interesses públicos primário e secundário daquela municipalidade; 9. Em que pese a contratação irregular de servidor público não seja per si sinônimo de ato ímprobo, a situação retratada nos autos recai exatamente sobre a ressalva firmada no Tema Repetitivo n.º 1108, visto que não se trata de simples ilicitude e <em>dano</em> ocasionados ao Poder Público em razão de incompetência ou do mau exercício do múnus público (dolo genérico), mas sim em razão de uma gestão permeada por atos distanciados da moralidade e da honestidade administrativas que, ao final, lesaram de forma consecutiva e irreversível o patrimônio do Município de Coari (dolo específico); 10. Forçosa a conclusão pela presença dos elementos subjetivo e objetivo da conduta imputada pelo parquet ao apelado, notadamente porque restou demonstrada a contratação irregular de servidores públicos que ocasionou <em>danos</em> irreversíveis ao patrimônio público do Município de Coari, bem como a consciência e vontade do apelado para a prática do ato ímprobo; 11. Tendo em vista a natureza sancionatória do regime de improbidade e fazendo um cotejo entre a redação originária da Lei n.º 8.429/92 e a atualmente vigente, alcança-se a conclusão de que as sanções vigentes à época dos fatos são menos gravosas, razão pela qual não se pode cogitar da retroatividade das penalidades da Lei n.º 14.230/21 para atingir a situação do apelado; 12. Considerando as peculiaridades do agente, as circunstâncias fáticas do caso e a extensão do <em>dano</em> causado, conclui-se que as penalidades de recomposição do <em>dano</em> e multa revelam-se suficientemente adequadas para reprimir o ato ímprobo, mormente porque a aplicação conjunta das demais cominações dos incisos do art. 12 da Lei n.º 8.429/92 deve destinar-se aos casos extremos, em observância os princípios da proporcionalidade e da razoabilidade; 13. Sentença parcialmente reformada para julgar procedente o pedido de condenação do apelado pela prática do ato de improbidade do art. 10, I e XII, da Lei n.º 8.429/92, com a cominação das penas do art. 12, II, da Lei n.º 8.429/91, quais sejam: (a) a recomposição do <em>dano</em> causado ao erário do Município de Coari, nos moldes delimitados pelo parquet em sua inicial e (b) o pagamento de multa correspondente ao valor do <em>dano</em> provocado ao erário público, ambos devidamente atualizados, e, por fim, julgar improcedente o pedido de condenação do apelado nas condutas do art. 11, I e V, da Lei n.º 8.429/91; 14. Recurso de apelação e reexame oficial conhecidos e parcialmente providos, em harmonia com o parecer ministerial.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363931" cdForo="0" >
+										0008015-33.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363931" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363931);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363931" style="display: none;" >
+	<div id="textAreaDados_3363931" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. V&Iacute;CIO DE CONSENTIMENTO. VIOLA&Ccedil;&Atilde;O AO DEVER DE INFORMA&Ccedil;&Atilde;O. CONVERS&Atilde;O EM EMPR&Eacute;STIMO CONSIGNADO. REPETI&Ccedil;&Atilde;O EM DOBRO. DANOS MORAIS. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que deu provimento &agrave; apela&ccedil;&atilde;o do banco agravado, em a&ccedil;&atilde;o na qual a consumidora alegou ter contratado empr&eacute;stimo consignado, mas sofreu descontos mensais decorrentes de cart&atilde;o de cr&eacute;dito consignado n&atilde;o solicitado ou compreendido. Sustentou n&atilde;o ter recebido o cart&atilde;o, nem ter ci&ecirc;ncia de que os descontos seriam feitos a t&iacute;tulo de pagamento m&iacute;nimo da fatura, em sistema de juros rotativos que tornou a d&iacute;vida infind&aacute;vel. Pleiteou a declara&ccedil;&atilde;o de nulidade do contrato, convers&atilde;o da contrata&ccedil;&atilde;o para empr&eacute;stimo consignado, devolu&ccedil;&atilde;o em dobro dos valores pagos indevidamente e indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) verificar se houve v&iacute;cio de consentimento na contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado, por viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o; (ii) determinar se &eacute; cab&iacute;vel a convers&atilde;o do contrato para a modalidade de empr&eacute;stimo consignado, com devolu&ccedil;&atilde;o em dobro dos valores pagos indevidamente; (iii) estabelecer se est&atilde;o presentes os requisitos para a condena&ccedil;&atilde;o em danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A institui&ccedil;&atilde;o financeira viola o dever de informa&ccedil;&atilde;o ao n&atilde;o apresentar, de forma clara e acess&iacute;vel, elementos essenciais do contrato de cart&atilde;o de cr&eacute;dito consignado, como meios de quita&ccedil;&atilde;o da d&iacute;vida, cobran&ccedil;a integral do valor sacado, mecanismo de incid&ecirc;ncia de juros e acesso &agrave;s faturas.
+4. A aus&ecirc;ncia de preenchimento de campos essenciais no contrato, como o &quot;Quadro IV&quot;, que indicaria a forma de pagamento, revela nulidade contratual por falta de clareza e transpar&ecirc;ncia, contrariando as teses firmadas no IRDR n&ordm; 0005217-75.2019.8.04.0000.
+5. A repeti&ccedil;&atilde;o em dobro do ind&eacute;bito &eacute; cab&iacute;vel, independentemente de demonstra&ccedil;&atilde;o de m&aacute;-f&eacute;, bastando a conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva da institui&ccedil;&atilde;o financeira, conforme tese 4 do IRDR.
+6. Os saques e compras comprovadamente realizados pela consumidora com o cart&atilde;o devem ser compensados na fase de liquida&ccedil;&atilde;o, sob pena de enriquecimento il&iacute;cito, conforme tese 5 do IRDR.
+7. A configura&ccedil;&atilde;o do dano moral decorre da frustra&ccedil;&atilde;o leg&iacute;tima de expectativas do consumidor, da viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o e do prolongamento indevido da d&iacute;vida, justificando indeniza&ccedil;&atilde;o pecuni&aacute;ria nos termos da tese 3 do IRDR.
+IV. DISPOSITIVO E TESE
+8. Recurso parcialmente provido.
+Tese de julgamento:
+1) A contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado sem a inequ&iacute;voca ci&ecirc;ncia dos termos contratuais viola o dever de informa&ccedil;&atilde;o e configura v&iacute;cio de consentimento.
+2) A invalidade do contrato por aus&ecirc;ncia de informa&ccedil;&atilde;o autoriza sua convers&atilde;o para empr&eacute;stimo consignado, com aplica&ccedil;&atilde;o da taxa de juros correspondente &agrave; modalidade.
+3) A repeti&ccedil;&atilde;o em dobro dos valores pagos indevidamente &eacute; cab&iacute;vel sem necessidade de prova de m&aacute;-f&eacute;, bastando a viola&ccedil;&atilde;o &agrave; boa-f&eacute; objetiva.
+4) A configura&ccedil;&atilde;o de dano moral decorre da conduta abusiva da institui&ccedil;&atilde;o financeira, sendo devida a indeniza&ccedil;&atilde;o, ainda que n&atilde;o haja utiliza&ccedil;&atilde;o do cart&atilde;o pelo consumidor.
+5) Os valores efetivamente utilizados pelo consumidor por meio do cart&atilde;o de cr&eacute;dito devem ser compensados na fase de liquida&ccedil;&atilde;o, para evitar enriquecimento il&iacute;cito.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, X; CC, arts. 170, 186, 927, 944; CDC, arts. 14, 42, par&aacute;grafo &uacute;nico, 51, IV e XV; CPC, art. 932, V, &quot;c&quot;.
+Jurisprud&ecirc;ncia relevante citada: TJAM, IRDR n&ordm; 0005217-75.2019.8.04.0000, Rel. Des. Jos&eacute; Hamilton Saraiva dos Santos, Tribunal Pleno, j. 01.02.2022. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0008015-33.2024.8.04.0000; Relator (a): Cezar Luiz Bandiera; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 10/07/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Cezar Luiz Bandiera
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									10/07/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO EM EMPRÉSTIMO CONSIGNADO. REPETIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em>. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento à apelação do banco agravado, em ação na qual a consumidora
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. CONVERSÃO EM EMPRÉSTIMO CONSIGNADO. REPETIÇÃO EM DOBRO. <em>DANOS</em> <em>MORAIS</em>. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento à apelação do banco agravado, em ação na qual a consumidora alegou ter contratado empréstimo consignado, mas sofreu descontos mensais decorrentes de cartão de crédito consignado não solicitado ou compreendido. Sustentou não ter recebido o cartão, nem ter ciência de que os descontos seriam feitos a título de pagamento mínimo da fatura, em sistema de juros rotativos que tornou a dívida infindável. Pleiteou a declaração de nulidade do contrato, conversão da contratação para empréstimo consignado, devolução em dobro dos valores pagos indevidamente e indenização por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) verificar se houve vício de consentimento na contratação de cartão de crédito consignado, por violação ao dever de informação; (ii) determinar se é cabível a conversão do contrato para a modalidade de empréstimo consignado, com devolução em dobro dos valores pagos indevidamente; (iii) estabelecer se estão presentes os requisitos para a condenação em <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3. A instituição financeira viola o dever de informação ao não apresentar, de forma clara e acessível, elementos essenciais do contrato de cartão de crédito consignado, como meios de quitação da dívida, cobrança integral do valor sacado, mecanismo de incidência de juros e acesso às faturas.
+4. A ausência de preenchimento de campos essenciais no contrato, como o "Quadro IV", que indicaria a forma de pagamento, revela nulidade contratual por falta de clareza e transparência, contrariando as teses firmadas no IRDR nº 0005217-75.2019.8.04.0000.
+5. A repetição em dobro do indébito é cabível, independentemente de demonstração de má-fé, bastando a conduta contrária à boa-fé objetiva da instituição financeira, conforme tese 4 do IRDR.
+6. Os saques e compras comprovadamente realizados pela consumidora com o cartão devem ser compensados na fase de liquidação, sob pena de enriquecimento ilícito, conforme tese 5 do IRDR.
+7. A configuração do <em>dano</em> <em>moral</em> decorre da frustração legítima de expectativas do consumidor, da violação ao dever de informação e do prolongamento indevido da dívida, justificando indenização pecuniária nos termos da tese 3 do IRDR.
+IV. DISPOSITIVO E TESE
+8. Recurso parcialmente provido.
+Tese de julgamento:
+1) A contratação de cartão de crédito consignado sem a inequívoca ciência dos termos contratuais viola o dever de informação e configura vício de consentimento.
+2) A invalidade do contrato por ausência de informação autoriza sua conversão para empréstimo consignado, com aplicação da taxa de juros correspondente à modalidade.
+3) A repetição em dobro dos valores pagos indevidamente é cabível sem necessidade de prova de má-fé, bastando a violação à boa-fé objetiva.
+4) A configuração de <em>dano</em> <em>moral</em> decorre da conduta abusiva da instituição financeira, sendo devida a indenização, ainda que não haja utilização do cartão pelo consumidor.
+5) Os valores efetivamente utilizados pelo consumidor por meio do cartão de crédito devem ser compensados na fase de liquidação, para evitar enriquecimento ilícito.
+Dispositivos relevantes citados: CF/1988, art. 5º, X; CC, arts. 170, 186, 927, 944; CDC, arts. 14, 42, parágrafo único, 51, IV e XV; CPC, art. 932, V, "c".
+Jurisprudência relevante citada: TJAM, IRDR nº 0005217-75.2019.8.04.0000, Rel. Des. José Hamilton Saraiva dos Santos, Tribunal Pleno, j. 01.02.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363747" cdForo="0" >
+										0628624-87.2021.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363747" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363747);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363747" style="display: none;" >
+	<div id="textAreaDados_3363747" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. RESPONSABILIDADE CIVIL. V&Iacute;CIO DO PRODUTO. RESTITUI&Ccedil;&Atilde;O DO VALOR PAGO PELO VE&Iacute;CULO. DANO MORAL. REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO PROVIDO EM PARTE.
+I. CASO EM EXAME
+Apela&ccedil;&otilde;es c&iacute;veis interpostas pelos requeridos contra senten&ccedil;a que julgou procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos materiais e morais, determinando, solidariamente, a substitui&ccedil;&atilde;o de ve&iacute;culo automotor com v&iacute;cio oculto por outro zero quil&ocirc;metro ou, alternativamente, a restitui&ccedil;&atilde;o integral da quantia paga, acrescida de juros e corre&ccedil;&atilde;o monet&aacute;ria, al&eacute;m de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 20.000,00. O voto vencido diverge parcialmente do entendimento da relatora, entendendo excessiva a substitui&ccedil;&atilde;o do ve&iacute;culo usado por um novo e desproporcional o montante indenizat&oacute;rio, votando pela restitui&ccedil;&atilde;o do valor conforme Tabela FIPE, com descontos legais, e redu&ccedil;&atilde;o dos danos morais para R$ 10.000,00.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; devida a substitui&ccedil;&atilde;o do ve&iacute;culo com v&iacute;cio oculto por outro zero quil&ocirc;metro ou apenas a restitui&ccedil;&atilde;o proporcional do valor pago; (ii) estabelecer o valor adequado da indeniza&ccedil;&atilde;o por danos morais diante do caso concreto.
+III. RAZ&Otilde;ES DE DECIDIR
+1) A responsabilidade solid&aacute;ria entre fabricante e concession&aacute;ria por v&iacute;cio no produto &eacute; aplic&aacute;vel nos moldes do C&oacute;digo de Defesa do Consumidor, especialmente quando o v&iacute;cio reduz o valor do bem ou o torna impr&oacute;prio ao uso.
+2) A substitui&ccedil;&atilde;o do ve&iacute;culo usado por outro novo mostra-se desproporcional quando n&atilde;o h&aacute; demonstra&ccedil;&atilde;o de inutilidade do bem nem de impossibilidade de reparo dentro do prazo legal.
+3) O reparo do ve&iacute;culo foi realizado em tempo h&aacute;bil e a consumidora permaneceu em posse do bem, sem novas reclama&ccedil;&otilde;es, indicando que a concession&aacute;ria n&atilde;o foi privada da chance de sanar o defeito.
+4) A restitui&ccedil;&atilde;o do valor do ve&iacute;culo com base na Tabela FIPE, com dedu&ccedil;&atilde;o de d&eacute;bitos existentes, atende &agrave; repara&ccedil;&atilde;o integral sem configurar enriquecimento sem causa.
+5) O valor de R$ 10.000,00 por danos morais mostra-se razo&aacute;vel e proporcional ao preju&iacute;zo extrapatrimonial experimentado pela parte autora.
+IV. DISPOSITIVO E TESE
+Recursos providos em parte.
+Pedidos procedentes em parte.
+Tese de julgamento:
+1) A substitui&ccedil;&atilde;o de ve&iacute;culo usado por outro zero quil&ocirc;metro exige prova de inutilidade ou irreparabilidade do bem, n&atilde;o sendo cab&iacute;vel apenas por exist&ecirc;ncia de v&iacute;cio san&aacute;vel.
+2) A restitui&ccedil;&atilde;o do valor do ve&iacute;culo com base na Tabela FIPE, com descontos legais, &eacute; medida adequada quando constatado v&iacute;cio no produto e j&aacute; transcorrido tempo razo&aacute;vel desde a aquisi&ccedil;&atilde;o.
+3) A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, podendo ser reduzida quando excessiva em rela&ccedil;&atilde;o &agrave;s circunst&acirc;ncias do caso concreto.
+Dispositivos relevantes citados: CDC, art. 6&ordm;, VI; art. 18 e &sect;1&ordm;. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0628624-87.2021.8.04.0001; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 05/06/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Rescisão do contrato e devolução do dinheiro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									05/06/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÕES CÍVEIS. RESPONSABILIDADE CIVIL. VÍCIO DO PRODUTO. RESTITUIÇÃO DO VALOR PAGO PELO VEÍCULO. <em>DANO</em> <em>MORAL</em>. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PROVIDO EM PARTE.
+I. CASO EM EXAME
+Apelações cíveis interpostas pelos requeridos contra sentença que julgou procedente ação de indenização por <em>danos</em> materiais e <em>morais</em>, determinando,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÕES CÍVEIS. RESPONSABILIDADE CIVIL. VÍCIO DO PRODUTO. RESTITUIÇÃO DO VALOR PAGO PELO VEÍCULO. <em>DANO</em> <em>MORAL</em>. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PROVIDO EM PARTE.
+I. CASO EM EXAME
+Apelações cíveis interpostas pelos requeridos contra sentença que julgou procedente ação de indenização por <em>danos</em> materiais e <em>morais</em>, determinando, solidariamente, a substituição de veículo automotor com vício oculto por outro zero quilômetro ou, alternativamente, a restituição integral da quantia paga, acrescida de juros e correção monetária, além de indenização por <em>danos</em> <em>morais</em> no valor de R$ 20.000,00. O voto vencido diverge parcialmente do entendimento da relatora, entendendo excessiva a substituição do veículo usado por um novo e desproporcional o montante indenizatório, votando pela restituição do valor conforme Tabela FIPE, com descontos legais, e redução dos <em>danos</em> <em>morais</em> para R$ 10.000,00.
+II. QUESTÃO EM DISCUSSÃO
+Há duas questões em discussão: (i) definir se é devida a substituição do veículo com vício oculto por outro zero quilômetro ou apenas a restituição proporcional do valor pago; (ii) estabelecer o valor adequado da indenização por <em>danos</em> <em>morais</em> diante do caso concreto.
+III. RAZÕES DE DECIDIR
+1) A responsabilidade solidária entre fabricante e concessionária por vício no produto é aplicável nos moldes do Código de Defesa do Consumidor, especialmente quando o vício reduz o valor do bem ou o torna impróprio ao uso.
+2) A substituição do veículo usado por outro novo mostra-se desproporcional quando não há demonstração de inutilidade do bem nem de impossibilidade de reparo dentro do prazo legal.
+3) O reparo do veículo foi realizado em tempo hábil e a consumidora permaneceu em posse do bem, sem novas reclamações, indicando que a concessionária não foi privada da chance de sanar o defeito.
+4) A restituição do valor do veículo com base na Tabela FIPE, com dedução de débitos existentes, atende à reparação integral sem configurar enriquecimento sem causa.
+5) O valor de R$ 10.000,00 por <em>danos</em> <em>morais</em> mostra-se razoável e proporcional ao prejuízo extrapatrimonial experimentado pela parte autora.
+IV. DISPOSITIVO E TESE
+Recursos providos em parte.
+Pedidos procedentes em parte.
+Tese de julgamento:
+1) A substituição de veículo usado por outro zero quilômetro exige prova de inutilidade ou irreparabilidade do bem, não sendo cabível apenas por existência de vício sanável.
+2) A restituição do valor do veículo com base na Tabela FIPE, com descontos legais, é medida adequada quando constatado vício no produto e já transcorrido tempo razoável desde a aquisição.
+3) A fixação de indenização por <em>danos</em> <em>morais</em> deve observar os princípios da razoabilidade e proporcionalidade, podendo ser reduzida quando excessiva em relação às circunstâncias do caso concreto.
+Dispositivos relevantes citados: CDC, art. 6º, VI; art. 18 e §1º.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363745" cdForo="0" >
+										4013261-73.2023.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363745" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363745);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363745" style="display: none;" >
+	<div id="textAreaDados_3363745" class="mensagemSemFormatacao" >
+		Ementa: AGRAVO DE INSTRUMENTO. GRATUIDADE DA JUSTI&Ccedil;A. PESSOA F&Iacute;SICA. DECLARA&Ccedil;&Atilde;O DE HIPOSSUFICI&Ecirc;NCIA ECON&Ocirc;MICA. PRESUN&Ccedil;&Atilde;O RELATIVA DE VERACIDADE. DEMAIS DOCUMENTOS QUE CORROBORAM A ALEGA&Ccedil;&Atilde;O. PREENCHIMENTO DOS PRESSUPOSTOS NECESS&Aacute;RIOS &Agrave; CONCESS&Atilde;O DA GRATUIDADE. RECURSO CONHECIDO E PROVIDO. DECIS&Atilde;O REFORMADA PARA CONCEDER A GRATUIDADE DA JUSTI&Ccedil;A AO AUTOR. 1. O art. 99, &sect; 3&ordm; do CPC disp&otilde;e que a afirma&ccedil;&atilde;o de hipossufici&ecirc;ncia econ&ocirc;mica deduzida por pessoa natural possui presun&ccedil;&atilde;o relativa de veracidade e, justamente em raz&atilde;o deste car&aacute;ter relativo, &eacute; que o mesmo diploma autoriza que o magistrado, verificando a exist&ecirc;ncia de elementos que evidenciem a falta dos pressupostos legais para a concess&atilde;o do benef&iacute;cio, indefira o pleito, devendo antes oportunizar &agrave; parte que comprove a presen&ccedil;a de tais pressupostos. 2. No caso concreto, o Ju&iacute;zo a quo, observando o procedimento previsto pelo art. 99, &sect; 2&ordm;, do CPC, determinou &agrave; agravante que apresentasse documentos comprobat&oacute;rios da alegada insufici&ecirc;ncia de recursos, a fim de avaliar a possibilidade de concess&atilde;o do benef&iacute;cio da gratuidade de justi&ccedil;a e, ap&oacute;s cumprida tal determina&ccedil;&atilde;o, decidiu indeferir o pedido. 3. Sucede que os documentos juntados aos autos corroboram a alega&ccedil;&atilde;o de hipossufici&ecirc;ncia econ&ocirc;mica deduzida pela agravante, devendo ser concedida em seu favor a gratuidade de justi&ccedil;a, na forma do art. 98, caput e &sect; 1&ordm;, do C&oacute;digo de Processo Civil, garantindo-lhe o direito fundamental ao acesso &agrave; justi&ccedil;a (art. 5&ordm;, XXXV, CF). 4. Recurso conhecido e provido. Decis&atilde;o reformada para conceder a gratuidade da justi&ccedil;a ao autor.  <br><br>(Agravo de Instrumento N&ordm; 4013261-73.2023.8.04.0000; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 05/06/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Assistência Judiciária Gratuita
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									05/06/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. GRATUIDADE DA JUSTIÇA. PESSOA FÍSICA. DECLARAÇÃO DE HIPOSSUFICIÊNCIA ECONÔMICA. PRESUNÇÃO RELATIVA DE VERACIDADE. DEMAIS DOCUMENTOS QUE CORROBORAM A ALEGAÇÃO. PREENCHIMENTO DOS PRESSUPOSTOS NECESSÁRIOS À CONCESSÃO DA GRATUIDADE. RECURSO CONHECIDO E PROVIDO. DECISÃO REFORMADA PARA CONCEDER A GRATUIDADE DA JUSTIÇA AO AUTOR. 1. O art. 99, § 3º do CPC dispõe que a afirmação de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. GRATUIDADE DA JUSTIÇA. PESSOA FÍSICA. DECLARAÇÃO DE HIPOSSUFICIÊNCIA ECONÔMICA. PRESUNÇÃO RELATIVA DE VERACIDADE. DEMAIS DOCUMENTOS QUE CORROBORAM A ALEGAÇÃO. PREENCHIMENTO DOS PRESSUPOSTOS NECESSÁRIOS À CONCESSÃO DA GRATUIDADE. RECURSO CONHECIDO E PROVIDO. DECISÃO REFORMADA PARA CONCEDER A GRATUIDADE DA JUSTIÇA AO AUTOR. 1. O art. 99, § 3º do CPC dispõe que a afirmação de hipossuficiência econômica deduzida por pessoa natural possui presunção relativa de veracidade e, justamente em razão deste caráter relativo, é que o mesmo diploma autoriza que o magistrado, verificando a existência de elementos que evidenciem a falta dos pressupostos legais para a concessão do benefício, indefira o pleito, devendo antes oportunizar à parte que comprove a presença de tais pressupostos. 2. No caso concreto, o Juízo a quo, observando o procedimento previsto pelo art. 99, § 2º, do CPC, determinou à agravante que apresentasse documentos comprobatórios da alegada insuficiência de recursos, a fim de avaliar a possibilidade de concessão do benefício da gratuidade de justiça e, após cumprida tal determinação, decidiu indeferir o pedido. 3. Sucede que os documentos juntados aos autos corroboram a alegação de hipossuficiência econômica deduzida pela agravante, devendo ser concedida em seu favor a gratuidade de justiça, na forma do art. 98, caput e § 1º, do Código de Processo Civil, garantindo-lhe o direito fundamental ao acesso à justiça (art. 5º, XXXV, CF). 4. Recurso conhecido e provido. Decisão reformada para conceder a gratuidade da justiça ao autor.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="EMENTA">
+									<label for="ckTermo1">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="RECURSO">
+									<label for="ckTermo2">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="APELAÇÃO">
+									<label for="ckTermo3">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="CONHECIDO">
+									<label for="ckTermo4">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="CÍVEL">
+									<label for="ckTermo5">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="PROVIDO">
+									<label for="ckTermo6">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="AÇÃO">
+									<label for="ckTermo7">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="Recurso">
+									<label for="ckTermo8">
+										Recurso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="conhecido">
+									<label for="ckTermo9">
+										conhecido
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="SENTENÇA">
+									<label for="ckTermo10">
+										SENTENÇA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="DIREITO">
+									<label for="ckTermo11">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="CIVIL">
+									<label for="ckTermo12">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="DANOS">
+									<label for="ckTermo13">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="MORAIS">
+									<label for="ckTermo14">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="provido">
+									<label for="ckTermo15">
+										provido
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 10
+			</strong>
+			de 54334
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjam/samples/cjsg/results_normal_page_02.html
+++ b/tests/tjam/samples/cjsg/results_normal_page_02.html
@@ -1,0 +1,1959 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(54334)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="54334" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363743" cdForo="0" >
+										4005406-43.2023.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363743" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363743);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363743" style="display: none;" >
+	<div id="textAreaDados_3363743" class="mensagemSemFormatacao" >
+		Ementa: AGRAVO DE INSTRUMENTO. EXCE&Ccedil;&Atilde;O DE PR&Eacute;-EXECUTIVIDADE. EXCESSO DE EXECU&Ccedil;&Atilde;O. CONSECT&Aacute;RIOS LEGAIS. MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA. RECURSO CONHECIDO E PROVIDO. DECIS&Atilde;O REFORMADA. 1. Consiste o objeto da insurg&ecirc;ncia recursal a decis&atilde;o que deixou de analisar a exce&ccedil;&atilde;o de pr&eacute;-executividade apresentada pela agravante sob a alega&ccedil;&atilde;o de excesso de execu&ccedil;&atilde;o por entender o magistrado de piso ser inadequada a via eleita e diante da preclus&atilde;o por aus&ecirc;ncia de impugna&ccedil;&atilde;o ao cumprimento de senten&ccedil;a. 2. De acordo com o Superior Tribunal de Justi&ccedil;a, a quest&atilde;o afeta aos juros de mora e &agrave; corre&ccedil;&atilde;o monet&aacute;ria, como consect&aacute;rios legais da condena&ccedil;&atilde;o principal, ostenta natureza de ordem p&uacute;blica. 3. N&atilde;o se pode olvidar que no processo de execu&ccedil;&atilde;o o magistrado a quo tem o dever de verificar a conformidade entre o t&iacute;tulo executivo e o valor cobrado, independentemente da impugna&ccedil;&atilde;o do devedor, mormente quando se tratar de execu&ccedil;&atilde;o de t&iacute;tulo judicial, para se evitar excessos e irregularidades que prejudiquem as partes e o pr&oacute;prio interesse da jurisdi&ccedil;&atilde;o. 4. Recurso conhecido e provido. Decis&atilde;o reformada.  <br><br>(Agravo de Instrumento N&ordm; 4005406-43.2023.8.04.0000; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 05/06/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Efeitos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									05/06/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. EXCEÇÃO DE PRÉ-EXECUTIVIDADE. EXCESSO DE EXECUÇÃO. CONSECTÁRIOS LEGAIS. MATÉRIA DE ORDEM PÚBLICA. RECURSO CONHECIDO E PROVIDO. DECISÃO REFORMADA. 1. Consiste o objeto da insurgência recursal a decisão que deixou de analisar a exceção de pré-executividade apresentada pela agravante sob a alegação de excesso de execução por entender o magistrado de piso ser inadequada a via
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. EXCEÇÃO DE PRÉ-EXECUTIVIDADE. EXCESSO DE EXECUÇÃO. CONSECTÁRIOS LEGAIS. MATÉRIA DE ORDEM PÚBLICA. RECURSO CONHECIDO E PROVIDO. DECISÃO REFORMADA. 1. Consiste o objeto da insurgência recursal a decisão que deixou de analisar a exceção de pré-executividade apresentada pela agravante sob a alegação de excesso de execução por entender o magistrado de piso ser inadequada a via eleita e diante da preclusão por ausência de impugnação ao cumprimento de sentença. 2. De acordo com o Superior Tribunal de Justiça, a questão afeta aos juros de mora e à correção monetária, como consectários legais da condenação principal, ostenta natureza de ordem pública. 3. Não se pode olvidar que no processo de execução o magistrado a quo tem o dever de verificar a conformidade entre o título executivo e o valor cobrado, independentemente da impugnação do devedor, mormente quando se tratar de execução de título judicial, para se evitar excessos e irregularidades que prejudiquem as partes e o próprio interesse da jurisdição. 4. Recurso conhecido e provido. Decisão reformada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363741" cdForo="0" >
+										0696361-10.2021.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363741" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363741);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363741" style="display: none;" >
+	<div id="textAreaDados_3363741" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&ccedil;&atilde;o  REVISIONAL DE CONTRATO cumulada com danos morais e materiais. CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL (RMC).&nbsp;CONTRATO N&Atilde;O JUNTADOS AOS AUTOS. CONSUMIDOR QUE FAZ USO REGULAR DO CART&Atilde;O DESDE 2010 PAGANDO FATURAS SEM FAZER QUALQUER QUESTIONAMENTO QUANTO AOS VALORES COBRADOS. ALEGA&Ccedil;&Atilde;O DE FRAUDE QUE N&Atilde;O SE COADUNA COM AS PROVAS DOS AUTOS. COMPORTAMENTO QUE DEMONSTRA TOTAL CONHECIMENTO QUANTO AO SERVI&Ccedil;O CONTRATADO. PROIBI&Ccedil;&Atilde;O DO VENIRE CONTRA FACTUM PROPRIUM. DANO MORAL N&Atilde;O CONFIGURADO. RECURSO CONHECIDO E DESPROVIDO. SENTEN&Ccedil;A MANTIDA. 1. Cinge-se a controv&eacute;rsia a determinar se estavam presentes os requisitos configuradores da responsabilidade civil consumerista que ampare a condena&ccedil;&atilde;o em danos morais e a restitui&ccedil;&atilde;o do ind&eacute;bito, em dobro, decorrente da cobran&ccedil;a das faturas do cart&atilde;o n. 54926403, contratado em 11/11/2009, denominado BB PREVID&Ecirc;NCIA SOCIAL VISA. 2. In casu, a autora utilizava o referido cart&atilde;o desde fevereiro de 2010, tendo realizado o pagamento de diversas faturas correspondentes, o que imediatamente afasta a hip&oacute;tese de fraude contra a cliente. 3. Em que pese a institui&ccedil;&atilde;o financeira n&atilde;o apresente o contrato o comportamento deste que paga por prolongado per&iacute;odo, isto &eacute;, desde fevereiro/2010 (fls. 331/438), constitui-se como consentimento t&aacute;cito da contrata&ccedil;&atilde;o de tais servi&ccedil;os. 4. Nesse sentido, tem-se que o consumidor ao efetuar, durante anos, os pagamentos das respectivas faturas do cart&atilde;o cr&eacute;dito que, hoje vem a impugnar, gerou a expectativa da institui&ccedil;&atilde;o financeira de ter aquele anu&iacute;do com tais cobran&ccedil;as. 5. A teoria dos atos pr&oacute;prios, ou a proibi&ccedil;&atilde;o de venire contra factum proprium protege uma parte contra aquela que pretenda exercer uma posi&ccedil;&atilde;o jur&iacute;dica em contradi&ccedil;&atilde;o com o comportamento assumido anteriormente. 6. Recurso conhecido e desprovido. Senten&ccedil;a mantida. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0696361-10.2021.8.04.0001; Relator (a): D&eacute;lcio Lu&iacute;s Santos; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 26/05/2025; Data de registro: 05/06/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Délcio Luís Santos
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									05/06/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. Ação  REVISIONAL DE CONTRATO cumulada com <em>danos</em> <em>morais</em> e materiais. CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC). CONTRATO NÃO JUNTADOS AOS AUTOS. CONSUMIDOR QUE FAZ USO REGULAR DO CARTÃO DESDE 2010 PAGANDO FATURAS SEM FAZER QUALQUER QUESTIONAMENTO QUANTO AOS VALORES COBRADOS. ALEGAÇÃO DE FRAUDE QUE NÃO SE COADUNA COM AS PROVAS DOS AUTOS.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. Ação  REVISIONAL DE CONTRATO cumulada com <em>danos</em> <em>morais</em> e materiais. CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC). CONTRATO NÃO JUNTADOS AOS AUTOS. CONSUMIDOR QUE FAZ USO REGULAR DO CARTÃO DESDE 2010 PAGANDO FATURAS SEM FAZER QUALQUER QUESTIONAMENTO QUANTO AOS VALORES COBRADOS. ALEGAÇÃO DE FRAUDE QUE NÃO SE COADUNA COM AS PROVAS DOS AUTOS. COMPORTAMENTO QUE DEMONSTRA TOTAL CONHECIMENTO QUANTO AO SERVIÇO CONTRATADO. PROIBIÇÃO DO VENIRE CONTRA FACTUM PROPRIUM. <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO. RECURSO CONHECIDO E DESPROVIDO. SENTENÇA MANTIDA. 1. Cinge-se a controvérsia a determinar se estavam presentes os requisitos configuradores da responsabilidade civil consumerista que ampare a condenação em <em>danos</em> <em>morais</em> e a restituição do indébito, em dobro, decorrente da cobrança das faturas do cartão n. 54926403, contratado em 11/11/2009, denominado BB PREVIDÊNCIA SOCIAL VISA. 2. In casu, a autora utilizava o referido cartão desde fevereiro de 2010, tendo realizado o pagamento de diversas faturas correspondentes, o que imediatamente afasta a hipótese de fraude contra a cliente. 3. Em que pese a instituição financeira não apresente o contrato o comportamento deste que paga por prolongado período, isto é, desde fevereiro/2010 (fls. 331/438), constitui-se como consentimento tácito da contratação de tais serviços. 4. Nesse sentido, tem-se que o consumidor ao efetuar, durante anos, os pagamentos das respectivas faturas do cartão crédito que, hoje vem a impugnar, gerou a expectativa da instituição financeira de ter aquele anuído com tais cobranças. 5. A teoria dos atos próprios, ou a proibição de venire contra factum proprium protege uma parte contra aquela que pretenda exercer uma posição jurídica em contradição com o comportamento assumido anteriormente. 6. Recurso conhecido e desprovido. Sentença mantida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363740" cdForo="0" >
+										0007269-68.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363740" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363740);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363740" style="display: none;" >
+	<div id="textAreaDados_3363740" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. AGRAVO INTERNO EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. V&Iacute;CIO DE CONSENTIMENTO. DEVER DE INFORMA&Ccedil;&Atilde;O. NULIDADE DO CONTRATO. CONVERS&Atilde;O EM EMPR&Eacute;STIMO CONSIGNADO. RESTITUI&Ccedil;&Atilde;O EM DOBRO. DANO MORAL. REFORMA PARCIAL DA DECIS&Atilde;O.
+I. CASO EM EXAME
+1. Agravo Interno interposto por consumidora contra decis&atilde;o monocr&aacute;tica que negou provimento &agrave; apela&ccedil;&atilde;o c&iacute;vel, em demanda que versa sobre contrato banc&aacute;rio na modalidade cart&atilde;o de cr&eacute;dito consignado.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o:
+(i) verificar se houve viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o na contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado;
+(ii) apurar a ocorr&ecirc;ncia de v&iacute;cio de consentimento que justifique a nulidade contratual e sua convers&atilde;o em empr&eacute;stimo consignado;
+(iii) definir a responsabilidade da institui&ccedil;&atilde;o financeira pela devolu&ccedil;&atilde;o de valores pagos e pela indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O contrato firmado entre as partes n&atilde;o atende aos requisitos de clareza e transpar&ecirc;ncia definidos na tese firmada no IRDR n&ordm; 0005217-75.2019.8.04.0000 do TJAM, pois omite informa&ccedil;&otilde;es essenciais, como forma de quita&ccedil;&atilde;o da d&iacute;vida, valor das parcelas e condi&ccedil;&otilde;es de cobran&ccedil;a, caracterizando viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o.
+
+4. A aus&ecirc;ncia de informa&ccedil;&otilde;es claras quanto &agrave; sistem&aacute;tica de funcionamento do cart&atilde;o de cr&eacute;dito consignado evidencia v&iacute;cio de consentimento, por erro substancial sobre o objeto, o que conduz &agrave; nulidade do contrato banc&aacute;rio, conforme disp&otilde;e o art. 170 do C&oacute;digo Civil.
+5. Diante da invalidade da aven&ccedil;a, o contrato deve ser convertido em empr&eacute;stimo consignado convencional, ajustando-se os encargos financeiros &agrave;s condi&ccedil;&otilde;es dessa modalidade.
+6. &Eacute; devida a restitui&ccedil;&atilde;o em dobro dos valores descontados indevidamente, conforme previsto no par&aacute;grafo &uacute;nico do art. 42 do CDC e na tese firmada no IRDR supracitado, independentemente da comprova&ccedil;&atilde;o de m&aacute;-f&eacute; da institui&ccedil;&atilde;o financeira.
+7. Eventuais compras e saques realizados com o cart&atilde;o devem ser compensados na fase de liquida&ccedil;&atilde;o, em observ&acirc;ncia &agrave; tese 5 do IRDR e para evitar enriquecimento sem causa por parte do consumidor.
+8. Configura-se o dano moral pela frustra&ccedil;&atilde;o leg&iacute;tima de expectativas do consumidor, que foi induzido a contratar produto diverso do pretendido, ensejando responsabilidade objetiva da institui&ccedil;&atilde;o financeira nos termos do art. 14 do CDC.
+IV. DISPOSITIVO E TESE
+9. Recurso parcialmente provido.
+Tese de julgamento:
+1. A aus&ecirc;ncia de informa&ccedil;&otilde;es claras e precisas sobre os termos da contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado viola o dever de informa&ccedil;&atilde;o e caracteriza v&iacute;cio de consentimento.
+2. A nulidade do contrato banc&aacute;rio firmado nessa modalidade imp&otilde;e sua convers&atilde;o em empr&eacute;stimo consignado, nos termos do art. 170 do C&oacute;digo Civil.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, X; CC, arts. 170, 186, 927 e 944; CDC, arts. 14, 42, par&aacute;grafo &uacute;nico, e 51, IV e XV; CPC/2015, art. 932, V, &quot;c&quot;.
+Jurisprud&ecirc;ncia relevante citada: TJAM, IRDR n&ordm; 0005217-75.2019.8.04.0000, Rel. Des. Jos&eacute; Hamilton Saraiva dos Santos, Tribunal Pleno, j. 01.02.2022. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0007269-68.2024.8.04.0000; Relator (a): Cezar Luiz Bandiera; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 04/06/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(24 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Cezar Luiz Bandiera
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									04/06/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO EM APELAÇÃO CÍVEL. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. DEVER DE INFORMAÇÃO. NULIDADE DO CONTRATO. CONVERSÃO EM EMPRÉSTIMO CONSIGNADO. RESTITUIÇÃO EM DOBRO. <em>DANO</em> <em>MORAL</em>. REFORMA PARCIAL DA DECISÃO.
+I. CASO EM EXAME
+1. Agravo Interno interposto por consumidora contra decisão monocrática que negou provimento à apelação cível,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO EM APELAÇÃO CÍVEL. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. DEVER DE INFORMAÇÃO. NULIDADE DO CONTRATO. CONVERSÃO EM EMPRÉSTIMO CONSIGNADO. RESTITUIÇÃO EM DOBRO. <em>DANO</em> <em>MORAL</em>. REFORMA PARCIAL DA DECISÃO.
+I. CASO EM EXAME
+1. Agravo Interno interposto por consumidora contra decisão monocrática que negou provimento à apelação cível, em demanda que versa sobre contrato bancário na modalidade cartão de crédito consignado.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão:
+(i) verificar se houve violação ao dever de informação na contratação do cartão de crédito consignado;
+(ii) apurar a ocorrência de vício de consentimento que justifique a nulidade contratual e sua conversão em empréstimo consignado;
+(iii) definir a responsabilidade da instituição financeira pela devolução de valores pagos e pela indenização por <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3. O contrato firmado entre as partes não atende aos requisitos de clareza e transparência definidos na tese firmada no IRDR nº 0005217-75.2019.8.04.0000 do TJAM, pois omite informações essenciais, como forma de quitação da dívida, valor das parcelas e condições de cobrança, caracterizando violação ao dever de informação.
+
+4. A ausência de informações claras quanto à sistemática de funcionamento do cartão de crédito consignado evidencia vício de consentimento, por erro substancial sobre o objeto, o que conduz à nulidade do contrato bancário, conforme dispõe o art. 170 do Código Civil.
+5. Diante da invalidade da avença, o contrato deve ser convertido em empréstimo consignado convencional, ajustando-se os encargos financeiros às condições dessa modalidade.
+6. É devida a restituição em dobro dos valores descontados indevidamente, conforme previsto no parágrafo único do art. 42 do CDC e na tese firmada no IRDR supracitado, independentemente da comprovação de má-fé da instituição financeira.
+7. Eventuais compras e saques realizados com o cartão devem ser compensados na fase de liquidação, em observância à tese 5 do IRDR e para evitar enriquecimento sem causa por parte do consumidor.
+8. Configura-se o <em>dano</em> <em>moral</em> pela frustração legítima de expectativas do consumidor, que foi induzido a contratar produto diverso do pretendido, ensejando responsabilidade objetiva da instituição financeira nos termos do art. 14 do CDC.
+IV. DISPOSITIVO E TESE
+9. Recurso parcialmente provido.
+Tese de julgamento:
+1. A ausência de informações claras e precisas sobre os termos da contratação do cartão de crédito consignado viola o dever de informação e caracteriza vício de consentimento.
+2. A nulidade do contrato bancário firmado nessa modalidade impõe sua conversão em empréstimo consignado, nos termos do art. 170 do Código Civil.
+Dispositivos relevantes citados: CF/1988, art. 5º, X; CC, arts. 170, 186, 927 e 944; CDC, arts. 14, 42, parágrafo único, e 51, IV e XV; CPC/2015, art. 932, V, "c".
+Jurisprudência relevante citada: TJAM, IRDR nº 0005217-75.2019.8.04.0000, Rel. Des. José Hamilton Saraiva dos Santos, Tribunal Pleno, j. 01.02.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363731" cdForo="0" >
+										0635854-30.2014.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363731" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363731);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363731" style="display: none;" >
+	<div id="textAreaDados_3363731" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. DIREITO PROCESSUAL CIVIL. A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O E LUCROS CESSANTES. INTERRUP&Ccedil;&Otilde;ES CONSTANTES NO FORNECIMENTO DE ENERGIA EL&Eacute;TRICA SEM AVISO PR&Eacute;VIO. PRESTA&Ccedil;&Atilde;O INADEQUADA DO SERVI&Ccedil;O PELA CONCESSION&Aacute;RIA. INTERRUP&Ccedil;&Atilde;O DO PARQUE INDUSTRIAL. PREJU&Iacute;ZOS. NEXO DE CAUSALIDADE CONFIGURADO. DIREITO DO CONSUMIDOR. LAUDO PERICIAL. DANOS MATERIAIS E LUCROS CESSANTES DEVIDOS. DANO MORAL CONFIGURADO. RECURSOS CONHECIDOS E PROVIDO SOMENTE O DO AUTOR. SENTEN&Ccedil;A REFORMADA. 1. Segundo o CDC, deve-se priorizar a seguran&ccedil;a e efici&ecirc;ncia dos servi&ccedil;os prestados aos consumidores, especialmente nas pr&aacute;ticas relacionadas &agrave; presta&ccedil;&atilde;o de servi&ccedil;os essenciais, como ocorre in casu; 2. Deveria a empresa r&eacute;, ent&atilde;o concession&aacute;ria, averiguar e promover periodicamente a manuten&ccedil;&atilde;o da esta&ccedil;&atilde;o, al&eacute;m de viabilizar o restabelecimento do fornecimento normal de energia el&eacute;trica em prazo razo&aacute;vel; 3. A R&eacute; n&atilde;o logrou &ecirc;xito em demonstrar a inveracidade das alega&ccedil;&otilde;es descritas na exordial, raz&atilde;o pela qual resta configurada a sua responsabilidade pela falha na presta&ccedil;&atilde;o de seu servi&ccedil;o; 4. Demonstrado o nexo causal entre a conduta da empresa e os danos verificados, inafast&aacute;vel o dever indenizat&oacute;rio da R&eacute; em face dos preju&iacute;zos suportados pelo Autor, inclusive lucros cessantes; 5. Configurada a falha na presta&ccedil;&atilde;o do servi&ccedil;o e ausente qualquer causa excludente, deve a segunda Apelante responder objetivamente pelos danos causados ao consumidor, nos termos do art.&nbsp;14,&nbsp;do&nbsp;CDC&nbsp;e do art.&nbsp;37,&nbsp;&sect;6.&ordm;, da&nbsp;CF; 6. A interrup&ccedil;&atilde;o indevida no servi&ccedil;o de energia el&eacute;trica, de car&aacute;ter p&uacute;blico e essencial, acarreta danos morais in re ipsa ao consumidor. Jurisprud&ecirc;ncia; 7. A configura&ccedil;&atilde;o do dano moral ocorre em &acirc;mbito extrapatrimonial, sendo circunstanciado por uma frustra&ccedil;&atilde;o irrazo&aacute;vel, excedendo os limites do mero aborrecimento; 8. A indeniza&ccedil;&atilde;o por dano moral deve ser fixada pelo julgador segundo os princ&iacute;pios de razoabilidade e proporcionalidade, de modo a evitar a configura&ccedil;&atilde;o de enriquecimento il&iacute;cito, devendo atender sempre &agrave; fun&ccedil;&atilde;o compensat&oacute;ria ao ofendido e punitiva ao ofensor, por isso, o valor arbitrado de R$50.000,00 (cinquenta mil reais) se mostra proporcional &agrave; ofensa experimentada, e em conformidade ao adotado em situa&ccedil;&otilde;es assemelhadas; 9. Recursos conhecidos e provido somente o primeiro do Autor; 10. Senten&ccedil;a reformada. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0635854-30.2014.8.04.0001; Relator (a): Onilza Abreu Gerth; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 17/02/2025; Data de registro: 09/05/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(76 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Fornecimento de Energia Elétrica
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Onilza Abreu Gerth
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									17/02/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									09/05/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. DIREITO PROCESSUAL CIVIL. AÇÃO DE INDENIZAÇÃO E LUCROS CESSANTES. INTERRUPÇÕES CONSTANTES NO FORNECIMENTO DE ENERGIA ELÉTRICA SEM AVISO PRÉVIO. PRESTAÇÃO INADEQUADA DO SERVIÇO PELA CONCESSIONÁRIA. INTERRUPÇÃO DO PARQUE INDUSTRIAL. PREJUÍZOS. NEXO DE CAUSALIDADE CONFIGURADO. DIREITO DO CONSUMIDOR. LAUDO PERICIAL. <em>DANOS</em> MATERIAIS E LUCROS CESSANTES DEVIDOS. <em>DANO</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. DIREITO PROCESSUAL CIVIL. AÇÃO DE INDENIZAÇÃO E LUCROS CESSANTES. INTERRUPÇÕES CONSTANTES NO FORNECIMENTO DE ENERGIA ELÉTRICA SEM AVISO PRÉVIO. PRESTAÇÃO INADEQUADA DO SERVIÇO PELA CONCESSIONÁRIA. INTERRUPÇÃO DO PARQUE INDUSTRIAL. PREJUÍZOS. NEXO DE CAUSALIDADE CONFIGURADO. DIREITO DO CONSUMIDOR. LAUDO PERICIAL. <em>DANOS</em> MATERIAIS E LUCROS CESSANTES DEVIDOS. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSOS CONHECIDOS E PROVIDO SOMENTE O DO AUTOR. SENTENÇA REFORMADA. 1. Segundo o CDC, deve-se priorizar a segurança e eficiência dos serviços prestados aos consumidores, especialmente nas práticas relacionadas à prestação de serviços essenciais, como ocorre in casu; 2. Deveria a empresa ré, então concessionária, averiguar e promover periodicamente a manutenção da estação, além de viabilizar o restabelecimento do fornecimento normal de energia elétrica em prazo razoável; 3. A Ré não logrou êxito em demonstrar a inveracidade das alegações descritas na exordial, razão pela qual resta configurada a sua responsabilidade pela falha na prestação de seu serviço; 4. Demonstrado o nexo causal entre a conduta da empresa e os <em>danos</em> verificados, inafastável o dever indenizatório da Ré em face dos prejuízos suportados pelo Autor, inclusive lucros cessantes; 5. Configurada a falha na prestação do serviço e ausente qualquer causa excludente, deve a segunda Apelante responder objetivamente pelos <em>danos</em> causados ao consumidor, nos termos do art. 14, do CDC e do art. 37, §6.º, da CF; 6. A interrupção indevida no serviço de energia elétrica, de caráter público e essencial, acarreta <em>danos</em> <em>morais</em> in re ipsa ao consumidor. Jurisprudência; 7. A configuração do <em>dano</em> <em>moral</em> ocorre em âmbito extrapatrimonial, sendo circunstanciado por uma frustração irrazoável, excedendo os limites do mero aborrecimento; 8. A indenização por <em>dano</em> <em>moral</em> deve ser fixada pelo julgador segundo os princípios de razoabilidade e proporcionalidade, de modo a evitar a configuração de enriquecimento ilícito, devendo atender sempre à função compensatória ao ofendido e punitiva ao ofensor, por isso, o valor arbitrado de R$50.000,00 (cinquenta mil reais) se mostra proporcional à ofensa experimentada, e em conformidade ao adotado em situações assemelhadas; 9. Recursos conhecidos e provido somente o primeiro do Autor; 10. Sentença reformada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363729" cdForo="0" >
+										0583144-18.2023.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363729" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363729);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363729" style="display: none;" >
+	<div id="textAreaDados_3363729" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. SERVIDOR P&Uacute;BLICO ESTADUAL DA SES/AM. PROGRESS&Atilde;O FUNCIONAL. OMISS&Atilde;O ADMINISTRATIVA. DATAS-BASE DE 2020 E 2021. LEI ESTADUAL 4.852/19. DIREITO ADQUIRIDO. DANO MORAL. N&Atilde;O CONFIGURADO. SENTEN&Ccedil;A PARCIALMENTE REFORMADA. RECURSOS CONHECIDOS. PRIMEIRA APELA&Ccedil;&Atilde;O PROVIDA. SEGUNDA APELA&Ccedil;&Atilde;O N&Atilde;O PROVIDA.
+I - CASO EM EXAME
+1. Recursos de apela&ccedil;&atilde;o interpostos por Maria Solange Moreira Fontenele Figueira e pelo Estado do Amazonas contra senten&ccedil;a que julgou parcialmente procedente a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer. A senten&ccedil;a determinou a progress&atilde;o funcional da autora para a Classe A, refer&ecirc;ncia 2, com pagamento das verbas retroativas correspondentes, e julgou improcedentes os pedidos de danos morais e reajustes de datas-base.
+II - QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se h&aacute; direito &agrave; progress&atilde;o funcional autom&aacute;tica em raz&atilde;o de omiss&atilde;o administrativa; (ii) estabelecer se os reajustes de datas-base devem ser reconhecidos retroativamente; e (iii) determinar se a aus&ecirc;ncia de progress&atilde;o funcional configura dano moral indeniz&aacute;vel.
+III &ndash; RAZ&Otilde;ES DE DECIDIR
+3. A progress&atilde;o funcional de servidores p&uacute;blicos, quando preenchidos os requisitos legais, constitui direito subjetivo e ato vinculado da Administra&ccedil;&atilde;o P&uacute;blica, sendo poss&iacute;vel o controle judicial para suprir omiss&atilde;o administrativa.
+4. Os reajustes de datas-base de 2020 e 2021, previstos na Lei n&ordm; 4.852/19, configuram direito adquirido da autora, cuja implementa&ccedil;&atilde;o retroativa &eacute; leg&iacute;tima, acrescida de juros e corre&ccedil;&atilde;o monet&aacute;ria.
+5. N&atilde;o h&aacute; demonstra&ccedil;&atilde;o de viola&ccedil;&atilde;o &agrave; dignidade da pessoa ou aos direitos de personalidade que justifique a condena&ccedil;&atilde;o em danos morais pela aus&ecirc;ncia de progress&atilde;o funcional, conforme entendimento consolidado da jurisprud&ecirc;ncia.
+IV &ndash; DISPOSITIVO E TESE
+6. Recurso da autora parcialmente provido para determinar o pagamento dos reajustes de datas-base de 2020 e 2021, bem como a progress&atilde;o funcional para a Classe A, refer&ecirc;ncia 3. Recurso do Estado desprovido.
+TESES DE JULGAMENTO
+1. A progress&atilde;o funcional de servidor p&uacute;blico constitui direito subjetivo e ato vinculado, n&atilde;o se sujeitando ao ju&iacute;zo de conveni&ecirc;ncia e oportunidade da Administra&ccedil;&atilde;o P&uacute;blica.
+2. A omiss&atilde;o administrativa em realizar a avalia&ccedil;&atilde;o de desempenho do servidor n&atilde;o pode prejudic&aacute;-lo, impondo-se o reconhecimento do direito &agrave; progress&atilde;o funcional quando preenchidos os requisitos legais objetivos. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0583144-18.2023.8.04.0001; Relator (a): Maria das Gra&ccedil;as Pessoa Figueiredo; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 24/03/2025; Data de registro: 28/04/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Plano de Classificação de Cargos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Maria das Graças Pessoa Figueiredo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									24/03/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									28/04/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. SERVIDOR PÚBLICO ESTADUAL DA SES/AM. PROGRESSÃO FUNCIONAL. OMISSÃO ADMINISTRATIVA. DATAS-BASE DE 2020 E 2021. LEI ESTADUAL 4.852/19. DIREITO ADQUIRIDO. <em>DANO</em> <em>MORAL</em>. NÃO CONFIGURADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSOS CONHECIDOS. PRIMEIRA APELAÇÃO PROVIDA. SEGUNDA APELAÇÃO NÃO PROVIDA.
+I - CASO EM EXAME
+1. Recursos de apelação interpostos por Maria
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS. SERVIDOR PÚBLICO ESTADUAL DA SES/AM. PROGRESSÃO FUNCIONAL. OMISSÃO ADMINISTRATIVA. DATAS-BASE DE 2020 E 2021. LEI ESTADUAL 4.852/19. DIREITO ADQUIRIDO. <em>DANO</em> <em>MORAL</em>. NÃO CONFIGURADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSOS CONHECIDOS. PRIMEIRA APELAÇÃO PROVIDA. SEGUNDA APELAÇÃO NÃO PROVIDA.
+I - CASO EM EXAME
+1. Recursos de apelação interpostos por Maria Solange Moreira Fontenele Figueira e pelo Estado do Amazonas contra sentença que julgou parcialmente procedente ação de obrigação de fazer. A sentença determinou a progressão funcional da autora para a Classe A, referência 2, com pagamento das verbas retroativas correspondentes, e julgou improcedentes os pedidos de <em>danos</em> <em>morais</em> e reajustes de datas-base.
+II - QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se há direito à progressão funcional automática em razão de omissão administrativa; (ii) estabelecer se os reajustes de datas-base devem ser reconhecidos retroativamente; e (iii) determinar se a ausência de progressão funcional configura <em>dano</em> <em>moral</em> indenizável.
+III – RAZÕES DE DECIDIR
+3. A progressão funcional de servidores públicos, quando preenchidos os requisitos legais, constitui direito subjetivo e ato vinculado da Administração Pública, sendo possível o controle judicial para suprir omissão administrativa.
+4. Os reajustes de datas-base de 2020 e 2021, previstos na Lei nº 4.852/19, configuram direito adquirido da autora, cuja implementação retroativa é legítima, acrescida de juros e correção monetária.
+5. Não há demonstração de violação à dignidade da pessoa ou aos direitos de personalidade que justifique a condenação em <em>danos</em> <em>morais</em> pela ausência de progressão funcional, conforme entendimento consolidado da jurisprudência.
+IV – DISPOSITIVO E TESE
+6. Recurso da autora parcialmente provido para determinar o pagamento dos reajustes de datas-base de 2020 e 2021, bem como a progressão funcional para a Classe A, referência 3. Recurso do Estado desprovido.
+TESES DE JULGAMENTO
+1. A progressão funcional de servidor público constitui direito subjetivo e ato vinculado, não se sujeitando ao juízo de conveniência e oportunidade da Administração Pública.
+2. A omissão administrativa em realizar a avaliação de desempenho do servidor não pode prejudicá-lo, impondo-se o reconhecimento do direito à progressão funcional quando preenchidos os requisitos legais objetivos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363725" cdForo="0" >
+										0683524-20.2021.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363725" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363725);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363725" style="display: none;" >
+	<div id="textAreaDados_3363725" class="mensagemSemFormatacao" >
+		Ementa: Direito Processual Civil. Apela&ccedil;&atilde;o C&iacute;vel. A&ccedil;&atilde;o de Obriga&ccedil;&atilde;o de Fazer. Nulidade da senten&ccedil;a. Preliminar de Aus&ecirc;ncia de intima&ccedil;&atilde;o exclusiva do advogado indicado. Nulidade superada. comparecimento espont&acirc;neo nos autos. Cerceamento de defesa. pedido de produ&ccedil;&atilde;o de provas. n&atilde;o oportuniza&ccedil;&atilde;o. Nulidade reconhecida. Recurso conhecido e provido.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por Hapvida Assist&ecirc;ncia M&eacute;dica Ltda. contra senten&ccedil;a proferida pelo Ju&iacute;zo da 16&ordf; Vara C&iacute;vel e de Acidentes de Trabalho, que julgou procedente a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer, condenando a apelante ao pagamento de indeniza&ccedil;&atilde;o por danos materiais no valor de R$3.062,75 e por danos morais no valor de R$ 10.000,00, em favor de Cristiano Ronaldo de Melo Barroso, representado por seus genitores e av&oacute;. A apelante sustenta, em preliminar, nulidade da senten&ccedil;a por aus&ecirc;ncia de intima&ccedil;&atilde;o exclusiva do advogado indicado e cerceamento de defesa. Suscita, ainda, nulidade em face do cerceamento de defesa decorrente da n&atilde;o aprecia&ccedil;&atilde;o do pedido de aprecia&ccedil;&atilde;o de provas. No m&eacute;rito, discute a inexist&ecirc;ncia de danos indeniz&aacute;veis e defende a taxatividade do rol da ANS.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) verificar se a aus&ecirc;ncia de intima&ccedil;&atilde;o exclusiva do advogado indicado pela parte enseja a nulidade da senten&ccedil;a; e (ii) avaliar se o julgamento sem a an&aacute;lise do pedido de produ&ccedil;&atilde;o de provas constitui cerceamento de defesa.
+III. Raz&otilde;es de decidir
+3. O artigo 272, &sect; 5&ordm;, do CPC estabelece que, havendo pedido expresso para que as comunica&ccedil;&otilde;es dos atos processuais sejam feitas em nome de advogado espec&iacute;fico, a inobserv&acirc;ncia desse pedido acarreta nulidade, caso n&atilde;o haja comparecimento espont&acirc;neo ap&oacute;s a decis&atilde;o impugnada. No caso dos autos, o advogado compareceu espontaneamente aos autos, apresentando tempestivamente o recurso de Apela&ccedil;&atilde;o C&iacute;vel, o que gera a supera&ccedil;&atilde;o da preliminar;
+4. A n&atilde;o aprecia&ccedil;&atilde;o do pedido de produ&ccedil;&atilde;o de provas formulado pela parte, seguida de julgamento antecipado da lide, configura cerceamento de defesa, em viola&ccedil;&atilde;o aos princ&iacute;pios do contradit&oacute;rio e da ampla defesa, bem como ao princ&iacute;pio da coopera&ccedil;&atilde;o previsto no art. 6&ordm; do CPC. O devido processo legal exige que o magistrado fundamente a decis&atilde;o de deferir ou indeferir a produ&ccedil;&atilde;o de provas, n&atilde;o sendo poss&iacute;vel proferir senten&ccedil;a sem a an&aacute;lise desse pedido, sob pena de nulidade por &quot;error in procedendo&quot;.
+5. Em raz&atilde;o da nulidade reconhecida, imp&otilde;e-se o retorno dos autos ao ju&iacute;zo de origem para regular andamento do feito, garantindo-se o contradit&oacute;rio e a ampla defesa.
+IV. Dispositivo  e Teses
+4. Recurso conhecido e provido.
+Teses de julgamento:  O comparecimento espont&acirc;neo nos autos afasta a nulidade de intima&ccedil;&atilde;o aventada. O julgamento antecipado da lide, sem an&aacute;lise de pedido de produ&ccedil;&atilde;o de provas formulado pela parte, configura cerceamento de defesa e nulidade da senten&ccedil;a, em viola&ccedil;&atilde;o aos princ&iacute;pios do contradit&oacute;rio, da ampla defesa e da coopera&ccedil;&atilde;o.
+___________
+Dispositivos relevantes citados: CPC/2015, arts. 6&ordm;, 9&ordm;, 10, 272, &sect;5&ordm;, 369, 370 e 370, par&aacute;grafo &uacute;nico.
+
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg nos EDcl no AREsp n&ordm; 314.781/RS, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 3&ordf; Turma, j. 03.12.2015; STJ, AgInt no AREsp n&ordm; 1.869.213/RR, Rel. Min. Herman Benjamin, 2&ordf; Turma, j. 16.11.2021; STJ, AgInt no REsp n&ordm; 1.784.631/SP, Rel. Min. Antonio Carlos Ferreira, 4&ordf; Turma, j. 19.04.2021; TJAM, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0600206-59.2021.8.04.2000, Rel. Des. Yedo Sim&otilde;es de Oliveira, 2&ordf; C&acirc;mara C&iacute;vel, j. 29.05.2023. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0683524-20.2021.8.04.0001; Relator (a): Yedo Sim&otilde;es de Oliveira; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 10/03/2025; Data de registro: 25/04/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Yedo Simões de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/03/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									25/04/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito Processual Civil. Apelação Cível. Ação de Obrigação de Fazer. Nulidade da sentença. Preliminar de Ausência de intimação exclusiva do advogado indicado. Nulidade superada. comparecimento espontâneo nos autos. Cerceamento de defesa. pedido de produção de provas. não oportunização. Nulidade reconhecida. Recurso conhecido e provido.
+I. Caso em exame
+1. Apelação cível interposta por Hapvida
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito Processual Civil. Apelação Cível. Ação de Obrigação de Fazer. Nulidade da sentença. Preliminar de Ausência de intimação exclusiva do advogado indicado. Nulidade superada. comparecimento espontâneo nos autos. Cerceamento de defesa. pedido de produção de provas. não oportunização. Nulidade reconhecida. Recurso conhecido e provido.
+I. Caso em exame
+1. Apelação cível interposta por Hapvida Assistência Médica Ltda. contra sentença proferida pelo Juízo da 16ª Vara Cível e de Acidentes de Trabalho, que julgou procedente ação de obrigação de fazer, condenando a apelante ao pagamento de indenização por <em>danos</em> materiais no valor de R$3.062,75 e por <em>danos</em> <em>morais</em> no valor de R$ 10.000,00, em favor de Cristiano Ronaldo de Melo Barroso, representado por seus genitores e avó. A apelante sustenta, em preliminar, nulidade da sentença por ausência de intimação exclusiva do advogado indicado e cerceamento de defesa. Suscita, ainda, nulidade em face do cerceamento de defesa decorrente da não apreciação do pedido de apreciação de provas. No mérito, discute a inexistência de <em>danos</em> indenizáveis e defende a taxatividade do rol da ANS.
+II. Questão em discussão
+2. Há duas questões em discussão: (i) verificar se a ausência de intimação exclusiva do advogado indicado pela parte enseja a nulidade da sentença; e (ii) avaliar se o julgamento sem a análise do pedido de produção de provas constitui cerceamento de defesa.
+III. Razões de decidir
+3. O artigo 272, § 5º, do CPC estabelece que, havendo pedido expresso para que as comunicações dos atos processuais sejam feitas em nome de advogado específico, a inobservância desse pedido acarreta nulidade, caso não haja comparecimento espontâneo após a decisão impugnada. No caso dos autos, o advogado compareceu espontaneamente aos autos, apresentando tempestivamente o recurso de Apelação Cível, o que gera a superação da preliminar;
+4. A não apreciação do pedido de produção de provas formulado pela parte, seguida de julgamento antecipado da lide, configura cerceamento de defesa, em violação aos princípios do contraditório e da ampla defesa, bem como ao princípio da cooperação previsto no art. 6º do CPC. O devido processo legal exige que o magistrado fundamente a decisão de deferir ou indeferir a produção de provas, não sendo possível proferir sentença sem a análise desse pedido, sob pena de nulidade por "error in procedendo".
+5. Em razão da nulidade reconhecida, impõe-se o retorno dos autos ao juízo de origem para regular andamento do feito, garantindo-se o contraditório e a ampla defesa.
+IV. Dispositivo  e Teses
+4. Recurso conhecido e provido.
+Teses de julgamento:  O comparecimento espontâneo nos autos afasta a nulidade de intimação aventada. O julgamento antecipado da lide, sem análise de pedido de produção de provas formulado pela parte, configura cerceamento de defesa e nulidade da sentença, em violação aos princípios do contraditório, da ampla defesa e da cooperação.
+___________
+Dispositivos relevantes citados: CPC/2015, arts. 6º, 9º, 10, 272, §5º, 369, 370 e 370, parágrafo único.
+
+Jurisprudência relevante citada: STJ, AgRg nos EDcl no AREsp nº 314.781/RS, Rel. Min. Ricardo Villas Bôas Cueva, 3ª Turma, j. 03.12.2015; STJ, AgInt no AREsp nº 1.869.213/RR, Rel. Min. Herman Benjamin, 2ª Turma, j. 16.11.2021; STJ, AgInt no REsp nº 1.784.631/SP, Rel. Min. Antonio Carlos Ferreira, 4ª Turma, j. 19.04.2021; TJAM, Apelação Cível nº 0600206-59.2021.8.04.2000, Rel. Des. Yedo Simões de Oliveira, 2ª Câmara Cível, j. 29.05.2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363722" cdForo="0" >
+										0006913-73.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363722" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363722);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363722" style="display: none;" >
+	<div id="textAreaDados_3363722" class="mensagemSemFormatacao" >
+		Ementa: DIREITO DO CONSUMIDOR. AGRAVO INTERNO EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. V&Iacute;CIO DE CONSENTIMENTO. VIOLA&Ccedil;&Atilde;O AO DEVER DE INFORMA&Ccedil;&Atilde;O. NULIDADE DO CONTRATO. CONVERS&Atilde;O PARA EMPR&Eacute;STIMO CONSIGNADO. REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO EM DOBRO. DANO MORAL CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que deu provimento &agrave; apela&ccedil;&atilde;o para reconhecer a invalidade de contrato de cart&atilde;o de cr&eacute;dito consignado, diante da aus&ecirc;ncia de informa&ccedil;&otilde;es essenciais e inequ&iacute;vocas &agrave; consumidora sobre a sistem&aacute;tica da opera&ccedil;&atilde;o contratada. A agravante alegou irregularidade na forma de contrata&ccedil;&atilde;o e viola&ccedil;&atilde;o ao Incidente de Resolu&ccedil;&atilde;o de Demandas Repetitivas (IRDR) n&ordm; 0005217-75.2019.8.04.0000, postulando a convers&atilde;o do contrato em empr&eacute;stimo consignado, repeti&ccedil;&atilde;o do ind&eacute;bito em dobro e indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se houve v&iacute;cio de consentimento na contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado por aus&ecirc;ncia de informa&ccedil;&otilde;es essenciais; (ii) determinar a possibilidade de convers&atilde;o do contrato nulo em empr&eacute;stimo consignado; (iii) verificar a presen&ccedil;a de dano moral e a viabilidade da repeti&ccedil;&atilde;o do ind&eacute;bito em dobro.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A aus&ecirc;ncia de informa&ccedil;&otilde;es claras sobre os meios de quita&ccedil;&atilde;o da d&iacute;vida, acesso &agrave;s faturas e cobran&ccedil;a integral do saque no m&ecirc;s subsequente configura viola&ccedil;&atilde;o ao dever de informa&ccedil;&atilde;o previsto no CDC e nas teses do IRDR n&ordm; 0005217-75.2019.8.04.0000.
+4. A contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado, sem ci&ecirc;ncia inequ&iacute;voca dos seus termos, revela v&iacute;cio de consentimento por erro substancial, tornando o contrato inv&aacute;lido.
+5. A convers&atilde;o do contrato nulo em contrato de empr&eacute;stimo consignado convencional &eacute; admiss&iacute;vel, nos termos do art. 170 do C&oacute;digo Civil, respeitando a leg&iacute;tima expectativa do consumidor.
+6. A restitui&ccedil;&atilde;o em dobro dos valores descontados indevidamente &eacute; cab&iacute;vel, independentemente da demonstra&ccedil;&atilde;o de m&aacute;-f&eacute;, conforme o art. 42, par&aacute;grafo &uacute;nico, do CDC e a tese 4 do IRDR.
+7. Configurado o dano moral decorrente da frustra&ccedil;&atilde;o contratual e da conduta lesiva da institui&ccedil;&atilde;o financeira, imp&otilde;e-se a indeniza&ccedil;&atilde;o, com base na responsabilidade objetiva (art. 14 do CDC) e nas teses fixadas no IRDR.
+8. As compras e saques efetivamente realizados devem ser compensados na fase de liquida&ccedil;&atilde;o, a fim de evitar o enriquecimento il&iacute;cito da consumidora.
+IV. DISPOSITIVO E TESE
+9. Recurso provido.
+Tese de julgamento:
+1. A contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado sem a presta&ccedil;&atilde;o de informa&ccedil;&otilde;es claras e completas acarreta nulidade do contrato por v&iacute;cio de consentimento.
+2. O contrato nulo pode ser convertido em empr&eacute;stimo consignado, conforme o art. 170 do C&oacute;digo Civil e as leg&iacute;timas expectativas do consumidor.
+3. &Eacute; devida a restitui&ccedil;&atilde;o em dobro dos valores descontados indevidamente, nos termos do art. 42, par&aacute;grafo &uacute;nico, do CDC, sendo prescind&iacute;vel a demonstra&ccedil;&atilde;o de m&aacute;-f&eacute;.
+4. O dano moral decorrente da contrata&ccedil;&atilde;o irregular de cart&atilde;o de cr&eacute;dito consignado imp&otilde;e o dever de indenizar, com base na responsabilidade objetiva da institui&ccedil;&atilde;o financeira.
+5. Eventuais valores efetivamente utilizados pela consumidora devem ser compensados na fase de liquida&ccedil;&atilde;o para evitar enriquecimento il&iacute;cito. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0006913-73.2024.8.04.0000; Relator (a): Cezar Luiz Bandiera; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 14/04/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Cezar Luiz Bandiera
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO EM APELAÇÃO CÍVEL. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. NULIDADE DO CONTRATO. CONVERSÃO PARA EMPRÉSTIMO CONSIGNADO. REPETIÇÃO DO INDÉBITO EM DOBRO. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento à apelação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. AGRAVO INTERNO EM APELAÇÃO CÍVEL. CARTÃO DE CRÉDITO CONSIGNADO. VÍCIO DE CONSENTIMENTO. VIOLAÇÃO AO DEVER DE INFORMAÇÃO. NULIDADE DO CONTRATO. CONVERSÃO PARA EMPRÉSTIMO CONSIGNADO. REPETIÇÃO DO INDÉBITO EM DOBRO. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento à apelação para reconhecer a invalidade de contrato de cartão de crédito consignado, diante da ausência de informações essenciais e inequívocas à consumidora sobre a sistemática da operação contratada. A agravante alegou irregularidade na forma de contratação e violação ao Incidente de Resolução de Demandas Repetitivas (IRDR) nº 0005217-75.2019.8.04.0000, postulando a conversão do contrato em empréstimo consignado, repetição do indébito em dobro e indenização por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se houve vício de consentimento na contratação de cartão de crédito consignado por ausência de informações essenciais; (ii) determinar a possibilidade de conversão do contrato nulo em empréstimo consignado; (iii) verificar a presença de <em>dano</em> <em>moral</em> e a viabilidade da repetição do indébito em dobro.
+III. RAZÕES DE DECIDIR
+3. A ausência de informações claras sobre os meios de quitação da dívida, acesso às faturas e cobrança integral do saque no mês subsequente configura violação ao dever de informação previsto no CDC e nas teses do IRDR nº 0005217-75.2019.8.04.0000.
+4. A contratação do cartão de crédito consignado, sem ciência inequívoca dos seus termos, revela vício de consentimento por erro substancial, tornando o contrato inválido.
+5. A conversão do contrato nulo em contrato de empréstimo consignado convencional é admissível, nos termos do art. 170 do Código Civil, respeitando a legítima expectativa do consumidor.
+6. A restituição em dobro dos valores descontados indevidamente é cabível, independentemente da demonstração de má-fé, conforme o art. 42, parágrafo único, do CDC e a tese 4 do IRDR.
+7. Configurado o <em>dano</em> <em>moral</em> decorrente da frustração contratual e da conduta lesiva da instituição financeira, impõe-se a indenização, com base na responsabilidade objetiva (art. 14 do CDC) e nas teses fixadas no IRDR.
+8. As compras e saques efetivamente realizados devem ser compensados na fase de liquidação, a fim de evitar o enriquecimento ilícito da consumidora.
+IV. DISPOSITIVO E TESE
+9. Recurso provido.
+Tese de julgamento:
+1. A contratação de cartão de crédito consignado sem a prestação de informações claras e completas acarreta nulidade do contrato por vício de consentimento.
+2. O contrato nulo pode ser convertido em empréstimo consignado, conforme o art. 170 do Código Civil e as legítimas expectativas do consumidor.
+3. É devida a restituição em dobro dos valores descontados indevidamente, nos termos do art. 42, parágrafo único, do CDC, sendo prescindível a demonstração de má-fé.
+4. O <em>dano</em> <em>moral</em> decorrente da contratação irregular de cartão de crédito consignado impõe o dever de indenizar, com base na responsabilidade objetiva da instituição financeira.
+5. Eventuais valores efetivamente utilizados pela consumidora devem ser compensados na fase de liquidação para evitar enriquecimento ilícito.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363720" cdForo="0" >
+										0607261-20.2016.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363720" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363720);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363720" style="display: none;" >
+	<div id="textAreaDados_3363720" class="mensagemSemFormatacao" >
+		Ementa: DIREITO CIVIL. RECURSOS DE APELA&Ccedil;&Atilde;O. ATRASO NA ENTREGA DE IM&Oacute;VEL. LUCROS CESSANTES. TERMO FINAL.  CL&Aacute;USULA DE TOLER&Acirc;NCIA DE 180 DIAS. AUS&Ecirc;NCIA DE JUSTIFICATIVA. DANO MORAL. CONFIGURADOS. PRIMEIRO RECURSO PARCIALMENTE PROVIDO E SEGUNDO RECURSO N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Recursos de Apela&ccedil;&atilde;o C&iacute;vel interpostos por ambas as partes contra senten&ccedil;a que julgou parcialmente procedentes os pedidos de indeniza&ccedil;&atilde;o por lucros cessantes e improcedente o pedido de danos morais, decorrentes de atraso na entrega de im&oacute;vel. O autor-apelante alegou necessidade de corre&ccedil;&atilde;o do termo final dos lucros cessantes e pleiteou a condena&ccedil;&atilde;o por danos morais. A construtora-apelada argumentou pela validade da cl&aacute;usula de toler&acirc;ncia de 180 dias e pela improced&ecirc;ncia da condena&ccedil;&atilde;o.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; v&aacute;lida a cl&aacute;usula de toler&acirc;ncia de 180 dias sem justificativas concretas; (ii) estabelecer qual &eacute; o termo final para a incid&ecirc;ncia dos lucros cessantes; e (iii) determinar a exist&ecirc;ncia de dano moral pass&iacute;vel de indeniza&ccedil;&atilde;o.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A cl&aacute;usula de toler&acirc;ncia de 180 dias &eacute; considerada nula quando n&atilde;o h&aacute; comprova&ccedil;&atilde;o de justa causa para o atraso, conforme jurisprud&ecirc;ncia consolidada pelo IRDR n. 0005477-60.2016.8.04.0000. No caso, a construtora n&atilde;o apresentou justificativa v&aacute;lida, sendo mantida a decis&atilde;o que afastou a cl&aacute;usula;
+4. O termo final para incid&ecirc;ncia dos lucros cessantes deve ser a data de entrega das chaves, e n&atilde;o a expedi&ccedil;&atilde;o do habite-se, por ser o momento em que o comprador efetivamente pode usufruir do im&oacute;vel. Precedentes do STJ;
+5. Quanto ao dano moral, este ficou caracterizado, j&aacute; que o atraso na entrega do im&oacute;vel, quando n&atilde;o demonstrado justificativa v&aacute;lida, enseja repara&ccedil;&atilde;o moral, fixando-se a indeniza&ccedil;&atilde;o em R$ 10.000,00, valor razo&aacute;vel e proporcional aos preju&iacute;zos sofridos pelo apelante.
+IV. DISPOSITIVO E TESE
+4.  Primeiro recurso parcialmente provido.
+5. Segundo recurso n&atilde;o provido.
+Tese de julgamento: 1. Cl&aacute;usula de toler&acirc;ncia de 180 dias &eacute; nula quando desprovida de justificativa concreta e v&aacute;lida. 2. O termo final para incid&ecirc;ncia dos lucros cessantes &eacute; a data de entrega das chaves ao comprador.
+Dispositivos relevantes citados: CC, arts. 402, 403 e 475.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no Ag 1036023/RJ, AgRg no REsp 1049894/RJ; IRDR n. 0005477-60.2016.8.04.0000. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0607261-20.2016.8.04.0001; Relator (a): Joana dos Santos Meirelles; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Primeira C&acirc;mara C&iacute;vel; Data do julgamento: 24/03/2025; Data de registro: 11/04/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(48 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Indenização por Dano Material
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Joana dos Santos Meirelles
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Primeira Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									24/03/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									11/04/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. RECURSOS DE APELAÇÃO. ATRASO NA ENTREGA DE IMÓVEL. LUCROS CESSANTES. TERMO FINAL.  CLÁUSULA DE TOLERÂNCIA DE 180 DIAS. AUSÊNCIA DE JUSTIFICATIVA. <em>DANO</em> <em>MORAL</em>. CONFIGURADOS. PRIMEIRO RECURSO PARCIALMENTE PROVIDO E SEGUNDO RECURSO NÃO PROVIDO.
+I. CASO EM EXAME
+1. Recursos de Apelação Cível interpostos por ambas as partes contra sentença que julgou parcialmente
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. RECURSOS DE APELAÇÃO. ATRASO NA ENTREGA DE IMÓVEL. LUCROS CESSANTES. TERMO FINAL.  CLÁUSULA DE TOLERÂNCIA DE 180 DIAS. AUSÊNCIA DE JUSTIFICATIVA. <em>DANO</em> <em>MORAL</em>. CONFIGURADOS. PRIMEIRO RECURSO PARCIALMENTE PROVIDO E SEGUNDO RECURSO NÃO PROVIDO.
+I. CASO EM EXAME
+1. Recursos de Apelação Cível interpostos por ambas as partes contra sentença que julgou parcialmente procedentes os pedidos de indenização por lucros cessantes e improcedente o pedido de <em>danos</em> <em>morais</em>, decorrentes de atraso na entrega de imóvel. O autor-apelante alegou necessidade de correção do termo final dos lucros cessantes e pleiteou a condenação por <em>danos</em> <em>morais</em>. A construtora-apelada argumentou pela validade da cláusula de tolerância de 180 dias e pela improcedência da condenação.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se é válida a cláusula de tolerância de 180 dias sem justificativas concretas; (ii) estabelecer qual é o termo final para a incidência dos lucros cessantes; e (iii) determinar a existência de <em>dano</em> <em>moral</em> passível de indenização.
+III. RAZÕES DE DECIDIR
+3. A cláusula de tolerância de 180 dias é considerada nula quando não há comprovação de justa causa para o atraso, conforme jurisprudência consolidada pelo IRDR n. 0005477-60.2016.8.04.0000. No caso, a construtora não apresentou justificativa válida, sendo mantida a decisão que afastou a cláusula;
+4. O termo final para incidência dos lucros cessantes deve ser a data de entrega das chaves, e não a expedição do habite-se, por ser o momento em que o comprador efetivamente pode usufruir do imóvel. Precedentes do STJ;
+5. Quanto ao <em>dano</em> <em>moral</em>, este ficou caracterizado, já que o atraso na entrega do imóvel, quando não demonstrado justificativa válida, enseja reparação <em>moral</em>, fixando-se a indenização em R$ 10.000,00, valor razoável e proporcional aos prejuízos sofridos pelo apelante.
+IV. DISPOSITIVO E TESE
+4.  Primeiro recurso parcialmente provido.
+5. Segundo recurso não provido.
+Tese de julgamento: 1. Cláusula de tolerância de 180 dias é nula quando desprovida de justificativa concreta e válida. 2. O termo final para incidência dos lucros cessantes é a data de entrega das chaves ao comprador.
+Dispositivos relevantes citados: CC, arts. 402, 403 e 475.
+Jurisprudência relevante citada: STJ, AgRg no Ag 1036023/RJ, AgRg no REsp 1049894/RJ; IRDR n. 0005477-60.2016.8.04.0000.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363717" cdForo="0" >
+										0009477-25.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363717" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363717);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363717" style="display: none;" >
+	<div id="textAreaDados_3363717" class="mensagemSemFormatacao" >
+		Ementa: DIREITO CIVIL. AGRAVO INTERNO. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. VALIDADE DO CONTRATO. INFORMA&Ccedil;&Atilde;O ADEQUADA. NEG&Oacute;CIO JUR&Iacute;DICO V&Aacute;LIDO. AUS&Ecirc;NCIA DE ATO IL&Iacute;CITO. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que deu provimento ao recurso de apela&ccedil;&atilde;o da parte autora em a&ccedil;&atilde;o que discutia a validade e regularidade de contrato de cart&atilde;o de cr&eacute;dito consignado. A parte agravante sustentou que a contrata&ccedil;&atilde;o foi v&aacute;lida, com assinatura da contratante, comprova&ccedil;&atilde;o do dep&oacute;sito dos valores contratados (R$ 1.280,00 e R$ 375,84), entrega de via contratual e informa&ccedil;&otilde;es claras quanto &agrave; modalidade de cr&eacute;dito.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em definir se o contrato de cart&atilde;o de cr&eacute;dito consignado firmado entre as partes atendeu aos requisitos legais de validade e informa&ccedil;&atilde;o adequada, a ponto de afastar alega&ccedil;&otilde;es de nulidade contratual e consequente responsabiliza&ccedil;&atilde;o por danos materiais e morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O contrato apresentado cumpre integralmente os crit&eacute;rios estabelecidos pelo Tribunal de Justi&ccedil;a do Amazonas no julgamento do IRDR n&ordm; 0005217-75.2019.8.04.0000, contendo cl&aacute;usulas claras, objetivas e de f&aacute;cil compreens&atilde;o acerca da forma de quita&ccedil;&atilde;o, cobran&ccedil;a dos saques, disponibiliza&ccedil;&atilde;o de faturas, encargos e limites da consigna&ccedil;&atilde;o.
+4. A exist&ecirc;ncia de assinatura da contratante, bem como a entrega de c&oacute;pia do contrato, restam comprovadas nos autos, sendo desnecess&aacute;ria a assinatura de todas as p&aacute;ginas do documento, conforme jurisprud&ecirc;ncia desta Corte.
+5. N&atilde;o se verifica pr&aacute;tica abusiva ou aus&ecirc;ncia de informa&ccedil;&atilde;o pela institui&ccedil;&atilde;o financeira, afastando-se a configura&ccedil;&atilde;o de ato il&iacute;cito que justificasse a restitui&ccedil;&atilde;o de valores ou indeniza&ccedil;&atilde;o por danos morais.
+IV. DISPOSITIVO E TESE
+6. Recurso provido.
+Tese de julgamento:
+1. A validade do contrato de cart&atilde;o de cr&eacute;dito consignado exige o atendimento dos requisitos de clareza, informa&ccedil;&atilde;o adequada e ci&ecirc;ncia da modalidade contratada, nos termos fixados no IRDR n&ordm; 0005217-75.2019.8.04.0000.
+2. A assinatura em todas as p&aacute;ginas do contrato n&atilde;o &eacute; requisito de validade do instrumento, sendo suficiente a assinatura na &uacute;ltima folha acompanhada da entrega da via contratual.
+3. A aus&ecirc;ncia de ilicitude na conduta da institui&ccedil;&atilde;o financeira afasta o dever de restitui&ccedil;&atilde;o de valores e de indeniza&ccedil;&atilde;o por danos morais.
+Dispositivos relevantes citados: CC, arts. 104, I a III, e 113; CDC, arts. 6&ordm;, III, e 46; CPC, art. 1.021.
+Jurisprud&ecirc;ncia relevante citada: TJ-AM, IRDR n&ordm; 0005217-75.2019.8.04.0000; TJ-AM, AC n&ordm; 0632305-36.2019.8.04.0000, Rel. Des. Paulo C&eacute;sar Caminha e Lima, j. 13.02.2023. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0009477-25.2024.8.04.0000; Relator (a): Cezar Luiz Bandiera; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 09/04/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Cezar Luiz Bandiera
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									09/04/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. AGRAVO INTERNO. CARTÃO DE CRÉDITO CONSIGNADO. VALIDADE DO CONTRATO. INFORMAÇÃO ADEQUADA. NEGÓCIO JURÍDICO VÁLIDO. AUSÊNCIA DE ATO ILÍCITO. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento ao recurso de apelação da parte autora em ação que discutia a validade e regularidade de contrato de cartão de crédito consignado. A
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. AGRAVO INTERNO. CARTÃO DE CRÉDITO CONSIGNADO. VALIDADE DO CONTRATO. INFORMAÇÃO ADEQUADA. NEGÓCIO JURÍDICO VÁLIDO. AUSÊNCIA DE ATO ILÍCITO. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que deu provimento ao recurso de apelação da parte autora em ação que discutia a validade e regularidade de contrato de cartão de crédito consignado. A parte agravante sustentou que a contratação foi válida, com assinatura da contratante, comprovação do depósito dos valores contratados (R$ 1.280,00 e R$ 375,84), entrega de via contratual e informações claras quanto à modalidade de crédito.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em definir se o contrato de cartão de crédito consignado firmado entre as partes atendeu aos requisitos legais de validade e informação adequada, a ponto de afastar alegações de nulidade contratual e consequente responsabilização por <em>danos</em> materiais e <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3. O contrato apresentado cumpre integralmente os critérios estabelecidos pelo Tribunal de Justiça do Amazonas no julgamento do IRDR nº 0005217-75.2019.8.04.0000, contendo cláusulas claras, objetivas e de fácil compreensão acerca da forma de quitação, cobrança dos saques, disponibilização de faturas, encargos e limites da consignação.
+4. A existência de assinatura da contratante, bem como a entrega de cópia do contrato, restam comprovadas nos autos, sendo desnecessária a assinatura de todas as páginas do documento, conforme jurisprudência desta Corte.
+5. Não se verifica prática abusiva ou ausência de informação pela instituição financeira, afastando-se a configuração de ato ilícito que justificasse a restituição de valores ou indenização por <em>danos</em> <em>morais</em>.
+IV. DISPOSITIVO E TESE
+6. Recurso provido.
+Tese de julgamento:
+1. A validade do contrato de cartão de crédito consignado exige o atendimento dos requisitos de clareza, informação adequada e ciência da modalidade contratada, nos termos fixados no IRDR nº 0005217-75.2019.8.04.0000.
+2. A assinatura em todas as páginas do contrato não é requisito de validade do instrumento, sendo suficiente a assinatura na última folha acompanhada da entrega da via contratual.
+3. A ausência de ilicitude na conduta da instituição financeira afasta o dever de restituição de valores e de indenização por <em>danos</em> <em>morais</em>.
+Dispositivos relevantes citados: CC, arts. 104, I a III, e 113; CDC, arts. 6º, III, e 46; CPC, art. 1.021.
+Jurisprudência relevante citada: TJ-AM, IRDR nº 0005217-75.2019.8.04.0000; TJ-AM, AC nº 0632305-36.2019.8.04.0000, Rel. Des. Paulo César Caminha e Lima, j. 13.02.2023.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3363716" cdForo="0" >
+										0013627-49.2024.8.04.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3363716" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3363716);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3363716" style="display: none;" >
+	<div id="textAreaDados_3363716" class="mensagemSemFormatacao" >
+		Ementa: DIREITO CIVIL E BANC&Aacute;RIO. AGRAVO INTERNO. A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO BANC&Aacute;RIO. JUROS REMUNERAT&Oacute;RIOS. ABUSIVIDADE VERIFICADA. LIMITA&Ccedil;&Atilde;O &Agrave; TAXA M&Eacute;DIA DE MERCADO. REPETI&Ccedil;&Atilde;O SIMPLES DO IND&Eacute;BITO. DANO MORAL INEXISTENTE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que julgou improcedentes os pedidos formulados em a&ccedil;&atilde;o revisional de contrato banc&aacute;rio, ajuizada por consumidor visando &agrave; revis&atilde;o da taxa de juros remunerat&oacute;rios aplicada em contrato de empr&eacute;stimo pessoal firmado com a institui&ccedil;&atilde;o financeira agravada. O agravante sustenta que a taxa contratada (10,76% a.m.) excede em mais do que o dobro a taxa m&eacute;dia de mercado divulgada pelo BACEN &agrave; &eacute;poca da contrata&ccedil;&atilde;o (5,13% a.m.), configurando abusividade e viola&ccedil;&atilde;o aos direitos b&aacute;sicos do consumidor, com pedido de restitui&ccedil;&atilde;o dos valores pagos a maior e indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) verificar se a taxa de juros remunerat&oacute;rios pactuada no contrato supera abusivamente a m&eacute;dia de mercado, autorizando sua revis&atilde;o judicial; (ii) determinar se a cobran&ccedil;a de juros em patamar abusivo enseja a restitui&ccedil;&atilde;o em dobro dos valores pagos; (iii) analisar se a cobran&ccedil;a considerada abusiva configura, por si s&oacute;, viola&ccedil;&atilde;o a direito da personalidade, apta a justificar indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A jurisprud&ecirc;ncia do STJ admite a revis&atilde;o das taxas de juros remunerat&oacute;rios quando constatada abusividade manifesta, especialmente em contratos banc&aacute;rios celebrados no &acirc;mbito de rela&ccedil;&otilde;es de consumo, sendo v&aacute;lido o par&acirc;metro da taxa m&eacute;dia de mercado apurada pelo Banco Central para aferi&ccedil;&atilde;o da excessividade.
+4. A taxa contratada (10,76% a.m. e 240,70% a.a.) mostra-se mais do que o dobro da taxa m&eacute;dia praticada &agrave; &eacute;poca da contrata&ccedil;&atilde;o (5,13% a.m. e 82,32% a.a.), evidenciando desequil&iacute;brio contratual e desvantagem excessiva ao consumidor, o que justifica a revis&atilde;o judicial da cl&aacute;usula de juros.
+5. A repeti&ccedil;&atilde;o em dobro do ind&eacute;bito exige a comprova&ccedil;&atilde;o de m&aacute;-f&eacute; da institui&ccedil;&atilde;o financeira, nos termos da jurisprud&ecirc;ncia consolidada do STJ, o que n&atilde;o restou evidenciado no caso concreto, sendo devida a restitui&ccedil;&atilde;o apenas na forma simples.
+6. A cobran&ccedil;a de juros acima da m&eacute;dia do mercado, ainda que abusiva, n&atilde;o caracteriza, por si s&oacute;, les&atilde;o a direito da personalidade, sendo insuficiente para justificar condena&ccedil;&atilde;o por danos morais na aus&ecirc;ncia de provas espec&iacute;ficas do preju&iacute;zo extrapatrimonial sofrido.
+IV. DISPOSITIVO E TESE
+7. Recurso parcialmente provido.
+Teses de julgamento:
+1. &Eacute; admiss&iacute;vel a revis&atilde;o judicial da taxa de juros remunerat&oacute;rios pactuada em contrato banc&aacute;rio quando se comprova discrep&acirc;ncia relevante em rela&ccedil;&atilde;o &agrave; taxa m&eacute;dia de mercado divulgada pelo BACEN.
+2. A devolu&ccedil;&atilde;o em dobro dos valores pagos a maior por cl&aacute;usula abusiva exige a comprova&ccedil;&atilde;o de m&aacute;-f&eacute; da institui&ccedil;&atilde;o financeira, sendo cab&iacute;vel, na aus&ecirc;ncia desta, apenas a restitui&ccedil;&atilde;o simples.
+3. A cobran&ccedil;a de juros abusivos, por si s&oacute;, n&atilde;o configura dano moral indeniz&aacute;vel, quando ausente viola&ccedil;&atilde;o a direito da personalidade ou prova do abalo extrapatrimonial. <br><br>(Agravo Interno C&iacute;vel N&ordm; 0013627-49.2024.8.04.0000; Relator (a): Cezar Luiz Bandiera; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 01/06/2004; Data de registro: 09/04/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(52 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Cezar Luiz Bandiera
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/06/2004
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									09/04/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E BANCÁRIO. AGRAVO INTERNO. AÇÃO REVISIONAL DE CONTRATO BANCÁRIO. JUROS REMUNERATÓRIOS. ABUSIVIDADE VERIFICADA. LIMITAÇÃO À TAXA MÉDIA DE MERCADO. REPETIÇÃO SIMPLES DO INDÉBITO. <em>DANO</em> <em>MORAL</em> INEXISTENTE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que julgou improcedentes os pedidos formulados em ação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E BANCÁRIO. AGRAVO INTERNO. AÇÃO REVISIONAL DE CONTRATO BANCÁRIO. JUROS REMUNERATÓRIOS. ABUSIVIDADE VERIFICADA. LIMITAÇÃO À TAXA MÉDIA DE MERCADO. REPETIÇÃO SIMPLES DO INDÉBITO. <em>DANO</em> <em>MORAL</em> INEXISTENTE. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Agravo Interno interposto contra decisão monocrática que julgou improcedentes os pedidos formulados em ação revisional de contrato bancário, ajuizada por consumidor visando à revisão da taxa de juros remuneratórios aplicada em contrato de empréstimo pessoal firmado com a instituição financeira agravada. O agravante sustenta que a taxa contratada (10,76% a.m.) excede em mais do que o dobro a taxa média de mercado divulgada pelo BACEN à época da contratação (5,13% a.m.), configurando abusividade e violação aos direitos básicos do consumidor, com pedido de restituição dos valores pagos a maior e indenização por <em>danos</em> <em>morais</em>.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) verificar se a taxa de juros remuneratórios pactuada no contrato supera abusivamente a média de mercado, autorizando sua revisão judicial; (ii) determinar se a cobrança de juros em patamar abusivo enseja a restituição em dobro dos valores pagos; (iii) analisar se a cobrança considerada abusiva configura, por si só, violação a direito da personalidade, apta a justificar indenização por <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3. A jurisprudência do STJ admite a revisão das taxas de juros remuneratórios quando constatada abusividade manifesta, especialmente em contratos bancários celebrados no âmbito de relações de consumo, sendo válido o parâmetro da taxa média de mercado apurada pelo Banco Central para aferição da excessividade.
+4. A taxa contratada (10,76% a.m. e 240,70% a.a.) mostra-se mais do que o dobro da taxa média praticada à época da contratação (5,13% a.m. e 82,32% a.a.), evidenciando desequilíbrio contratual e desvantagem excessiva ao consumidor, o que justifica a revisão judicial da cláusula de juros.
+5. A repetição em dobro do indébito exige a comprovação de má-fé da instituição financeira, nos termos da jurisprudência consolidada do STJ, o que não restou evidenciado no caso concreto, sendo devida a restituição apenas na forma simples.
+6. A cobrança de juros acima da média do mercado, ainda que abusiva, não caracteriza, por si só, lesão a direito da personalidade, sendo insuficiente para justificar condenação por <em>danos</em> <em>morais</em> na ausência de provas específicas do prejuízo extrapatrimonial sofrido.
+IV. DISPOSITIVO E TESE
+7. Recurso parcialmente provido.
+Teses de julgamento:
+1. É admissível a revisão judicial da taxa de juros remuneratórios pactuada em contrato bancário quando se comprova discrepância relevante em relação à taxa média de mercado divulgada pelo BACEN.
+2. A devolução em dobro dos valores pagos a maior por cláusula abusiva exige a comprovação de má-fé da instituição financeira, sendo cabível, na ausência desta, apenas a restituição simples.
+3. A cobrança de juros abusivos, por si só, não configura <em>dano</em> <em>moral</em> indenizável, quando ausente violação a direito da personalidade ou prova do abalo extrapatrimonial.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="EMENTA">
+									<label for="ckTermo1">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="RECURSO">
+									<label for="ckTermo2">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="APELAÇÃO">
+									<label for="ckTermo3">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="CONHECIDO">
+									<label for="ckTermo4">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="CÍVEL">
+									<label for="ckTermo5">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="PROVIDO">
+									<label for="ckTermo6">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="AÇÃO">
+									<label for="ckTermo7">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="Recurso">
+									<label for="ckTermo8">
+										Recurso
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="conhecido">
+									<label for="ckTermo9">
+										conhecido
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="SENTENÇA">
+									<label for="ckTermo10">
+										SENTENÇA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="DIREITO">
+									<label for="ckTermo11">
+										DIREITO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="CIVIL">
+									<label for="ckTermo12">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="DANOS">
+									<label for="ckTermo13">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="MORAIS">
+									<label for="ckTermo14">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="provido">
+									<label for="ckTermo15">
+										provido
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				11 a 20
+			</strong>
+			de 54334
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+			<a name="A1" title="Página anterior">
+				&lt;
+			</a>
+
+
+
+
+
+
+
+
+
+
+
+					<a name="A1" style="padding-left:4px" >
+						1
+					</a>
+
+
+
+
+
+					<span class="paginaAtual" >
+						2
+					</span>
+
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A3" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjam/samples/cjsg/single_page.html
+++ b/tests/tjam/samples/cjsg/single_page.html
@@ -1,0 +1,418 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(1)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="1" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3178816" cdForo="0" >
+										0266025-40.2011.8.04.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3178816" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3178816);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3178816" style="display: none;" >
+	<div id="textAreaDados_3178816" class="mensagemSemFormatacao" >
+		Ementa: APELA&Ccedil;&Atilde;O C&Iacute;VEL. USUCAPI&Atilde;O ESPECIAL. N&Atilde;O PREENCHIMENTO DOS REQUISITOS. FUNGIBILIDADE ENTRE AS A&Ccedil;&Otilde;ES DE USUCAPI&Atilde;O. PREENCHIMENTO DOS REQUISITOS PARA CONCESS&Atilde;O DA USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIA. ART. 1.238, PAR&Aacute;GRAFO &Uacute;NICO DO C&Oacute;DIGO CIVIL. PRAZO. IMPLEMENTA&Ccedil;&Atilde;O NO CURSO DA DEMANDA. POSSIBILIDADE. PRECEDENTES DO STJ. DIREITO SOCIAL &Agrave; MORADIA. PRINC&Iacute;PIO DA FRATERNIDADE. RECURSO CONHECIDO E PROVIDO.
+1. Da an&aacute;lise dos auto v&ecirc;-se que a apelante, inicialmente, cumpre todos os requisitos da usucapi&atilde;o especial urbana, &agrave; exce&ccedil;&atilde;o da &uacute;ltima parte, que segundo o documento p&uacute;blico de fls. 216-19, &eacute; propriet&aacute;ria na fra&ccedil;&atilde;o de 10% (dez por cento), junto com seu filho, de outro im&oacute;vel.
+2. Entretanto a apelante preenche os requisitos para concess&atilde;o da usucapi&atilde;o exordin&aacute;ria disposta no par&aacute;grafo &uacute;nico do art. 1.238 do C&oacute;digo Civil.
+3. Atendendo aos requisitos de coopera&ccedil;&atilde;o, efici&ecirc;ncia, economia e celeridade processuais consagrados pelo C&oacute;digo de Processo Civil e tendo em conta as particularidades das a&ccedil;&otilde;es de usucapi&atilde;o, &eacute; poss&iacute;vel aplicar o princ&iacute;pio da fungibilidade entre as esp&eacute;cies.
+4. Com efeito, apesar de quando do ajuizamento da a&ccedil;&atilde;o, 07/12/2011, a apelante, em tese, n&atilde;o teria preenchido o requisito temporal, o Superior Tribunal de Justi&ccedil;a entende que cabe ao magistrado examinar o requisito temporal da usucapi&atilde;o ao proferir a senten&ccedil;a, permitindo que o prazo seja completado no curso do processo judicial.
+5. No presente caso, o princ&iacute;pio da fraternidade, quando aplicado ao direito &agrave; moradia, refor&ccedil;a a import&acirc;ncia de promover uma sociedade solid&aacute;ria e inclusiva, na qual todos os indiv&iacute;duos tenham acesso a condi&ccedil;&otilde;es dignas de habita&ccedil;&atilde;o. A fraternidade implica em reconhecer que somos parte de uma comunidade em que devemos cuidar uns dos outros, especialmente daqueles que est&atilde;o em situa&ccedil;&atilde;o de vulnerabilidade, como apelante, pessoa idosa.
+6. Recurso conhecido e provido, para fins de reformar a senten&ccedil;a julgando procedente o pedido, declarando a usucapi&atilde;o extraordin&aacute;ria, com fundamento art. 1.238 do CC/02, em favor de Maria Jos&eacute; dos Santos. <br><br>(Apela&ccedil;&atilde;o C&iacute;vel N&ordm; 0266025-40.2011.8.04.0001; Relator (a): Socorro Guedes Moura; Comarca: Manaus/AM; &Oacute;rg&atilde;o julgador: Segunda C&acirc;mara C&iacute;vel; Data do julgamento: 19/09/2023; Data de registro: 19/09/2023)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(43 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Especial (Constitucional)
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Socorro Guedes Moura
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Manaus
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Segunda Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									19/09/2023
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									19/09/2023
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> ESPECIAL. NÃO PREENCHIMENTO DOS REQUISITOS. FUNGIBILIDADE ENTRE AS AÇÕES DE <em>USUCAPIÃO</em>. PREENCHIMENTO DOS REQUISITOS PARA CONCESSÃO DA <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. ART. 1.238, PARÁGRAFO ÚNICO DO CÓDIGO CIVIL. PRAZO. IMPLEMENTAÇÃO NO CURSO DA DEMANDA. POSSIBILIDADE. PRECEDENTES DO STJ. DIREITO SOCIAL À MORADIA. PRINCÍPIO DA FRATERNIDADE.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> ESPECIAL. NÃO PREENCHIMENTO DOS REQUISITOS. FUNGIBILIDADE ENTRE AS AÇÕES DE <em>USUCAPIÃO</em>. PREENCHIMENTO DOS REQUISITOS PARA CONCESSÃO DA <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. ART. 1.238, PARÁGRAFO ÚNICO DO CÓDIGO CIVIL. PRAZO. IMPLEMENTAÇÃO NO CURSO DA DEMANDA. POSSIBILIDADE. PRECEDENTES DO STJ. DIREITO SOCIAL À MORADIA. PRINCÍPIO DA FRATERNIDADE. RECURSO CONHECIDO E PROVIDO.
+1. Da análise dos auto vê-se que a apelante, inicialmente, cumpre todos os requisitos da <em>usucapião</em> especial urbana, à exceção da última parte, que segundo o documento público de fls. 216-19, é proprietária na fração de 10% (dez por cento), junto com seu filho, de outro imóvel.
+2. Entretanto a apelante preenche os requisitos para concessão da <em>usucapião</em> exordinária disposta no parágrafo único do art. 1.238 do Código Civil.
+3. Atendendo aos requisitos de cooperação, eficiência, economia e celeridade processuais consagrados pelo Código de Processo Civil e tendo em conta as particularidades das ações de <em>usucapião</em>, é possível aplicar o princípio da fungibilidade entre as espécies.
+4. Com efeito, apesar de quando do ajuizamento da ação, 07/12/2011, a apelante, em tese, não teria preenchido o requisito temporal, o Superior Tribunal de Justiça entende que cabe ao magistrado examinar o requisito temporal da <em>usucapião</em> ao proferir a sentença, permitindo que o prazo seja completado no curso do processo judicial.
+5. No presente caso, o princípio da fraternidade, quando aplicado ao direito à moradia, reforça a importância de promover uma sociedade solidária e inclusiva, na qual todos os indivíduos tenham acesso a condições dignas de habitação. A fraternidade implica em reconhecer que somos parte de uma comunidade em que devemos cuidar uns dos outros, especialmente daqueles que estão em situação de vulnerabilidade, como apelante, pessoa idosa.
+6. Recurso conhecido e provido, para fins de reformar a sentença julgando procedente o pedido, declarando a <em>usucapião</em> <em>extraordinária</em>, com fundamento art. 1.238 do CC/02, em favor de Maria José dos Santos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="07122011">
+									<label for="ckTermo1">
+										07122011
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="1238">
+									<label for="ckTermo2">
+										1238
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="21619">
+									<label for="ckTermo3">
+										21619
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="APELAÇÃO">
+									<label for="ckTermo4">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="Atendendo">
+									<label for="ckTermo5">
+										Atendendo
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="AÇÕES">
+									<label for="ckTermo6">
+										AÇÕES
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="CC02">
+									<label for="ckTermo7">
+										CC02
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="CIVIL">
+									<label for="ckTermo8">
+										CIVIL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="CONCESSÃO">
+									<label for="ckTermo9">
+										CONCESSÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="CONHECIDO">
+									<label for="ckTermo10">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="CURSO">
+									<label for="ckTermo11">
+										CURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="Civil">
+									<label for="ckTermo12">
+										Civil
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="CÍVEL">
+									<label for="ckTermo13">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="CÓDIGO">
+									<label for="ckTermo14">
+										CÓDIGO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="Código">
+									<label for="ckTermo15">
+										Código
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 1
+			</strong>
+			de 1
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjam/test_cjsg_contract.py
+++ b/tests/tjam/test_cjsg_contract.py
@@ -1,0 +1,86 @@
+"""Offline contract tests for TJAM cjsg.
+
+Mocks ``resultadoCompleta.do`` + ``trocaDePagina.do`` with captured samples
+(see ``tests/fixtures/capture/tjam.py``) and asserts the public DataFrame
+contract. Covers typical multi-page, single-page, and zero-result scenarios.
+"""
+import pandas as pd
+import responses
+from responses.matchers import query_param_matcher, urlencoded_params_matcher
+
+import juscraper as jus
+from tests._helpers import load_sample_bytes
+from tests.fixtures.capture._util import make_esaj_body
+
+BASE = "https://consultasaj.tjam.jus.br/cjsg"
+CJSG_MIN_COLUMNS = {"processo", "cd_acordao", "cd_foro", "ementa"}
+
+
+def _add_post(pesquisa: str) -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjam", "cjsg/post_initial.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(make_esaj_body(pesquisa), allow_blank=True)],
+    )
+
+
+def _add_get(pagina: int, sample_path: str) -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjam", sample_path),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": str(pagina)})],
+    )
+
+
+@responses.activate
+def test_cjsg_typical_com_paginacao(tmp_path, mocker):
+    """Typical multi-page query returns a DataFrame with the minimum schema."""
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+    _add_get(2, "cjsg/results_normal_page_02.html")
+
+    df = jus.scraper("tjam", download_path=str(tmp_path)).cjsg(
+        "dano moral", paginas=range(1, 3)
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_single_page(tmp_path, mocker):
+    """Query whose hits fit in one page skips the per-page loop."""
+    mocker.patch("time.sleep")
+    _add_post("usucapiao extraordinario predio rural familia")
+    _add_get(1, "cjsg/single_page.html")
+
+    df = jus.scraper("tjam", download_path=str(tmp_path)).cjsg(
+        "usucapiao extraordinario predio rural familia", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_no_results(tmp_path, mocker):
+    """Zero-result query returns an empty DataFrame instead of raising."""
+    mocker.patch("time.sleep")
+    _add_post("juscraper_probe_zero_hits_xyzqwe")
+    _add_get(1, "cjsg/no_results.html")
+
+    df = jus.scraper("tjam", download_path=str(tmp_path)).cjsg(
+        "juscraper_probe_zero_hits_xyzqwe", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty

--- a/tests/tjce/samples/cjsg/no_results.html
+++ b/tests/tjce/samples/cjsg/no_results.html
@@ -1,0 +1,18 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(0)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="0" />
+
+
+
+			<div align="center" class="ementaClass" style="padding: 80px;">
+				<strong>
+					Não foi encontrado nenhum resultado correspondente à busca realizada.
+				</strong>
+			</div>

--- a/tests/tjce/samples/cjsg/post_initial.html
+++ b/tests/tjce/samples/cjsg/post_initial.html
@@ -1,0 +1,4525 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Nodo 2 -->
+
+<html>
+	<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+
+
+
+
+
+
+
+
+
+
+
+    <script language="javascript" type="text/JavaScript"
+            src="https://esaj.tjce.jus.br/sajcas/verificarLogin.js?script=1776718197640"></script>
+
+    <script language="javascript">
+        if (window.sajcas && window.sajcas.usuarioLogadoNoCasServer) {
+            var GATEWAY_TRUE = 'gateway=true', GATEWAY_FALSE = 'gateway=false';
+            var urlRetornoSistema = 'https://esaj.tjce.jus.br/cjsg/consultaCompleta.do';
+            if (urlRetornoSistema === '') {
+                urlRetornoSistema = window.location.href;
+            }
+
+            if (urlRetornoSistema.indexOf(GATEWAY_FALSE) !== -1) {
+                urlRetornoSistema = urlRetornoSistema.replace(GATEWAY_FALSE, GATEWAY_TRUE);
+            } else {
+                urlRetornoSistema.lastIndexOf('?') !== -1 ? urlRetornoSistema += '&' : urlRetornoSistema += '?';
+                urlRetornoSistema += GATEWAY_TRUE;
+            }
+
+            window.location.href = urlRetornoSistema;
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+	<title>Consulta de Jurisprudência do Segundo Grau</title>
+	<script>
+		window.saj = window.saj || {};
+		window.saj.env = window.saj.env || {};
+		window.saj.env.root = '/cjsg';
+		window.saj.env.css = '/cjsg/css';
+		window.saj.env.js = '/cjsg/js';
+		window.saj.env.imagens = '/cjsg/imagens';
+		window.saj.env.cliente = 'CE';
+	</script>
+ 	<script src="/cjsg/js/jquery/jquery.min.js?n=4581fd7c-9ec2-49a4-ad22-f7dd84301d5c"></script>
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/saj/saj-web-2.2.41-4.js?n=af174629-bda5-45db-925e-d69edf29372c"></script>
+
+
+ 	<script>var localeJS = "pt_BR"; </script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMsg.js"></script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMap_pt.js"></script>
+	<script src="/cjsg/js/jquery/jquery.browser.min.js?n=42ede9cb-25cc-4ade-94e6-f368013dd789"></script>
+ 	<script src="/cjsg/js/spw/spwConcatenado.js?n=a5b798b3-3b8d-4f2e-9089-1c8c3c40eee1"></script>
+ 	<link href="/cjsg/css/spw/spwConcatenado.css" rel="stylesheet" type="text/css" />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+<meta http-equiv="pragma" content="no-cache"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<meta http-equiv="expires" content="0"/>
+
+<link href="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/css/esajComum.css" rel="stylesheet" type="text/css" />
+<link href="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/css/esajLayout.css" rel="stylesheet" type="text/css" />
+<link href="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/clientes/CE/css/esajLayoutCE.css" rel="stylesheet" type="text/css" />
+
+<style type="text/css">
+<!--
+/* botao default means o mais claro, que seria o "botï¿½o principal" */
+.spwBotaoDefault, .spwBotaoDefault-o {
+	background-image: url(https://esaj.tjce.jus.br/esaj-layout/tema/padrao/clientes/CE/imagens/layout/fundoBotaoDefault.gif);
+}
+/* o botao secundario, menos provavel de ser clicado, mais escuro */
+.spwBotao, .spwBotao-o {
+	background-image: url(https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/fundoBotao.gif);
+}
+-->
+</style>
+
+
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/js/menu.js?n=2553626853"></script>
+
+<link rel="shortcut icon" href="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/clientes/CE/imagens/favicon.ico" type="image/x-icon" />
+
+
+
+
+<script>
+    var dict = {
+        'certificado.tituloCertificadoDigital': 'Certificado digital',
+        'certificado.msgCarregandoCertificado': 'Carregando certificados...',
+        'certificado.msgNenhumCertificadoEncontrado': 'Nenhum certificado encontrado',
+        'certificado.msgErroCarregarCertificado': 'Erro ao carregar certificados',
+        'certificado.msgCertificadoExpirado': '[Expirado]',
+        'certificado.msgCertificadoNaoValido': '[Ainda não válido]',
+        'certificado.msgCertificadoNaoIcpBrasil': '[Não ICP-Brasil]',
+        'certificado.tituloProblemasAoAssinar': 'Falha de comunicação com o dispositivo de assinatura digital',
+
+        'label.contato': 'Contato',
+        'label.identificarSe': 'Identificar-se ',
+
+        'mensagem.aguarde': 'Por favor, aguarde.',
+        'mensagem.paginaNaoCarregada': 'Não foi possível carregar a página.',
+        'mensagem.marcarLido': 'Marcar como lido',
+        'mensagem.registrosSelecionados': 'Registros selecionados',
+        'mensagem.registroJaSelecionado': 'Este registro já está selecionado',
+
+        'mensagem.data.invalida': 'A data digitada é inválida.',
+        'mensagem.data.anoInvalido': 'O ano informado deve ser maior que',
+        'mensagem.data.mesInvalido': 'O mês não pode ser maior que 12.',
+        'mensagem.data.mes': 'O mês',
+        'mensagem.data.mesMaior29dias': 'não pode ter mais que 29 dias.',
+        'mensagem.data.mesMaior28dias': 'não pode ter mais que 28 dias.',
+        'mensagem.data.mesMaior31dias': 'não pode ter mais que 31 dias.',
+        'mensagem.data.mesMaior30dias': 'não pode ter mais que 30 dias.',
+
+        'mensagem.email.invalido': 'O formato do endereço de e-mail não é válido. Verifique se ele tem o formato "usuario@dominio".',
+        'mensagem.email.caracteresInvalidos': 'O endereço de e-mail possui caracteres inválidos',
+        'mensagem.email.usuarioInvalido': 'O formato do usuário informado no endereço de e-mail não é válido.',
+        'mensagem.email.ipInvalido': 'O endereço IP informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioInvalido': 'O formato do domínio informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioIncompleto': 'O domínio informado no endereço de e-mail deve possuir pelo menos duas partes. Por exemplo: "usuario@empresa.com.br".',
+
+        'mensagem.texto.tamanhoInvalido': 'O tamanho do texto digitado é maior do que o tamanho permitido. Tamanho permitido:',
+        'mensagem.texto.caracter': 'O caracter',
+        'mensagem.texto.caracterPosicaoInvalida': 'não está permitido na posição',
+
+        'mensagem.numero.numeroInvalido': 'O valor digitado não é um número válido.',
+        'mensagem.numero.numeroNaoPodeCasasDecimais': 'O número não pode conter casas decimais',
+        'mensagem.numero.numeroCasaDecimaisInvalidas': 'O número de casas decimais é inválido. O número pode conter apenas',
+        'mensagem.numero.casaDecimais': 'casas decimais',
+        'mensagem.numero.numeroInteiroInvalido': 'O número de dígitos inteiros é inválido. O número pode conter apenas',
+        'mensagem.numero.digitosInteiros': 'dígitos inteiros',
+        'mensagem.numero.numeroTamanhoInvalido': 'O número digitado não pode ser maior que',
+        'mensagem.numero.numeroZeroInvalido': 'O número digitado deve ser diferente de zero.'
+    }
+</script>
+
+
+
+
+
+
+
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/cjsg-2.2.5-0.js?n=260410155"></script>
+ 	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/CE/cjsg.css" />
+	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/CE/link.css" />
+
+
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/spw/spwTab.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-popup-modal.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-tree.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/cjsg.css" />
+
+
+		<script type="text/JavaScript" src="/cjsg/js/jquery/jquery.blockUI.min.js?n=c2e3653c-0ac3-4939-b56d-dd50b13a64d1"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tooltip.js?n=ad0ad931-ab89-4b50-9f6d-abf681bc3728"></script>
+		<script type="text/JavaScript" src="/cjsg/js/spw/spwTab.js?n=2803951349"></script>
+		<script type="text/javascript" src="/cjsg/js/saj/saj-popup-modal-1.0.0-1.js?n=be87bf23-5f04-4a99-b125-5db0ca308e17"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-popup.js?n=2538966893"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tree-2.5.1-2.js?n=fd6aa449-79ac-4e1a-acd2-95a4467b7ecb"></script>
+
+		<!-- remover valor da versao na proxima versao do sistema -->
+		<script type="text/JavaScript" src="/cjsg/js/filtrosLaterais.js?n=2874483102?c=123"></script>
+		<script type="text/JavaScript" src="/cjsg/jsp/completa/consultaCompleta.js?n=3513975997"></script>
+	</head>
+
+	<body style="margin: 0px;">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoCliente" summary=" " role="presentation">
+	<tr>
+		<td><a href="http://www.tjce.jus.br"><img src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/clientes/CE/imagens/layout/cabecalhoLogo.jpg" alt="Tribunal de Justi&ccedil;a do Cear&aacute;" height="65" width="462" /></a></td>
+		<td align="right" valign="top"><img  alt=" " src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/clientes/CE/imagens/layout/cabecalhoImagem.jpg" width="353" height="65" /></td>
+	</tr>
+</table>
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/js/libras.js?n=369456521"></script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- cabecalho e-Saj -->
+<table width="100%" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoServico" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaCabecalhoServicoLogo">
+
+
+
+
+<a href="https://esaj.tjce.jus.br/esaj-layout/redirecionarNovoEsaj.do"><img src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServico.gif" title="Voltar para página inicial do e-SAJ" alt="Voltar para página inicial do e-SAJ" width="255" height="53" border="0" /></a><img src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServicoInf.gif" alt=" " width="255" height="28" border="0" />
+</td>
+		<td class="esajCelulaCabecalhoServicoMenu">
+		    <table width="100%" border="0" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+				<tr>
+					<td align="right">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Devido ao alinhamento inline das imagens, elas nÃ£o podem ter nenhum tipo de espaÃ§amento entre elas, portanto Ã© necessÃ¡rio finalizar a linha iniciando um comentÃ¡rio e fechar o comentÃ¡rio imediatamente antes da abertura da nova tag-->
+<img height="24" width="47" alt=" " src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/inicioMenuSup.jpg"/><a href="https://esaj.tjce.jus.br/caixapostal"><!--
+
+    --><img height="24" width="83" border="0" alt="Caixa Postal" src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/caixaPostal.gif"/></a><!--
+    --><img height="24" width="4" alt=" " src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a href="https://esaj.tjce.jus.br/esaj/cadastro.do"><!--
+
+--><img src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/cadastro.gif" alt="Cadastro" width="81" height="24" border="0" /></a><!--
+
+
+    --><img height="24" width="4" alt=" " src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a target="blank" href="https://esaj.tjce.jus.br/WebHelp/"><!--
+    --><img height="24" width="61" border="0" alt="Ajuda do e-Saj" src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/ajuda.gif"/></a><!--
+
+
+-->
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaIdentificacaoServico" >
+
+
+
+
+<style>
+
+    td.esajCelulaIdentificacao, td.esajCelulaIdentificacaoServico {
+        position: relative;
+    }
+
+    button.escolhaBeta {
+        border: 0;
+        background: #0078D7;
+        color: #fff;
+        margin-right: 5px;
+        font-family: verdana;
+        font-size: 12px;
+        height: 27px;
+        line-height: 14px;
+        border-radius: 0;
+        text-shadow: 1px 1px 1px #797979;
+        position: absolute;
+        top: 30px;
+        right: 3px;
+        padding: 7px 12px;
+        cursor: pointer;
+    }
+
+    button.escolhaBeta:hover {
+        background-color: #0b5c9c;
+    }
+</style>
+
+<span id="identificacao"></span>
+
+<button style="display: none" class="escolhaBeta"></button>
+
+
+
+
+
+
+        <script language="javascript" type="text/JavaScript" src="https://esaj.tjce.jus.br/sajcas/conteudoIdentificacao?script=1776673310655"></script>
+
+
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaCabecalhoServicoCaminho" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<a href="" class="esajCaminhoLink"></a>
+
+ &gt;
+
+
+<a href="https://esaj.tjce.jus.br/esaj?servico=740000" class="esajCaminhoLink">Bem-vindo</a>
+
+ &gt;
+
+
+<a href="https://esaj.tjce.jus.br/esaj?servico=190090" class="esajCaminhoLink">Consultas</a>
+
+ &gt;
+
+
+
+Jurisprudência
+</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+<!-- CONTEUDO -->
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaTitulo" role="presentation">
+	<tr>
+		<td class="esajCelulaMenuSuspenso">
+		<a href="#" onclick="return showMenuSuspenso()"><img src="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSuspenso.gif" alt="Menu de servi&ccedil;os" width="243" height="21" style="display:block" /></a>
+		<div id="layerMenu" style="display:none">
+
+
+<!-- MENU -->
+<ul id="esajMenuArea">
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Consultas Processuais</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/cpopg/open.do">Consulta de Processos de 1º Grau</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Ordem de Processos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoPg.do">Julgamento de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/cop/abrirConsultaDeOrdemDeAtoPg.do">Publicação e Cumprimento de Atos de 1º Grau</a></li>
+</ul>
+  </li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/cposg5/open.do">Consulta de Processos de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/cjpg">Consulta de Julgados de Primeiro Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/cjsg/consultaCompleta.do">Consultas de Jurisprudência</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/cdje">Diário da Justiça Eletrônico</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas Processuais</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=1&flTipoCusta=0&cdServicoCalculoCusta=690003">Custas Iniciais</a></li>
+  <li class="esajMenuItem"><a href="#">Custas dos Juizados</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=2&flTipoCusta=1&cdServicoCalculoCusta=690008">Custas Intermediárias</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=4&flTipoCusta=2&cdServicoCalculoCusta=690006">Custas Complementares</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=7&flTipoCusta=0&cdServicoCalculoCusta=690004">Incidentes Processuais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=8&flTipoCusta=5&cdServicoCalculoCusta=690007">Atos Avulsos</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=3&flTipoCusta=5&cdServicoCalculoCusta=690010">Certidões</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=10&flTipoCusta=0&cdServicoCalculoCusta=690005">Execuções Fiscais - Pagamento antes do julgamento dos Embargos</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=11&flTipoCusta=0&cdServicoCalculoCusta=690002">Execuções Fiscais - Pagamento após o julgamento dos Embargos</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=9&flTipoCusta=0&cdServicoCalculoCusta=690009">Execuções Fiscais - Pagamento antes da Penhora</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/ccpweb/abrirConsultaCustas.do">Consulta de Custas</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico</a>
+<ul>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico de 1º Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petpg/abrirNovaPeticaoInicial.do?instancia=PG">Peticionamento Inicial - Primeiro Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petpg/abrirNovaPeticaoIntermediaria.do?instancia=PG">Peticionamento Intermediário - Primeiro Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petpg/abrirConsultaPeticoes.do">Consulta de Petições - Primeiro Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico de 2º Grau - Tribunal de Justiça</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petsg/abrirNovaPeticaoInicial.do?instancia=SG">Peticionamento Inicial de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petsg/abrirNovaPeticaoIntermediaria.do?instancia=SG">Peticionamento Intermediário de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petsg/abrirConsultaPeticoes.do">Consulta de Petições de 2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico de 2º Grau - Turmas Recursais</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petcr/abrirNovaPeticaoInicial.do?instancia=CR">Peticionamento Inicial - Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petcr/abrirNovaPeticaoIntermediaria.do?instancia=CR">Peticionamento Intermediário - Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/petcr/abrirConsultaPeticoes.do">Consulta de Petições - Turmas Recursais</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+  <li class="esajMenuFechado"><a href="https://esaj.tjce.jus.br/push/">Push</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Intimações e Citações On-line</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/intimacoesweb/abrirConsultaAtosNaoRecebidos.do">Recebimento de Intimações e Citações</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/intimacoesweb/abrirConsultaAtosRecebidos.do">Consulta de Intimações e Citações Recebidas </a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Conferência de Documento Digital</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/pastadigital/pg/abrirConferenciaDocumento.do">Conferência de Documento Digital do 1ºGrau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/pastadigital/sg/abrirConferenciaDocumento.do">Conferência de Documento Digital do 2ºGrau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Pauta Julgamento</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjce.jus.br/pauta-julgamento/consulta">Consulta da Pauta de Julgamento</a></li>
+</ul>
+  </li>
+</ul>
+
+		</div>
+		</td>
+		<td class="esajCelulaTituloServico"><h1 class="esajTituloPagina">Jurisprudência</h1></td>
+	</tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaConteudoServico" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <span class="esajTituloOrientacoes">Orientações</span>
+
+
+
+
+            <ul class="esajUlOrientacoes" id="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<li>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Para detalhes sobre cada campo de busca, selecione o campo específico.
+
+
+
+	</li>
+
+
+
+
+            </ul>
+
+
+
+
+    <br>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<form name="consultaCompletaForm" method="post" action="/cjsg/resultadoCompleta.do;jsessionid=5D982ECC964A9F73186077A0C99AAE84.cjsg2" autocomplete="off" enctype="" onsubmit="return applySubmit(this, eval('function spwSubmit(t, e){decodificaInputMulSelOnSubmit();if (!IS_enableSubmit) return false; return BENV_isCamposValidos(t); } spwSubmit(this, event);'));" id="" target="">
+	<input type="hidden" name="conversationId" value="">
+
+
+
+
+
+<div style="display: none;">
+
+	<div id="inteiroTeor">
+		<b>"Pesquisa Livre"</b> <br />Busca acórdãos que contenham as <br /> palavras/expressões desejadas no seu inteiro teor.
+	</div>
+
+	<div id="ementa">
+		<b>"Ementa"</b><br>Busca acórdaos que contenham as palavras/express&otilde;es<br />desejadas na ementa do acórdão.
+	</div>
+
+	<div id="classesTooltip">
+		<b>"Classe"</b><br />Busca decisões que sejam de uma determinada classe processual.<br> Exemplo: Ação Penal.
+	</div>
+
+	<div id="assuntosTooltip">
+		<b>"Assuntos"</b><br />Busca acórdãos que sejam de um determinado assunto.
+	</div>
+
+	<div id="secoesTooltip">
+		<b>"Orgão julgadores"</b><br /> Busca acórdãos que sejam de uma determinado orgão julgador.
+	</div>
+
+	<div id="dtJulgamentoInicioTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtJulgamentoFimTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoInicioTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoFimTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroInicioTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroFimTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="orgaoJulgador">
+		<b>"Órgão Julgador"</b><br />Busca acórdãos que sejam de um determinado órgão julgador.<br />Exemplo: 10ª Câmara de Direito Público.
+	</div>
+
+	<div id="comarcaTooltip">
+		<b>"Comarca"</b><br>Busca acórdãos que sejam de uma determinada comarca de origem.<br> Exemplo: São Paulo.
+	</div>
+
+	<div id="agenteTooltip">
+		<b>"Relator"</b><br>Busca acórdãos que sejam de um determinado relator.
+	</div>
+
+	<div id="situacaoProvimentoTooltip">
+		<b>"Classificação do resultado"</b><br>Busca acórdãos que sejam de um determinado tipo de classificação do resultado.
+	</div>
+
+	<div id="juizProlatorTooltip">
+		<b>"Juiz prolator"</b><br>Busca acórdãos para o juiz prolator selecionado.<br />
+	</div>
+
+	<div id="nuRegistro">
+		<b>&quot;N&uacute;mero do Registro&quot;</b><br>Busca acórdãos que tenham sido registrados<br />com o número informado.
+	</div>
+
+	<div id="nuProcOrigem">
+		<b>"Número do recurso"</b><br/>Busca acórdãos que se referem ao<br/>número de recurso informado.
+	</div>
+
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Consulta Completa
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaInteiroTeor';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="top">
+
+
+
+
+				<label for="iddados.buscaInteiroTeor" class="" style="float:left;font-weight:bold;margin-top:3px;">Pesquisa livre</label><div style="text-align:right;font-weight:bold;margin-top:3px;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="top">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaInteiroTeor" maxlength="" size="100" value="dano moral" formatType="TEXT" formato="120" obrigatorio="" rotulo="Pesquisa livre" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaInteiroTeor" title="" alt="">
+
+
+
+
+
+
+
+						<div class="botoesOperadores" style="margin-top: 3px;">
+							<input type="button" value=" E " name="E" />
+							<input type="button" value=" OU " name="OU" />
+							<input type="button" value=" N&Atilde;O " name="NAO" />
+							<input type="button" value='"&nbsp;&nbsp;"' name="ASP" />
+							<a style="font-size: 11px; font-weight: bold; padding-left: 10px; padding-right: 2px;" href="https://esaj.tjce.jus.br/WebHelp//#id_operadores_logicos.htm" target="_blank">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="">
+
+
+
+	<span id="">Como utilizar os filtros</span>
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+							</a>
+							<input type="checkbox" name="dados.pesquisarComSinonimos" value="S" checked="checked" uncheckedValue="N"  onclick="CH_updateHiddenValue(this);" style="width: 10px" id="checkBoxSinonimos"><input type="hidden" value="S" name="dados.pesquisarComSinonimos" inputCheckBox="true">
+							<label for="checkBoxSinonimos" >
+								Pesquisar por sinônimos
+							</label>
+							&nbsp;&nbsp;&nbsp;
+						</div>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Pesquisa por campos específicos
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaEmenta';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="iddados.buscaEmenta" class="" style="float:left;font-weight:bold;">Ementa</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaEmenta" maxlength="" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Ementa" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaEmenta" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuProcOrigem';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="iddados.nuProcOrigem" class="" style="float:left;font-weight:bold;">Número do recurso</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuProcOrigem" maxlength="" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do recurso" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuProcOrigem" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuRegistro';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.relator" class="" style="float:left;font-weight:bold;">Relator(a)</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var agenteNomeCamposArray = new Array();
+ agenteNomeCamposArray[0] = 'codigoCr';
+ agenteNomeCamposArray[1] = 'codigoTr';
+ agenteNomeCamposArray[2] = 'nmAgente';
+ var codigoCrNomeCamposArray = agenteNomeCamposArray;
+ var codigoTrNomeCamposArray = agenteNomeCamposArray;
+ var nmAgenteNomeCamposArray = agenteNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="agente" idPai="null" filtroPai="null" url="jsp/search/searchAgente.jsp" input-select="agente" property="dados.agentes" name="codigoCr" title="Relatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="agenteSelectedEntitiesList"  value="" id="agenteSelectedEntitiesList" />
+<input type="hidden" name="contadoragente"  value="0" id="contadoragente" />
+<input type="hidden" name="contadorMaioragente"  value="0" id="contadorMaioragente" />
+    <tr>
+								<td >
+            <input type="text" name="codigoCr" id="codigoCr" bindingReference="codigoCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoTr" id="codigoTr" bindingReference="codigoTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoTr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="nmAgente" id="nmAgente" bindingReference="nmAgente" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'nmAgente', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="agente" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr','','/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('agente');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="agenteLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.juizProlator" class="" style="float:left;font-weight:bold;">Magistrado prolator</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var juizProlatorNomeCamposArray = new Array();
+ juizProlatorNomeCamposArray[0] = 'codigoJuizCr';
+ juizProlatorNomeCamposArray[1] = 'codigoJuizTr';
+ juizProlatorNomeCamposArray[2] = 'nmJuiz';
+ var codigoJuizCrNomeCamposArray = juizProlatorNomeCamposArray;
+ var codigoJuizTrNomeCamposArray = juizProlatorNomeCamposArray;
+ var nmJuizNomeCamposArray = juizProlatorNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="juizProlator" idPai="null" filtroPai="null" url="jsp/search/searchJuizProlator.jsp" input-select="juizProlator" property="dados.juizesProlatores" name="codigoJuizCr" title="Juizes prolatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="juizProlatorSelectedEntitiesList"  value="" id="juizProlatorSelectedEntitiesList" />
+<input type="hidden" name="contadorjuizProlator"  value="0" id="contadorjuizProlator" />
+<input type="hidden" name="contadorMaiorjuizProlator"  value="0" id="contadorMaiorjuizProlator" />
+    <tr>
+								<td >
+            <input type="text" name="codigoJuizCr" id="codigoJuizCr" bindingReference="codigoJuizCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoJuizTr" id="codigoJuizTr" bindingReference="codigoJuizTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizTr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="nmJuiz" id="nmJuiz" bindingReference="nmJuiz" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'nmJuiz', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="juizProlator" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr','','/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('juizProlator');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="juizLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="classes_selectionText" class="" style="float:left;font-weight:bold;">Classe</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="classesId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="classesTreeSelection.values" value="" id="classes">
+						<span id="classes_action" value="/cjsg/classesTreeSelect.do" />
+
+						<input type="text" name="classesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'classes',
+								treeSelectId: 'classesId',
+								url: '/cjsg/classesTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="classes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_classes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_classes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'classes',
+				treeSelectId: 'classesId',
+				url: '/cjsg/classesTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true,
+				titulo: 'Classe'
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_classes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_classes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="assuntos_selectionText" class="" style="float:left;font-weight:bold;">Assunto</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="assuntosId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="assuntosTreeSelection.values" value="" id="assuntos">
+						<span id="assuntos_action" value="/cjsg/assuntosTreeSelect.do" />
+
+						<input type="text" name="assuntosTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'assuntos',
+								treeSelectId: 'assuntosId',
+								url: '/cjsg/assuntosTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="assuntos_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_assuntos"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_assuntos"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'assuntos',
+				treeSelectId: 'assuntosId',
+				url: '/cjsg/assuntosTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true,
+				titulo: 'Assunto'
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_assuntos').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_assuntos').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="secoes_selectionText" class="" style="float:left;font-weight:bold;">Órgão julgador</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="secaoId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="secoesTreeSelection.values" value="" id="secoes">
+						<span id="secoes_action" value="/cjsg/secaoTreeSelect.do" />
+
+						<input type="text" name="secoesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'secoes',
+								treeSelectId: 'secaoId',
+								url: '/cjsg/secaoTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="secoes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_secoes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_secoes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'secoes',
+				treeSelectId: 'secaoId',
+				url: '/cjsg/secaoTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true,
+				titulo: 'Órgão julgador'
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_secoes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_secoes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtJulgamento" class="" style="float:left;font-weight:bold;">Data do julgamento</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoInicio">
+
+
+
+	<input type="text" name="dados.dtJulgamentoInicio" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoFim">
+
+
+
+	<input type="text" name="dados.dtJulgamentoFim" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							<span id="dtJulgamentoFormato">
+								(dd/mm/aaaa)
+							</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtPublicacao" class="" style="float:left;font-weight:bold;">Data de publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoInicio">
+
+
+
+	<input type="text" name="dados.dtPublicacaoInicio" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoFim">
+
+
+
+	<input type="text" name="dados.dtPublicacaoFim" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						<span id="dtPublicacaoFormato">
+							(dd/mm/aaaa)
+						</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.origem" class="" style="float:left;font-weight:bold;">Origem</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<input type="checkbox" name="dados.origensSelecionadas" value="T" checked="checked" id="origem2grau">
+						<label for="origem2grau">
+							2° grau
+						</label>
+						<input type="checkbox" name="dados.origensSelecionadas" value="R" id="origemRecursal">
+						<label for="origemRecursal">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Colégios Recursais
+
+
+						</label>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.tpDecisao" class="" style="float:left;font-weight:bold;">Tipo de Publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<div id="linhaTipoDecisao">
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="A" checked="checked" id="Acheckbox">
+								<label for="Acheckbox">
+									Acórdãos
+								</label>
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="D" id="Dcheckbox">
+								<label for="Dcheckbox">
+									Decisões Monocráticas
+								</label>
+
+						</div>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.ordenar" class="" style="float:left;font-weight:bold;">Ordenar por</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenardtPublicacao">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenardtPublicacao" value="dtPublicacao" style="vertical-align:middle;" onclick="" class="" title=""  checked/>
+			Data de publicação
+		</label>
+
+	</span>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenarRelevancia">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenarRelevancia" value="relevancia" style="vertical-align:middle;" onclick="" class="" title=""  />
+			Relevância
+		</label>
+
+	</span>
+
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<table id="" class="secaoBotoesBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+		<tr>
+
+ 				<td width="150">&nbsp;</td>
+
+			<td align="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="submit" name="pbSubmit" value="Pesquisar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotaoDefault " id="pbSubmit">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="button" name="pbLimpar" value="Limpar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotao " id="pbLimpar">
+
+
+
+			</td>
+		</tr>
+	</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <div style="padding-bottom: 5px;">
+        <script src="https://www.google.com/recaptcha/api.js?render=6LdpxZUaAAAAAJ1AepRoXdpMKHu8uTeRJMsH76ym"></script>
+        <input type="hidden" name="recaptcha_response_token" id="id_recaptcha_response_token">
+        <input id="uuidCaptcha" type="hidden" name="uuidCaptcha" value=""/>
+    </div>
+
+
+<script type="text/javascript">
+
+    const oldReduce = Array.prototype.reduce;
+
+    function loadCaptcha() {
+        grecaptcha.ready(function () {
+            grecaptcha.execute('6LdpxZUaAAAAAJ1AepRoXdpMKHu8uTeRJMsH76ym', {action: 'consulta'}).then(function (token) {
+                document.getElementById('id_recaptcha_response_token').value = token;
+            });
+        });
+    }
+
+    function restoreReduce() {
+        Array.prototype.reduce = function(callback, initialVal) {
+            var accumulator = initialVal;
+            for (var i = 0; i < this.length; i++) {
+                if (accumulator)
+                    accumulator = callback.call(undefined, accumulator, this[i], i, this);
+                else
+                    accumulator = this[i];
+            }
+            return accumulator;
+        };
+    }
+
+    setInterval(function () {
+        loadCaptcha();
+    }, 90000);
+
+    loadCaptcha();
+
+    (function ($) {
+        $.saj = $.saj || {};
+
+        $.saj.obterIdentificadorDoCaptcha = function () {
+            $.ajax({
+                type: "POST",
+                url: '/cjsg/captchaControleAcesso.do',
+                data: {
+                    uuidCaptcha: $('#uuidCaptcha').val()
+                },
+                success: function (conteudoCaptcha) {
+                    restoreReduce();
+                    if (conteudoCaptcha.uuidCaptcha) {
+                        $('#uuidCaptcha').val(conteudoCaptcha.uuidCaptcha);
+                    } else {
+                        let data = JSON.parse(conteudoCaptcha);
+                        $('#uuidCaptcha').val(data.uuidCaptcha);
+                    }
+                },
+                error: function (error) {
+                    console.log(error);
+                }
+            });
+        };
+
+        $(function () {
+            $.saj.obterIdentificadorDoCaptcha();
+            Array.prototype.reduce = oldReduce;
+        });
+    })(jQuery);
+</script>
+
+
+
+</form>
+
+
+
+
+			<!-- Resultado consulta -->
+
+			<!-- Resultado consulta -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</td>
+</tr>
+</table>
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaRodape" summary=" " role="presentation">
+    <tr>
+        <td class="esajCelulaRodapeCentro">
+            Desenvolvido pela Softplan em parceria com o Tribunal de Justiça do Ceará
+
+        </td>
+    </tr>
+</table>
+<link href="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/css/saj-popup-modal.css" rel="stylesheet" type="text/css">
+<link href="https://esaj.tjce.jus.br/esaj-layout/tema/padrao/css/popup-beta.css" rel="stylesheet" type="text/css">
+
+
+<script>
+    var appEsajLayout = appEsajLayout || {};
+    appEsajLayout.tituloCertificadoDigital = 'Certificado digital';
+    appEsajLayout.cliente = 'CE';
+    appEsajLayout.emailParaContato = '';
+    appEsajLayout.utilizarBotaoContato = 'false';
+    appEsajLayout.contexto = 'https://esaj.tjce.jus.br/esaj-layout';
+    appEsajLayout.webSignerParametro = '';
+
+    if(window.jQuery) {
+        jQuery.saj = jQuery.saj || {};
+        jQuery.saj.certificado = jQuery.saj.certificado || {};
+        jQuery.saj.certificado.cliente = 'CE';
+        jQuery.saj.certificado.urlConteudoAjudaWebSigner = appEsajLayout.contexto + '/ajudaWebSigner.do';
+        jQuery.saj.certificado.licenca = 'AqYAKi5zYWphZG0udGpzcC5qdXMuYnIsKi5zZWEuc2MuZ292LmJyLCouc29mdHBsYW4uY29tLmJyLCoudGphYy5qdXMuYnIsKi50amFsLmp1cy5iciwqLnRqYW0uanVzLmJyLCoudGpjZS5qdXMuYnIsKi50am1zLmp1cy5iciwqLnRqcHIuanVzLmJyLCoudGpzYy5qdXMuYnIsKi50anNwLmp1cy5ickMAaXA0OjEwLjAuMC4wLzgsaXA0OjEyNy4wLjAuMC84LGlwNDoxNzIuMTYuMC4wLzEyLGlwNDoxOTIuMTY4LjAuMC8xNggAU3RhbmRhcmQAAAABcfpZUu/QD3s2bqedB8v9T7MiMQxcHNu0pUzGzO+7Ta++o+BbAVgPau7lzj6IUFI7RPFkPSnm0ZbCFAVBnKrqinyvE8MwEvmQhFcjlhGK+FfVV5mhVkkxSC3khDEUR8gsAPVvFncyyW2vTU2ODkyGdU0S/g62wHFtSwfGP6OFqlWpZTqbxbEGd1vfe9yHHulTYI7RcsGxaTMD6XgtPlStbOn9DxSYhN3S+4oTtIq7pUR6ETavPqYlXh5hwkxIpTe3Sf4awQucSigQ95sS9g7QpcGyVUVscm0J/rah9YwPCnHShzsttWA9aCmKrNdgFSTTo8TUOmESEP93TH6Z3dss+A==';
+        jQuery.saj.certificado.webSignerParametro = '';
+        jQuery.saj.certificado.cofreDigital = jQuery.saj.certificado.cofreDigital || {};
+        jQuery.saj.certificado.cofreDigital.habilitado = 'false' === 'true';
+        jQuery.saj.certificado.cofreDigital.enderecoBase = 'https://esaj.tjce.jus.br/esaj-layout';
+    }
+
+</script>
+<script src="https://esaj.tjce.jus.br/esaj-layout/js/app-bundle.js?n=2978165087"></script>
+<script src="https://esaj.tjce.jus.br/esaj-layout/seletorVersaoBeta.js?n=32db3647-04d8-4058-8c7b-79513d6c2143&versao=1"></script>
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjce.jus.br/esaj-layout/js/softplan-websigner-2.5.1.js?n=736057767"></script>
+<script language="javascript" type="text/JavaScript" src=""></script>
+
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjce.jus.br/esaj-layout/js/saj-certificado.js?n=47741893"></script>
+
+
+
+<div id="webSignerNaoInstalado" style="display: none;">
+    <p>Para utilização do certificado digital no Portal e-SAJ é necessário a instalação do plug-in Web Signer. Por favor, realize a instalação antes de continuar.</p>
+    <div class="footer_certificado">
+        <button id="redirecionarParaPaginaInstalacao" class="actionPrincipal spwBotaoDefault">Instalar</button>
+        <button class="fecharModalInstalacao spwBotao">Cancelar</button>
+        <button class="spwBotao" onclick="window.open('https://esaj.tjce.jus.br/WebHelp//#id_instalacao_lacuna.htm','_blank')">Ajuda</button>
+    </div>
+</div>
+
+<div id="webSignerNaoSuportado" style="display: none;">
+    <p>O navegador utilizado não é compatível com a tecnologia (Web Signer) necessária para utilização do certificado digital. Por favor, utilize um dos navegadores homologados. Em caso de dúvidas, efetue a validação de requisitos <a href="/petpg/abrirVerificacaoRequisitosPet.do" target="_blank">aqui</a>.</p>
+    <div class="footer_certificado">
+        <button class="fecharModalInstalacao spwBotaoDefault actionPrincipal">OK</button>
+    </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+	</body>
+</html>

--- a/tests/tjce/samples/cjsg/results_normal_page_01.html
+++ b/tests/tjce/samples/cjsg/results_normal_page_01.html
@@ -1,0 +1,4403 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(100860)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="100860" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3834193" cdForo="0" >
+										0206389-11.2024.8.06.0300
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3834193" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3834193);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3834193" style="display: none;" >
+	<div id="textAreaDados_3834193" class="mensagemSemFormatacao" >
+		Constitucional e Processual Penal. Recurso especial. Negativa de seguimento. Tese 280 da repercuss&atilde;o geral. Agravo interno desprovido.
+I. Caso em exame
+1. Agravo interno contra a decis&atilde;o monocr&aacute;tica que negou seguimento ao recurso especial.
+II. Quest&otilde;es em discuss&atilde;o
+2. H&aacute; uma quest&atilde;o em discuss&atilde;o (i) saber se teria havido nulidade da busca domiciliar e, por conseguinte, das provas dela decorrentes, inviabilizando a condena&ccedil;&atilde;o do r&eacute;u.
+III. Raz&otilde;es de decidir
+3. O aresto objeto do recurso especial assentou um conjunto de circunst&acirc;ncias f&aacute;ticas pr&eacute;vias e objetivas: den&uacute;ncias reiteradas acerca da pr&aacute;tica de tr&aacute;fico de drogas e expuls&atilde;o de moradores; informa&ccedil;&atilde;o de que pessoas vindas de fora estariam atuando na localidade; conhecimento pr&eacute;vio de que a &aacute;rea era marcada por tal contexto de criminalidade; montagem de opera&ccedil;&atilde;o para averigua&ccedil;&atilde;o das not&iacute;cias; visualiza&ccedil;&atilde;o da fuga dos suspeitos; abordagem durante a evas&atilde;o; e apreens&atilde;o imediata, com eles, de materiais il&iacute;citos. Assim, n&atilde;o seriam nulas as provas decorrentes da dilig&ecirc;ncia, realizada em conson&acirc;ncia com o art. 5&ordm;, XI, da CF/1988 e com os arts. 240, &sect; 1&ordm; do CPP.
+4. Essa situa&ccedil;&atilde;o f&aacute;tico-probat&oacute;ria adequa-se perfeitamente, para fins de aplica&ccedil;&atilde;o do art. 1.030, I, do CPC, &agrave; Tese 280 da Repercuss&atilde;o Geral: A entrada for&ccedil;ada em domic&iacute;lio sem mandado judicial s&oacute; &eacute; l&iacute;cita, mesmo em per&iacute;odo noturno, quando amparada em fundadas raz&otilde;es, devidamente justificadas &quot;a posteriori&quot;, que indiquem que dentro da casa ocorre situa&ccedil;&atilde;o de flagrante delito, sob pena de responsabilidade disciplinar, civil e penal do agente ou da autoridade, e de nulidade dos atos praticados.
+IV. Parte dispositiva e tese
+5. Agravo interno conhecido e desprovido.
+_______________
+Legisla&ccedil;&atilde;o relevante citada: CF/1988, art. 5&ordm;, XI; CPP, arts. 240, &sect; 1&ordm; do CPP; CPC, art. 1.030.
+Jurisprud&ecirc;ncia relevante citada: STF, Tese 280 da Repercuss&atilde;o Geral; STF, S&uacute;mula 279; STJ, S&uacute;mula 7.
+
+AC&Oacute;RD&Atilde;O
+
+Acordam os Desembargadores integrantes do &Oacute;rg&atilde;o Especial do Egr&eacute;gio Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, nos autos deste Agravo Interno, por maioria, em conhecer do recurso e negar-lhe provimento, tudo de conformidade com o voto do eminente Relator.
+
+Fortaleza, data e hora indicadas no sistema.  <br><br>(Agravo Interno Criminal&nbsp;-  0206389-11.2024.8.06.0300, Rel. Desembargador(a)  VICE PRESIDENTE TJCE, &Oacute;rg&atilde;o Especial, data do julgamento:&nbsp; 16/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 17/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> VICE PRESIDENTE TJCE
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Jaguaruana
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Órgão Especial
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									206389112024806030050000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Constitucional e Processual Penal. Recurso especial. Negativa de seguimento. Tese 280 da repercussão geral. Agravo interno desprovido.
+I. Caso em exame
+1. Agravo interno contra a decisão monocrática que negou seguimento ao recurso especial.
+II. Questões em discussão
+2. Há uma questão em discussão (i) saber se teria havido nulidade da busca domiciliar e, por conseguinte, das provas dela
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Constitucional e Processual Penal. Recurso especial. Negativa de seguimento. Tese 280 da repercussão geral. Agravo interno desprovido.
+I. Caso em exame
+1. Agravo interno contra a decisão monocrática que negou seguimento ao recurso especial.
+II. Questões em discussão
+2. Há uma questão em discussão (i) saber se teria havido nulidade da busca domiciliar e, por conseguinte, das provas dela decorrentes, inviabilizando a condenação do réu.
+III. Razões de decidir
+3. O aresto objeto do recurso especial assentou um conjunto de circunstâncias fáticas prévias e objetivas: denúncias reiteradas acerca da prática de tráfico de drogas e expulsão de moradores; informação de que pessoas vindas de fora estariam atuando na localidade; conhecimento prévio de que a área era marcada por tal contexto de criminalidade; montagem de operação para averiguação das notícias; visualização da fuga dos suspeitos; abordagem durante a evasão; e apreensão imediata, com eles, de materiais ilícitos. Assim, não seriam nulas as provas decorrentes da diligência, realizada em consonância com o art. 5º, XI, da CF/1988 e com os arts. 240, § 1º do CPP.
+4. Essa situação fático-probatória adequa-se perfeitamente, para fins de aplicação do art. 1.030, I, do CPC, à Tese 280 da Repercussão Geral: A entrada forçada em domicílio sem mandado judicial só é lícita, mesmo em período noturno, quando amparada em fundadas razões, devidamente justificadas "a posteriori", que indiquem que dentro da casa ocorre situação de flagrante delito, sob pena de responsabilidade disciplinar, civil e penal do agente ou da autoridade, e de nulidade dos atos praticados.
+IV. Parte dispositiva e tese
+5. Agravo interno conhecido e desprovido.
+_______________
+Legislação relevante citada: CF/1988, art. 5º, XI; CPP, arts. 240, § 1º do CPP; CPC, art. 1.030.
+Jurisprudência relevante citada: STF, Tese 280 da Repercussão Geral; STF, Súmula 279; STJ, Súmula 7.
+
+ACÓRDÃO
+
+Acordam os Desembargadores integrantes do Órgão Especial do Egrégio Tribunal de Justiça do Estado do Ceará, nos autos deste Agravo Interno, por maioria, em conhecer do recurso e negar-lhe provimento, tudo de conformidade com o voto do eminente Relator.
+
+Fortaleza, data e hora indicadas no sistema.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3834012" cdForo="0" >
+										0203465-48.2024.8.06.0293
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3834012" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3834012);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3834012" style="display: none;" >
+	<div id="textAreaDados_3834012" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. RECURSO EM SENTIDO ESTRITO. TRIBUNAL DO J&Uacute;RI. TENTATIVA DE HOMIC&Iacute;DIO QUALIFICADO CONTRA POLICIAL MILITAR. NULIDADE POR AUS&Ecirc;NCIA DE EXAME DE CORPO DE DELITO. INOCORR&Ecirc;NCIA. EXCESSO DE LINGUAGEM NA PRON&Uacute;NCIA. CONFIGURA&Ccedil;&Atilde;O. ANULA&Ccedil;&Atilde;O PARCIAL DA DECIS&Atilde;O. RECURSO PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Trata-se de Recurso em Sentido Estrito interposto pela defesa de Carlos Wesley do Carmo Almeida contra decis&atilde;o de pron&uacute;ncia proferida pelo Ju&iacute;zo da Vara &Uacute;nica Criminal da Comarca de Aquiraz/CE, que o submeteu a julgamento pelo Tribunal do J&uacute;ri pela suposta pr&aacute;tica de tentativa de homic&iacute;dio contra policial militar em servi&ccedil;o.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se a aus&ecirc;ncia de exame de corpo de delito no acusado gera nulidade processual; (ii) estabelecer se a decis&atilde;o de pron&uacute;ncia incorreu em excesso de linguagem apto a comprometer a imparcialidade do Tribunal do J&uacute;ri; e (iii) verificar a legalidade da manuten&ccedil;&atilde;o da pris&atilde;o preventiva.
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+3. A aus&ecirc;ncia de exame de corpo de delito no acusado n&atilde;o compromete a materialidade do crime de tentativa de homic&iacute;dio, uma vez que eventual les&atilde;o sofrida pelo recorrente n&atilde;o integra o n&uacute;cleo do tipo penal imputado.
+
+4. Nessa linha, a declara&ccedil;&atilde;o de nulidade exige demonstra&ccedil;&atilde;o de preju&iacute;zo, nos termos do art. 563 do CPP, o que n&atilde;o foi comprovado pela defesa.
+
+5. Superada essa quest&atilde;o, verifica-se que a decis&atilde;o de pron&uacute;ncia, por sua natureza, limita-se a um ju&iacute;zo de admissibilidade da acusa&ccedil;&atilde;o, exigindo apenas prova da materialidade e ind&iacute;cios suficientes de autoria, sem adentrar no m&eacute;rito da causa, que &eacute; reservado ao Tribunal do J&uacute;ri.
+
+6. No entanto, observa-se que o magistrado de origem ultrapassa esses limites ao empregar express&otilde;es que revelam convic&ccedil;&atilde;o quanto &agrave; inten&ccedil;&atilde;o de matar e &agrave; autoria delitiva, convertendo o ju&iacute;zo de probabilidade em verdadeiro ju&iacute;zo de certeza.
+
+7. Tal postura caracteriza excesso de linguagem, v&iacute;cio que compromete a imparcialidade do julgamento pelo Conselho de Senten&ccedil;a, na medida em que possui aptid&atilde;o para influenciar indevidamente os jurados, impondo, por conseguinte, a anula&ccedil;&atilde;o da decis&atilde;o de pron&uacute;ncia para que outra seja proferida com a devida sobriedade.
+
+8. No que concerne &agrave; cust&oacute;dia cautelar, a pris&atilde;o preventiva encontra-se devidamente fundamentada na garantia da ordem p&uacute;blica, evidenciada pela gravidade concreta da conduta imputada.
+
+9. Al&eacute;m disso, os antecedentes do acusado e o risco de reitera&ccedil;&atilde;o delitiva refor&ccedil;am a necessidade da medida extrema, mostrando-se insuficientes as cautelares diversas da pris&atilde;o.
+
+10. Por fim, n&atilde;o se verifica excesso de prazo, considerando a regular tramita&ccedil;&atilde;o do feito e sua complexidade.
+
+IV. DISPOSITIVO
+11. Recurso conhecido e parcialmente provido.  <br><br>(Recurso em Sentido Estrito&nbsp;-  0203465-48.2024.8.06.0293, Rel. Desembargador(a)  MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 15/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Recurso em Sentido Estrito / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIA ILNA LIMA DE CASTRO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aquiraz
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. RECURSO EM SENTIDO ESTRITO. TRIBUNAL DO JÚRI. TENTATIVA DE HOMICÍDIO QUALIFICADO CONTRA POLICIAL MILITAR. NULIDADE POR AUSÊNCIA DE EXAME DE CORPO DE DELITO. INOCORRÊNCIA. EXCESSO DE LINGUAGEM NA PRONÚNCIA. CONFIGURAÇÃO. ANULAÇÃO PARCIAL DA DECISÃO. RECURSO PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Trata-se de Recurso em Sentido Estrito interposto pela defesa
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. RECURSO EM SENTIDO ESTRITO. TRIBUNAL DO JÚRI. TENTATIVA DE HOMICÍDIO QUALIFICADO CONTRA POLICIAL MILITAR. NULIDADE POR AUSÊNCIA DE EXAME DE CORPO DE DELITO. INOCORRÊNCIA. EXCESSO DE LINGUAGEM NA PRONÚNCIA. CONFIGURAÇÃO. ANULAÇÃO PARCIAL DA DECISÃO. RECURSO PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Trata-se de Recurso em Sentido Estrito interposto pela defesa de Carlos Wesley do Carmo Almeida contra decisão de pronúncia proferida pelo Juízo da Vara Única Criminal da Comarca de Aquiraz/CE, que o submeteu a julgamento pelo Tribunal do Júri pela suposta prática de tentativa de homicídio contra policial militar em serviço.
+
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se a ausência de exame de corpo de delito no acusado gera nulidade processual; (ii) estabelecer se a decisão de pronúncia incorreu em excesso de linguagem apto a comprometer a imparcialidade do Tribunal do Júri; e (iii) verificar a legalidade da manutenção da prisão preventiva.
+
+III. RAZÕES DE DECIDIR
+
+3. A ausência de exame de corpo de delito no acusado não compromete a materialidade do crime de tentativa de homicídio, uma vez que eventual lesão sofrida pelo recorrente não integra o núcleo do tipo penal imputado.
+
+4. Nessa linha, a declaração de nulidade exige demonstração de prejuízo, nos termos do art. 563 do CPP, o que não foi comprovado pela defesa.
+
+5. Superada essa questão, verifica-se que a decisão de pronúncia, por sua natureza, limita-se a um juízo de admissibilidade da acusação, exigindo apenas prova da materialidade e indícios suficientes de autoria, sem adentrar no mérito da causa, que é reservado ao Tribunal do Júri.
+
+6. No entanto, observa-se que o magistrado de origem ultrapassa esses limites ao empregar expressões que revelam convicção quanto à intenção de matar e à autoria delitiva, convertendo o juízo de probabilidade em verdadeiro juízo de certeza.
+
+7. Tal postura caracteriza excesso de linguagem, vício que compromete a imparcialidade do julgamento pelo Conselho de Sentença, na medida em que possui aptidão para influenciar indevidamente os jurados, impondo, por conseguinte, a anulação da decisão de pronúncia para que outra seja proferida com a devida sobriedade.
+
+8. No que concerne à custódia cautelar, a prisão preventiva encontra-se devidamente fundamentada na garantia da ordem pública, evidenciada pela gravidade concreta da conduta imputada.
+
+9. Além disso, os antecedentes do acusado e o risco de reiteração delitiva reforçam a necessidade da medida extrema, mostrando-se insuficientes as cautelares diversas da prisão.
+
+10. Por fim, não se verifica excesso de prazo, considerando a regular tramitação do feito e sua complexidade.
+
+IV. DISPOSITIVO
+11. Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3834004" cdForo="0" >
+										0200154-49.2024.8.06.0293
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3834004" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3834004);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3834004" style="display: none;" >
+	<div id="textAreaDados_3834004" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIME. EMBRIAGUEZ AO VOLANTE E DIRE&Ccedil;&Atilde;O SEM HABILITA&Ccedil;&Atilde;O (ARTS. 306 E 309 DO CTB). MANUTEN&Ccedil;&Atilde;O DA DOSIMETRIA E DA REPARA&Ccedil;&Atilde;O CIVIL. RECURSO DESPROVIDO.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o Criminal interposta por Francisco Helio de Aquino contra senten&ccedil;a que o condenou pela pr&aacute;tica dos crimes previstos nos arts. 306, &sect;1&ordm;, I, e 309, ambos da Lei n&ordm; 9.503/1997 (CTB), &agrave; pena de 1 ano, 1 m&ecirc;s e 21 dias de deten&ccedil;&atilde;o, em regime aberto, al&eacute;m de suspens&atilde;o da habilita&ccedil;&atilde;o e condena&ccedil;&atilde;o ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 2.000,00 para cada v&iacute;tima. O apelante colidiu ve&iacute;culo automotor, sob efeito de &aacute;lcool e sem habilita&ccedil;&atilde;o, contra mobili&aacute;rio e motocicleta em via p&uacute;blica. A defesa pugna pela reforma da dosimetria (fra&ccedil;&atilde;o da confiss&atilde;o), exclus&atilde;o da indeniza&ccedil;&atilde;o civil e substitui&ccedil;&atilde;o da pena privativa de liberdade por restritivas de direitos.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se a fra&ccedil;&atilde;o de redu&ccedil;&atilde;o pela atenuante da confiss&atilde;o espont&acirc;nea deve ser superior a 1/6; (ii) verificar se &eacute; leg&iacute;tima a fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o de danos morais quando h&aacute; pedido expresso na den&uacute;ncia; e (iii) analisar se o r&eacute;u preenche os requisitos para a substitui&ccedil;&atilde;o da pena privativa de liberdade por restritivas de direitos.
+III. Raz&otilde;es de decidir
+3. Na dosimetria, a jurisprud&ecirc;ncia consolidada do STJ (AgRg no AREsp 1.811.717/GO) orienta que a fra&ccedil;&atilde;o de 1/6 para agravantes e atenuantes &eacute; o patamar ideal de proporcionalidade, salvo fundamenta&ccedil;&atilde;o espec&iacute;fica para patamar diverso, o que n&atilde;o se verifica no caso, mantendo-se o c&aacute;lculo da senten&ccedil;a.
+4. &Eacute; devida a fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o de danos (art. 387, IV, CPP) quando houver pedido expresso do Minist&eacute;rio P&uacute;blico na exordial acusat&oacute;ria, sendo desnecess&aacute;ria instru&ccedil;&atilde;o probat&oacute;ria espec&iacute;fica para o dano moral, que em casos de crimes de tr&acirc;nsito com perigo concreto e ofensas subsequentes, configura-se pela pr&oacute;pria gravidade do fato e reflexos emocionais nas v&iacute;timas.
+5. A substitui&ccedil;&atilde;o da pena privativa de liberdade por restritivas de direitos (art. 44, CP) mostra-se invi&aacute;vel quando o r&eacute;u ostenta maus antecedentes, indicando que a medida n&atilde;o &eacute; socialmente recomend&aacute;vel ou suficiente para a reprova&ccedil;&atilde;o e preven&ccedil;&atilde;o do crime.
+IV. Dispositivo e tese
+6. Recurso conhecido e desprovido.
+Tese de julgamento:&quot;1. A ado&ccedil;&atilde;o de fra&ccedil;&atilde;o inferior a 1/6 pela atenuante da confiss&atilde;o espont&acirc;nea exige fundamenta&ccedil;&atilde;o concreta, sendo o patamar de um sexto o par&acirc;metro jurisprudencial de proporcionalidade. 2. A fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o de danos morais na senten&ccedil;a penal (art. 387, IV, do CPP) &eacute; leg&iacute;tima quando houver pedido expresso da acusa&ccedil;&atilde;o, independentemente de dila&ccedil;&atilde;o probat&oacute;ria espec&iacute;fica sobre a extens&atilde;o do dano.&quot;
+Dispositivos relevantes citados: CTB, arts. 306 e 309; CP, arts. 44, 59, 65, III, 'd' e 91, I; CPP, art. 387, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no AREsp n. 1.811.717/GO, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, j. 14.11.2022; STJ, REsp n. 1.675.874/MS, Rel. Min. Rogerio Schietti Cruz, Terceira Se&ccedil;&atilde;o, j. 28.2.2018.  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0200154-49.2024.8.06.0293, Rel. Desembargador(a)  MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 15/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(59 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Crimes de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIA ILNA LIMA DE CASTRO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Nova Olinda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIME. EMBRIAGUEZ AO VOLANTE E DIREÇÃO SEM HABILITAÇÃO (ARTS. 306 E 309 DO CTB). MANUTENÇÃO DA DOSIMETRIA E DA REPARAÇÃO CIVIL. RECURSO DESPROVIDO.
+I. Caso em exame
+1. Apelação Criminal interposta por Francisco Helio de Aquino contra sentença que o condenou pela prática dos crimes previstos nos arts. 306, §1º, I, e 309, ambos da Lei nº 9.503/1997
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIME. EMBRIAGUEZ AO VOLANTE E DIREÇÃO SEM HABILITAÇÃO (ARTS. 306 E 309 DO CTB). MANUTENÇÃO DA DOSIMETRIA E DA REPARAÇÃO CIVIL. RECURSO DESPROVIDO.
+I. Caso em exame
+1. Apelação Criminal interposta por Francisco Helio de Aquino contra sentença que o condenou pela prática dos crimes previstos nos arts. 306, §1º, I, e 309, ambos da Lei nº 9.503/1997 (CTB), à pena de 1 ano, 1 mês e 21 dias de detenção, em regime aberto, além de suspensão da habilitação e condenação ao pagamento de indenização por <em>danos</em> <em>morais</em> no valor de R$ 2.000,00 para cada vítima. O apelante colidiu veículo automotor, sob efeito de álcool e sem habilitação, contra mobiliário e motocicleta em via pública. A defesa pugna pela reforma da dosimetria (fração da confissão), exclusão da indenização civil e substituição da pena privativa de liberdade por restritivas de direitos.
+II. Questão em discussão
+2. Há três questões em discussão: (i) saber se a fração de redução pela atenuante da confissão espontânea deve ser superior a 1/6; (ii) verificar se é legítima a fixação de valor mínimo para reparação de <em>danos</em> <em>morais</em> quando há pedido expresso na denúncia; e (iii) analisar se o réu preenche os requisitos para a substituição da pena privativa de liberdade por restritivas de direitos.
+III. Razões de decidir
+3. Na dosimetria, a jurisprudência consolidada do STJ (AgRg no AREsp 1.811.717/GO) orienta que a fração de 1/6 para agravantes e atenuantes é o patamar ideal de proporcionalidade, salvo fundamentação específica para patamar diverso, o que não se verifica no caso, mantendo-se o cálculo da sentença.
+4. É devida a fixação de valor mínimo para reparação de <em>danos</em> (art. 387, IV, CPP) quando houver pedido expresso do Ministério Público na exordial acusatória, sendo desnecessária instrução probatória específica para o <em>dano</em> <em>moral</em>, que em casos de crimes de trânsito com perigo concreto e ofensas subsequentes, configura-se pela própria gravidade do fato e reflexos emocionais nas vítimas.
+5. A substituição da pena privativa de liberdade por restritivas de direitos (art. 44, CP) mostra-se inviável quando o réu ostenta maus antecedentes, indicando que a medida não é socialmente recomendável ou suficiente para a reprovação e prevenção do crime.
+IV. Dispositivo e tese
+6. Recurso conhecido e desprovido.
+Tese de julgamento:"1. A adoção de fração inferior a 1/6 pela atenuante da confissão espontânea exige fundamentação concreta, sendo o patamar de um sexto o parâmetro jurisprudencial de proporcionalidade. 2. A fixação de valor mínimo para reparação de <em>danos</em> <em>morais</em> na sentença penal (art. 387, IV, do CPP) é legítima quando houver pedido expresso da acusação, independentemente de dilação probatória específica sobre a extensão do <em>dano</em>."
+Dispositivos relevantes citados: CTB, arts. 306 e 309; CP, arts. 44, 59, 65, III, 'd' e 91, I; CPP, art. 387, IV.
+Jurisprudência relevante citada: STJ, AgRg no AREsp n. 1.811.717/GO, Rel. Min. Sebastião Reis Júnior, Sexta Turma, j. 14.11.2022; STJ, REsp n. 1.675.874/MS, Rel. Min. Rogerio Schietti Cruz, Terceira Seção, j. 28.2.2018.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3834058" cdForo="0" >
+										0246533-51.2024.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3834058" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3834058);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3834058" style="display: none;" >
+	<div id="textAreaDados_3834058" class="mensagemSemFormatacao" >
+		PENAL. PROCESSO PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TR&Aacute;FICO DE DROGAS. POSSE IRREGULAR DE ARMA DE FOGO. SENTEN&Ccedil;A CONDENAT&Oacute;RIA. RECURSOS DEFENSIVOS.    1. ALEGA&Ccedil;&Atilde;O DE NULIDADE POR VIOLA&Ccedil;&Atilde;O DE DOMIC&Iacute;LIO. DESCABIMENTO. DEN&Uacute;NCIAS PR&Eacute;VIAS ESPEC&Iacute;FICAS COM RELA&Ccedil;&Atilde;O A UM DOS R&Eacute;US E AO IM&Oacute;VEL. FUGA AO AVISTAR A COMPOSI&Ccedil;&Atilde;O POLICIAL. ENTRADA DOS AGENTES DE SEGURAN&Ccedil;A P&Uacute;BLICA AUTORIZADA. FUNDADAS SUSPEITAS. 2. ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE FUNDAMENTA&Ccedil;&Atilde;O ID&Ocirc;NEA PARA N&Atilde;O OFERECIMENTO DE ANPP. N&Atilde;O ACOLHIMENTO. ADEQUA&Ccedil;&Atilde;O AO TEMA 1.098, JULGADO EM SEDE DE RECURSOS REPETITIVOS. MINIST&Eacute;RIO P&Uacute;BLICO J&Aacute; SE MANIFESTOU A RESPEITO DA IMPOSSIBILIDADE DE OFERECIMENTO DE ACORDO. 3. PEDIDO DE ABSOLVI&Ccedil;&Atilde;O PELO ART. 33. IMPOSSIBILIDADE. DEPOIMENTOS QUE APONTAM PARA O ENVOLVIMENTO DOS APELANTES COM AS DROGAS. DEPOIMENTO DOS POLICIAIS QUE S&Atilde;O COERENTES COM O RESTANTE DO FEITO. DECLARA&Ccedil;&Otilde;ES DOS R&Eacute;US CONTRADIT&Oacute;RIAS. APREENS&Atilde;O DE ELEMENTOS INDICATIVOS DO TR&Aacute;FICO (BALAN&Ccedil;A DE PRECIS&Atilde;O E DINHEIRO EM ESP&Eacute;CIE). POSSIBILIDADE DE COEXIST&Ecirc;NCIA DA CONDI&Ccedil;&Atilde;O DE USU&Aacute;RIO E TRAFICANTE. 4. PRETENS&Atilde;O ABSOLUT&Oacute;RIA DO DELITO DE POSSE IRREGULAR DE MUNI&Ccedil;&Atilde;O. DESCABIMENTO. CRIME DE MERA CONDUTA E DE PERIGO ABSTRATO. TIPICIDADE QUE SE IMP&Otilde;E. AUTORIA E MATERIALIDADE DEMONSTRADAS NOS AUTOS. CONDENA&Ccedil;&Atilde;O MANTIDA. 5. DOSIMETRIA EFETUADA NA FORMA LEGALMENTE PREVISTA. IMPOSSIBILIDADE DE APLICA&Ccedil;&Atilde;O DO TR&Aacute;FICO PRIVILEGIADO. ELEMENTOS QUE POSSIBILITAM VERIFICA&Ccedil;&Atilde;O DE DEDICA&Ccedil;&Atilde;O &Agrave;S ATIVIDADES DELITIVAS. SENTEN&Ccedil;A INALTERADA.
+
+I. CASO EM EXAME
+1. Trata-se os autos de Recurso de Apela&ccedil;&atilde;o interposto por Francisco Ermerson Morais Saboia e Jos&eacute; de Oliveira Maciel Neto, insurgindo-se contra a senten&ccedil;a prolatada &agrave;s fls. 432/455, pelo Ju&iacute;zo da 3&ordf; Vara de Delitos de Tr&aacute;fico de Drogas da Comarca de Fortaleza, que os condenou nas tenazes do art. 33 da Lei n.&ordm; 11.343/2006 e art. 12 da Lei n.&ordm; 10.826/2003.
+
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; cinco quest&otilde;es em discuss&atilde;o: (i) examinar a alega&ccedil;&atilde;o de nulidade com rela&ccedil;&atilde;o a suposta viola&ccedil;&atilde;o de domic&iacute;lio; (ii) avaliar a sustentada aus&ecirc;ncia de fundamenta&ccedil;&atilde;o id&ocirc;nea para n&atilde;o oferecimento de ANPP; (iii) analisar o pleito de absolvi&ccedil;&atilde;o pelo crime de tr&aacute;fico de drogas e, subsidiariamente, o pedido de desclassifica&ccedil;&atilde;o da conduta para a prevista no art. 28 da Lei n.&ordm; 11.343/2006; (iv) aferir o pleito de absolvi&ccedil;&atilde;o quanto ao delito previsto no art. 12 da Lei n.&ordm; 10.826/2003; (v) verificar a dosimetria e regime inicial de cumprimento de pena.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3. Com rela&ccedil;&atilde;o ao pleito preliminar de nulidade por viola&ccedil;&atilde;o de domic&iacute;lio, al&eacute;m da autoriza&ccedil;&atilde;o, houve fundadas suspeitas pr&eacute;vias, geradas pelo contexto f&aacute;tico de informa&ccedil;&otilde;es pr&eacute;vias em rela&ccedil;&atilde;o a um dos acusados e &agrave; resid&ecirc;ncia, bem como tentativa de fuga de um dos abordados, ao visualizar a composi&ccedil;&atilde;o policial (estando em conformidade com o exigido pelos arts. 240 e 244 do CPP), o que levou os agentes a adentrarem o local e confirmarem &agrave;s den&uacute;ncias.
+4. O Minist&eacute;rio P&uacute;blico, quando do oferecimento da exordial delat&oacute;ria, j&aacute; se manifestou contrariamente ao oferecimento do ANPP, encontrando respaldo na legisla&ccedil;&atilde;o vigente, devendo os crimes serem considerados em concurso, conforme julgados deste eg. Tribunal.
+5. Quanto ao pedido de absolvi&ccedil;&atilde;o pelo delito de tr&aacute;fico de drogas, entende-se que, al&eacute;m de materialidade delitiva demonstrada, a autoria resta caracterizada, diante de todos os elementos colacionados ao feito.
+6. Ainda se usu&aacute;rios fossem, de acordo com entendimento jurisprudencial p&aacute;trio, n&atilde;o h&aacute; impedimento em coexistir na figura de uma mesma pessoa o usu&aacute;rio e o traficante, pois estes, em muitos casos, utilizam o proveito advindo da comercializa&ccedil;&atilde;o de drogas para sustentarem os seus pr&oacute;prios v&iacute;cios.
+7. Resta caracterizada a conduta dos acusados quanto ao delito previsto no art. 12 do Estatuto do Desarmamento, estando a autoria e materialidade demonstrada nos autos, sobretudo pelos depoimentos colhidos em sede de instru&ccedil;&atilde;o processual.
+8.    Diante dos apetrechos apreendidos com os r&eacute;us, &eacute; poss&iacute;vel concluir pela dedica&ccedil;&atilde;o deles &agrave;s atividades criminosas, o que est&aacute; em conson&acirc;ncia com a jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a, impedindo a aplica&ccedil;&atilde;o do tr&aacute;fico privilegiado.
+9. Mantidas as penas imputadas aos acusados, n&atilde;o h&aacute; que se falar em altera&ccedil;&atilde;o de regime inicial de cumprimento de pena ou substitui&ccedil;&atilde;o por penas restritivas de direitos.
+
+IV. DISPOSITIVO
+10. Recursos conhecidos e desprovidos.
+________________________________________________________
+Dispositivos relevantes citados: CPP, arts. 28-A, 155 e 157; Lei n.&ordm; 11.343/2006, arts. 28 e 33, caput e &sect; 4&ordm;; CRFB/88 , art. 5&ordm;, XI.
+
+Jurisprud&ecirc;ncias relevantes citadas: RE nos EDcl no AgRg no REsp n. 2.041.450/RS, relator Ministro Antonio Saldanha Palheiro, Sexta Turma, julgado em 27/8/2025, DJEN de 2/9/2025; AgRg no AREsp n. 2.703.590/RJ, relator Ministro Reynaldo Soares da Fonseca, Quinta Turma, julgado em 17/12/2024, DJe de 23/12/2024; Apela&ccedil;&atilde;o Criminal - 0205152-31.2022.8.06.0293, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:  19/11/2025, data da publica&ccedil;&atilde;o:  19/11/2025; Habeas Corpus Criminal - 0639499-60.2024.8.06.0000, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:  22/01/2025, data da publica&ccedil;&atilde;o:  22/01/2025; Apela&ccedil;&atilde;o Criminal - 0201848-62.2022.8.06.0151, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:  10/07/2024, data da publica&ccedil;&atilde;o:  10/07/2024; AgRg no RHC n. 204.818/PB, relator Ministro Messod Azulay Neto, Quinta Turma, julgado em 24/6/2025, DJEN de 30/6/2025; AgRg no HC n. 1.012.835/MT, relator Ministro Rogerio Schietti Cruz, Sexta Turma, julgado em 29/10/2025, DJEN de 6/11/2025.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Apela&ccedil;&atilde;o Criminal n.&ordm; 0246533-51.2024.8.06.0001, em que figuram como recorrentes Francisco Ermerson Morais Saboia e Jos&eacute; de Oliveira Maciel Neto, e recorrido o Minist&eacute;rio P&uacute;blico do Estado do Cear&aacute;.
+
+ACORDAM os Desembargadores integrantes da 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em CONHECER dos recursos, para NEGAR-LHES PROVIMENTO, nos termos do voto do eminente Relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0246533-51.2024.8.06.0001, Rel. Desembargador(a)  FRANCISCO EDUARDO TORQUATO SCORSAFAVA, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 15/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(19 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>PENAL. PROCESSO PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. POSSE IRREGULAR DE ARMA DE FOGO. SENTENÇA CONDENATÓRIA. RECURSOS DEFENSIVOS.    1. ALEGAÇÃO DE NULIDADE POR VIOLAÇÃO DE DOMICÍLIO. DESCABIMENTO. DENÚNCIAS PRÉVIAS ESPECÍFICAS COM RELAÇÃO A UM DOS RÉUS E AO IMÓVEL. FUGA AO AVISTAR A COMPOSIÇÃO POLICIAL. ENTRADA DOS AGENTES DE SEGURANÇA PÚBLICA AUTORIZADA. FUNDADAS SUSPEITAS. 2. ALEGAÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>PENAL. PROCESSO PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. POSSE IRREGULAR DE ARMA DE FOGO. SENTENÇA CONDENATÓRIA. RECURSOS DEFENSIVOS.    1. ALEGAÇÃO DE NULIDADE POR VIOLAÇÃO DE DOMICÍLIO. DESCABIMENTO. DENÚNCIAS PRÉVIAS ESPECÍFICAS COM RELAÇÃO A UM DOS RÉUS E AO IMÓVEL. FUGA AO AVISTAR A COMPOSIÇÃO POLICIAL. ENTRADA DOS AGENTES DE SEGURANÇA PÚBLICA AUTORIZADA. FUNDADAS SUSPEITAS. 2. ALEGAÇÃO DE AUSÊNCIA DE FUNDAMENTAÇÃO IDÔNEA PARA NÃO OFERECIMENTO DE ANPP. NÃO ACOLHIMENTO. ADEQUAÇÃO AO TEMA 1.098, JULGADO EM SEDE DE RECURSOS REPETITIVOS. MINISTÉRIO PÚBLICO JÁ SE MANIFESTOU A RESPEITO DA IMPOSSIBILIDADE DE OFERECIMENTO DE ACORDO. 3. PEDIDO DE ABSOLVIÇÃO PELO ART. 33. IMPOSSIBILIDADE. DEPOIMENTOS QUE APONTAM PARA O ENVOLVIMENTO DOS APELANTES COM AS DROGAS. DEPOIMENTO DOS POLICIAIS QUE SÃO COERENTES COM O RESTANTE DO FEITO. DECLARAÇÕES DOS RÉUS CONTRADITÓRIAS. APREENSÃO DE ELEMENTOS INDICATIVOS DO TRÁFICO (BALANÇA DE PRECISÃO E DINHEIRO EM ESPÉCIE). POSSIBILIDADE DE COEXISTÊNCIA DA CONDIÇÃO DE USUÁRIO E TRAFICANTE. 4. PRETENSÃO ABSOLUTÓRIA DO DELITO DE POSSE IRREGULAR DE MUNIÇÃO. DESCABIMENTO. CRIME DE MERA CONDUTA E DE PERIGO ABSTRATO. TIPICIDADE QUE SE IMPÕE. AUTORIA E MATERIALIDADE DEMONSTRADAS NOS AUTOS. CONDENAÇÃO MANTIDA. 5. DOSIMETRIA EFETUADA NA FORMA LEGALMENTE PREVISTA. IMPOSSIBILIDADE DE APLICAÇÃO DO TRÁFICO PRIVILEGIADO. ELEMENTOS QUE POSSIBILITAM VERIFICAÇÃO DE DEDICAÇÃO ÀS ATIVIDADES DELITIVAS. SENTENÇA INALTERADA.
+
+I. CASO EM EXAME
+1. Trata-se os autos de Recurso de Apelação interposto por Francisco Ermerson <em>Morais</em> Saboia e José de Oliveira Maciel Neto, insurgindo-se contra a sentença prolatada às fls. 432/455, pelo Juízo da 3ª Vara de Delitos de Tráfico de Drogas da Comarca de Fortaleza, que os condenou nas tenazes do art. 33 da Lei n.º 11.343/2006 e art. 12 da Lei n.º 10.826/2003.
+
+II. QUESTÕES EM DISCUSSÃO
+2. Há cinco questões em discussão: (i) examinar a alegação de nulidade com relação a suposta violação de domicílio; (ii) avaliar a sustentada ausência de fundamentação idônea para não oferecimento de ANPP; (iii) analisar o pleito de absolvição pelo crime de tráfico de drogas e, subsidiariamente, o pedido de desclassificação da conduta para a prevista no art. 28 da Lei n.º 11.343/2006; (iv) aferir o pleito de absolvição quanto ao delito previsto no art. 12 da Lei n.º 10.826/2003; (v) verificar a dosimetria e regime inicial de cumprimento de pena.
+
+III. RAZÕES DE DECIDIR
+3. Com relação ao pleito preliminar de nulidade por violação de domicílio, além da autorização, houve fundadas suspeitas prévias, geradas pelo contexto fático de informações prévias em relação a um dos acusados e à residência, bem como tentativa de fuga de um dos abordados, ao visualizar a composição policial (estando em conformidade com o exigido pelos arts. 240 e 244 do CPP), o que levou os agentes a adentrarem o local e confirmarem às denúncias.
+4. O Ministério Público, quando do oferecimento da exordial delatória, já se manifestou contrariamente ao oferecimento do ANPP, encontrando respaldo na legislação vigente, devendo os crimes serem considerados em concurso, conforme julgados deste eg. Tribunal.
+5. Quanto ao pedido de absolvição pelo delito de tráfico de drogas, entende-se que, além de materialidade delitiva demonstrada, a autoria resta caracterizada, diante de todos os elementos colacionados ao feito.
+6. Ainda se usuários fossem, de acordo com entendimento jurisprudencial pátrio, não há impedimento em coexistir na figura de uma mesma pessoa o usuário e o traficante, pois estes, em muitos casos, utilizam o proveito advindo da comercialização de drogas para sustentarem os seus próprios vícios.
+7. Resta caracterizada a conduta dos acusados quanto ao delito previsto no art. 12 do Estatuto do Desarmamento, estando a autoria e materialidade demonstrada nos autos, sobretudo pelos depoimentos colhidos em sede de instrução processual.
+8.    Diante dos apetrechos apreendidos com os réus, é possível concluir pela dedicação deles às atividades criminosas, o que está em consonância com a jurisprudência do Superior Tribunal de Justiça, impedindo a aplicação do tráfico privilegiado.
+9. Mantidas as penas imputadas aos acusados, não há que se falar em alteração de regime inicial de cumprimento de pena ou substituição por penas restritivas de direitos.
+
+IV. DISPOSITIVO
+10. Recursos conhecidos e desprovidos.
+________________________________________________________
+Dispositivos relevantes citados: CPP, arts. 28-A, 155 e 157; Lei n.º 11.343/2006, arts. 28 e 33, caput e § 4º; CRFB/88 , art. 5º, XI.
+
+Jurisprudências relevantes citadas: RE nos EDcl no AgRg no REsp n. 2.041.450/RS, relator Ministro Antonio Saldanha Palheiro, Sexta Turma, julgado em 27/8/2025, DJEN de 2/9/2025; AgRg no AREsp n. 2.703.590/RJ, relator Ministro Reynaldo Soares da Fonseca, Quinta Turma, julgado em 17/12/2024, DJe de 23/12/2024; Apelação Criminal - 0205152-31.2022.8.06.0293, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2ª Câmara Criminal, data do julgamento:  19/11/2025, data da publicação:  19/11/2025; Habeas Corpus Criminal - 0639499-60.2024.8.06.0000, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2ª Câmara Criminal, data do julgamento:  22/01/2025, data da publicação:  22/01/2025; Apelação Criminal - 0201848-62.2022.8.06.0151, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2ª Câmara Criminal, data do julgamento:  10/07/2024, data da publicação:  10/07/2024; AgRg no RHC n. 204.818/PB, relator Ministro Messod Azulay Neto, Quinta Turma, julgado em 24/6/2025, DJEN de 30/6/2025; AgRg no HC n. 1.012.835/MT, relator Ministro Rogerio Schietti Cruz, Sexta Turma, julgado em 29/10/2025, DJEN de 6/11/2025.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Apelação Criminal n.º 0246533-51.2024.8.06.0001, em que figuram como recorrentes Francisco Ermerson <em>Morais</em> Saboia e José de Oliveira Maciel Neto, e recorrido o Ministério Público do Estado do Ceará.
+
+ACORDAM os Desembargadores integrantes da 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em CONHECER dos recursos, para NEGAR-LHES PROVIMENTO, nos termos do voto do eminente Relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3834057" cdForo="0" >
+										0004234-25.2017.8.06.0054
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3834057" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3834057);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3834057" style="display: none;" >
+	<div id="textAreaDados_3834057" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TRIBUNAL DO J&Uacute;RI. DOIS CRIMES. R&Eacute;U ABSOLVIDO PELO QUESITO GEN&Eacute;RICO EM RELA&Ccedil;&Atilde;O AO CRIME DE HOMIC&Iacute;DIO E CONDENADO EM RELA&Ccedil;&Atilde;O AO CRIME DE TENTATIVA DE HOMIC&Iacute;DIO QUALIFICADO. RECURSO DO MINIST&Eacute;RIO P&Uacute;BLICO E DA DEFESA. ALEGA&Ccedil;&Atilde;O DUPLA DE DECIS&Atilde;O N&Atilde;O MANIFESTAMENTE CONTR&Aacute;RIA &Agrave; PROVA DOS AUTOS. N&Atilde;O OCORR&Ecirc;NCIA. SOBERANIA DOS VEREDICTOS. PLEITOS SUBSIDI&Aacute;RIOS DA DEFESA. DESCLASSIFICA&Ccedil;&Atilde;O PARA LES&Atilde;O CORPORAL. IMPOSSIBILIDADE. VONTADE ASSASSINA COMPROVADA NOS AUTOS. EXCLUS&Atilde;O DE INDENIZA&Ccedil;&Atilde;O. POSSIBILIDADE. AUS&Ecirc;NCIA DE PEDIDO EXPRESSO NA DEN&Uacute;NCIA. RECURSO MINISTERIAL DESPROVIDO E DEFENSIVO PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es criminais interpostas pelo Minist&eacute;rio P&uacute;blico e pela defesa contra senten&ccedil;a do Tribunal do J&uacute;ri que condenou o r&eacute;u por tentativa de homic&iacute;dio qualificado, fixando pena de 6 anos de reclus&atilde;o, em regime semiaberto, al&eacute;m de indeniza&ccedil;&atilde;o m&iacute;nima de R$ 10.000,00, e absolveu quanto ao homic&iacute;dio consumado com base em quesito gen&eacute;rico.
+2. O Minist&eacute;rio P&uacute;blico pleiteia a anula&ccedil;&atilde;o do julgamento por suposta decis&atilde;o manifestamente contr&aacute;ria &agrave; prova dos autos. A defesa requer absolvi&ccedil;&atilde;o, desclassifica&ccedil;&atilde;o da conduta ou exclus&atilde;o da indeniza&ccedil;&atilde;o fixada.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+3. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) analisar se a decis&atilde;o do Tribunal do J&uacute;ri &eacute; manifestamente contr&aacute;ria &agrave; prova dos autos; (ii) verificar se &eacute; poss&iacute;vel a revis&atilde;o do veredicto absolut&oacute;rio diante da soberania dos jurados; (iii) aferir se &eacute; cab&iacute;vel a fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima sem pedido expresso na den&uacute;ncia.
+
+III. RAZ&Otilde;ES DE DECIDIR
+4. A apela&ccedil;&atilde;o fundada no art. 593, III, &quot;d&quot;, do CPP exige demonstra&ccedil;&atilde;o inequ&iacute;voca de que o veredicto apresenta-se completamente dissociado do conjunto probat&oacute;rio, n&atilde;o bastando mera diverg&ecirc;ncia interpretativa.
+5. A soberania dos veredictos (art. 5&ordm;, XXXVIII, &quot;c&quot;, CF) impede a substitui&ccedil;&atilde;o da decis&atilde;o dos jurados quando existente suporte probat&oacute;rio para a tese acolhida, ainda que coexistam vers&otilde;es conflitantes.
+6. No caso, h&aacute; elementos probat&oacute;rios que sustentam tanto a tese acusat&oacute;ria quanto a defensiva, especialmente quanto &agrave; alega&ccedil;&atilde;o de leg&iacute;tima defesa ou inexigibilidade de conduta diversa, legitimando a op&ccedil;&atilde;o dos jurados pela absolvi&ccedil;&atilde;o no quesito gen&eacute;rico.
+7. A condena&ccedil;&atilde;o pela tentativa de homic&iacute;dio tamb&eacute;m encontra respaldo no conjunto probat&oacute;rio, n&atilde;o havendo flagrante desconformidade com as provas.
+8. A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima revela-se indevida, diante da aus&ecirc;ncia de pedido expresso na den&uacute;ncia, em observ&acirc;ncia ao contradit&oacute;rio e &agrave; ampla defesa.
+
+IV. DISPOSITIVO E TESE
+9. Recursos conhecidos. Recurso ministerial desprovido. Recurso defensivo parcialmente provido para excluir a indeniza&ccedil;&atilde;o fixada.
+Tese de julgamento: 1. A anula&ccedil;&atilde;o de julgamento do Tribunal do J&uacute;ri somente &eacute; cab&iacute;vel quando o veredicto for manifestamente dissociado do conjunto probat&oacute;rio. 2. A exist&ecirc;ncia de vers&otilde;es plaus&iacute;veis e amparadas em prova impede a revis&atilde;o da decis&atilde;o dos jurados. 3. A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima exige pedido expresso na pe&ccedil;a acusat&oacute;ria.
+
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, XXXVIII; CPP, art. 593, III, &quot;d&quot;; CP, arts. 121, &sect;2&ordm;, II, e 14, II.
+
+Jurisprud&ecirc;ncia relevante citada: STF, S&uacute;mula 713; STF, ARE 1225185 (Tema 1087); STJ, AgRg no HC 933.661/PR.
+
+
+
+
+
+
+
+
+
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Apela&ccedil;&atilde;o Criminal n.&ordm; 0004234-25.2017.8.06.0054, em que figuram como recorrentes/recorridos o Minist&eacute;rio P&uacute;blico e Mac&aacute;rio dos Santos Batista.
+
+ACORDAM os Desembargadores integrantes da 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em CONHECER dos recursos, para negar provimento ao apelo do Minist&eacute;rio P&uacute;blico e conceder parcial provimento ao apelo da defesa, para excluir a condena&ccedil;&atilde;o a t&iacute;tulo de indeniza&ccedil;&atilde;o, nos termos do voto do eminente Relator.
+
+Fortaleza, hora e data indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0004234-25.2017.8.06.0054, Rel. Desembargador(a)  FRANCISCO EDUARDO TORQUATO SCORSAFAVA, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 15/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 15/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campos Sales
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRIBUNAL DO JÚRI. DOIS CRIMES. RÉU ABSOLVIDO PELO QUESITO GENÉRICO EM RELAÇÃO AO CRIME DE HOMICÍDIO E CONDENADO EM RELAÇÃO AO CRIME DE TENTATIVA DE HOMICÍDIO QUALIFICADO. RECURSO DO MINISTÉRIO PÚBLICO E DA DEFESA. ALEGAÇÃO DUPLA DE DECISÃO NÃO MANIFESTAMENTE CONTRÁRIA À PROVA DOS AUTOS. NÃO OCORRÊNCIA. SOBERANIA DOS VEREDICTOS. PLEITOS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRIBUNAL DO JÚRI. DOIS CRIMES. RÉU ABSOLVIDO PELO QUESITO GENÉRICO EM RELAÇÃO AO CRIME DE HOMICÍDIO E CONDENADO EM RELAÇÃO AO CRIME DE TENTATIVA DE HOMICÍDIO QUALIFICADO. RECURSO DO MINISTÉRIO PÚBLICO E DA DEFESA. ALEGAÇÃO DUPLA DE DECISÃO NÃO MANIFESTAMENTE CONTRÁRIA À PROVA DOS AUTOS. NÃO OCORRÊNCIA. SOBERANIA DOS VEREDICTOS. PLEITOS SUBSIDIÁRIOS DA DEFESA. DESCLASSIFICAÇÃO PARA LESÃO CORPORAL. IMPOSSIBILIDADE. VONTADE ASSASSINA COMPROVADA NOS AUTOS. EXCLUSÃO DE INDENIZAÇÃO. POSSIBILIDADE. AUSÊNCIA DE PEDIDO EXPRESSO NA DENÚNCIA. RECURSO MINISTERIAL DESPROVIDO E DEFENSIVO PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Apelações criminais interpostas pelo Ministério Público e pela defesa contra sentença do Tribunal do Júri que condenou o réu por tentativa de homicídio qualificado, fixando pena de 6 anos de reclusão, em regime semiaberto, além de indenização mínima de R$ 10.000,00, e absolveu quanto ao homicídio consumado com base em quesito genérico.
+2. O Ministério Público pleiteia a anulação do julgamento por suposta decisão manifestamente contrária à prova dos autos. A defesa requer absolvição, desclassificação da conduta ou exclusão da indenização fixada.
+
+II. QUESTÃO EM DISCUSSÃO
+3. Há três questões em discussão: (i) analisar se a decisão do Tribunal do Júri é manifestamente contrária à prova dos autos; (ii) verificar se é possível a revisão do veredicto absolutório diante da soberania dos jurados; (iii) aferir se é cabível a fixação de indenização mínima sem pedido expresso na denúncia.
+
+III. RAZÕES DE DECIDIR
+4. A apelação fundada no art. 593, III, "d", do CPP exige demonstração inequívoca de que o veredicto apresenta-se completamente dissociado do conjunto probatório, não bastando mera divergência interpretativa.
+5. A soberania dos veredictos (art. 5º, XXXVIII, "c", CF) impede a substituição da decisão dos jurados quando existente suporte probatório para a tese acolhida, ainda que coexistam versões conflitantes.
+6. No caso, há elementos probatórios que sustentam tanto a tese acusatória quanto a defensiva, especialmente quanto à alegação de legítima defesa ou inexigibilidade de conduta diversa, legitimando a opção dos jurados pela absolvição no quesito genérico.
+7. A condenação pela tentativa de homicídio também encontra respaldo no conjunto probatório, não havendo flagrante desconformidade com as provas.
+8. A fixação de indenização mínima revela-se indevida, diante da ausência de pedido expresso na denúncia, em observância ao contraditório e à ampla defesa.
+
+IV. DISPOSITIVO E TESE
+9. Recursos conhecidos. Recurso ministerial desprovido. Recurso defensivo parcialmente provido para excluir a indenização fixada.
+Tese de julgamento: 1. A anulação de julgamento do Tribunal do Júri somente é cabível quando o veredicto for manifestamente dissociado do conjunto probatório. 2. A existência de versões plausíveis e amparadas em prova impede a revisão da decisão dos jurados. 3. A fixação de indenização mínima exige pedido expresso na peça acusatória.
+
+Dispositivos relevantes citados: CF/1988, art. 5º, XXXVIII; CPP, art. 593, III, "d"; CP, arts. 121, §2º, II, e 14, II.
+
+Jurisprudência relevante citada: STF, Súmula 713; STF, ARE 1225185 (Tema 1087); STJ, AgRg no HC 933.661/PR.
+
+
+
+
+
+
+
+
+
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Apelação Criminal n.º 0004234-25.2017.8.06.0054, em que figuram como recorrentes/recorridos o Ministério Público e Macário dos Santos Batista.
+
+ACORDAM os Desembargadores integrantes da 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em CONHECER dos recursos, para negar provimento ao apelo do Ministério Público e conceder parcial provimento ao apelo da defesa, para excluir a condenação a título de indenização, nos termos do voto do eminente Relator.
+
+Fortaleza, hora e data indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833742" cdForo="0" >
+										0025842-97.2024.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833742" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833742);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833742" style="display: none;" >
+	<div id="textAreaDados_3833742" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Otilde;ES CRIMINAIS. ORGANIZA&Ccedil;&Atilde;O CRIMINOSA ARMADA. TR&Aacute;FICO DE DROGAS. PROVA DIGITAL. EXTRA&Ccedil;&Atilde;O DE DADOS DE APARELHO CELULAR. VALIDADE. MATERIALIDADE E AUTORIA COMPROVADAS. MAJORANTES. EMPREGO DE ARMA DE FOGO. CONEX&Atilde;O ENTRE ORGANIZA&Ccedil;&Otilde;ES CRIMINOSAS. DOSIMETRIA. FUNDAMENTA&Ccedil;&Atilde;O ID&Ocirc;NEA. RECURSOS DESPROVIDOS.
+1. Caso em Exame
+Apela&ccedil;&otilde;es criminais interpostas contra senten&ccedil;a que condenou os r&eacute;us pelos crimes de integrar organiza&ccedil;&atilde;o criminosa armada, com conex&atilde;o com outras organiza&ccedil;&otilde;es criminosas (art. 2&ordm;, &sect;&sect; 2&ordm; e 4&ordm;, IV, da Lei n&ordm; 12.850/2013), e, em rela&ccedil;&atilde;o a um dos acusados, tamb&eacute;m pelo crime de tr&aacute;fico de drogas (art. 33 da Lei n&ordm; 11.343/2006), com imposi&ccedil;&atilde;o de penas em regime inicial fechado. Os r&eacute;us pleiteiam absolvi&ccedil;&atilde;o por insufici&ecirc;ncia probat&oacute;ria, afastamento das majorantes e redimensionamento das penas.
+2. Quest&atilde;o em Discuss&atilde;o
+H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) verificar a validade e sufici&ecirc;ncia da prova digital obtida por extra&ccedil;&atilde;o de dados de aparelho celular para comprova&ccedil;&atilde;o da materialidade e autoria; (ii) definir se restou caracterizada a participa&ccedil;&atilde;o dos apelantes em organiza&ccedil;&atilde;o criminosa; (iii) analisar a incid&ecirc;ncia das majorantes do emprego de arma de fogo e da conex&atilde;o com outras organiza&ccedil;&otilde;es criminosas; (iv) examinar a corre&ccedil;&atilde;o da dosimetria da pena e eventual ocorr&ecirc;ncia de bis in idem.
+3. Raz&otilde;es de Decidir
+3.1. A prova digital obtida mediante autoriza&ccedil;&atilde;o judicial, consistente na extra&ccedil;&atilde;o de dados de aparelho celular de lideran&ccedil;a da organiza&ccedil;&atilde;o criminosa, revela-se l&iacute;cita e id&ocirc;nea, inexistindo ind&iacute;cios de viola&ccedil;&atilde;o da cadeia de cust&oacute;dia, sendo corroborada por prova testemunhal e demais elementos dos autos. 3.2. Restou comprovada a ades&atilde;o consciente e volunt&aacute;ria dos apelantes &agrave; organiza&ccedil;&atilde;o criminosa, evidenciada por di&aacute;logos, &aacute;udios e demais registros que demonstram participa&ccedil;&atilde;o ativa na estrutura e nas atividades do grupo, sendo irrelevante a aus&ecirc;ncia de atua&ccedil;&atilde;o direta em atos execut&oacute;rios, por se tratar de crime formal e permanente. 3.3 A condena&ccedil;&atilde;o por tr&aacute;fico de drogas prescinde da apreens&atilde;o de entorpecentes quando existirem outros elementos probat&oacute;rios aptos a demonstrar a mercancia il&iacute;cita, como mensagens e &aacute;udios que evidenciem negocia&ccedil;&atilde;o e circula&ccedil;&atilde;o de drogas. 3.4A majorante do emprego de arma de fogo possui natureza objetiva, sendo suficiente a demonstra&ccedil;&atilde;o de que a organiza&ccedil;&atilde;o criminosa se vale de armamento, independentemente de apreens&atilde;o ou uso direto por cada agente.3.5 A causa de aumento relativa &agrave; conex&atilde;o com outras organiza&ccedil;&otilde;es criminosas restou configurada diante da atua&ccedil;&atilde;o coordenada entre fac&ccedil;&otilde;es distintas, ainda que sem v&iacute;nculo formal, sendo adequada a aplica&ccedil;&atilde;o da fra&ccedil;&atilde;o m&iacute;nima ante a aus&ecirc;ncia de demonstra&ccedil;&atilde;o individualizada de maior envolvimento dos r&eacute;us nessa interface.3.6A dosimetria da pena observou os crit&eacute;rios legais, com fundamenta&ccedil;&atilde;o concreta para a exaspera&ccedil;&atilde;o da pena-base, n&atilde;o se verificando bis in idem, uma vez que as circunst&acirc;ncias judiciais foram valoradas com base em elementos distintos e espec&iacute;ficos do caso concreto.
+4. Dispositivo e Tese Recursos conhecidos e desprovidos.
+Tese de julgamento: &quot;&Eacute; v&aacute;lida a prova obtida por extra&ccedil;&atilde;o de dados de aparelho celular, quando precedida de autoriza&ccedil;&atilde;o judicial e corroborada por outros elementos, sendo suficiente para comprovar a autoria e materialidade dos crimes de organiza&ccedil;&atilde;o criminosa e tr&aacute;fico de drogas; a aus&ecirc;ncia de apreens&atilde;o de entorpecentes n&atilde;o impede a condena&ccedil;&atilde;o por tr&aacute;fico quando demonstrada a mercancia por outros meios; a majorante do emprego de arma de fogo em organiza&ccedil;&atilde;o criminosa prescinde de apreens&atilde;o do armamento, bastando a comprova&ccedil;&atilde;o de seu uso pela estrutura delitiva; e a exaspera&ccedil;&atilde;o da pena-base exige fundamenta&ccedil;&atilde;o concreta e foram devidamente valoradas com base em elementos distintos e espec&iacute;ficos do caso concreto, n&atilde;o se configurando bis in idem.
+Dispositivos Relevantes Citados: Constitui&ccedil;&atilde;o Federal, art. 93, IX; C&oacute;digo Penal, arts. 59 e 68; C&oacute;digo de Processo Penal, arts. 156 e 386; Lei n&ordm; 11.343/2006, art. 33; Lei n&ordm; 12.850/2013, art. 2&ordm;, &sect;&sect; 2&ordm; e 4&ordm;, IV. Jurisprud&ecirc;ncia Relevante Citada: Apela&ccedil;&atilde;o Criminal  0216817-81.2021.8 .06.0001, Rel. Desembargador(a) LIGIA ANDRADE DE ALENCAR MAGALH&Atilde;ES, 1&ordf; C&acirc;mara Criminal, data do julgamento: 20/08/2024, data da publica&ccedil;&atilde;o:&nbsp; 21/08/2024; TJ-CE - Apela&ccedil;&atilde;o Criminal: 02106877520218060001 Fortaleza, Relator.: SILVIA SOARES DE S&Aacute; NOBREGA, Data de Julgamento: 10/02/2026, 4&ordf; C&acirc;mara Criminal, Data de Publica&ccedil;&atilde;o: 10/02/2026; ARE 1.476.455-AgR, Rel. Min. Alexandre de Moraes, Primeira Turma, DJe de 24/04/2024
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em conhecer dos recursos e negar-lhes provimento, nos termos do voto do Relator.
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0025842-97.2024.8.06.0001, Rel. Desembargador(a)  FRANCISCO  JAIME MEDEIROS NETO, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Promoção, constituição, financiamento ou integração de Organização Criminosa
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO  JAIME MEDEIROS NETO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÕES CRIMINAIS. ORGANIZAÇÃO CRIMINOSA ARMADA. TRÁFICO DE DROGAS. PROVA DIGITAL. EXTRAÇÃO DE DADOS DE APARELHO CELULAR. VALIDADE. MATERIALIDADE E AUTORIA COMPROVADAS. MAJORANTES. EMPREGO DE ARMA DE FOGO. CONEXÃO ENTRE ORGANIZAÇÕES CRIMINOSAS. DOSIMETRIA. FUNDAMENTAÇÃO IDÔNEA. RECURSOS DESPROVIDOS.
+1. Caso em Exame
+Apelações criminais interpostas contra
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÕES CRIMINAIS. ORGANIZAÇÃO CRIMINOSA ARMADA. TRÁFICO DE DROGAS. PROVA DIGITAL. EXTRAÇÃO DE DADOS DE APARELHO CELULAR. VALIDADE. MATERIALIDADE E AUTORIA COMPROVADAS. MAJORANTES. EMPREGO DE ARMA DE FOGO. CONEXÃO ENTRE ORGANIZAÇÕES CRIMINOSAS. DOSIMETRIA. FUNDAMENTAÇÃO IDÔNEA. RECURSOS DESPROVIDOS.
+1. Caso em Exame
+Apelações criminais interpostas contra sentença que condenou os réus pelos crimes de integrar organização criminosa armada, com conexão com outras organizações criminosas (art. 2º, §§ 2º e 4º, IV, da Lei nº 12.850/2013), e, em relação a um dos acusados, também pelo crime de tráfico de drogas (art. 33 da Lei nº 11.343/2006), com imposição de penas em regime inicial fechado. Os réus pleiteiam absolvição por insuficiência probatória, afastamento das majorantes e redimensionamento das penas.
+2. Questão em Discussão
+Há quatro questões em discussão: (i) verificar a validade e suficiência da prova digital obtida por extração de dados de aparelho celular para comprovação da materialidade e autoria; (ii) definir se restou caracterizada a participação dos apelantes em organização criminosa; (iii) analisar a incidência das majorantes do emprego de arma de fogo e da conexão com outras organizações criminosas; (iv) examinar a correção da dosimetria da pena e eventual ocorrência de bis in idem.
+3. Razões de Decidir
+3.1. A prova digital obtida mediante autorização judicial, consistente na extração de dados de aparelho celular de liderança da organização criminosa, revela-se lícita e idônea, inexistindo indícios de violação da cadeia de custódia, sendo corroborada por prova testemunhal e demais elementos dos autos. 3.2. Restou comprovada a adesão consciente e voluntária dos apelantes à organização criminosa, evidenciada por diálogos, áudios e demais registros que demonstram participação ativa na estrutura e nas atividades do grupo, sendo irrelevante a ausência de atuação direta em atos executórios, por se tratar de crime formal e permanente. 3.3 A condenação por tráfico de drogas prescinde da apreensão de entorpecentes quando existirem outros elementos probatórios aptos a demonstrar a mercancia ilícita, como mensagens e áudios que evidenciem negociação e circulação de drogas. 3.4A majorante do emprego de arma de fogo possui natureza objetiva, sendo suficiente a demonstração de que a organização criminosa se vale de armamento, independentemente de apreensão ou uso direto por cada agente.3.5 A causa de aumento relativa à conexão com outras organizações criminosas restou configurada diante da atuação coordenada entre facções distintas, ainda que sem vínculo formal, sendo adequada a aplicação da fração mínima ante a ausência de demonstração individualizada de maior envolvimento dos réus nessa interface.3.6A dosimetria da pena observou os critérios legais, com fundamentação concreta para a exasperação da pena-base, não se verificando bis in idem, uma vez que as circunstâncias judiciais foram valoradas com base em elementos distintos e específicos do caso concreto.
+4. Dispositivo e Tese Recursos conhecidos e desprovidos.
+Tese de julgamento: "É válida a prova obtida por extração de dados de aparelho celular, quando precedida de autorização judicial e corroborada por outros elementos, sendo suficiente para comprovar a autoria e materialidade dos crimes de organização criminosa e tráfico de drogas; a ausência de apreensão de entorpecentes não impede a condenação por tráfico quando demonstrada a mercancia por outros meios; a majorante do emprego de arma de fogo em organização criminosa prescinde de apreensão do armamento, bastando a comprovação de seu uso pela estrutura delitiva; e a exasperação da pena-base exige fundamentação concreta e foram devidamente valoradas com base em elementos distintos e específicos do caso concreto, não se configurando bis in idem.
+Dispositivos Relevantes Citados: Constituição Federal, art. 93, IX; Código Penal, arts. 59 e 68; Código de Processo Penal, arts. 156 e 386; Lei nº 11.343/2006, art. 33; Lei nº 12.850/2013, art. 2º, §§ 2º e 4º, IV. Jurisprudência Relevante Citada: Apelação Criminal  0216817-81.2021.8 .06.0001, Rel. Desembargador(a) LIGIA ANDRADE DE ALENCAR MAGALHÃES, 1ª Câmara Criminal, data do julgamento: 20/08/2024, data da publicação:  21/08/2024; TJ-CE - Apelação Criminal: 02106877520218060001 Fortaleza, Relator.: SILVIA SOARES DE SÁ NOBREGA, Data de Julgamento: 10/02/2026, 4ª Câmara Criminal, Data de Publicação: 10/02/2026; ARE 1.476.455-AgR, Rel. Min. Alexandre de Moraes, Primeira Turma, DJe de 24/04/2024
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em conhecer dos recursos e negar-lhes provimento, nos termos do voto do Relator.
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833734" cdForo="0" >
+										0201792-93.2024.8.06.0301
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833734" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833734);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833734" style="display: none;" >
+	<div id="textAreaDados_3833734" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. INJ&Uacute;RIA RACIAL. ALEGA&Ccedil;&Atilde;O DE NULIDADE POR AUS&Ecirc;NCIA DE INCIDENTE DE INSANIDADE MENTAL. INEXIST&Ecirc;NCIA DE D&Uacute;VIDA RAZO&Aacute;VEL. IMPUTABILIDADE MANTIDA. SEMI-IMPUTABILIDADE N&Atilde;O CONFIGURADA. AGRAVANTE DO ART. 61, II, &quot;G&quot;, DO CP. PROFESSOR. AMBIENTE ESCOLAR. MANUTEN&Ccedil;&Atilde;O. DOSIMETRIA. PENA ACIMA DO M&Iacute;NIMO LEGAL JUSTIFICADA. SUBSTITUI&Ccedil;&Atilde;O DA PENA. INVIABILIDADE. INDENIZA&Ccedil;&Atilde;O M&Iacute;NIMA. REDU&Ccedil;&Atilde;O. CONDI&Ccedil;&Otilde;ES DO REGIME ABERTO. CURSO DE TEM&Aacute;TICA RACIAL. ADEQUA&Ccedil;&Atilde;O. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME:
+1. Trata-se de Apela&ccedil;&atilde;o Criminal interposta por Francisco Gilberto Coelho Filipe contra senten&ccedil;a que o condenou pela pr&aacute;tica do crime de inj&uacute;ria racial (art. 2&ordm;-A da Lei n&ordm; 7.716/1989), &agrave; pena de 2 anos e 8 meses de reclus&atilde;o e 10 dias-multa, insurgindo-se quanto &agrave; nulidade por aus&ecirc;ncia de incidente de insanidade mental, reconhecimento de inimputabilidade ou semi-imputabilidade, afastamento de agravante, revis&atilde;o da dosimetria, substitui&ccedil;&atilde;o da pena, redu&ccedil;&atilde;o da indeniza&ccedil;&atilde;o e exclus&atilde;o de condi&ccedil;&otilde;es impostas no regime aberto.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O:
+2. H&aacute; seis quest&otilde;es em discuss&atilde;o: (i) definir se a aus&ecirc;ncia de instaura&ccedil;&atilde;o de incidente de insanidade mental gera nulidade processual; (ii) estabelecer se &eacute; cab&iacute;vel o reconhecimento da inimputabilidade ou semi-imputabilidade do r&eacute;u; (iii) verificar a incid&ecirc;ncia da agravante do art. 61, II, &quot;g&quot;, do C&oacute;digo Penal; (iv) analisar a adequa&ccedil;&atilde;o da dosimetria da pena e a possibilidade de fixa&ccedil;&atilde;o no m&iacute;nimo legal; (v) determinar a possibilidade de substitui&ccedil;&atilde;o da pena privativa de liberdade por restritivas de direitos; (vi) examinar a revis&atilde;o da indeniza&ccedil;&atilde;o m&iacute;nima e a legalidade das condi&ccedil;&otilde;es impostas no regime aberto.
+III. RAZ&Otilde;ES DE DECIDIR:
+3. A instaura&ccedil;&atilde;o do incidente de insanidade mental exige d&uacute;vida razo&aacute;vel acerca da integridade ps&iacute;quica do acusado, inexistente quando o conjunto probat&oacute;rio demonstra capacidade de compreens&atilde;o e autodetermina&ccedil;&atilde;o ao tempo dos fatos.
+4. A mera exist&ecirc;ncia de transtornos psiqui&aacute;tricos, desacompanhada de prova de incapacidade total ou relevante comprometimento das faculdades mentais, n&atilde;o afasta a imputabilidade penal nem autoriza o reconhecimento da semi-imputabilidade.
+5. A conduta consciente, direcionada e dotada de conte&uacute;do discriminat&oacute;rio, inclusive confessada pelo r&eacute;u, evidencia plena capacidade de entendimento da ilicitude do fato.
+6. Incide a agravante do art. 61, II, &quot;g&quot;, do C&oacute;digo Penal quando o agente, na condi&ccedil;&atilde;o de professor, pratica o delito em ambiente escolar, violando dever inerente &agrave; fun&ccedil;&atilde;o e ampliando a reprovabilidade da conduta.
+7. A fixa&ccedil;&atilde;o da pena-base acima do m&iacute;nimo legal &eacute; leg&iacute;tima quando fundamentada em circunst&acirc;ncias judiciais desfavor&aacute;veis, especialmente culpabilidade acentuada e consequ&ecirc;ncias concretas do crime.
+8. A substitui&ccedil;&atilde;o da pena privativa de liberdade por restritivas de direitos n&atilde;o se mostra adequada quando as circunst&acirc;ncias do caso evidenciam elevada gravidade concreta e insufici&ecirc;ncia da medida alternativa.
+9. A indeniza&ccedil;&atilde;o m&iacute;nima por danos morais deve observar os princ&iacute;pios da proporcionalidade e razoabilidade, sendo poss&iacute;vel sua redu&ccedil;&atilde;o quando excessiva em rela&ccedil;&atilde;o &agrave;s circunst&acirc;ncias do caso.
+10. A imposi&ccedil;&atilde;o de condi&ccedil;&atilde;o especial no regime aberto, consistente na participa&ccedil;&atilde;o em curso de tem&aacute;tica racial, &eacute; v&aacute;lida quando possui car&aacute;ter pedag&oacute;gico e rela&ccedil;&atilde;o com a natureza do delito.
+IV. DISPOSITIVO:
+11. Recurso parcialmente provido.
+Tese de julgamento: 1. A instaura&ccedil;&atilde;o do incidente de insanidade mental depende da exist&ecirc;ncia de d&uacute;vida razo&aacute;vel fundada em elementos concretos sobre a incapacidade ps&iacute;quica do acusado; 2. A comprova&ccedil;&atilde;o de transtornos mentais, sem demonstra&ccedil;&atilde;o de incapacidade ou redu&ccedil;&atilde;o significativa da autodetermina&ccedil;&atilde;o, n&atilde;o autoriza o reconhecimento de inimputabilidade ou semi-imputabilidade; 3. Incide a agravante do art. 61, II, &quot;g&quot;, do C&oacute;digo Penal quando o agente viola dever funcional em ambiente institucional relacionado ao exerc&iacute;cio de sua profiss&atilde;o; 4. A fixa&ccedil;&atilde;o da pena acima do m&iacute;nimo legal &eacute; v&aacute;lida quando baseada em circunst&acirc;ncias judiciais desfavor&aacute;veis devidamente fundamentadas; 5. A substitui&ccedil;&atilde;o da pena privativa de liberdade exige sufici&ecirc;ncia da medida alternativa, podendo ser afastada diante da gravidade concreta do delito; 6. A indeniza&ccedil;&atilde;o m&iacute;nima pode ser revista para adequa&ccedil;&atilde;o aos princ&iacute;pios da proporcionalidade e razoabilidade; 7. &Eacute; leg&iacute;tima a imposi&ccedil;&atilde;o de condi&ccedil;&otilde;es especiais no regime aberto com finalidade pedag&oacute;gica e ressocializadora, compat&iacute;veis com a natureza do crime.
+
+Dispositivos legais relevantes citados: CP, arts. 26, caput e par&aacute;grafo &uacute;nico, 44, 59 e 61, II, &quot;g&quot;; CPP, arts. 149 e 387, IV; Lei n&ordm; 7.716/1989, art. 2&ordm;-A; LEP, art. 115.
+Jurisprud&ecirc;ncia relevante citada: TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0003497-55.2019.8.06.0182, Rel. Des. Vanja Fontenele Pontes, j. 10/02/2026; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0043442-68.2023.8.06.0001, Rel. Des. M&aacute;rio Parente Te&oacute;filo Neto, j. 13/05/2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0201741-76.2024.8.06.0303, Rel. Des. Lira Ramos de Oliveira, j. 10/02/2026; STJ, AgRg no REsp 2058428/MG, Rel. Min. Jesu&iacute;no Rissato, j. 20/05/2024.
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, em CONHECER DO RECURSO, para DAR-LHE PARCIAL PROVIMENTO, nos termos do voto do relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0201792-93.2024.8.06.0301, Rel. Desembargador(a)  FRANCISCO  JAIME MEDEIROS NETO, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Intolerância e/ou Injúria Racial, de Cor e/ou Etnia
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO  JAIME MEDEIROS NETO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Jardim
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. INJÚRIA RACIAL. ALEGAÇÃO DE NULIDADE POR AUSÊNCIA DE INCIDENTE DE INSANIDADE MENTAL. INEXISTÊNCIA DE DÚVIDA RAZOÁVEL. IMPUTABILIDADE MANTIDA. SEMI-IMPUTABILIDADE NÃO CONFIGURADA. AGRAVANTE DO ART. 61, II, "G", DO CP. PROFESSOR. AMBIENTE ESCOLAR. MANUTENÇÃO. DOSIMETRIA. PENA ACIMA DO MÍNIMO LEGAL JUSTIFICADA. SUBSTITUIÇÃO DA PENA. INVIABILIDADE.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. INJÚRIA RACIAL. ALEGAÇÃO DE NULIDADE POR AUSÊNCIA DE INCIDENTE DE INSANIDADE MENTAL. INEXISTÊNCIA DE DÚVIDA RAZOÁVEL. IMPUTABILIDADE MANTIDA. SEMI-IMPUTABILIDADE NÃO CONFIGURADA. AGRAVANTE DO ART. 61, II, "G", DO CP. PROFESSOR. AMBIENTE ESCOLAR. MANUTENÇÃO. DOSIMETRIA. PENA ACIMA DO MÍNIMO LEGAL JUSTIFICADA. SUBSTITUIÇÃO DA PENA. INVIABILIDADE. INDENIZAÇÃO MÍNIMA. REDUÇÃO. CONDIÇÕES DO REGIME ABERTO. CURSO DE TEMÁTICA RACIAL. ADEQUAÇÃO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME:
+1. Trata-se de Apelação Criminal interposta por Francisco Gilberto Coelho Filipe contra sentença que o condenou pela prática do crime de injúria racial (art. 2º-A da Lei nº 7.716/1989), à pena de 2 anos e 8 meses de reclusão e 10 dias-multa, insurgindo-se quanto à nulidade por ausência de incidente de insanidade mental, reconhecimento de inimputabilidade ou semi-imputabilidade, afastamento de agravante, revisão da dosimetria, substituição da pena, redução da indenização e exclusão de condições impostas no regime aberto.
+II. QUESTÃO EM DISCUSSÃO:
+2. Há seis questões em discussão: (i) definir se a ausência de instauração de incidente de insanidade mental gera nulidade processual; (ii) estabelecer se é cabível o reconhecimento da inimputabilidade ou semi-imputabilidade do réu; (iii) verificar a incidência da agravante do art. 61, II, "g", do Código Penal; (iv) analisar a adequação da dosimetria da pena e a possibilidade de fixação no mínimo legal; (v) determinar a possibilidade de substituição da pena privativa de liberdade por restritivas de direitos; (vi) examinar a revisão da indenização mínima e a legalidade das condições impostas no regime aberto.
+III. RAZÕES DE DECIDIR:
+3. A instauração do incidente de insanidade mental exige dúvida razoável acerca da integridade psíquica do acusado, inexistente quando o conjunto probatório demonstra capacidade de compreensão e autodeterminação ao tempo dos fatos.
+4. A mera existência de transtornos psiquiátricos, desacompanhada de prova de incapacidade total ou relevante comprometimento das faculdades mentais, não afasta a imputabilidade penal nem autoriza o reconhecimento da semi-imputabilidade.
+5. A conduta consciente, direcionada e dotada de conteúdo discriminatório, inclusive confessada pelo réu, evidencia plena capacidade de entendimento da ilicitude do fato.
+6. Incide a agravante do art. 61, II, "g", do Código Penal quando o agente, na condição de professor, pratica o delito em ambiente escolar, violando dever inerente à função e ampliando a reprovabilidade da conduta.
+7. A fixação da pena-base acima do mínimo legal é legítima quando fundamentada em circunstâncias judiciais desfavoráveis, especialmente culpabilidade acentuada e consequências concretas do crime.
+8. A substituição da pena privativa de liberdade por restritivas de direitos não se mostra adequada quando as circunstâncias do caso evidenciam elevada gravidade concreta e insuficiência da medida alternativa.
+9. A indenização mínima por <em>danos</em> <em>morais</em> deve observar os princípios da proporcionalidade e razoabilidade, sendo possível sua redução quando excessiva em relação às circunstâncias do caso.
+10. A imposição de condição especial no regime aberto, consistente na participação em curso de temática racial, é válida quando possui caráter pedagógico e relação com a natureza do delito.
+IV. DISPOSITIVO:
+11. Recurso parcialmente provido.
+Tese de julgamento: 1. A instauração do incidente de insanidade mental depende da existência de dúvida razoável fundada em elementos concretos sobre a incapacidade psíquica do acusado; 2. A comprovação de transtornos mentais, sem demonstração de incapacidade ou redução significativa da autodeterminação, não autoriza o reconhecimento de inimputabilidade ou semi-imputabilidade; 3. Incide a agravante do art. 61, II, "g", do Código Penal quando o agente viola dever funcional em ambiente institucional relacionado ao exercício de sua profissão; 4. A fixação da pena acima do mínimo legal é válida quando baseada em circunstâncias judiciais desfavoráveis devidamente fundamentadas; 5. A substituição da pena privativa de liberdade exige suficiência da medida alternativa, podendo ser afastada diante da gravidade concreta do delito; 6. A indenização mínima pode ser revista para adequação aos princípios da proporcionalidade e razoabilidade; 7. É legítima a imposição de condições especiais no regime aberto com finalidade pedagógica e ressocializadora, compatíveis com a natureza do crime.
+
+Dispositivos legais relevantes citados: CP, arts. 26, caput e parágrafo único, 44, 59 e 61, II, "g"; CPP, arts. 149 e 387, IV; Lei nº 7.716/1989, art. 2º-A; LEP, art. 115.
+Jurisprudência relevante citada: TJCE, Apelação Criminal nº 0003497-55.2019.8.06.0182, Rel. Des. Vanja Fontenele Pontes, j. 10/02/2026; TJCE, Apelação Criminal nº 0043442-68.2023.8.06.0001, Rel. Des. Mário Parente Teófilo Neto, j. 13/05/2025; TJCE, Apelação Criminal nº 0201741-76.2024.8.06.0303, Rel. Des. Lira Ramos de Oliveira, j. 10/02/2026; STJ, AgRg no REsp 2058428/MG, Rel. Min. Jesuíno Rissato, j. 20/05/2024.
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, em CONHECER DO RECURSO, para DAR-LHE PARCIAL PROVIMENTO, nos termos do voto do relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833735" cdForo="0" >
+										0204305-37.2024.8.06.0300
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833735" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833735);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833735" style="display: none;" >
+	<div id="textAreaDados_3833735" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TR&Aacute;FICO IL&Iacute;CITO DE ENTORPECENTES (ART. 33, CAPUT, DA LEI N&ordm; 11.343/2006). PRELIMINARES DE NULIDADE DA PROVA. ALEGA&Ccedil;&Atilde;O DE VIOL&Ecirc;NCIA POLICIAL NO MOMENTO DA ABORDAGEM. INEXIST&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O ID&Ocirc;NEA. LAUDO DE EXAME DE CORPO DE DELITO QUE REGISTRA ESCORIA&Ccedil;&Atilde;O LEVE COMPAT&Iacute;VEL COM ARRANH&Otilde;ES SOFRIDOS DURANTE A FUGA. DECLARA&Ccedil;&Atilde;O DO PR&Oacute;PRIO ACUSADO EM AUDI&Ecirc;NCIA DE CUST&Oacute;DIA NO SENTIDO DE QUE N&Atilde;O SOFREU AGRESS&Otilde;ES. AUS&Ecirc;NCIA DE CONTAMINA&Ccedil;&Atilde;O DA CADEIA PROBAT&Oacute;RIA. ALEGA&Ccedil;&Atilde;O DE INOBSERV&Acirc;NCIA DO DIREITO AO SIL&Ecirc;NCIO. SUPOSTA CONFISS&Atilde;O INFORMAL N&Atilde;O ERIGIDA A FUNDAMENTO EXCLUSIVO OU DETERMINANTE DA CONDENA&Ccedil;&Atilde;O. DEPOIMENTOS POLICIAIS COLHIDOS SOB O CRIVO DO CONTRADIT&Oacute;RIO E CORROBORADOS POR ELEMENTOS OBJETIVOS DE APREENS&Atilde;O. AUS&Ecirc;NCIA DE DEMONSTRA&Ccedil;&Atilde;O DE PREJU&Iacute;ZO. ART. 563 DO CPP. MATERIALIDADE E AUTORIA COMPROVADAS. FLAGRANTE AP&Oacute;S INFORMA&Ccedil;&Atilde;O DE DISPAROS DE ARMA DE FOGO EM VIA P&Uacute;BLICA. VISUALIZA&Ccedil;&Atilde;O DO ACUSADO EMBALANDO DROGAS EM LOGRADOURO P&Uacute;BLICO. FUGA PARA O MATAGAL E POSTERIOR CAPTURA. APREENS&Atilde;O DE EXPRESSIVA QUANTIDADE E VARIEDADE DE ENTORPECENTES, COM DROGAS FRACIONADAS E TAMB&Eacute;M ACONDICIONADAS EM TABLETES. APREENS&Atilde;O DE CRACK, COCA&Iacute;NA E MACONHA. LOCALIZA&Ccedil;&Atilde;O DE BALAN&Ccedil;A DE PRECIS&Atilde;O, SACOS PL&Aacute;STICOS UTILIZADOS PARA EMBALAGEM E APARELHOS CELULARES. CONTEXTO F&Aacute;TICO INCOMPAT&Iacute;VEL COM USO PESSOAL E REVELADOR DE MERCANCIA IL&Iacute;CITA. RELEV&Acirc;NCIA PROBAT&Oacute;RIA DA PALAVRA DOS POLICIAIS QUANDO HARM&Ocirc;NICA ENTRE SI E EM CONSON&Acirc;NCIA COM O ACERVO MATERIAL DOS AUTOS. TR&Aacute;FICO PRIVILEGIADO. INAPLICABILIDADE DA CAUSA DE DIMINUI&Ccedil;&Atilde;O DO ART. 33, &sect; 4&ordm;, DA LEI N&ordm; 11.343/2006. IMPOSSIBILIDADE DE AFASTAR A MINORANTE COM BASE EXCLUSIVA EM PROCESSOS EM CURSO. TEMA 1139 DO STJ. MANUTEN&Ccedil;&Atilde;O, TODAVIA, DO AFASTAMENTO DA BENESSE POR FUNDAMENTO CONCRETO EXTRA&Iacute;DO DAS CIRCUNST&Acirc;NCIAS DO CASO. QUANTIDADE, NATUREZA, VARIEDADE E FORMA DE ACONDICIONAMENTO DAS DROGAS, ALIADAS &Agrave; APREENS&Atilde;O DE APETRECHOS T&Iacute;PICOS DA TRAFIC&Acirc;NCIA, QUE EVIDENCIAM DEDICA&Ccedil;&Atilde;O A ATIVIDADES CRIMINOSAS. DOSIMETRIA DA PENA. AFASTAMENTO DA VALORA&Ccedil;&Atilde;O NEGATIVA DA CONDUTA SOCIAL. INVIABILIDADE DE UTILIZA&Ccedil;&Atilde;O DE REGISTROS PROCESSUAIS SEM TR&Acirc;NSITO EM JULGADO PARA DESABONAR VETORIAL DO ART. 59 DO CP. MANUTEN&Ccedil;&Atilde;O DA VALORA&Ccedil;&Atilde;O NEGATIVA DAS CIRCUNST&Acirc;NCIAS DO CRIME. TR&Aacute;FICO PRATICADO DE FORMA OSTENSIVA EM VIA P&Uacute;BLICA, COM FRACIONAMENTO E EMBALAGEM DO ENTORPECENTE PARA COMERCIALIZA&Ccedil;&Atilde;O. NECESSIDADE DE REDIMENSIONAMENTO DA PENA-BASE POR AUS&Ecirc;NCIA DE FUNDAMENTA&Ccedil;&Atilde;O ESPEC&Iacute;FICA QUANTO AO QUANTUM DE EXASPERA&Ccedil;&Atilde;O. READEQUA&Ccedil;&Atilde;O DA REPRIMENDA PARA 6 ANOS E 3 MESES DE RECLUS&Atilde;O E 625 DIAS-MULTA. MANUTEN&Ccedil;&Atilde;O DO REGIME INICIAL FECHADO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta por r&eacute;u condenado pela pr&aacute;tica do crime do art. 33, caput, da Lei n&ordm; 11.343/2006, &agrave; pena de 8 anos e 4 meses de reclus&atilde;o e 680 dias-multa, em regime inicial fechado. A defesa suscita, preliminarmente, a nulidade das provas por suposta viol&ecirc;ncia policial e por alegada inobserv&acirc;ncia do direito ao sil&ecirc;ncio no momento da abordagem. No m&eacute;rito, requer a incid&ecirc;ncia da causa de diminui&ccedil;&atilde;o do art. 33, &sect; 4&ordm;, da Lei n&ordm; 11.343/2006, a revis&atilde;o da dosimetria da pena, com fixa&ccedil;&atilde;o da pena-base no m&iacute;nimo legal, e a readequa&ccedil;&atilde;o do regime inicial. Consta dos autos que o apelante foi preso em flagrante ap&oacute;s ser visualizado por policiais militares embalando drogas em via p&uacute;blica, sendo apreendidos entorpecentes de naturezas diversas, j&aacute; fracionados, al&eacute;m de balan&ccedil;a de precis&atilde;o, sacos pl&aacute;sticos e dois aparelhos celulares.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se as provas devem ser declaradas il&iacute;citas em raz&atilde;o de suposta viol&ecirc;ncia policial e contamina&ccedil;&atilde;o da cadeia probat&oacute;ria; (ii) estabelecer se houve nulidade por inobserv&acirc;ncia do direito ao sil&ecirc;ncio no momento da abordagem policial; (iii) determinar se est&atilde;o presentes os requisitos para a incid&ecirc;ncia da causa especial de diminui&ccedil;&atilde;o prevista no art. 33, &sect; 4&ordm;, da Lei n&ordm; 11.343/2006; e (iv) verificar se a pena-base foi fixada com fundamenta&ccedil;&atilde;o id&ocirc;nea e proporcional.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O laudo de exame de corpo de delito registra apenas escoria&ccedil;&atilde;o linear na coxa esquerda e consigna que o pr&oacute;prio periciando relatou ter se arranhado durante a fuga, sem indica&ccedil;&atilde;o de agress&atilde;o policial.
+4. O acusado declarou em audi&ecirc;ncia de cust&oacute;dia que n&atilde;o sofreu viol&ecirc;ncia policial, inexistindo registro contempor&acirc;neo de abuso estatal, o que enfraquece a alega&ccedil;&atilde;o defensiva posterior.
+5. A nulidade por viol&ecirc;ncia policial exige demonstra&ccedil;&atilde;o concreta de ilicitude e de preju&iacute;zo, n&atilde;o bastando alega&ccedil;&atilde;o unilateral dissociada do laudo pericial e dos demais elementos dos autos.
+6. Os depoimentos judiciais dos policiais n&atilde;o revelam que a condena&ccedil;&atilde;o se funde em confiss&atilde;o informal obtida na abordagem, mas em elementos objetivos, como a visualiza&ccedil;&atilde;o do r&eacute;u embalando drogas, a fuga e a apreens&atilde;o dos entorpecentes e apetrechos.
+7. A exig&ecirc;ncia de advert&ecirc;ncia formal sobre o direito ao sil&ecirc;ncio no momento da abordagem policial n&atilde;o encontra, at&eacute; o momento, defini&ccedil;&atilde;o vinculante do Supremo Tribunal Federal, e a jurisprud&ecirc;ncia citada do Superior Tribunal de Justi&ccedil;a admite que tal provid&ecirc;ncia &eacute; exigida especificamente nos interrogat&oacute;rios policial e judicial.
+8. Ainda que se cogitasse irregularidade na abordagem, a defesa n&atilde;o demonstra qual elemento probat&oacute;rio decisivo teria sido produzido por viola&ccedil;&atilde;o direta ao direito ao sil&ecirc;ncio, nem preju&iacute;zo concreto, nos termos do art. 563 do C&oacute;digo de Processo Penal.
+9. O afastamento do tr&aacute;fico privilegiado n&atilde;o pode apoiar-se apenas em processos em andamento, medidas cautelares ou recursos sem tr&acirc;nsito em julgado, em respeito ao princ&iacute;pio da presun&ccedil;&atilde;o de inoc&ecirc;ncia e ao entendimento firmado no Tema 1139 do Superior Tribunal de Justi&ccedil;a.
+10. O Tribunal pode manter o afastamento da minorante por fundamenta&ccedil;&atilde;o id&ocirc;nea extra&iacute;da dos elementos concretos dos autos, sem reformatio in pejus, &agrave; luz do Tema 1214 do Superior Tribunal de Justi&ccedil;a e da S&uacute;mula 55 do TJCE.
+11. A expressiva quantidade e variedade de drogas apreendidas, o fracionamento em m&uacute;ltiplas por&ccedil;&otilde;es, a apreens&atilde;o de balan&ccedil;a de precis&atilde;o, sacos pl&aacute;sticos para embalagem e aparelhos celulares evidenciam dedica&ccedil;&atilde;o a atividades criminosas e afastam o perfil de traficante eventual.
+12. A conduta social n&atilde;o se confunde com antecedentes criminais nem com registros de processos em andamento, de modo que sua valora&ccedil;&atilde;o negativa com base em &quot;passagens&quot; e a&ccedil;&otilde;es penais sem tr&acirc;nsito em julgado viola a t&eacute;cnica do art. 59 do C&oacute;digo Penal e o princ&iacute;pio da presun&ccedil;&atilde;o de inoc&ecirc;ncia.
+13. A circunst&acirc;ncia judicial relativa &agrave;s circunst&acirc;ncias do fato pode ser negativamente valorada quando o r&eacute;u pratica o tr&aacute;fico de forma ostensiva em via p&uacute;blica, fracionando e embalando entorpecente para comercializa&ccedil;&atilde;o, circunst&acirc;ncia concreta que extrapola a normalidade do tipo penal.
+14. A fixa&ccedil;&atilde;o da pena-base exige motiva&ccedil;&atilde;o proporcional e individualizada quanto ao quantum de exaspera&ccedil;&atilde;o, raz&atilde;o pela qual, afastada a valora&ccedil;&atilde;o negativa da conduta social e remanescendo apenas uma vetorial desfavor&aacute;vel, imp&otilde;e-se o redimensionamento da reprimenda.
+15. Aplicado o crit&eacute;rio de 1/8 da diferen&ccedil;a entre as penas m&iacute;nima e m&aacute;xima cominadas ao art. 33, caput, da Lei n&ordm; 11.343/2006, a pena-base deve ser fixada em 6 anos e 3 meses de reclus&atilde;o e 625 dias-multa, patamar mantido nas fases subsequentes por aus&ecirc;ncia de agravantes, atenuantes e causas modificadoras.
+16. O regime inicial fechado &eacute; mantido em raz&atilde;o da exist&ecirc;ncia de circunst&acirc;ncia judicial desfavor&aacute;vel, nos termos do art. 33, &sect;&sect; 2&ordm; e 3&ordm;, do C&oacute;digo Penal.
+IV. DISPOSITIVO E TESE
+16. Recurso conhecido e parcialmente provido.
+
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, LXIII. CPP, arts. 157, 186 e 563. CP, arts. 33, &sect; 2&ordm;, b, &sect; 3&ordm;, 59, 61, 62 e 65. Lei n&ordm; 11.343/2006, arts. 33, caput e &sect; 4&ordm;, e 42.
+Jurisprud&ecirc;ncia relevante citada: STF, RE 1.177.984 (Tema 1.185 da repercuss&atilde;o geral), Rel. Min. Edson Fachin, Tribunal Pleno, j. 02.12.2021, DJe 03.02.2022. STJ, Tema 1139. STJ, Tema 1214. STJ, AgRg no HC 809.283/GO, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, j. 22.05.2023, DJe 24.05.2023. STJ, AgRg no HC 978.083/SP, Rel. Min. Messod Azulay Neto, Quinta Turma, j. 10.06.2025, DJEN 18.06.2025. STJ, AgRg no AREsp 2.676.524/SP, Rel. Min. Messod Azulay Neto, Quinta Turma, j. 18.02.2025, DJEN 25.02.2025. STJ, AgRg no HC 888.851/ES, Rel. Min. Og Fernandes, Sexta Turma, j. 19.02.2025, DJEN 24.02.2025. TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0204129-98.2023.8.06.0298, Rel. Des. Cid Peixoto do Amaral Neto, 3&ordf; C&acirc;mara Criminal, j. 03.02.2026. TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0218279-34.2025.8.06.0001, Rel. Desa. Vanja Fontenele Pontes, 4&ordf; C&acirc;mara Criminal, j. 10.02.2026. TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0206602-07.2025.8.06.0001, Rel. Des. Francisco Eduardo Torquato Scorsafava, 2&ordf; C&acirc;mara Criminal, j. 04.02.2026. TJCE, S&uacute;mula 55.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER do presente recurso para DAR-LHE PARCIAL PROVIMENTO, nos termos do voto do Relator.
+
+Fortaleza, data e hora da assinatura digital.
+
+DESEMBARGADORA S&Iacute;LVIA SOARES DE S&Aacute; N&Oacute;BREGA
+Presidente do &Oacute;rg&atilde;o Julgador
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0204305-37.2024.8.06.0300, Rel. Desembargador(a)  FRANCISCO  JAIME MEDEIROS NETO, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO  JAIME MEDEIROS NETO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Horizonte
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO ILÍCITO DE ENTORPECENTES (ART. 33, CAPUT, DA LEI Nº 11.343/2006). PRELIMINARES DE NULIDADE DA PROVA. ALEGAÇÃO DE VIOLÊNCIA POLICIAL NO MOMENTO DA ABORDAGEM. INEXISTÊNCIA DE COMPROVAÇÃO IDÔNEA. LAUDO DE EXAME DE CORPO DE DELITO QUE REGISTRA ESCORIAÇÃO LEVE COMPATÍVEL COM ARRANHÕES SOFRIDOS DURANTE A FUGA. DECLARAÇÃO DO PRÓPRIO ACUSADO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO ILÍCITO DE ENTORPECENTES (ART. 33, CAPUT, DA LEI Nº 11.343/2006). PRELIMINARES DE NULIDADE DA PROVA. ALEGAÇÃO DE VIOLÊNCIA POLICIAL NO MOMENTO DA ABORDAGEM. INEXISTÊNCIA DE COMPROVAÇÃO IDÔNEA. LAUDO DE EXAME DE CORPO DE DELITO QUE REGISTRA ESCORIAÇÃO LEVE COMPATÍVEL COM ARRANHÕES SOFRIDOS DURANTE A FUGA. DECLARAÇÃO DO PRÓPRIO ACUSADO EM AUDIÊNCIA DE CUSTÓDIA NO SENTIDO DE QUE NÃO SOFREU AGRESSÕES. AUSÊNCIA DE CONTAMINAÇÃO DA CADEIA PROBATÓRIA. ALEGAÇÃO DE INOBSERVÂNCIA DO DIREITO AO SILÊNCIO. SUPOSTA CONFISSÃO INFORMAL NÃO ERIGIDA A FUNDAMENTO EXCLUSIVO OU DETERMINANTE DA CONDENAÇÃO. DEPOIMENTOS POLICIAIS COLHIDOS SOB O CRIVO DO CONTRADITÓRIO E CORROBORADOS POR ELEMENTOS OBJETIVOS DE APREENSÃO. AUSÊNCIA DE DEMONSTRAÇÃO DE PREJUÍZO. ART. 563 DO CPP. MATERIALIDADE E AUTORIA COMPROVADAS. FLAGRANTE APÓS INFORMAÇÃO DE DISPAROS DE ARMA DE FOGO EM VIA PÚBLICA. VISUALIZAÇÃO DO ACUSADO EMBALANDO DROGAS EM LOGRADOURO PÚBLICO. FUGA PARA O MATAGAL E POSTERIOR CAPTURA. APREENSÃO DE EXPRESSIVA QUANTIDADE E VARIEDADE DE ENTORPECENTES, COM DROGAS FRACIONADAS E TAMBÉM ACONDICIONADAS EM TABLETES. APREENSÃO DE CRACK, COCAÍNA E MACONHA. LOCALIZAÇÃO DE BALANÇA DE PRECISÃO, SACOS PLÁSTICOS UTILIZADOS PARA EMBALAGEM E APARELHOS CELULARES. CONTEXTO FÁTICO INCOMPATÍVEL COM USO PESSOAL E REVELADOR DE MERCANCIA ILÍCITA. RELEVÂNCIA PROBATÓRIA DA PALAVRA DOS POLICIAIS QUANDO HARMÔNICA ENTRE SI E EM CONSONÂNCIA COM O ACERVO MATERIAL DOS AUTOS. TRÁFICO PRIVILEGIADO. INAPLICABILIDADE DA CAUSA DE DIMINUIÇÃO DO ART. 33, § 4º, DA LEI Nº 11.343/2006. IMPOSSIBILIDADE DE AFASTAR A MINORANTE COM BASE EXCLUSIVA EM PROCESSOS EM CURSO. TEMA 1139 DO STJ. MANUTENÇÃO, TODAVIA, DO AFASTAMENTO DA BENESSE POR FUNDAMENTO CONCRETO EXTRAÍDO DAS CIRCUNSTÂNCIAS DO CASO. QUANTIDADE, NATUREZA, VARIEDADE E FORMA DE ACONDICIONAMENTO DAS DROGAS, ALIADAS À APREENSÃO DE APETRECHOS TÍPICOS DA TRAFICÂNCIA, QUE EVIDENCIAM DEDICAÇÃO A ATIVIDADES CRIMINOSAS. DOSIMETRIA DA PENA. AFASTAMENTO DA VALORAÇÃO NEGATIVA DA CONDUTA SOCIAL. INVIABILIDADE DE UTILIZAÇÃO DE REGISTROS PROCESSUAIS SEM TRÂNSITO EM JULGADO PARA DESABONAR VETORIAL DO ART. 59 DO CP. MANUTENÇÃO DA VALORAÇÃO NEGATIVA DAS CIRCUNSTÂNCIAS DO CRIME. TRÁFICO PRATICADO DE FORMA OSTENSIVA EM VIA PÚBLICA, COM FRACIONAMENTO E EMBALAGEM DO ENTORPECENTE PARA COMERCIALIZAÇÃO. NECESSIDADE DE REDIMENSIONAMENTO DA PENA-BASE POR AUSÊNCIA DE FUNDAMENTAÇÃO ESPECÍFICA QUANTO AO QUANTUM DE EXASPERAÇÃO. READEQUAÇÃO DA REPRIMENDA PARA 6 ANOS E 3 MESES DE RECLUSÃO E 625 DIAS-MULTA. MANUTENÇÃO DO REGIME INICIAL FECHADO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta por réu condenado pela prática do crime do art. 33, caput, da Lei nº 11.343/2006, à pena de 8 anos e 4 meses de reclusão e 680 dias-multa, em regime inicial fechado. A defesa suscita, preliminarmente, a nulidade das provas por suposta violência policial e por alegada inobservância do direito ao silêncio no momento da abordagem. No mérito, requer a incidência da causa de diminuição do art. 33, § 4º, da Lei nº 11.343/2006, a revisão da dosimetria da pena, com fixação da pena-base no mínimo legal, e a readequação do regime inicial. Consta dos autos que o apelante foi preso em flagrante após ser visualizado por policiais militares embalando drogas em via pública, sendo apreendidos entorpecentes de naturezas diversas, já fracionados, além de balança de precisão, sacos plásticos e dois aparelhos celulares.
+II. QUESTÃO EM DISCUSSÃO
+2. Há quatro questões em discussão: (i) definir se as provas devem ser declaradas ilícitas em razão de suposta violência policial e contaminação da cadeia probatória; (ii) estabelecer se houve nulidade por inobservância do direito ao silêncio no momento da abordagem policial; (iii) determinar se estão presentes os requisitos para a incidência da causa especial de diminuição prevista no art. 33, § 4º, da Lei nº 11.343/2006; e (iv) verificar se a pena-base foi fixada com fundamentação idônea e proporcional.
+III. RAZÕES DE DECIDIR
+3. O laudo de exame de corpo de delito registra apenas escoriação linear na coxa esquerda e consigna que o próprio periciando relatou ter se arranhado durante a fuga, sem indicação de agressão policial.
+4. O acusado declarou em audiência de custódia que não sofreu violência policial, inexistindo registro contemporâneo de abuso estatal, o que enfraquece a alegação defensiva posterior.
+5. A nulidade por violência policial exige demonstração concreta de ilicitude e de prejuízo, não bastando alegação unilateral dissociada do laudo pericial e dos demais elementos dos autos.
+6. Os depoimentos judiciais dos policiais não revelam que a condenação se funde em confissão informal obtida na abordagem, mas em elementos objetivos, como a visualização do réu embalando drogas, a fuga e a apreensão dos entorpecentes e apetrechos.
+7. A exigência de advertência formal sobre o direito ao silêncio no momento da abordagem policial não encontra, até o momento, definição vinculante do Supremo Tribunal Federal, e a jurisprudência citada do Superior Tribunal de Justiça admite que tal providência é exigida especificamente nos interrogatórios policial e judicial.
+8. Ainda que se cogitasse irregularidade na abordagem, a defesa não demonstra qual elemento probatório decisivo teria sido produzido por violação direta ao direito ao silêncio, nem prejuízo concreto, nos termos do art. 563 do Código de Processo Penal.
+9. O afastamento do tráfico privilegiado não pode apoiar-se apenas em processos em andamento, medidas cautelares ou recursos sem trânsito em julgado, em respeito ao princípio da presunção de inocência e ao entendimento firmado no Tema 1139 do Superior Tribunal de Justiça.
+10. O Tribunal pode manter o afastamento da minorante por fundamentação idônea extraída dos elementos concretos dos autos, sem reformatio in pejus, à luz do Tema 1214 do Superior Tribunal de Justiça e da Súmula 55 do TJCE.
+11. A expressiva quantidade e variedade de drogas apreendidas, o fracionamento em múltiplas porções, a apreensão de balança de precisão, sacos plásticos para embalagem e aparelhos celulares evidenciam dedicação a atividades criminosas e afastam o perfil de traficante eventual.
+12. A conduta social não se confunde com antecedentes criminais nem com registros de processos em andamento, de modo que sua valoração negativa com base em "passagens" e ações penais sem trânsito em julgado viola a técnica do art. 59 do Código Penal e o princípio da presunção de inocência.
+13. A circunstância judicial relativa às circunstâncias do fato pode ser negativamente valorada quando o réu pratica o tráfico de forma ostensiva em via pública, fracionando e embalando entorpecente para comercialização, circunstância concreta que extrapola a normalidade do tipo penal.
+14. A fixação da pena-base exige motivação proporcional e individualizada quanto ao quantum de exasperação, razão pela qual, afastada a valoração negativa da conduta social e remanescendo apenas uma vetorial desfavorável, impõe-se o redimensionamento da reprimenda.
+15. Aplicado o critério de 1/8 da diferença entre as penas mínima e máxima cominadas ao art. 33, caput, da Lei nº 11.343/2006, a pena-base deve ser fixada em 6 anos e 3 meses de reclusão e 625 dias-multa, patamar mantido nas fases subsequentes por ausência de agravantes, atenuantes e causas modificadoras.
+16. O regime inicial fechado é mantido em razão da existência de circunstância judicial desfavorável, nos termos do art. 33, §§ 2º e 3º, do Código Penal.
+IV. DISPOSITIVO E TESE
+16. Recurso conhecido e parcialmente provido.
+
+Dispositivos relevantes citados: CF/1988, art. 5º, LXIII. CPP, arts. 157, 186 e 563. CP, arts. 33, § 2º, b, § 3º, 59, 61, 62 e 65. Lei nº 11.343/2006, arts. 33, caput e § 4º, e 42.
+Jurisprudência relevante citada: STF, RE 1.177.984 (Tema 1.185 da repercussão geral), Rel. Min. Edson Fachin, Tribunal Pleno, j. 02.12.2021, DJe 03.02.2022. STJ, Tema 1139. STJ, Tema 1214. STJ, AgRg no HC 809.283/GO, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, j. 22.05.2023, DJe 24.05.2023. STJ, AgRg no HC 978.083/SP, Rel. Min. Messod Azulay Neto, Quinta Turma, j. 10.06.2025, DJEN 18.06.2025. STJ, AgRg no AREsp 2.676.524/SP, Rel. Min. Messod Azulay Neto, Quinta Turma, j. 18.02.2025, DJEN 25.02.2025. STJ, AgRg no HC 888.851/ES, Rel. Min. Og Fernandes, Sexta Turma, j. 19.02.2025, DJEN 24.02.2025. TJCE, Apelação Criminal nº 0204129-98.2023.8.06.0298, Rel. Des. Cid Peixoto do Amaral Neto, 3ª Câmara Criminal, j. 03.02.2026. TJCE, Apelação Criminal nº 0218279-34.2025.8.06.0001, Rel. Desa. Vanja Fontenele Pontes, 4ª Câmara Criminal, j. 10.02.2026. TJCE, Apelação Criminal nº 0206602-07.2025.8.06.0001, Rel. Des. Francisco Eduardo Torquato Scorsafava, 2ª Câmara Criminal, j. 04.02.2026. TJCE, Súmula 55.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER do presente recurso para DAR-LHE PARCIAL PROVIMENTO, nos termos do voto do Relator.
+
+Fortaleza, data e hora da assinatura digital.
+
+DESEMBARGADORA SÍLVIA SOARES DE SÁ NÓBREGA
+Presidente do Órgão Julgador
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833829" cdForo="0" >
+										0221078-50.2025.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833829" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833829);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833829" style="display: none;" >
+	<div id="textAreaDados_3833829" class="mensagemSemFormatacao" >
+		PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Otilde;ES. TR&Aacute;FICO DE DROGAS. POSSE ILEGAL DE ARMA DE FOGO DE USO RESTRITO. RECURSOS DEFENSIVOS. 1. DOCUMENTOS COLIGIDOS EM GRAU RECURSAL. 2. ABSOLVI&Ccedil;&Atilde;O POR INSUFICI&Ecirc;NCIA DE PROVAS. MATERIALIDADE E AUTORIA COMPROVADAS. DESCLASSIFICA&Ccedil;&Atilde;O PARA USO PESSOAL. INVIABILIDADE. 3. REDIMENSIONAMENTO DA PENA DEFINITIVA, DE OF&Iacute;CIO. CONFISS&Atilde;O QUALIFICADA. COMPENSA&Ccedil;&Atilde;O PARCIAL COM A REINCID&Ecirc;NCIA. 4. ISEN&Ccedil;&Atilde;O DA PENA DE MULTA. HIPOSSUFICI&Ecirc;NCIA. N&Atilde;O CONHECIMENTO. RECURSO DE DANIEL DA SILVA MENEZES CONHECIDO E DESPROVIDO. PENA REDIMENSIONADA, DE OF&Iacute;CIO. APELO DE FRANCISCO JOS&Eacute; EUG&Ecirc;NIO DO NASCIMENTO N&Atilde;O CONHECIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es criminais interpostas pelos r&eacute;us Daniel da Silva Menezes e  Francisco Jos&eacute; Eug&ecirc;nio Nascimento contra senten&ccedil;a que condenou Daniel  pela pr&aacute;tica dos crimes de tr&aacute;fico de drogas e posse ilegal de arma de fogo de uso restrito, em concurso material, e Francisco Jos&eacute; apenas pela posse ilegal de arma de fogo de uso restrito, com absolvi&ccedil;&atilde;o quanto ao tr&aacute;fico. A defesa de Daniel pleiteia absolvi&ccedil;&atilde;o, desclassifica&ccedil;&atilde;o para uso pr&oacute;prio e juntada de documentos; j&aacute; a defesa de Francisco Jos&eacute; requer dispensa da pena de multa por hipossufici&ecirc;ncia.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; admiss&iacute;vel a juntada de documentos em sede recursal; (ii) verificar se o conjunto probat&oacute;rio sustenta a condena&ccedil;&atilde;o por tr&aacute;fico de drogas e posse de arma de fogo de uso restrito, bem como se &eacute; cab&iacute;vel a desclassifica&ccedil;&atilde;o para uso pr&oacute;prio; (iii) determinar a possibilidade de revis&atilde;o da dosimetria da pena, inclusive de of&iacute;cio; (iv) aferir a possibilidade de conhecimento do recurso quanto ao pleito de isen&ccedil;&atilde;o da pena de multa.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Admite-se a juntada de documentos em grau recursal na aus&ecirc;ncia de m&aacute;-f&eacute;, desde assegurado o exerc&iacute;cio da ampla defesa e do contradit&oacute;rio, nos termos do C&oacute;digo de Processo Penal e da jurisprud&ecirc;ncia. No caso concreto, o Minist&eacute;rio P&uacute;blico disp&ocirc;s de oportunidade para manifesta&ccedil;&atilde;o por ocasi&atilde;o das contrarraz&otilde;es, circunst&acirc;ncia apta ao afastamento de eventual preju&iacute;zo ao contradit&oacute;rio.
+4. A materialidade e a autoria delitivas restam robustamente comprovadas por laudos periciais, auto de apresenta&ccedil;&atilde;o e apreens&atilde;o, depoimentos policiais colhidos sob o crivo do contradit&oacute;rio e confiss&atilde;o qualificada do acusado. Os depoimentos prestados por policiais constituem meio de prova id&ocirc;neo quando harm&ocirc;nicos, coerentes e corroborados por outros elementos probat&oacute;rios.
+5. A apreens&atilde;o de 48g de crack, a forma de acondicionamento, balan&ccedil;a de precis&atilde;o e artefatos b&eacute;licos evidenciam a narco trafic&acirc;ncia. O crime de tr&aacute;fico de entorpecentes &eacute; de a&ccedil;&atilde;o m&uacute;ltipla, sendo prescind&iacute;vel a comprova&ccedil;&atilde;o de mercancia direta, bastando a pr&aacute;tica de um dos n&uacute;cleos do tipo.
+6. A desclassifica&ccedil;&atilde;o para o crime de porte para consumo pessoal de drogas &eacute; invi&aacute;vel diante do contexto probat&oacute;rio e dos elementos caracter&iacute;sticos da trafic&acirc;ncia.
+7. A posse de arma de fogo de uso restrito resta demonstrada pela apreens&atilde;o de arma com numera&ccedil;&atilde;o raspada, muni&ccedil;&otilde;es e confiss&atilde;o do acusado.
+8. A dosimetria pode ser revista de of&iacute;cio, conforme entendimento sumulado do TJCE.
+9. A exaspera&ccedil;&atilde;o da basilar em raz&atilde;o da natureza e da quantidade da droga apreendida revela-se adequada e proporcional, porquanto a apreens&atilde;o de consider&aacute;vel quantidade de crack (48g), subst&acirc;ncia de elevado potencial de depend&ecirc;ncia, constitui circunst&acirc;ncia preponderante autorizadora da valora&ccedil;&atilde;o negativa.
+10. A confiss&atilde;o qualificada do acusado, mediante reconhecimento da posse dos entorpecentes e da arma de fogo, aliada &agrave; apresenta&ccedil;&atilde;o de justificativa destinada ao afastamento da ilicitude, imp&otilde;e o reconhecimento da atenuante de forma proporcional, com compensa&ccedil;&atilde;o parcial em rela&ccedil;&atilde;o &agrave; agravante da reincid&ecirc;ncia, mediante aplica&ccedil;&atilde;o da fra&ccedil;&atilde;o de 1/12 (um doze avos) sobre a pena-base, autorizando o redimensionamento da reprimenda, inclusive de of&iacute;cio.
+11. Pena de Daniel da Silva Menezes reduzida para 9 (nove) anos, 6 (seis) meses e 25 (vinte e cinco) dias de reclus&atilde;o e ao pagamento de 643 (seiscentos e quarenta e tr&ecirc;s) dias-multa. O regime inicial fechado &eacute; adequado diante do quantum da pena e das circunst&acirc;ncias judiciais desfavor&aacute;veis.
+12. A pena de multa ostenta natureza de san&ccedil;&atilde;o penal cogente, decorrente do preceito secund&aacute;rio do tipo incriminador, inexistindo discricionariedade judicial para afastamento sob alega&ccedil;&atilde;o de hipossufici&ecirc;ncia econ&ocirc;mica, motivo pelo qual a an&aacute;lise acerca de incapacidade financeira e eventual parcelamento, suspens&atilde;o ou afastamento da cobran&ccedil;a constitui mat&eacute;ria afeta exclusivamente ao Ju&iacute;zo das Execu&ccedil;&otilde;es Penais, impondo o n&atilde;o conhecimento do recurso.
+IV. DISPOSITIVO
+13. Recurso conhecido e desprovido e, de of&iacute;cio, pena redimensionada para o acusado Daniel da Silva Menezes; apelo do r&eacute;u Francisco Jos&eacute; Eug&ecirc;nio Nascimento n&atilde;o conhecido.
+_________________
+Teses de julgamento: 1. Admite-se a juntada de documentos em grau recursal desde que respeitados o contradit&oacute;rio e a boa-f&eacute;. 2. Depoimentos policiais, corroborados por outros elementos e colhidos sob contradit&oacute;rio, s&atilde;o suficientes para fundamentar condena&ccedil;&atilde;o penal. 3. A apreens&atilde;o de droga associada a instrumentos t&iacute;picos do tr&aacute;fico e armamento afasta a desclassifica&ccedil;&atilde;o para uso pr&oacute;prio. 4. O crime de tr&aacute;fico de drogas prescinde de prova de mercancia por se tratar de tipo penal de a&ccedil;&atilde;o m&uacute;ltipla. 5. A confiss&atilde;o qualificada autoriza a atenua&ccedil;&atilde;o da pena, ainda que parcialmente compensada com a reincid&ecirc;ncia 6. A an&aacute;lise da hipossufici&ecirc;ncia para fins de dispensa da pena de multa compete ao ju&iacute;zo da execu&ccedil;&atilde;o penal.
+
+Dispositivos relevantes citados: CPP, art. 231; CP, arts. 59, 61, I, 63, 44, 77 e 33, &sect;&sect; 2&ordm; e 3&ordm;; Lei n&ordm; 11.343/2006, arts. 28, 33 e 42; Lei n&ordm; 10.826/2003, art. 16; LEP, art. 164.
+
+Jurisprud&ecirc;ncia relevante citada: TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0023603-91.2022.8.06.0001, Rel. Des. Francisco Jaime Medeiros Neto, j. 14/10/2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0216095-42.2024.8.06.0001, Rel. Des. Silvia Soares de S&aacute; N&oacute;brega, j. 01/04/2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0216513-43.2025.8.06.0001, Rel. Des. Vanja Fontenele Pontes, j. 17/03/2026; STJ, AgRg no RHC 164.509/SP, Rel. Min. Reynaldo Soares da Fonseca, j. 17/05/2022. TJCE, S&uacute;mula 62.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, ACORDA a 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER do recurso do acusado Daniel da Silva Menezes, para NEGAR-LHE PROVIMENTO e, DE OF&Iacute;CIO, redimensionar a sua pena definitiva, bem como N&Atilde;O CONHECER do apelo do r&eacute;u Francisco Jos&eacute; Eug&ecirc;nio Nascimento, nos termos do voto da Relatora.
+
+Fortaleza, 14 de abril de 2026.
+
+DESEMBARGADORA &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0221078-50.2025.8.06.0001, Rel. Desembargador(a)  &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>PENAL E PROCESSUAL PENAL. APELAÇÕES. TRÁFICO DE DROGAS. POSSE ILEGAL DE ARMA DE FOGO DE USO RESTRITO. RECURSOS DEFENSIVOS. 1. DOCUMENTOS COLIGIDOS EM GRAU RECURSAL. 2. ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. MATERIALIDADE E AUTORIA COMPROVADAS. DESCLASSIFICAÇÃO PARA USO PESSOAL. INVIABILIDADE. 3. REDIMENSIONAMENTO DA PENA DEFINITIVA, DE OFÍCIO. CONFISSÃO QUALIFICADA. COMPENSAÇÃO PARCIAL COM A
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>PENAL E PROCESSUAL PENAL. APELAÇÕES. TRÁFICO DE DROGAS. POSSE ILEGAL DE ARMA DE FOGO DE USO RESTRITO. RECURSOS DEFENSIVOS. 1. DOCUMENTOS COLIGIDOS EM GRAU RECURSAL. 2. ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. MATERIALIDADE E AUTORIA COMPROVADAS. DESCLASSIFICAÇÃO PARA USO PESSOAL. INVIABILIDADE. 3. REDIMENSIONAMENTO DA PENA DEFINITIVA, DE OFÍCIO. CONFISSÃO QUALIFICADA. COMPENSAÇÃO PARCIAL COM A REINCIDÊNCIA. 4. ISENÇÃO DA PENA DE MULTA. HIPOSSUFICIÊNCIA. NÃO CONHECIMENTO. RECURSO DE DANIEL DA SILVA MENEZES CONHECIDO E DESPROVIDO. PENA REDIMENSIONADA, DE OFÍCIO. APELO DE FRANCISCO JOSÉ EUGÊNIO DO NASCIMENTO NÃO CONHECIDO.
+I. CASO EM EXAME
+1. Apelações criminais interpostas pelos réus Daniel da Silva Menezes e  Francisco José Eugênio Nascimento contra sentença que condenou Daniel  pela prática dos crimes de tráfico de drogas e posse ilegal de arma de fogo de uso restrito, em concurso material, e Francisco José apenas pela posse ilegal de arma de fogo de uso restrito, com absolvição quanto ao tráfico. A defesa de Daniel pleiteia absolvição, desclassificação para uso próprio e juntada de documentos; já a defesa de Francisco José requer dispensa da pena de multa por hipossuficiência.
+II. QUESTÕES EM DISCUSSÃO
+2. Há quatro questões em discussão: (i) definir se é admissível a juntada de documentos em sede recursal; (ii) verificar se o conjunto probatório sustenta a condenação por tráfico de drogas e posse de arma de fogo de uso restrito, bem como se é cabível a desclassificação para uso próprio; (iii) determinar a possibilidade de revisão da dosimetria da pena, inclusive de ofício; (iv) aferir a possibilidade de conhecimento do recurso quanto ao pleito de isenção da pena de multa.
+III. RAZÕES DE DECIDIR
+3. Admite-se a juntada de documentos em grau recursal na ausência de má-fé, desde assegurado o exercício da ampla defesa e do contraditório, nos termos do Código de Processo Penal e da jurisprudência. No caso concreto, o Ministério Público dispôs de oportunidade para manifestação por ocasião das contrarrazões, circunstância apta ao afastamento de eventual prejuízo ao contraditório.
+4. A materialidade e a autoria delitivas restam robustamente comprovadas por laudos periciais, auto de apresentação e apreensão, depoimentos policiais colhidos sob o crivo do contraditório e confissão qualificada do acusado. Os depoimentos prestados por policiais constituem meio de prova idôneo quando harmônicos, coerentes e corroborados por outros elementos probatórios.
+5. A apreensão de 48g de crack, a forma de acondicionamento, balança de precisão e artefatos bélicos evidenciam a narco traficância. O crime de tráfico de entorpecentes é de ação múltipla, sendo prescindível a comprovação de mercancia direta, bastando a prática de um dos núcleos do tipo.
+6. A desclassificação para o crime de porte para consumo pessoal de drogas é inviável diante do contexto probatório e dos elementos característicos da traficância.
+7. A posse de arma de fogo de uso restrito resta demonstrada pela apreensão de arma com numeração raspada, munições e confissão do acusado.
+8. A dosimetria pode ser revista de ofício, conforme entendimento sumulado do TJCE.
+9. A exasperação da basilar em razão da natureza e da quantidade da droga apreendida revela-se adequada e proporcional, porquanto a apreensão de considerável quantidade de crack (48g), substância de elevado potencial de dependência, constitui circunstância preponderante autorizadora da valoração negativa.
+10. A confissão qualificada do acusado, mediante reconhecimento da posse dos entorpecentes e da arma de fogo, aliada à apresentação de justificativa destinada ao afastamento da ilicitude, impõe o reconhecimento da atenuante de forma proporcional, com compensação parcial em relação à agravante da reincidência, mediante aplicação da fração de 1/12 (um doze avos) sobre a pena-base, autorizando o redimensionamento da reprimenda, inclusive de ofício.
+11. Pena de Daniel da Silva Menezes reduzida para 9 (nove) anos, 6 (seis) meses e 25 (vinte e cinco) dias de reclusão e ao pagamento de 643 (seiscentos e quarenta e três) dias-multa. O regime inicial fechado é adequado diante do quantum da pena e das circunstâncias judiciais desfavoráveis.
+12. A pena de multa ostenta natureza de sanção penal cogente, decorrente do preceito secundário do tipo incriminador, inexistindo discricionariedade judicial para afastamento sob alegação de hipossuficiência econômica, motivo pelo qual a análise acerca de incapacidade financeira e eventual parcelamento, suspensão ou afastamento da cobrança constitui matéria afeta exclusivamente ao Juízo das Execuções Penais, impondo o não conhecimento do recurso.
+IV. DISPOSITIVO
+13. Recurso conhecido e desprovido e, de ofício, pena redimensionada para o acusado Daniel da Silva Menezes; apelo do réu Francisco José Eugênio Nascimento não conhecido.
+_________________
+Teses de julgamento: 1. Admite-se a juntada de documentos em grau recursal desde que respeitados o contraditório e a boa-fé. 2. Depoimentos policiais, corroborados por outros elementos e colhidos sob contraditório, são suficientes para fundamentar condenação penal. 3. A apreensão de droga associada a instrumentos típicos do tráfico e armamento afasta a desclassificação para uso próprio. 4. O crime de tráfico de drogas prescinde de prova de mercancia por se tratar de tipo penal de ação múltipla. 5. A confissão qualificada autoriza a atenuação da pena, ainda que parcialmente compensada com a reincidência 6. A análise da hipossuficiência para fins de dispensa da pena de multa compete ao juízo da execução penal.
+
+Dispositivos relevantes citados: CPP, art. 231; CP, arts. 59, 61, I, 63, 44, 77 e 33, §§ 2º e 3º; Lei nº 11.343/2006, arts. 28, 33 e 42; Lei nº 10.826/2003, art. 16; LEP, art. 164.
+
+Jurisprudência relevante citada: TJCE, Apelação Criminal nº 0023603-91.2022.8.06.0001, Rel. Des. Francisco Jaime Medeiros Neto, j. 14/10/2025; TJCE, Apelação Criminal nº 0216095-42.2024.8.06.0001, Rel. Des. Silvia Soares de Sá Nóbrega, j. 01/04/2025; TJCE, Apelação Criminal nº 0216513-43.2025.8.06.0001, Rel. Des. Vanja Fontenele Pontes, j. 17/03/2026; STJ, AgRg no RHC 164.509/SP, Rel. Min. Reynaldo Soares da Fonseca, j. 17/05/2022. TJCE, Súmula 62.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, ACORDA a 4ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER do recurso do acusado Daniel da Silva Menezes, para NEGAR-LHE PROVIMENTO e, DE OFÍCIO, redimensionar a sua pena definitiva, bem como NÃO CONHECER do apelo do réu Francisco José Eugênio Nascimento, nos termos do voto da Relatora.
+
+Fortaleza, 14 de abril de 2026.
+
+DESEMBARGADORA ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833828" cdForo="0" >
+										0185025-17.2018.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833828" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833828);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833828" style="display: none;" >
+	<div id="textAreaDados_3833828" class="mensagemSemFormatacao" >
+		PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O. ROUBO MAJORADO PELO CONCURSO DE PESSOAS. RECURSO DA DEFESA. ABSOLVI&Ccedil;&Atilde;O POR INSUFICI&Ecirc;NCIA DE PROVAS. RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a proferida pelo Ju&iacute;zo da 6&ordf; Vara Criminal da Comarca de Fortaleza que condenou o recorrente pela pr&aacute;tica do crime de roubo majorado, &agrave; pena de 06 (seis) anos, 02 (dois) meses e 21 (vinte e um) dias de reclus&atilde;o, em regime semiaberto.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Consiste em definir se o conjunto probat&oacute;rio produzido nos autos &eacute; suficiente para sustentar a condena&ccedil;&atilde;o do apelante pela pr&aacute;tica do crime de roubo majorado. A dosimetria foi reexaminada, de of&iacute;cio.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O conjunto probat&oacute;rio &eacute; harm&ocirc;nico e consistente, pois os depoimentos dos policiais militares descrevem a persegui&ccedil;&atilde;o, o capotamento do ve&iacute;culo roubado e a pris&atilde;o em flagrante dos acusados na posse dos bens subtra&iacute;dos.
+4. A materialidade delitiva &eacute; comprovada pelo auto de apreens&atilde;o e pela recupera&ccedil;&atilde;o do ve&iacute;culo, dinheiro e objetos das v&iacute;timas em poder dos acusados.
+5. A palavra da v&iacute;tima &eacute; firme, coerente e detalhada, descrevendo a din&acirc;mica do roubo, o emprego de grave amea&ccedil;a e o reconhecimento inequ&iacute;voco dos autores, tanto na fase policial quanto em ju&iacute;zo.
+6. A aus&ecirc;ncia de testemunhas oculares policiais n&atilde;o invalida a condena&ccedil;&atilde;o, pois o ordenamento admite a forma&ccedil;&atilde;o do convencimento com base em provas indiretas e circunstanciais robustas.
+7. A confiss&atilde;o judicial do corr&eacute;u confirma a participa&ccedil;&atilde;o do apelante no delito, refor&ccedil;ando a vers&atilde;o acusat&oacute;ria.
+8. Os depoimentos policiais, prestados sob contradit&oacute;rio, possuem validade probat&oacute;ria e convergem com os demais elementos dos autos.
+9. A tese defensiva de insufici&ecirc;ncia de provas n&atilde;o se sustenta diante do conjunto probat&oacute;rio coeso, inexistindo d&uacute;vida razo&aacute;vel a justificar absolvi&ccedil;&atilde;o.
+IV. DISPOSITIVO
+10. Recurso conhecido e desprovido.
+
+Teses de julgamento: 1. A condena&ccedil;&atilde;o por roubo pode ser fundada em conjunto probat&oacute;rio harm&ocirc;nico, ainda que ausentes testemunhas oculares do fato. 2. A palavra da v&iacute;tima, quando coerente e corroborada por outros elementos de prova, possui especial relev&acirc;ncia nos crimes patrimoniais. 3. A pris&atilde;o em flagrante na posse dos bens subtra&iacute;dos constitui forte elemento de prova da autoria delitiva. 4. Depoimentos de policiais s&atilde;o meios id&ocirc;neos de prova quando prestados sob contradit&oacute;rio e em conson&acirc;ncia com os demais elementos dos autos. 5. A confiss&atilde;o judicial de corr&eacute;u refor&ccedil;a a comprova&ccedil;&atilde;o da autoria quando alinhada &agrave;s demais provas.
+
+Dispositivos relevantes citados: CP, art. 157, &sect; 2&ordm;, II; CPP, art. 386, V e VII; CP, arts. 33, &sect; 2&ordm;, &quot;b&quot;, e 44.
+
+Jurisprud&ecirc;ncia relevante citada: TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0015248-51.2017.8.06.0136, Rel. Des. L&iacute;gia Andrade de Alencar Magalh&atilde;es, j. 01.04.2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0203126-05.2023.8.06.0300, Rel. Des. Francisco Carneiro Lima, j. 27.08.2024.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos, ACORDAM os Desembargadores integrantes da 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Cear&aacute;, por unanimidade, em CONHECER do recurso, para NEGAR-LHE PROVIMENTO, nos termos do voto da Relatora.
+
+Fortaleza, 14 de abril de 2026.
+
+DESEMBARGADORA &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0185025-17.2018.8.06.0001, Rel. Desembargador(a)  &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Roubo Majorado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>PENAL E PROCESSUAL PENAL. APELAÇÃO. ROUBO MAJORADO PELO CONCURSO DE PESSOAS. RECURSO DA DEFESA. ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença proferida pelo Juízo da 6ª Vara Criminal da Comarca de Fortaleza que condenou o recorrente pela prática do crime de roubo majorado, à pena de 06 (seis) anos, 02
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>PENAL E PROCESSUAL PENAL. APELAÇÃO. ROUBO MAJORADO PELO CONCURSO DE PESSOAS. RECURSO DA DEFESA. ABSOLVIÇÃO POR INSUFICIÊNCIA DE PROVAS. RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença proferida pelo Juízo da 6ª Vara Criminal da Comarca de Fortaleza que condenou o recorrente pela prática do crime de roubo majorado, à pena de 06 (seis) anos, 02 (dois) meses e 21 (vinte e um) dias de reclusão, em regime semiaberto.
+II. QUESTÃO EM DISCUSSÃO
+2. Consiste em definir se o conjunto probatório produzido nos autos é suficiente para sustentar a condenação do apelante pela prática do crime de roubo majorado. A dosimetria foi reexaminada, de ofício.
+III. RAZÕES DE DECIDIR
+3. O conjunto probatório é harmônico e consistente, pois os depoimentos dos policiais militares descrevem a perseguição, o capotamento do veículo roubado e a prisão em flagrante dos acusados na posse dos bens subtraídos.
+4. A materialidade delitiva é comprovada pelo auto de apreensão e pela recuperação do veículo, dinheiro e objetos das vítimas em poder dos acusados.
+5. A palavra da vítima é firme, coerente e detalhada, descrevendo a dinâmica do roubo, o emprego de grave ameaça e o reconhecimento inequívoco dos autores, tanto na fase policial quanto em juízo.
+6. A ausência de testemunhas oculares policiais não invalida a condenação, pois o ordenamento admite a formação do convencimento com base em provas indiretas e circunstanciais robustas.
+7. A confissão judicial do corréu confirma a participação do apelante no delito, reforçando a versão acusatória.
+8. Os depoimentos policiais, prestados sob contraditório, possuem validade probatória e convergem com os demais elementos dos autos.
+9. A tese defensiva de insuficiência de provas não se sustenta diante do conjunto probatório coeso, inexistindo dúvida razoável a justificar absolvição.
+IV. DISPOSITIVO
+10. Recurso conhecido e desprovido.
+
+Teses de julgamento: 1. A condenação por roubo pode ser fundada em conjunto probatório harmônico, ainda que ausentes testemunhas oculares do fato. 2. A palavra da vítima, quando coerente e corroborada por outros elementos de prova, possui especial relevância nos crimes patrimoniais. 3. A prisão em flagrante na posse dos bens subtraídos constitui forte elemento de prova da autoria delitiva. 4. Depoimentos de policiais são meios idôneos de prova quando prestados sob contraditório e em consonância com os demais elementos dos autos. 5. A confissão judicial de corréu reforça a comprovação da autoria quando alinhada às demais provas.
+
+Dispositivos relevantes citados: CP, art. 157, § 2º, II; CPP, art. 386, V e VII; CP, arts. 33, § 2º, "b", e 44.
+
+Jurisprudência relevante citada: TJCE, Apelação Criminal nº 0015248-51.2017.8.06.0136, Rel. Des. Lígia Andrade de Alencar Magalhães, j. 01.04.2025; TJCE, Apelação Criminal nº 0203126-05.2023.8.06.0300, Rel. Des. Francisco Carneiro Lima, j. 27.08.2024.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos, ACORDAM os Desembargadores integrantes da 4ª Câmara Criminal do Tribunal de Justiça do Ceará, por unanimidade, em CONHECER do recurso, para NEGAR-LHE PROVIMENTO, nos termos do voto da Relatora.
+
+Fortaleza, 14 de abril de 2026.
+
+DESEMBARGADORA ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833818" cdForo="0" >
+										0049378-42.2017.8.06.0112
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833818" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833818);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833818" style="display: none;" >
+	<div id="textAreaDados_3833818" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O. ROUBO SIMPLES. RECURSO DA DEFESA. 1. PEDIDO DE APLICA&Ccedil;&Atilde;O DO PRINC&Iacute;PIO DA INSIGNIFIC&Acirc;NCIA. 2. PLEITO DE DESCLASSIFICA&Ccedil;&Atilde;O PARA FURTO . RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a prolatada pelo Juiz de Direito da 3&ordf; Vara Criminal da Comarca de Juazeiro do Norte/CE, que condenou o r&eacute;u pela pr&aacute;tica do crime de roubo simples &agrave; pena de 5 (cinco) anos e 6 (seis) meses de reclus&atilde;o, em regime inicial fechado, e 30 dias-multa, em raz&atilde;o de ter subtra&iacute;do bens da v&iacute;tima mediante simula&ccedil;&atilde;o de porte de arma. A defesa requer a absolvi&ccedil;&atilde;o pela aplica&ccedil;&atilde;o do princ&iacute;pio da insignific&acirc;ncia ou, subsidiariamente, a desclassifica&ccedil;&atilde;o para furto.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; aplic&aacute;vel o princ&iacute;pio da insignific&acirc;ncia ao crime de roubo praticado com simula&ccedil;&atilde;o de arma; (ii) estabelecer se a conduta deve ser desclassificada para furto diante da alegada aus&ecirc;ncia de grave amea&ccedil;a.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O princ&iacute;pio da insignific&acirc;ncia exige m&iacute;nima ofensividade, aus&ecirc;ncia de periculosidade social, reduzido grau de reprovabilidade e inexpressividade da les&atilde;o, requisitos n&atilde;o preenchidos quando h&aacute; grave amea&ccedil;a na conduta.
+4. A simula&ccedil;&atilde;o de porte de arma, acompanhada de amea&ccedil;a, revela elevada reprovabilidade e periculosidade social, afastando a atipicidade material, ainda que o valor dos bens subtra&iacute;dos seja reduzido.
+5. A jurisprud&ecirc;ncia do STJ afasta a aplica&ccedil;&atilde;o do princ&iacute;pio da insignific&acirc;ncia nos crimes de roubo, por envolverem viol&ecirc;ncia ou grave amea&ccedil;a &agrave; pessoa.
+6. A reincid&ecirc;ncia e os antecedentes criminais do agente refor&ccedil;am a inaplicabilidade da bagatela, evidenciando maior reprovabilidade da conduta.
+7. A grave amea&ccedil;a se configura pela simula&ccedil;&atilde;o de arma e pela intimida&ccedil;&atilde;o efetiva da v&iacute;tima, suficiente para impedir resist&ecirc;ncia e viabilizar a subtra&ccedil;&atilde;o.
+8. A palavra da v&iacute;tima, corroborada pela prova testemunhal e pela confiss&atilde;o do r&eacute;u, demonstra de forma consistente o emprego de grave amea&ccedil;a.
+9. A desclassifica&ccedil;&atilde;o para furto &eacute; invi&aacute;vel, pois comprovado que a subtra&ccedil;&atilde;o ocorreu mediante intimida&ccedil;&atilde;o relevante, t&iacute;pica do crime de roubo.
+IV. DISPOSITIVO
+10. Recurso  conhecido e desprovido.
+
+Teses de julgamento: 1. O princ&iacute;pio da insignific&acirc;ncia n&atilde;o se aplica ao crime de roubo quando presente grave amea&ccedil;a, ainda que o valor do bem subtra&iacute;do seja reduzido. 2. A simula&ccedil;&atilde;o de porte de arma constitui meio id&ocirc;neo para caracterizar grave amea&ccedil;a no crime de roubo. 3. A exist&ecirc;ncia de antecedentes e reincid&ecirc;ncia afasta a incid&ecirc;ncia da bagatela penal. 4. &Eacute; invi&aacute;vel a desclassifica&ccedil;&atilde;o para furto quando comprovado que a subtra&ccedil;&atilde;o ocorreu mediante intimida&ccedil;&atilde;o da v&iacute;tima.
+Dispositivos relevantes citados: CP, arts. 155 e 157, caput; CPP, art. 386, III.
+
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no AREsp 1.748.266/SP, Rel. Min. Nefi Cordeiro, Sexta Turma, DJe 05.03.2021; STJ, AgRg no REsp 1.986.801/PB, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, DJe 29.11.2024; STJ, AgRg no AREsp 2.601.293/RJ, Rel. Min. Daniela Teixeira, Quinta Turma, DJe 17.12.2024; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0142111-35.2018.8.06.0001, Rel. Desa. L&iacute;gia Andrade de Alencar Magalh&atilde;es, j. 12.08.2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0261228-10.2024.8.06.0001, Rel. Des. M&aacute;rio Parente Te&oacute;filo Neto, j. 18.03.2025.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos,  ACORDAM os Desembargadores integrantes da 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Cear&aacute;, por unanimidade, em CONHECER e julgar DESPROVIDO o apelo, nos termos do voto da Relatora.
+Fortaleza, 14 de abril de 2026.
+
+DESEMBARGADORA &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora   <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0049378-42.2017.8.06.0112, Rel. Desembargador(a)  &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Roubo
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Juazeiro do Norte
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO. ROUBO SIMPLES. RECURSO DA DEFESA. 1. PEDIDO DE APLICAÇÃO DO PRINCÍPIO DA INSIGNIFICÂNCIA. 2. PLEITO DE DESCLASSIFICAÇÃO PARA FURTO . RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença prolatada pelo Juiz de Direito da 3ª Vara Criminal da Comarca de Juazeiro do Norte/CE, que condenou o réu pela prática do
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO. ROUBO SIMPLES. RECURSO DA DEFESA. 1. PEDIDO DE APLICAÇÃO DO PRINCÍPIO DA INSIGNIFICÂNCIA. 2. PLEITO DE DESCLASSIFICAÇÃO PARA FURTO . RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença prolatada pelo Juiz de Direito da 3ª Vara Criminal da Comarca de Juazeiro do Norte/CE, que condenou o réu pela prática do crime de roubo simples à pena de 5 (cinco) anos e 6 (seis) meses de reclusão, em regime inicial fechado, e 30 dias-multa, em razão de ter subtraído bens da vítima mediante simulação de porte de arma. A defesa requer a absolvição pela aplicação do princípio da insignificância ou, subsidiariamente, a desclassificação para furto.
+II. QUESTÕES EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se é aplicável o princípio da insignificância ao crime de roubo praticado com simulação de arma; (ii) estabelecer se a conduta deve ser desclassificada para furto diante da alegada ausência de grave ameaça.
+III. RAZÕES DE DECIDIR
+3. O princípio da insignificância exige mínima ofensividade, ausência de periculosidade social, reduzido grau de reprovabilidade e inexpressividade da lesão, requisitos não preenchidos quando há grave ameaça na conduta.
+4. A simulação de porte de arma, acompanhada de ameaça, revela elevada reprovabilidade e periculosidade social, afastando a atipicidade material, ainda que o valor dos bens subtraídos seja reduzido.
+5. A jurisprudência do STJ afasta a aplicação do princípio da insignificância nos crimes de roubo, por envolverem violência ou grave ameaça à pessoa.
+6. A reincidência e os antecedentes criminais do agente reforçam a inaplicabilidade da bagatela, evidenciando maior reprovabilidade da conduta.
+7. A grave ameaça se configura pela simulação de arma e pela intimidação efetiva da vítima, suficiente para impedir resistência e viabilizar a subtração.
+8. A palavra da vítima, corroborada pela prova testemunhal e pela confissão do réu, demonstra de forma consistente o emprego de grave ameaça.
+9. A desclassificação para furto é inviável, pois comprovado que a subtração ocorreu mediante intimidação relevante, típica do crime de roubo.
+IV. DISPOSITIVO
+10. Recurso  conhecido e desprovido.
+
+Teses de julgamento: 1. O princípio da insignificância não se aplica ao crime de roubo quando presente grave ameaça, ainda que o valor do bem subtraído seja reduzido. 2. A simulação de porte de arma constitui meio idôneo para caracterizar grave ameaça no crime de roubo. 3. A existência de antecedentes e reincidência afasta a incidência da bagatela penal. 4. É inviável a desclassificação para furto quando comprovado que a subtração ocorreu mediante intimidação da vítima.
+Dispositivos relevantes citados: CP, arts. 155 e 157, caput; CPP, art. 386, III.
+
+Jurisprudência relevante citada: STJ, AgRg no AREsp 1.748.266/SP, Rel. Min. Nefi Cordeiro, Sexta Turma, DJe 05.03.2021; STJ, AgRg no REsp 1.986.801/PB, Rel. Min. Sebastião Reis Júnior, Sexta Turma, DJe 29.11.2024; STJ, AgRg no AREsp 2.601.293/RJ, Rel. Min. Daniela Teixeira, Quinta Turma, DJe 17.12.2024; TJCE, Apelação Criminal nº 0142111-35.2018.8.06.0001, Rel. Desa. Lígia Andrade de Alencar Magalhães, j. 12.08.2025; TJCE, Apelação Criminal nº 0261228-10.2024.8.06.0001, Rel. Des. Mário Parente Teófilo Neto, j. 18.03.2025.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos,  ACORDAM os Desembargadores integrantes da 4ª Câmara Criminal do Tribunal de Justiça do Ceará, por unanimidade, em CONHECER e julgar DESPROVIDO o apelo, nos termos do voto da Relatora.
+Fortaleza, 14 de abril de 2026.
+
+DESEMBARGADORA ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833803" cdForo="0" >
+										0000154-68.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833803" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833803);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833803" style="display: none;" >
+	<div id="textAreaDados_3833803" class="mensagemSemFormatacao" >
+		DIREITO PENAL. DIREITO PROCESSUAL PENAL. CONFLITO DE JURISDI&Ccedil;&Atilde;O. CRIMES DE AMEA&Ccedil;A E DANO QUALIFICADO. CONTROV&Eacute;RSIA ACERCA DA MOTIVA&Ccedil;&Atilde;O DE G&Ecirc;NERO. DESNECESSIDADE DE DEMONSTRA&Ccedil;&Atilde;O ESPEC&Iacute;FICA. PRESUN&Ccedil;&Atilde;O LEGAL DE VULNERABILIDADE E INCID&Ecirc;NCIA DA LEI MARIA DA PENHA. COMPET&Ecirc;NCIA DO JUIZADO ESPECIAL CRIMINAL. CONFLITO DE JURISDI&Ccedil;&Atilde;O CONHECIDO, PARA DECLARAR A COMPET&Ecirc;NCIA DO JUIZ SUSCITADO.
+
+I. CASO EM EXAME
+1. Trata-se de Conflito Negativo de Jurisdi&ccedil;&atilde;o arguido pelo JUIZ DE DIREITO DA 2.&ordf; VARA CRIMINAL DA COMARCA DE CRATO/CE, em face do JUIZ DE DIREITO DO JUIZADO DE VIOL&Ecirc;NCIA DOM&Eacute;STICA E FAMILIAR CONTRA A MULHER DA COMARCA DE JUAZEIRO DO NORTE, referente ao Auto de Pris&atilde;o em Flagrante n&ordm; 0052214-46.2021.8.06.0112, instaurado em virtude da suposta pr&aacute;tica, por M. F. L.,  dos delitos de amea&ccedil;a e dano qualificado no &acirc;mbito da viol&ecirc;ncia dom&eacute;stica contra a mulher, previstos, respectivamente, nos artigos 147 e 163, par&aacute;grafo &uacute;nico, I, ambos do C&oacute;digo Penal Brasileiro, c/c Art. 7&ordm;, II e IV da Lei 11.340/06, tendo como v&iacute;tima I. F. L., irm&atilde; do infrator.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em determinar se a aplica&ccedil;&atilde;o da Lei n&ordm; 11.340/2006 (Lei Maria da Penha), com a fixa&ccedil;&atilde;o da compet&ecirc;ncia do Juizado especializado, depende da comprova&ccedil;&atilde;o da motiva&ccedil;&atilde;o de g&ecirc;nero.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3. Sobre o conceito de viol&ecirc;ncia de g&ecirc;nero, esta &eacute; configurada pela condi&ccedil;&atilde;o de mulher da v&iacute;tima, independentemente de sua idade, quando a viol&ecirc;ncia ocorre no &acirc;mbito dom&eacute;stico ou familiar, sendo a condi&ccedil;&atilde;o de g&ecirc;nero feminino suficiente para atrair a aplicabilidade da Lei Maria da Penha em casos de viol&ecirc;ncia dom&eacute;stica e familiar, consoante j&aacute; decidido pelo STJ, no Tema Repetitivo n&ordm; 1.186.
+4. Analisando os fatos constantes na c&oacute;pia do Inqu&eacute;rito Policial acostado aos autos (IPL n&ordm; 446-345/2021 &#150;  fls. 03/38), verifica-se que o que motivou as desaven&ccedil;as entre o autuado e sua irm&atilde;, ora v&iacute;tima, teriam sido as amea&ccedil;as de causar mal injusto a esta &uacute;ltima, bem como o fato de ter danificado v&aacute;rios utens&iacute;lios dom&eacute;sticos, o que ocasionou diversos preju&iacute;zos, devendo ser mencionado, ainda, que autuado &eacute; usu&aacute;rio de drogas licitas e il&iacute;citas e encontrava-se descontrolado no momento em que os delitos foram supostamente cometidos, o que requereu a utiliza&ccedil;&atilde;o de for&ccedil;a policial.
+5. Nesse contexto, destaco que o Superior Tribunal de Justi&ccedil;a entende ser presumida a hipossufici&ecirc;ncia e vulnerabilidade da mulher no contexto de viol&ecirc;ncia dom&eacute;stica, sendo desnecess&aacute;rio analisar a motiva&ccedil;&atilde;o espec&iacute;fica da conduta do agressor para a aplica&ccedil;&atilde;o da Lei Maria da Penha. A partir dos elementos informativos constantes no inqu&eacute;rito, ainda que os delitos imputados tenham decorr&ecirc;ncia, em tese, do quadro psicol&oacute;gico alterado em que se encontrava o indiciado, referido fato n&atilde;o afasta a presun&ccedil;&atilde;o de vulnerabilidade da mulher no contexto de viol&ecirc;ncia dom&eacute;stica. Jurisprud&ecirc;ncia citada.
+6. Assim, sendo evidenciada a pr&aacute;tica de viol&ecirc;ncia contra a mulher, no &acirc;mbito dom&eacute;stico e familiar, deve ser presumida a vulnerabilidade e hipossufici&ecirc;ncia da v&iacute;tima, o que atrai a incid&ecirc;ncia da Lei Maria da Penha e, por conseguinte, a compet&ecirc;ncia do Juiz de Direito do Juizado de Viol&ecirc;ncia Dom&eacute;stica e Familiar Contra a Mulher, para o processamento do feito.
+
+IV. DISPOSITIVO E TESE
+7. Conflito de Jurisdi&ccedil;&atilde;o conhecido, para declarar competente o ju&iacute;zo suscitado, qual seja, o JUIZ DE DIREITO DO JUIZADO DE VIOL&Ecirc;NCIA DOM&Eacute;STICA E FAMILIAR CONTRA A MULHER DA COMARCA DE JUAZEIRO DO NORTE.
+
+Tese de julgamento: &quot;Sendo evidenciada a pr&aacute;tica de viol&ecirc;ncia contra a mulher, no &acirc;mbito dom&eacute;stico e familiar, deve ser presumida a vulnerabilidade e hipossufici&ecirc;ncia da v&iacute;tima, o que atrai a incid&ecirc;ncia da Lei Maria da Penha e, por consequ&ecirc;ncia, a compet&ecirc;ncia do ju&iacute;zo especializado&quot;.
+
+Dispositivos relevantes citados: CPP, arts.114.
+
+Jurisprud&ecirc;ncia relevante citada: STJ - REsp n. 2.015.598/PA, relator Ministro Ribeiro Dantas, Terceira Se&ccedil;&atilde;o, julgado em 6/2/2025, DJEN de 13/2/2025; STJ - AREsp n. 2.373.233/GO, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 5/11/2024, DJe de 11/11/2024; TJCE - Conflito de Jurisdi&ccedil;&atilde;o - 0000244-13.2025.8.06.0000, Rel. Desembargador(a) FRANCISCO JAIME MEDEIROS NETO, 4 C&acirc;mara Criminal, data do julgamento:  19/08/2025, data da publica&ccedil;&atilde;o:  19/08/2025.
+
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos de Apela&ccedil;&atilde;o, ACORDAM os desembargadores da .1&ordf; C&Acirc;MARA CRIMINAL do TRIBUNAL DE JUSTI&Ccedil;A DO ESTADO DO CEAR&Aacute;, &agrave; unanimidade, em CONHECER do conflito de jurisdi&ccedil;&atilde;o, para declarar competente para o processamento do feito o JUIZ DE DIREITODO JUIZADO DE VIOL&Ecirc;NCIA DOM&Eacute;STICA E FAMILIAR CONTRA A MULHER DA COMARCA DE JUAZEIRO DO NORTE, tudo em conformidade com o voto do relator.
+
+Fortaleza, data da assinatura digital no sistema.
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator <br><br>(Conflito de Jurisdi&ccedil;&atilde;o&nbsp;-  0000154-68.2026.8.06.0000, Rel. Desembargador(a)  FRANCISCO CARNEIRO LIMA, 1&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Conflito de Jurisdição / Ameaça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO CARNEIRO LIMA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Crato
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL. DIREITO PROCESSUAL PENAL. CONFLITO DE JURISDIÇÃO. CRIMES DE AMEAÇA E <em>DANO</em> QUALIFICADO. CONTROVÉRSIA ACERCA DA MOTIVAÇÃO DE GÊNERO. DESNECESSIDADE DE DEMONSTRAÇÃO ESPECÍFICA. PRESUNÇÃO LEGAL DE VULNERABILIDADE E INCIDÊNCIA DA LEI MARIA DA PENHA. COMPETÊNCIA DO JUIZADO ESPECIAL CRIMINAL. CONFLITO DE JURISDIÇÃO CONHECIDO, PARA DECLARAR A COMPETÊNCIA DO JUIZ SUSCITADO.
+
+I.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL. DIREITO PROCESSUAL PENAL. CONFLITO DE JURISDIÇÃO. CRIMES DE AMEAÇA E <em>DANO</em> QUALIFICADO. CONTROVÉRSIA ACERCA DA MOTIVAÇÃO DE GÊNERO. DESNECESSIDADE DE DEMONSTRAÇÃO ESPECÍFICA. PRESUNÇÃO LEGAL DE VULNERABILIDADE E INCIDÊNCIA DA LEI MARIA DA PENHA. COMPETÊNCIA DO JUIZADO ESPECIAL CRIMINAL. CONFLITO DE JURISDIÇÃO CONHECIDO, PARA DECLARAR A COMPETÊNCIA DO JUIZ SUSCITADO.
+
+I. CASO EM EXAME
+1. Trata-se de Conflito Negativo de Jurisdição arguido pelo JUIZ DE DIREITO DA 2.ª VARA CRIMINAL DA COMARCA DE CRATO/CE, em face do JUIZ DE DIREITO DO JUIZADO DE VIOLÊNCIA DOMÉSTICA E FAMILIAR CONTRA A MULHER DA COMARCA DE JUAZEIRO DO NORTE, referente ao Auto de Prisão em Flagrante nº 0052214-46.2021.8.06.0112, instaurado em virtude da suposta prática, por M. F. L.,  dos delitos de ameaça e <em>dano</em> qualificado no âmbito da violência doméstica contra a mulher, previstos, respectivamente, nos artigos 147 e 163, parágrafo único, I, ambos do Código Penal Brasileiro, c/c Art. 7º, II e IV da Lei 11.340/06, tendo como vítima I. F. L., irmã do infrator.
+
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em determinar se a aplicação da Lei nº 11.340/2006 (Lei Maria da Penha), com a fixação da competência do Juizado especializado, depende da comprovação da motivação de gênero.
+
+III. RAZÕES DE DECIDIR
+3. Sobre o conceito de violência de gênero, esta é configurada pela condição de mulher da vítima, independentemente de sua idade, quando a violência ocorre no âmbito doméstico ou familiar, sendo a condição de gênero feminino suficiente para atrair a aplicabilidade da Lei Maria da Penha em casos de violência doméstica e familiar, consoante já decidido pelo STJ, no Tema Repetitivo nº 1.186.
+4. Analisando os fatos constantes na cópia do Inquérito Policial acostado aos autos (IPL nº 446-345/2021   fls. 03/38), verifica-se que o que motivou as desavenças entre o autuado e sua irmã, ora vítima, teriam sido as ameaças de causar mal injusto a esta última, bem como o fato de ter danificado vários utensílios domésticos, o que ocasionou diversos prejuízos, devendo ser mencionado, ainda, que autuado é usuário de drogas licitas e ilícitas e encontrava-se descontrolado no momento em que os delitos foram supostamente cometidos, o que requereu a utilização de força policial.
+5. Nesse contexto, destaco que o Superior Tribunal de Justiça entende ser presumida a hipossuficiência e vulnerabilidade da mulher no contexto de violência doméstica, sendo desnecessário analisar a motivação específica da conduta do agressor para a aplicação da Lei Maria da Penha. A partir dos elementos informativos constantes no inquérito, ainda que os delitos imputados tenham decorrência, em tese, do quadro psicológico alterado em que se encontrava o indiciado, referido fato não afasta a presunção de vulnerabilidade da mulher no contexto de violência doméstica. Jurisprudência citada.
+6. Assim, sendo evidenciada a prática de violência contra a mulher, no âmbito doméstico e familiar, deve ser presumida a vulnerabilidade e hipossuficiência da vítima, o que atrai a incidência da Lei Maria da Penha e, por conseguinte, a competência do Juiz de Direito do Juizado de Violência Doméstica e Familiar Contra a Mulher, para o processamento do feito.
+
+IV. DISPOSITIVO E TESE
+7. Conflito de Jurisdição conhecido, para declarar competente o juízo suscitado, qual seja, o JUIZ DE DIREITO DO JUIZADO DE VIOLÊNCIA DOMÉSTICA E FAMILIAR CONTRA A MULHER DA COMARCA DE JUAZEIRO DO NORTE.
+
+Tese de julgamento: "Sendo evidenciada a prática de violência contra a mulher, no âmbito doméstico e familiar, deve ser presumida a vulnerabilidade e hipossuficiência da vítima, o que atrai a incidência da Lei Maria da Penha e, por consequência, a competência do juízo especializado".
+
+Dispositivos relevantes citados: CPP, arts.114.
+
+Jurisprudência relevante citada: STJ - REsp n. 2.015.598/PA, relator Ministro Ribeiro Dantas, Terceira Seção, julgado em 6/2/2025, DJEN de 13/2/2025; STJ - AREsp n. 2.373.233/GO, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 5/11/2024, DJe de 11/11/2024; TJCE - Conflito de Jurisdição - 0000244-13.2025.8.06.0000, Rel. Desembargador(a) FRANCISCO JAIME MEDEIROS NETO, 4 Câmara Criminal, data do julgamento:  19/08/2025, data da publicação:  19/08/2025.
+
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos de Apelação, ACORDAM os desembargadores da .1ª CÂMARA CRIMINAL do TRIBUNAL DE JUSTIÇA DO ESTADO DO CEARÁ, à unanimidade, em CONHECER do conflito de jurisdição, para declarar competente para o processamento do feito o JUIZ DE DIREITODO JUIZADO DE VIOLÊNCIA DOMÉSTICA E FAMILIAR CONTRA A MULHER DA COMARCA DE JUAZEIRO DO NORTE, tudo em conformidade com o voto do relator.
+
+Fortaleza, data da assinatura digital no sistema.
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833799" cdForo="0" >
+										0010149-84.2012.8.06.0101
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833799" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833799);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833799" style="display: none;" >
+	<div id="textAreaDados_3833799" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TRIBUNAL DO J&Uacute;RI. TENTATIVA DE HOMIC&Iacute;DIO QUALIFICADO. DECIS&Atilde;O MANIFESTAMENTE CONTR&Aacute;RIA &Agrave; PROVA DOS AUTOS. SOBERANIA DOS VEREDICTOS. DOSIMETRIA DA PENA. MANUTEN&Ccedil;&Atilde;O DA CONDENA&Ccedil;&Atilde;O. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apela&ccedil;&atilde;o Criminal interposta pela defesa de Francisco Anderson Bezerra da Silva contra senten&ccedil;a condenat&oacute;ria proferida pelo Juiz de Direito da  1.&ordf; Vara do J&uacute;ri da Comarca de Fortaleza/CE, prolatada em conson&acirc;ncia  com a decis&atilde;o do Conselho de Senten&ccedil;a do Tribunal do J&uacute;ri, que o condenou pela pr&aacute;tica  do crime previsto no art. 121, &sect; 2.&ordm;, inciso IV, c/c o art. 14, inciso II, todos do C&oacute;digo  Penal, fixando-lhe a pena de 4 (quatro) anos, 5 (cinco) meses e 10 (dez) dias de reclus&atilde;o, a ser cumprida inicialmente em regime semiaberto.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se o veredito condenat&oacute;rio do Tribunal do J&uacute;ri &eacute; manifestamente contr&aacute;rio &agrave; prova dos autos, a justificar novo julgamento nos termos do art. 593, III, &quot;d&quot;, do CPP; (ii) estabelecer se a dosimetria da pena observou adequadamente os crit&eacute;rios legais e jurisprudenciais aplic&aacute;veis.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O conjunto probat&oacute;rio produzido nos autos comprova de forma harm&ocirc;nica a materialidade e a autoria delitivas, especialmente por meio do depoimento da testemunha ocular Walef Soares Brand&atilde;o, que descreve de forma coerente a din&acirc;mica do crime, apontando o recorrente como autor dos disparos.
+4. A aus&ecirc;ncia de mem&oacute;ria da v&iacute;tima quanto &agrave; autoria dos disparos, em raz&atilde;o do estado de embriaguez no momento dos fatos, n&atilde;o equivale &agrave; negativa de autoria e n&atilde;o possui aptid&atilde;o para infirmar a prova testemunhal id&ocirc;nea produzida em ju&iacute;zo.
+5. A anula&ccedil;&atilde;o do julgamento por decis&atilde;o manifestamente contr&aacute;ria &agrave; prova dos autos somente &eacute; admiss&iacute;vel quando o veredito estiver inteiramente dissociado do acervo probat&oacute;rio, hip&oacute;tese n&atilde;o verificada, em observ&acirc;ncia ao princ&iacute;pio constitucional da soberania dos veredictos.
+6. Havendo suporte probat&oacute;rio m&iacute;nimo para a tese acolhida pelos jurados, deve prevalecer a escolha do Conselho de Senten&ccedil;a, que decide com base na &iacute;ntima convic&ccedil;&atilde;o.
+7. A valora&ccedil;&atilde;o negativa da culpabilidade mostra-se id&ocirc;nea diante do elevado grau de reprovabilidade da conduta, evidenciado pelos disparos efetuados a curta dist&acirc;ncia e pelas costas da v&iacute;tima em tentativa de fuga.
+8. A exaspera&ccedil;&atilde;o das vetoriais circunst&acirc;ncias do crime tamb&eacute;m se revela adequada, pois os disparos ocorreram em estabelecimento comercial em funcionamento e com circula&ccedil;&atilde;o de terceiros, expondo outros bens jur&iacute;dicos a risco.
+9. A incid&ecirc;ncia da atenuante da menoridade relativa foi corretamente reconhecida, bem como a causa de diminui&ccedil;&atilde;o da tentativa na fra&ccedil;&atilde;o m&aacute;xima de 2/3, em raz&atilde;o da aus&ecirc;ncia de elementos t&eacute;cnicos que autorizassem redutor inferior.
+10. Mant&eacute;m-se a pena fixada, bem como o regime inicial semiaberto, em raz&atilde;o do quantum da reprimenda.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e improvido.
+
+Teses de julgamento: 1. A decis&atilde;o do Tribunal do J&uacute;ri somente pode ser anulada quando manifestamente e integralmente contr&aacute;ria &agrave; prova dos autos. 2. Havendo lastro probat&oacute;rio m&iacute;nimo para a tese acolhida pelos jurados, imp&otilde;e-se a preserva&ccedil;&atilde;o do veredito em respeito &agrave; soberania constitucional do j&uacute;ri. 3. &Eacute; leg&iacute;tima a exaspera&ccedil;&atilde;o da pena-base quando a conduta revela maior reprovabilidade e &eacute; praticada em local com circula&ccedil;&atilde;o de terceiros, com risco ampliado a outros bens jur&iacute;dicos. 4. Na aus&ecirc;ncia de elementos t&eacute;cnicos sobre o iter criminis, aplica-se a fra&ccedil;&atilde;o m&aacute;xima de diminui&ccedil;&atilde;o da tentativa.
+Dispositivos relevantes citados: CF/1988, art. 5.&ordm;, XXXVIII, &quot;c&quot;; CPP, art. 593, III, &quot;d&quot;; CP, arts. 121, &sect; 2.&ordm;, IV, 14, II e par&aacute;grafo &uacute;nico, 33, &sect; 2.&ordm;, &quot;a&quot;, e 65, I.
+Jurisprud&ecirc;ncia relevante citada: S&uacute;mula n&ordm; 6 do TJCE; TJCE, Apela&ccedil;&atilde;o Criminal - 0002450-62.2018.8.06.0091, Rel. Desembargador(a) LIRA RAMOS DE OLIVEIRA, 1&ordf; C&acirc;mara Criminal, data do julgamento: 01/07/2025, data da publica&ccedil;&atilde;o: 02/07/2025; STF - ARE: 1280954 SP 0000143-71.2016.8.26.0052, Relator: EDSON FACHIN, Data de Julgamento: 23/11/2021, Segunda Turma, Data de Publica&ccedil;&atilde;o: 10/01/2022; (TJCE - Embargos Infringentes e de Nulidade - 0006207-63.2013.8.06.0051, Rel. Desembargador(a) BENEDITO HELDER AFONSO IBIAPINA, Se&ccedil;&atilde;o Criminal, data do julgamento: 28/07/2025, data da publica&ccedil;&atilde;o: 28/07/2025; TJCE, Apela&ccedil;&atilde;o Criminal - 0020892-60.2015.8.06.0001, Rel. Desembargador(a) LIRA RAMOS DE OLIVEIRA, 1&ordf; C&acirc;mara Criminal, data do julgamento: 05/11/2024, data da publica&ccedil;&atilde;o: 06/11/2024.
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos os presentes autos de Apela&ccedil;&atilde;o Criminal, acordam os Desembargadores da 1&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, &agrave; unanimidade, em conhecer dos recursos e negar-lhe provimento, tudo em conformidade com o voto do Relator.
+
+
+Fortaleza-CE, 14 de abril de 2026.
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator
+
+  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0010149-84.2012.8.06.0101, Rel. Desembargador(a)  FRANCISCO CARNEIRO LIMA, 1&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO CARNEIRO LIMA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Itapipoca
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRIBUNAL DO JÚRI. TENTATIVA DE HOMICÍDIO QUALIFICADO. DECISÃO MANIFESTAMENTE CONTRÁRIA À PROVA DOS AUTOS. SOBERANIA DOS VEREDICTOS. DOSIMETRIA DA PENA. MANUTENÇÃO DA CONDENAÇÃO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apelação Criminal interposta pela defesa de Francisco Anderson Bezerra da Silva contra sentença condenatória
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRIBUNAL DO JÚRI. TENTATIVA DE HOMICÍDIO QUALIFICADO. DECISÃO MANIFESTAMENTE CONTRÁRIA À PROVA DOS AUTOS. SOBERANIA DOS VEREDICTOS. DOSIMETRIA DA PENA. MANUTENÇÃO DA CONDENAÇÃO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apelação Criminal interposta pela defesa de Francisco Anderson Bezerra da Silva contra sentença condenatória proferida pelo Juiz de Direito da  1.ª Vara do Júri da Comarca de Fortaleza/CE, prolatada em consonância  com a decisão do Conselho de Sentença do Tribunal do Júri, que o condenou pela prática  do crime previsto no art. 121, § 2.º, inciso IV, c/c o art. 14, inciso II, todos do Código  Penal, fixando-lhe a pena de 4 (quatro) anos, 5 (cinco) meses e 10 (dez) dias de reclusão, a ser cumprida inicialmente em regime semiaberto.
+
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se o veredito condenatório do Tribunal do Júri é manifestamente contrário à prova dos autos, a justificar novo julgamento nos termos do art. 593, III, "d", do CPP; (ii) estabelecer se a dosimetria da pena observou adequadamente os critérios legais e jurisprudenciais aplicáveis.
+III. RAZÕES DE DECIDIR
+3. O conjunto probatório produzido nos autos comprova de forma harmônica a materialidade e a autoria delitivas, especialmente por meio do depoimento da testemunha ocular Walef Soares Brandão, que descreve de forma coerente a dinâmica do crime, apontando o recorrente como autor dos disparos.
+4. A ausência de memória da vítima quanto à autoria dos disparos, em razão do estado de embriaguez no momento dos fatos, não equivale à negativa de autoria e não possui aptidão para infirmar a prova testemunhal idônea produzida em juízo.
+5. A anulação do julgamento por decisão manifestamente contrária à prova dos autos somente é admissível quando o veredito estiver inteiramente dissociado do acervo probatório, hipótese não verificada, em observância ao princípio constitucional da soberania dos veredictos.
+6. Havendo suporte probatório mínimo para a tese acolhida pelos jurados, deve prevalecer a escolha do Conselho de Sentença, que decide com base na íntima convicção.
+7. A valoração negativa da culpabilidade mostra-se idônea diante do elevado grau de reprovabilidade da conduta, evidenciado pelos disparos efetuados a curta distância e pelas costas da vítima em tentativa de fuga.
+8. A exasperação das vetoriais circunstâncias do crime também se revela adequada, pois os disparos ocorreram em estabelecimento comercial em funcionamento e com circulação de terceiros, expondo outros bens jurídicos a risco.
+9. A incidência da atenuante da menoridade relativa foi corretamente reconhecida, bem como a causa de diminuição da tentativa na fração máxima de 2/3, em razão da ausência de elementos técnicos que autorizassem redutor inferior.
+10. Mantém-se a pena fixada, bem como o regime inicial semiaberto, em razão do quantum da reprimenda.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e improvido.
+
+Teses de julgamento: 1. A decisão do Tribunal do Júri somente pode ser anulada quando manifestamente e integralmente contrária à prova dos autos. 2. Havendo lastro probatório mínimo para a tese acolhida pelos jurados, impõe-se a preservação do veredito em respeito à soberania constitucional do júri. 3. É legítima a exasperação da pena-base quando a conduta revela maior reprovabilidade e é praticada em local com circulação de terceiros, com risco ampliado a outros bens jurídicos. 4. Na ausência de elementos técnicos sobre o iter criminis, aplica-se a fração máxima de diminuição da tentativa.
+Dispositivos relevantes citados: CF/1988, art. 5.º, XXXVIII, "c"; CPP, art. 593, III, "d"; CP, arts. 121, § 2.º, IV, 14, II e parágrafo único, 33, § 2.º, "a", e 65, I.
+Jurisprudência relevante citada: Súmula nº 6 do TJCE; TJCE, Apelação Criminal - 0002450-62.2018.8.06.0091, Rel. Desembargador(a) LIRA RAMOS DE OLIVEIRA, 1ª Câmara Criminal, data do julgamento: 01/07/2025, data da publicação: 02/07/2025; STF - ARE: 1280954 SP 0000143-71.2016.8.26.0052, Relator: EDSON FACHIN, Data de Julgamento: 23/11/2021, Segunda Turma, Data de Publicação: 10/01/2022; (TJCE - Embargos Infringentes e de Nulidade - 0006207-63.2013.8.06.0051, Rel. Desembargador(a) BENEDITO HELDER AFONSO IBIAPINA, Seção Criminal, data do julgamento: 28/07/2025, data da publicação: 28/07/2025; TJCE, Apelação Criminal - 0020892-60.2015.8.06.0001, Rel. Desembargador(a) LIRA RAMOS DE OLIVEIRA, 1ª Câmara Criminal, data do julgamento: 05/11/2024, data da publicação: 06/11/2024.
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos os presentes autos de Apelação Criminal, acordam os Desembargadores da 1ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, à unanimidade, em conhecer dos recursos e negar-lhe provimento, tudo em conformidade com o voto do Relator.
+
+
+Fortaleza-CE, 14 de abril de 2026.
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator
+
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833798" cdForo="0" >
+										0201491-63.2024.8.06.0167
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833798" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833798);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833798" style="display: none;" >
+	<div id="textAreaDados_3833798" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. INJ&Uacute;RIA RACIAL E AMEA&Ccedil;A. SUFICI&Ecirc;NCIA PROBAT&Oacute;RIA. PALAVRA DA V&Iacute;TIMA CORROBORADA POR TESTEMUNHAS PRESENCIAIS. DOSIMETRIA DA PENA. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO DESPROVIDO.
+
+I. CASO EM EXAME
+1. Trata-se de Apela&ccedil;&atilde;o Criminal interposta pela defesa de Ant&ocirc;nio Raimundo Marques Liberato contra senten&ccedil;a condenat&oacute;ria proferida pela Ju&iacute;za de Direito da 3.&ordf; Vara Criminal da Comarca de Sobral/CE, que o condenou pela pr&aacute;tica dos crimes previstos nos art. 2.&ordm;- A, da Lei n.&ordm; 7.716/89 e no art. 147 do C&oacute;digo Penal, na forma do art. 69 do C&oacute;digo Penal, fixando-lhe a pena de 2 (dois) anos e 4 (quatro) meses de reclus&atilde;o, 1 (um) m&ecirc;s de deten&ccedil;&atilde;o, al&eacute;m do pagamento de 12 (doze) dias-multa, a ser cumprida inicialmente em regime aberto.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; 3 quest&otilde;es em discuss&atilde;o: (i) definir se o conjunto probat&oacute;rio &eacute; suficiente para comprovar a autoria e a materialidade dos crimes de inj&uacute;ria racial e amea&ccedil;a; (ii) estabelecer se a dosimetria da pena foi corretamente fixada, especialmente quanto &agrave; valora&ccedil;&atilde;o negativa das circunst&acirc;ncias do crime; (iii) determinar se est&atilde;o presentes os requisitos legais para a substitui&ccedil;&atilde;o da pena privativa de liberdade ou para a suspens&atilde;o condicional da pena.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3. A materialidade e a autoria do crime de inj&uacute;ria racial restam demonstradas pela notic&iacute;a-crime, boletim de ocorr&ecirc;ncia, inqu&eacute;rito policial, depoimento da v&iacute;tima e testemunhos colhidos sob contradit&oacute;rio, todos convergentes no sentido de que o apelante proferiu a express&atilde;o racista &quot;macaco&quot; em via p&uacute;blica, na presen&ccedil;a de terceiros.
+4. A palavra da v&iacute;tima assume especial relev&acirc;ncia probat&oacute;ria, pois se apresenta firme, coerente e integralmente corroborada por testemunhas presenciais, que confirmam tanto a inj&uacute;ria racial quanto a amea&ccedil;a de morte proferida pelo recorrente.
+5. A negativa de autoria apresentada pela defesa revela-se isolada, gen&eacute;rica e desprovida de suporte probat&oacute;rio m&iacute;nimo, sendo insuficiente para infirmar o conjunto probat&oacute;rio judicializado.
+6. O crime de amea&ccedil;a, por sua natureza formal, consuma-se com a simples exterioriza&ccedil;&atilde;o de promessa de mal injusto e grave apta a intimidar a v&iacute;tima, independentemente da efetiva inten&ccedil;&atilde;o de concretiza&ccedil;&atilde;o, circunst&acirc;ncia comprovada pela frase &quot;vou te matar&quot;.
+7. A dosimetria da pena foi corretamente fixada, com valora&ccedil;&atilde;o negativa da circunst&acirc;ncia judicial relativa &agrave;s circunst&acirc;ncias do crime de inj&uacute;ria racial, em raz&atilde;o da humilha&ccedil;&atilde;o p&uacute;blica causada pela ofensa proferida diante de vizinhos e frequentadores do local, o que acentua a reprovabilidade concreta da conduta.
+8. Mostra-se invi&aacute;vel a substitui&ccedil;&atilde;o da pena privativa de liberdade por restritivas de direitos e a concess&atilde;o do sursis, diante da exist&ecirc;ncia de circunst&acirc;ncia judicial desfavor&aacute;vel e do n&atilde;o preenchimento dos requisitos dos arts. 44, III, e 77 do C&oacute;digo Penal.
+
+IV. DISPOSITIVO E TESE
+9. Recurso conhecido e improvido.
+
+Tese de julgamento: 1. A palavra da v&iacute;tima, quando firme, coerente e corroborada por testemunhas presenciais, &eacute; suficiente para fundamentar condena&ccedil;&atilde;o pelos crimes de inj&uacute;ria racial e amea&ccedil;a.  2. O crime de amea&ccedil;a se consuma com a exterioriza&ccedil;&atilde;o id&ocirc;nea de promessa de mal injusto e grave, independentemente da efetiva execu&ccedil;&atilde;o do mal prometido. 3. A pr&aacute;tica de inj&uacute;ria racial em local p&uacute;blico e na presen&ccedil;a de terceiros justifica a valora&ccedil;&atilde;o negativa das circunst&acirc;ncias do crime na primeira fase da dosimetria. 4. A exist&ecirc;ncia de circunst&acirc;ncia judicial desfavor&aacute;vel afasta a substitui&ccedil;&atilde;o da pena privativa de liberdade por restritivas de direitos e a concess&atilde;o da suspens&atilde;o condicional da pena.
+
+Dispositivos relevantes citados: Lei n&ordm; 7.716/1989, art. 2.&ordm;-A; C&oacute;digo Penal, arts. 33, &sect; 2.&ordm;, &quot;c&quot;, 44, III, 69, 77 e 147; C&oacute;digo de Processo Penal, art. 386, II, III e VII.
+
+Jurisprud&ecirc;ncia relevante citada: TJCE, Apela&ccedil;&atilde;o Criminal - 0200748 97.2023.8.06.0293, Rel. Desembargador(a) BENEDITO HELDER AFONSO IBIAPINA, 2&ordf; C&acirc;mara Criminal, data do julgamento: 08/04/2026, data da publica&ccedil;&atilde;o: 08/04/2026; (TJCE, Apela&ccedil;&atilde;o Criminal - 0201378 41.2023.8.06.0298, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento: 08/04/2026, data da publica&ccedil;&atilde;o: 08/04/2026; TJCE, Apela&ccedil;&atilde;o Criminal - 0200118-85.2023.8.06.0052, Rel. Desembargador(a) LIGIA ANDRADE DE ALENCAR MAGALH&Atilde;ES, 1&ordf; C&acirc;mara Criminal, data do julgamento: 31/03/2026, data da publica&ccedil;&atilde;o: 01/04/2026.
+
+
+
+
+
+
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos os presentes autos de Apela&ccedil;&atilde;o Criminal, acordam os Desembargadores da 1.&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, &agrave; unanimidade, em conhecer do presente recurso, para negar-lhe provimento, tudo em conformidade com o voto do Relator.
+
+Fortaleza-CE, 14 de abril de 2026.
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator
+  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0201491-63.2024.8.06.0167, Rel. Desembargador(a)  FRANCISCO CARNEIRO LIMA, 1&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / (Fato até 10/01/2023) Injúria Preconceituosa em Razão de Raça
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO CARNEIRO LIMA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sobral
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. INJÚRIA RACIAL E AMEAÇA. SUFICIÊNCIA PROBATÓRIA. PALAVRA DA VÍTIMA CORROBORADA POR TESTEMUNHAS PRESENCIAIS. DOSIMETRIA DA PENA. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+
+I. CASO EM EXAME
+1. Trata-se de Apelação Criminal interposta pela defesa de Antônio Raimundo Marques Liberato contra sentença condenatória proferida pela Juíza de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. INJÚRIA RACIAL E AMEAÇA. SUFICIÊNCIA PROBATÓRIA. PALAVRA DA VÍTIMA CORROBORADA POR TESTEMUNHAS PRESENCIAIS. DOSIMETRIA DA PENA. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+
+I. CASO EM EXAME
+1. Trata-se de Apelação Criminal interposta pela defesa de Antônio Raimundo Marques Liberato contra sentença condenatória proferida pela Juíza de Direito da 3.ª Vara Criminal da Comarca de Sobral/CE, que o condenou pela prática dos crimes previstos nos art. 2.º- A, da Lei n.º 7.716/89 e no art. 147 do Código Penal, na forma do art. 69 do Código Penal, fixando-lhe a pena de 2 (dois) anos e 4 (quatro) meses de reclusão, 1 (um) mês de detenção, além do pagamento de 12 (doze) dias-multa, a ser cumprida inicialmente em regime aberto.
+II. QUESTÃO EM DISCUSSÃO
+2. Há 3 questões em discussão: (i) definir se o conjunto probatório é suficiente para comprovar a autoria e a materialidade dos crimes de injúria racial e ameaça; (ii) estabelecer se a dosimetria da pena foi corretamente fixada, especialmente quanto à valoração negativa das circunstâncias do crime; (iii) determinar se estão presentes os requisitos legais para a substituição da pena privativa de liberdade ou para a suspensão condicional da pena.
+
+III. RAZÕES DE DECIDIR
+3. A materialidade e a autoria do crime de injúria racial restam demonstradas pela noticía-crime, boletim de ocorrência, inquérito policial, depoimento da vítima e testemunhos colhidos sob contraditório, todos convergentes no sentido de que o apelante proferiu a expressão racista "macaco" em via pública, na presença de terceiros.
+4. A palavra da vítima assume especial relevância probatória, pois se apresenta firme, coerente e integralmente corroborada por testemunhas presenciais, que confirmam tanto a injúria racial quanto a ameaça de morte proferida pelo recorrente.
+5. A negativa de autoria apresentada pela defesa revela-se isolada, genérica e desprovida de suporte probatório mínimo, sendo insuficiente para infirmar o conjunto probatório judicializado.
+6. O crime de ameaça, por sua natureza formal, consuma-se com a simples exteriorização de promessa de mal injusto e grave apta a intimidar a vítima, independentemente da efetiva intenção de concretização, circunstância comprovada pela frase "vou te matar".
+7. A dosimetria da pena foi corretamente fixada, com valoração negativa da circunstância judicial relativa às circunstâncias do crime de injúria racial, em razão da humilhação pública causada pela ofensa proferida diante de vizinhos e frequentadores do local, o que acentua a reprovabilidade concreta da conduta.
+8. Mostra-se inviável a substituição da pena privativa de liberdade por restritivas de direitos e a concessão do sursis, diante da existência de circunstância judicial desfavorável e do não preenchimento dos requisitos dos arts. 44, III, e 77 do Código Penal.
+
+IV. DISPOSITIVO E TESE
+9. Recurso conhecido e improvido.
+
+Tese de julgamento: 1. A palavra da vítima, quando firme, coerente e corroborada por testemunhas presenciais, é suficiente para fundamentar condenação pelos crimes de injúria racial e ameaça.  2. O crime de ameaça se consuma com a exteriorização idônea de promessa de mal injusto e grave, independentemente da efetiva execução do mal prometido. 3. A prática de injúria racial em local público e na presença de terceiros justifica a valoração negativa das circunstâncias do crime na primeira fase da dosimetria. 4. A existência de circunstância judicial desfavorável afasta a substituição da pena privativa de liberdade por restritivas de direitos e a concessão da suspensão condicional da pena.
+
+Dispositivos relevantes citados: Lei nº 7.716/1989, art. 2.º-A; Código Penal, arts. 33, § 2.º, "c", 44, III, 69, 77 e 147; Código de Processo Penal, art. 386, II, III e VII.
+
+Jurisprudência relevante citada: TJCE, Apelação Criminal - 0200748 97.2023.8.06.0293, Rel. Desembargador(a) BENEDITO HELDER AFONSO IBIAPINA, 2ª Câmara Criminal, data do julgamento: 08/04/2026, data da publicação: 08/04/2026; (TJCE, Apelação Criminal - 0201378 41.2023.8.06.0298, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2ª Câmara Criminal, data do julgamento: 08/04/2026, data da publicação: 08/04/2026; TJCE, Apelação Criminal - 0200118-85.2023.8.06.0052, Rel. Desembargador(a) LIGIA ANDRADE DE ALENCAR MAGALHÃES, 1ª Câmara Criminal, data do julgamento: 31/03/2026, data da publicação: 01/04/2026.
+
+
+
+
+
+
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos os presentes autos de Apelação Criminal, acordam os Desembargadores da 1.ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, à unanimidade, em conhecer do presente recurso, para negar-lhe provimento, tudo em conformidade com o voto do Relator.
+
+Fortaleza-CE, 14 de abril de 2026.
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833796" cdForo="0" >
+										0202610-69.2024.8.06.0293
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833796" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833796);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833796" style="display: none;" >
+	<div id="textAreaDados_3833796" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TR&Aacute;FICO DE DROGAS. PRELIMINAR DE NULIDADE REJEITADA. EXIST&Ecirc;NCIA DE FUNDADAS RAZ&Otilde;ES PARA A A&Ccedil;&Atilde;O POLICIAL. CONSENTIMENTO DA PROPRIET&Aacute;RIA. PLEITOS ABSOLUT&Oacute;RIO E DESCLASSIFICAT&Oacute;RIO N&Atilde;O ACOLHIDOS. AUTORIA E MATERIALIDADE SUFICIENTEMENTE COMPROVADAS. REVIS&Atilde;O DA DOSIMETRIA. APLICA&Ccedil;&Atilde;O DO TR&Aacute;FICO PRIVILEGIADO EM 1/2. SAN&Ccedil;&Otilde;ES PARCIALMENTE REFORMADAS. READEQUA&Ccedil;&Atilde;O DO REGIME INICIAL DE CUMPRIMENTO DE PENA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a que condenou a r&eacute; pela pr&aacute;tica do crime previsto no art. 33 da Lei n.&ordm; 11.343/2006, &agrave; pena de 5 anos de reclus&atilde;o, em regime inicial semiaberto. A defesa suscita nulidade por invas&atilde;o de domic&iacute;lio, pleiteia absolvi&ccedil;&atilde;o por insufici&ecirc;ncia probat&oacute;ria ou desclassifica&ccedil;&atilde;o para uso pessoal e, subsidiariamente, a aplica&ccedil;&atilde;o do tr&aacute;fico privilegiado e readequa&ccedil;&atilde;o da pena.
+
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se houve nulidade da prova em raz&atilde;o de ingresso ilegal em domic&iacute;lio; (ii) estabelecer se est&atilde;o comprovadas a autoria e a materialidade do crime de tr&aacute;fico, aptas a sustentar a condena&ccedil;&atilde;o ou ensejar absolvi&ccedil;&atilde;o ou desclassifica&ccedil;&atilde;o; (iii) determinar se a dosimetria da pena deve ser revista, com aplica&ccedil;&atilde;o do tr&aacute;fico privilegiado e readequa&ccedil;&atilde;o do regime prisional.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3. A entrada em domic&iacute;lio sem mandado judicial &eacute; l&iacute;cita quando h&aacute; consentimento v&aacute;lido do morador, inexistindo prova de coa&ccedil;&atilde;o ou v&iacute;cio de vontade, conforme art. 5.&ordm;, XI, da CF, e Tema n&ordm; 280 do STF.
+
+4. A den&uacute;ncia an&ocirc;nima, embora insuficiente isoladamente, pode legitimar dilig&ecirc;ncia policial quando seguida de confirma&ccedil;&atilde;o por elementos concretos, como o consentimento da moradora e a posterior apreens&atilde;o de drogas.
+
+5. A materialidade delitiva est&aacute; comprovada por auto de apreens&atilde;o e laudos periciais que atestam a natureza il&iacute;cita das subst&acirc;ncias apreendidas, e a autoria se evidencia pelos depoimentos coerentes dos policiais e pela confiss&atilde;o extrajudicial da r&eacute;, sendo insuficiente sua negativa isolada em ju&iacute;zo para afastar o conjunto probat&oacute;rio.
+
+6. A quantidade, variedade e forma de acondicionamento fracionado das drogas evidenciam a destina&ccedil;&atilde;o mercantil, afastando a hip&oacute;tese de uso pessoal, de modo que a desclassifica&ccedil;&atilde;o para o art. 28 da Lei de Drogas &eacute; invi&aacute;vel diante das circunst&acirc;ncias f&aacute;ticas e dos crit&eacute;rios do art. 28, &sect; 2.&ordm;, da Lei n.&ordm; 11.343/2006.
+
+7. Em rela&ccedil;&atilde;o &agrave; dosimetria, verificou-se que a utiliza&ccedil;&atilde;o da mesma circunst&acirc;ncia (quantidade e natureza da droga) em mais de uma fase da dosimetria configura bis in idem, devendo ser corrigida.
+
+8. O tr&aacute;fico privilegiado deve ser reconhecido quando preenchidos os requisitos legais, sendo adequada a fra&ccedil;&atilde;o intermedi&aacute;ria de redu&ccedil;&atilde;o diante das peculiaridades do caso.
+
+9. A redu&ccedil;&atilde;o da pena autoriza a fixa&ccedil;&atilde;o de regime inicial mais brando e a substitui&ccedil;&atilde;o da pena privativa de liberdade por duas restritivas de direitos, a serem delimitadas e fiscalizadas pelo ju&iacute;zo da execu&ccedil;&atilde;o penal.
+
+IV. DISPOSITIVO E TESE
+10. Recurso conhecido e parcialmente provido.
+
+
+
+
+
+Tese de julgamento: 1. O ingresso em domic&iacute;lio com consentimento v&aacute;lido do morador afasta a ilicitude da prova, ainda que precedido de den&uacute;ncia an&ocirc;nima. 2. A apreens&atilde;o de drogas fracionadas, aliada &agrave;s circunst&acirc;ncias do caso, evidencia a destina&ccedil;&atilde;o mercantil e afasta a desclassifica&ccedil;&atilde;o para uso pessoal. 3. Depoimentos policiais coerentes e corroborados por laudos periciais s&atilde;o suficientes para embasar condena&ccedil;&atilde;o por tr&aacute;fico de drogas. 4. &Eacute; vedada a valora&ccedil;&atilde;o da mesma circunst&acirc;ncia em mais de uma fase da dosimetria da pena. 5. O tr&aacute;fico privilegiado deve ser aplicado quando ausentes elementos concretos de dedica&ccedil;&atilde;o a atividades criminosas, com redu&ccedil;&atilde;o proporcional &agrave;s circunst&acirc;ncias do caso. 6. A diminui&ccedil;&atilde;o da pena autoriza a fixa&ccedil;&atilde;o de regime inicial aberto e a substitui&ccedil;&atilde;o por penas restritivas de direitos.
+
+
+
+
+
+
+
+
+Dispositivos relevantes citados: CF/1988, art. 5.&ordm;, XI; CP, arts. 33, &sect; 2.&ordm;, &quot;c&quot;, 44 e 59; Lei n.&ordm; 11.343/2006, arts. 28, &sect; 2.&ordm;, e 33, caput e &sect; 4.&ordm;.
+
+Jurisprud&ecirc;ncia relevante citada: STF, RE 603.616/RO (Tema 280); STJ, HC n&ordm; 984.420/SP, Rel. Min. Og Fernandes, Sexta Turma, j. 04/03/2026; STJ, AgRg no HC n&ordm; 1.017.263/SP, Rel. Min. Antonio Saldanha Palheiro, Sexta Turma, j. 29/10/2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0219411-29.2025.8.06.0001, Rel. Des. Francisco Carneiro Lima, j. 07/04/2026; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0236113-89.2021.8.06.0001, Rel. Des. Lira Ramos de Oliveira, j. 31/03/2026.
+
+
+
+
+
+AC&Oacute;RD&Atilde;O
+Vistos, relatados e discutidos os presentes autos de Apela&ccedil;&atilde;o Criminal, acordam os Desembargadores da 1.&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, &agrave; unanimidade, em conhecer do presente recurso, para dar-lhe parcial provimento, tudo em conformidade com o voto do Relator.
+
+
+
+
+
+Fortaleza-CE, 14 de abril de 2026.
+
+
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator
+  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0202610-69.2024.8.06.0293, Rel. Desembargador(a)  FRANCISCO CARNEIRO LIMA, 1&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO CARNEIRO LIMA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Independência
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. PRELIMINAR DE NULIDADE REJEITADA. EXISTÊNCIA DE FUNDADAS RAZÕES PARA A AÇÃO POLICIAL. CONSENTIMENTO DA PROPRIETÁRIA. PLEITOS ABSOLUTÓRIO E DESCLASSIFICATÓRIO NÃO ACOLHIDOS. AUTORIA E MATERIALIDADE SUFICIENTEMENTE COMPROVADAS. REVISÃO DA DOSIMETRIA. APLICAÇÃO DO TRÁFICO PRIVILEGIADO EM 1/2. SANÇÕES PARCIALMENTE REFORMADAS.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. PRELIMINAR DE NULIDADE REJEITADA. EXISTÊNCIA DE FUNDADAS RAZÕES PARA A AÇÃO POLICIAL. CONSENTIMENTO DA PROPRIETÁRIA. PLEITOS ABSOLUTÓRIO E DESCLASSIFICATÓRIO NÃO ACOLHIDOS. AUTORIA E MATERIALIDADE SUFICIENTEMENTE COMPROVADAS. REVISÃO DA DOSIMETRIA. APLICAÇÃO DO TRÁFICO PRIVILEGIADO EM 1/2. SANÇÕES PARCIALMENTE REFORMADAS. READEQUAÇÃO DO REGIME INICIAL DE CUMPRIMENTO DE PENA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença que condenou a ré pela prática do crime previsto no art. 33 da Lei n.º 11.343/2006, à pena de 5 anos de reclusão, em regime inicial semiaberto. A defesa suscita nulidade por invasão de domicílio, pleiteia absolvição por insuficiência probatória ou desclassificação para uso pessoal e, subsidiariamente, a aplicação do tráfico privilegiado e readequação da pena.
+
+II. QUESTÕES EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se houve nulidade da prova em razão de ingresso ilegal em domicílio; (ii) estabelecer se estão comprovadas a autoria e a materialidade do crime de tráfico, aptas a sustentar a condenação ou ensejar absolvição ou desclassificação; (iii) determinar se a dosimetria da pena deve ser revista, com aplicação do tráfico privilegiado e readequação do regime prisional.
+
+III. RAZÕES DE DECIDIR
+3. A entrada em domicílio sem mandado judicial é lícita quando há consentimento válido do morador, inexistindo prova de coação ou vício de vontade, conforme art. 5.º, XI, da CF, e Tema nº 280 do STF.
+
+4. A denúncia anônima, embora insuficiente isoladamente, pode legitimar diligência policial quando seguida de confirmação por elementos concretos, como o consentimento da moradora e a posterior apreensão de drogas.
+
+5. A materialidade delitiva está comprovada por auto de apreensão e laudos periciais que atestam a natureza ilícita das substâncias apreendidas, e a autoria se evidencia pelos depoimentos coerentes dos policiais e pela confissão extrajudicial da ré, sendo insuficiente sua negativa isolada em juízo para afastar o conjunto probatório.
+
+6. A quantidade, variedade e forma de acondicionamento fracionado das drogas evidenciam a destinação mercantil, afastando a hipótese de uso pessoal, de modo que a desclassificação para o art. 28 da Lei de Drogas é inviável diante das circunstâncias fáticas e dos critérios do art. 28, § 2.º, da Lei n.º 11.343/2006.
+
+7. Em relação à dosimetria, verificou-se que a utilização da mesma circunstância (quantidade e natureza da droga) em mais de uma fase da dosimetria configura bis in idem, devendo ser corrigida.
+
+8. O tráfico privilegiado deve ser reconhecido quando preenchidos os requisitos legais, sendo adequada a fração intermediária de redução diante das peculiaridades do caso.
+
+9. A redução da pena autoriza a fixação de regime inicial mais brando e a substituição da pena privativa de liberdade por duas restritivas de direitos, a serem delimitadas e fiscalizadas pelo juízo da execução penal.
+
+IV. DISPOSITIVO E TESE
+10. Recurso conhecido e parcialmente provido.
+
+
+
+
+
+Tese de julgamento: 1. O ingresso em domicílio com consentimento válido do morador afasta a ilicitude da prova, ainda que precedido de denúncia anônima. 2. A apreensão de drogas fracionadas, aliada às circunstâncias do caso, evidencia a destinação mercantil e afasta a desclassificação para uso pessoal. 3. Depoimentos policiais coerentes e corroborados por laudos periciais são suficientes para embasar condenação por tráfico de drogas. 4. É vedada a valoração da mesma circunstância em mais de uma fase da dosimetria da pena. 5. O tráfico privilegiado deve ser aplicado quando ausentes elementos concretos de dedicação a atividades criminosas, com redução proporcional às circunstâncias do caso. 6. A diminuição da pena autoriza a fixação de regime inicial aberto e a substituição por penas restritivas de direitos.
+
+
+
+
+
+
+
+
+Dispositivos relevantes citados: CF/1988, art. 5.º, XI; CP, arts. 33, § 2.º, "c", 44 e 59; Lei n.º 11.343/2006, arts. 28, § 2.º, e 33, caput e § 4.º.
+
+Jurisprudência relevante citada: STF, RE 603.616/RO (Tema 280); STJ, HC nº 984.420/SP, Rel. Min. Og Fernandes, Sexta Turma, j. 04/03/2026; STJ, AgRg no HC nº 1.017.263/SP, Rel. Min. Antonio Saldanha Palheiro, Sexta Turma, j. 29/10/2025; TJCE, Apelação Criminal nº 0219411-29.2025.8.06.0001, Rel. Des. Francisco Carneiro Lima, j. 07/04/2026; TJCE, Apelação Criminal nº 0236113-89.2021.8.06.0001, Rel. Des. Lira Ramos de Oliveira, j. 31/03/2026.
+
+
+
+
+
+ACÓRDÃO
+Vistos, relatados e discutidos os presentes autos de Apelação Criminal, acordam os Desembargadores da 1.ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, à unanimidade, em conhecer do presente recurso, para dar-lhe parcial provimento, tudo em conformidade com o voto do Relator.
+
+
+
+
+
+Fortaleza-CE, 14 de abril de 2026.
+
+
+
+DESEMBARGADOR FRANCISCO CARNEIRO LIMA
+Relator
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833871" cdForo="0" >
+										0073781-59.2013.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833871" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833871);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833871" style="display: none;" >
+	<div id="textAreaDados_3833871" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. EMBARGOS DE DECLARA&Ccedil;&Atilde;O CRIMINAL. ASSISTENTE DA ACUSA&Ccedil;&Atilde;O. ALEGADAS CONTRADI&Ccedil;&Atilde;O, OBSCURIDADE E OMISS&Atilde;O. INEXIST&Ecirc;NCIA DE V&Iacute;CIOS INTEGRATIVOS. PRETENS&Atilde;O DE REDISCUSS&Atilde;O DA VALORA&Ccedil;&Atilde;O DA PROVA E DE REFORMA DO JULGADO ABSOLUT&Oacute;RIO. IMPOSSIBILIDADE. RECURSO CONHECIDO E DESPROVIDO
+
+I. Caso em exame
+1. Embargos de declara&ccedil;&atilde;o opostos pela Associa&ccedil;&atilde;o Cient&iacute;fica de Estudos Agr&aacute;rios &#150; ACEG, na qualidade de assistente da acusa&ccedil;&atilde;o, contra ac&oacute;rd&atilde;o que, em apela&ccedil;&atilde;o criminal, negou provimento ao recurso e manteve a absolvi&ccedil;&atilde;o do r&eacute;u da imputa&ccedil;&atilde;o prevista no art. 168, &sect; 1&ordm;, III, do C&oacute;digo Penal, ao fundamento de insufici&ecirc;ncia probat&oacute;ria quanto &agrave; autoria e ao dolo de apropria&ccedil;&atilde;o.
+Nos aclarat&oacute;rios, a embargante sustenta, em s&iacute;ntese, a exist&ecirc;ncia de contradi&ccedil;&atilde;o e obscuridade na decis&atilde;o embargada, sob o argumento de que a prova oral, documental, policial e cont&aacute;bil demonstraria a centralidade funcional do acusado na administra&ccedil;&atilde;o financeira da associa&ccedil;&atilde;o, requerendo, ao final, a reforma do ac&oacute;rd&atilde;o com atribui&ccedil;&atilde;o de efeitos modificativos, inclusive para condena&ccedil;&atilde;o do r&eacute;u e fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos
+
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o:
+(i) saber se os embargos de declara&ccedil;&atilde;o preenchem os requisitos de admissibilidade, notadamente legitimidade, interesse, tempestividade e regularidade formal;
+(ii) saber se o ac&oacute;rd&atilde;o embargado incorreu em contradi&ccedil;&atilde;o ao concluir pela aus&ecirc;ncia de prova segura e individualizada de autoria e dolo, apesar das alega&ccedil;&otilde;es da embargante quanto ao conte&uacute;do da prova oral, documental e policial;
+(iii) saber se houve obscuridade ou omiss&atilde;o quanto &agrave; valora&ccedil;&atilde;o do relat&oacute;rio de acompanhamento cont&aacute;bil, dos depoimentos judiciais e das demais pe&ccedil;as invocadas nos aclarat&oacute;rios; e
+(iv) saber se eventual saneamento de v&iacute;cio autorizaria a atribui&ccedil;&atilde;o de efeitos infringentes, com reforma do ac&oacute;rd&atilde;o absolut&oacute;rio, reconhecimento de continuidade delitiva, aplica&ccedil;&atilde;o do art. 383 do CPP e fixa&ccedil;&atilde;o de valor m&iacute;nimo de repara&ccedil;&atilde;o dos danos.
+
+III. Raz&otilde;es de decidir
+3. Os embargos de declara&ccedil;&atilde;o s&atilde;o admiss&iacute;veis, em tese, quando destinados ao saneamento de omiss&atilde;o, obscuridade, contradi&ccedil;&atilde;o, ambiguidade ou erro material, n&atilde;o se prestando &agrave; rediscuss&atilde;o da mat&eacute;ria de fundo j&aacute; apreciada. No caso, o recurso foi regularmente interposto por parte leg&iacute;tima, dentro do prazo legal e com exposi&ccedil;&atilde;o dos fundamentos impugnativos.
+4. O ac&oacute;rd&atilde;o embargado enfrentou de forma clara a controv&eacute;rsia devolvida, ao reconhecer a exist&ecirc;ncia de irregularidades e desorganiza&ccedil;&atilde;o administrativa na entidade associativa, mas concluir, de maneira expressa e coerente, que tais elementos n&atilde;o bastavam para demonstrar, com a seguran&ccedil;a exigida no processo penal, a individualiza&ccedil;&atilde;o de conduta t&iacute;pica de apropria&ccedil;&atilde;o, nem a presen&ccedil;a de dolo de assenhoramento definitivo.
+4. N&atilde;o se verifica contradi&ccedil;&atilde;o, obscuridade ou omiss&atilde;o no julgado embargado. A decis&atilde;o enfrentou o conte&uacute;do essencial do relat&oacute;rio cont&aacute;bil, dos depoimentos das testemunhas de acusa&ccedil;&atilde;o e da din&acirc;mica administrativa da associa&ccedil;&atilde;o, apenas lhes atribuindo efic&aacute;cia probat&oacute;ria insuficiente para afastar a d&uacute;vida razo&aacute;vel quanto &agrave; autoria e ao dolo.
+5. A insist&ecirc;ncia da embargante em reinterpretar o acervo probat&oacute;rio, sustentar a irrelev&acirc;ncia das testemunhas defensivas, postular continuidade delitiva, invocar a emendatio libelli e requerer repara&ccedil;&atilde;o m&iacute;nima revela mera inconformidade com o resultado do julgamento, buscando rediscutir o m&eacute;rito em via integrativa inadequada.
+6. Mantida a absolvi&ccedil;&atilde;o por insufici&ecirc;ncia de provas, resta prejudicado o pedido de fixa&ccedil;&atilde;o de valor m&iacute;nimo de repara&ccedil;&atilde;o, inexistindo espa&ccedil;o para atribui&ccedil;&atilde;o de efeitos modificativos.
+IV. Dispositivo e tese
+7. Embargos de declara&ccedil;&atilde;o conhecidos e desprovidos.
+Tese de julgamento:
+&quot;1. Os embargos de declara&ccedil;&atilde;o, no processo penal, destinam-se exclusivamente ao saneamento de omiss&atilde;o, obscuridade, contradi&ccedil;&atilde;o, ambiguidade ou erro material, n&atilde;o sendo cab&iacute;veis para rediscutir a valora&ccedil;&atilde;o da prova ou reformar o m&eacute;rito do julgamento sem v&iacute;cio intr&iacute;nseco no ac&oacute;rd&atilde;o.
+2. A constata&ccedil;&atilde;o de irregularidades administrativas e financeiras, desacompanhada de prova segura e individualizada de autoria e dolo de apropria&ccedil;&atilde;o, n&atilde;o autoriza a reforma de ac&oacute;rd&atilde;o absolut&oacute;rio por meio de embargos declarat&oacute;rios.
+3. Mantida a absolvi&ccedil;&atilde;o por insufici&ecirc;ncia probat&oacute;ria, resta prejudicado o pedido de fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos.&quot;
+Dispositivos relevantes citados: CP, arts. 168, &sect; 1&ordm;, III, e 71; CPP, arts. 271, 383, 387, IV, 598, 619 e 620; CPC, art. 1.022.
+Jurisprud&ecirc;ncias relevantes citadas: STJ, EDcl no AgRg no REsp n&ordm; 1.566.545/RJ, Rel. Min. Maria Thereza de Assis Moura, Sexta Turma, j. 18.08.2016; TJCE, Embargos de Declara&ccedil;&atilde;o Criminal n&ordm; 0267961-26.2023.8.06.0001/50000, Rel. Desa. L&iacute;gia Andrade de Alencar Magalh&atilde;es
+Vistos, relatados e discutidos os presentes autos de Apela&ccedil;&atilde;o, ACORDAM os Desembargadores integrantes da Quarta C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por vota&ccedil;&atilde;o un&acirc;nime, em conhecer dos embargos de declara&ccedil;&atilde;o e desprov&ecirc;-los, nos termos do voto da Relatora.
+
+Fortaleza, 14 de abril de 2026.
+
+ VANJA  FONTENELE PONTES
+Desembargadora Relatora <br><br>(Embargos de Declara&ccedil;&atilde;o Criminal&nbsp;-  0073781-59.2013.8.06.0001, Rel. Desembargador(a)  VANJA FONTENELE PONTES, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Criminal / Apropriação indébita
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> VANJA FONTENELE PONTES
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									73781592013806000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. EMBARGOS DE DECLARAÇÃO CRIMINAL. ASSISTENTE DA ACUSAÇÃO. ALEGADAS CONTRADIÇÃO, OBSCURIDADE E OMISSÃO. INEXISTÊNCIA DE VÍCIOS INTEGRATIVOS. PRETENSÃO DE REDISCUSSÃO DA VALORAÇÃO DA PROVA E DE REFORMA DO JULGADO ABSOLUTÓRIO. IMPOSSIBILIDADE. RECURSO CONHECIDO E DESPROVIDO
+
+I. Caso em exame
+1. Embargos de declaração opostos pela Associação Científica de Estudos
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. EMBARGOS DE DECLARAÇÃO CRIMINAL. ASSISTENTE DA ACUSAÇÃO. ALEGADAS CONTRADIÇÃO, OBSCURIDADE E OMISSÃO. INEXISTÊNCIA DE VÍCIOS INTEGRATIVOS. PRETENSÃO DE REDISCUSSÃO DA VALORAÇÃO DA PROVA E DE REFORMA DO JULGADO ABSOLUTÓRIO. IMPOSSIBILIDADE. RECURSO CONHECIDO E DESPROVIDO
+
+I. Caso em exame
+1. Embargos de declaração opostos pela Associação Científica de Estudos Agrários  ACEG, na qualidade de assistente da acusação, contra acórdão que, em apelação criminal, negou provimento ao recurso e manteve a absolvição do réu da imputação prevista no art. 168, § 1º, III, do Código Penal, ao fundamento de insuficiência probatória quanto à autoria e ao dolo de apropriação.
+Nos aclaratórios, a embargante sustenta, em síntese, a existência de contradição e obscuridade na decisão embargada, sob o argumento de que a prova oral, documental, policial e contábil demonstraria a centralidade funcional do acusado na administração financeira da associação, requerendo, ao final, a reforma do acórdão com atribuição de efeitos modificativos, inclusive para condenação do réu e fixação de valor mínimo para reparação dos <em>danos</em>
+
+II. Questão em discussão
+2. Há quatro questões em discussão:
+(i) saber se os embargos de declaração preenchem os requisitos de admissibilidade, notadamente legitimidade, interesse, tempestividade e regularidade formal;
+(ii) saber se o acórdão embargado incorreu em contradição ao concluir pela ausência de prova segura e individualizada de autoria e dolo, apesar das alegações da embargante quanto ao conteúdo da prova oral, documental e policial;
+(iii) saber se houve obscuridade ou omissão quanto à valoração do relatório de acompanhamento contábil, dos depoimentos judiciais e das demais peças invocadas nos aclaratórios; e
+(iv) saber se eventual saneamento de vício autorizaria a atribuição de efeitos infringentes, com reforma do acórdão absolutório, reconhecimento de continuidade delitiva, aplicação do art. 383 do CPP e fixação de valor mínimo de reparação dos <em>danos</em>.
+
+III. Razões de decidir
+3. Os embargos de declaração são admissíveis, em tese, quando destinados ao saneamento de omissão, obscuridade, contradição, ambiguidade ou erro material, não se prestando à rediscussão da matéria de fundo já apreciada. No caso, o recurso foi regularmente interposto por parte legítima, dentro do prazo legal e com exposição dos fundamentos impugnativos.
+4. O acórdão embargado enfrentou de forma clara a controvérsia devolvida, ao reconhecer a existência de irregularidades e desorganização administrativa na entidade associativa, mas concluir, de maneira expressa e coerente, que tais elementos não bastavam para demonstrar, com a segurança exigida no processo penal, a individualização de conduta típica de apropriação, nem a presença de dolo de assenhoramento definitivo.
+4. Não se verifica contradição, obscuridade ou omissão no julgado embargado. A decisão enfrentou o conteúdo essencial do relatório contábil, dos depoimentos das testemunhas de acusação e da dinâmica administrativa da associação, apenas lhes atribuindo eficácia probatória insuficiente para afastar a dúvida razoável quanto à autoria e ao dolo.
+5. A insistência da embargante em reinterpretar o acervo probatório, sustentar a irrelevância das testemunhas defensivas, postular continuidade delitiva, invocar a emendatio libelli e requerer reparação mínima revela mera inconformidade com o resultado do julgamento, buscando rediscutir o mérito em via integrativa inadequada.
+6. Mantida a absolvição por insuficiência de provas, resta prejudicado o pedido de fixação de valor mínimo de reparação, inexistindo espaço para atribuição de efeitos modificativos.
+IV. Dispositivo e tese
+7. Embargos de declaração conhecidos e desprovidos.
+Tese de julgamento:
+"1. Os embargos de declaração, no processo penal, destinam-se exclusivamente ao saneamento de omissão, obscuridade, contradição, ambiguidade ou erro material, não sendo cabíveis para rediscutir a valoração da prova ou reformar o mérito do julgamento sem vício intrínseco no acórdão.
+2. A constatação de irregularidades administrativas e financeiras, desacompanhada de prova segura e individualizada de autoria e dolo de apropriação, não autoriza a reforma de acórdão absolutório por meio de embargos declaratórios.
+3. Mantida a absolvição por insuficiência probatória, resta prejudicado o pedido de fixação de valor mínimo para reparação dos <em>danos</em>."
+Dispositivos relevantes citados: CP, arts. 168, § 1º, III, e 71; CPP, arts. 271, 383, 387, IV, 598, 619 e 620; CPC, art. 1.022.
+Jurisprudências relevantes citadas: STJ, EDcl no AgRg no REsp nº 1.566.545/RJ, Rel. Min. Maria Thereza de Assis Moura, Sexta Turma, j. 18.08.2016; TJCE, Embargos de Declaração Criminal nº 0267961-26.2023.8.06.0001/50000, Rel. Desa. Lígia Andrade de Alencar Magalhães
+Vistos, relatados e discutidos os presentes autos de Apelação, ACORDAM os Desembargadores integrantes da Quarta Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por votação unânime, em conhecer dos embargos de declaração e desprovê-los, nos termos do voto da Relatora.
+
+Fortaleza, 14 de abril de 2026.
+
+ VANJA  FONTENELE PONTES
+Desembargadora Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833903" cdForo="0" >
+										0200605-45.2022.8.06.0293
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833903" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833903);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833903" style="display: none;" >
+	<div id="textAreaDados_3833903" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TENTATIVA DE HOMIC&Iacute;DIO QUALIFICADO CONTRA POLICIAIS MILITARES. IMPRON&Uacute;NCIA POR AUS&Ecirc;NCIA DE IND&Iacute;CIOS SUFICIENTES DE AUTORIA E DOLO DE MATAR EM CONTEXTO DE TROCA DE TIROS EM LOCAL ESCURO. ORGANIZA&Ccedil;&Atilde;O CRIMINOSA. N&Atilde;O COMPROVA&Ccedil;&Atilde;O DE ESTABILIDADE, PERMAN&Ecirc;NCIA E DIVIS&Atilde;O DE TAREFAS. ABSOLVI&Ccedil;&Atilde;O MANTIDA. PORTE ILEGAL DE ARMA DE FOGO (REV&Oacute;LVER CALIBRE .32 COM MUNI&Ccedil;&Otilde;ES). CRIME DE PERIGO ABSTRATO. PROVA TESTEMUNHAL POLICIAL COESA. CONDENA&Ccedil;&Atilde;O MANTIDA. DOSIMETRIA. VALORA&Ccedil;&Atilde;O NEGATIVA DA CULPABILIDADE E CIRCUNST&Acirc;NCIAS DO CRIME (ATUA&Ccedil;&Atilde;O ARMADA EM GRUPO NA ENTRADA DE COMUNIDADE &Agrave; NOITE). PROPORCIONALIDADE OBSERVADA. RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es criminais interpostas pelo Minist&eacute;rio P&uacute;blico do Estado do Cear&aacute; e por Wanderson Mendes da Silva contra senten&ccedil;a que, ap&oacute;s troca de tiros entre policiais militares e indiv&iacute;duos armados em comunidade dominada por fac&ccedil;&atilde;o criminosa, impronunciou o acusado quanto &agrave; imputa&ccedil;&atilde;o de tentativa de homic&iacute;dio qualificado contra quatro policiais (art. 121, &sect;2&ordm;, I, III, IV e V c/c art. 14, II, CP), desclassificou a conduta para o crime de porte ilegal de arma de fogo (art. 14 da Lei n&ordm; 10.826/03), condenando-o &agrave; pena de 2 anos e 6 meses de reclus&atilde;o, e o absolveu do crime de organiza&ccedil;&atilde;o criminosa (art. 2&ordm; da Lei n&ordm; 12.850/2013). O Minist&eacute;rio P&uacute;blico requer a pron&uacute;ncia e condena&ccedil;&atilde;o; a defesa pleiteia absolvi&ccedil;&atilde;o e revis&atilde;o da pena.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se a prova produzida demonstra ind&iacute;cios suficientes de autoria e animus necandi na conduta de efetuar disparos contra policiais em contexto de confronto armado; (ii) estabelecer se h&aacute; comprova&ccedil;&atilde;o da integra&ccedil;&atilde;o do acusado em organiza&ccedil;&atilde;o criminosa com estabilidade e divis&atilde;o de tarefas; (iii) determinar se a condena&ccedil;&atilde;o por porte ilegal de arma de fogo e a dosimetria da pena est&atilde;o devidamente fundamentadas.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os depoimentos dos policiais militares s&atilde;o imprecisos quanto &agrave; identifica&ccedil;&atilde;o do autor dos disparos, pois relataram baixa visibilidade no local, aus&ecirc;ncia de ilumina&ccedil;&atilde;o e impossibilidade de reconhecer quem atirava, mencionando apenas &quot;clar&otilde;es&quot; dos tiros.
+4. O laudo residuogr&aacute;fico realizado no acusado apresentou resultado negativo, enfraquecendo a hip&oacute;tese de que ele tenha efetuado disparos.
+5. Nenhum policial foi atingido, e os relatos indicam que os disparos ocorreram em contexto de fuga e dispers&atilde;o do grupo, sem demonstra&ccedil;&atilde;o inequ&iacute;voca de direcionamento contra as v&iacute;timas.
+6. O conjunto probat&oacute;rio n&atilde;o comprova o animus necandi, sendo plaus&iacute;vel que a conduta visasse evitar a pris&atilde;o, e n&atilde;o produzir resultado morte.
+7. A aus&ecirc;ncia de prova judicializada robusta que confirme os elementos inquisitoriais impede o ju&iacute;zo de admissibilidade da acusa&ccedil;&atilde;o, impondo a impron&uacute;ncia nos termos do art. 414 do CPP.
+8. A caracteriza&ccedil;&atilde;o de organiza&ccedil;&atilde;o criminosa exige associa&ccedil;&atilde;o de quatro ou mais pessoas com estrutura ordenada, divis&atilde;o de tarefas e estabilidade, o que n&atilde;o foi demonstrado nos autos.
+9. As refer&ecirc;ncias &agrave; fac&ccedil;&atilde;o GDE, picha&ccedil;&otilde;es e contexto de disputa territorial n&atilde;o individualizam a conduta do acusado nem comprovam v&iacute;nculo est&aacute;vel com organiza&ccedil;&atilde;o criminosa.
+10. A inexist&ecirc;ncia de prova suficiente de autoria e participa&ccedil;&atilde;o justifica a absolvi&ccedil;&atilde;o pelo art. 386, VII, do CPP.
+11. A materialidade do crime de porte ilegal de arma de fogo est&aacute; comprovada pelo auto de apreens&atilde;o de rev&oacute;lver calibre .32 e muni&ccedil;&otilde;es encontradas nas proximidades do acusado.
+12. A autoria &eacute; confirmada pelos depoimentos policiais firmes e coerentes, colhidos sob contradit&oacute;rio, os quais possuem f&eacute; p&uacute;blica e s&atilde;o aptos a fundamentar a condena&ccedil;&atilde;o.
+13. O delito do art. 14 da Lei n&ordm; 10.826/03 &eacute; de perigo abstrato, sendo desnecess&aacute;ria a demonstra&ccedil;&atilde;o de potencialidade lesiva da arma.
+14. A culpabilidade &eacute; corretamente valorada negativamente em raz&atilde;o da atua&ccedil;&atilde;o armada em grupo na entrada da comunidade, gerando temor social.
+15. As circunst&acirc;ncias do crime justificam maior reprovabilidade, considerando a pr&aacute;tica noturna, em local sem ilumina&ccedil;&atilde;o e com diversidade de armas e muni&ccedil;&otilde;es.
+16. A fra&ccedil;&atilde;o de aumento da pena-base observa o crit&eacute;rio de 1/8 entre o m&iacute;nimo e o m&aacute;ximo legal, revelando proporcionalidade na fixa&ccedil;&atilde;o da pena.
+IV. DISPOSITIVO E TESE
+17. Recursos desprovidos.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos, nesta Comarca de Fortaleza, em que figuram as partes indicadas. ACORDAM os membros integrantes da 3&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER dos recursos interpostos para NEGAR-LHES PROVIMENTO, nos termos do voto da Relatora.
+Fortaleza, data da assinatura eletr&ocirc;nica.
+
+DESEMBARGADORA ANDR&Eacute;A MENDES BEZERRA DELFINO
+Relatora  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0200605-45.2022.8.06.0293, Rel. Desembargador(a)  ANDREA MENDES BEZERRA DELFINO, 3&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ANDREA MENDES BEZERRA DELFINO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Baturité
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TENTATIVA DE HOMICÍDIO QUALIFICADO CONTRA POLICIAIS MILITARES. IMPRONÚNCIA POR AUSÊNCIA DE INDÍCIOS SUFICIENTES DE AUTORIA E DOLO DE MATAR EM CONTEXTO DE TROCA DE TIROS EM LOCAL ESCURO. ORGANIZAÇÃO CRIMINOSA. NÃO COMPROVAÇÃO DE ESTABILIDADE, PERMANÊNCIA E DIVISÃO DE TAREFAS. ABSOLVIÇÃO MANTIDA. PORTE ILEGAL DE ARMA DE FOGO (REVÓLVER CALIBRE .32
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TENTATIVA DE HOMICÍDIO QUALIFICADO CONTRA POLICIAIS MILITARES. IMPRONÚNCIA POR AUSÊNCIA DE INDÍCIOS SUFICIENTES DE AUTORIA E DOLO DE MATAR EM CONTEXTO DE TROCA DE TIROS EM LOCAL ESCURO. ORGANIZAÇÃO CRIMINOSA. NÃO COMPROVAÇÃO DE ESTABILIDADE, PERMANÊNCIA E DIVISÃO DE TAREFAS. ABSOLVIÇÃO MANTIDA. PORTE ILEGAL DE ARMA DE FOGO (REVÓLVER CALIBRE .32 COM MUNIÇÕES). CRIME DE PERIGO ABSTRATO. PROVA TESTEMUNHAL POLICIAL COESA. CONDENAÇÃO MANTIDA. DOSIMETRIA. VALORAÇÃO NEGATIVA DA CULPABILIDADE E CIRCUNSTÂNCIAS DO CRIME (ATUAÇÃO ARMADA EM GRUPO NA ENTRADA DE COMUNIDADE À NOITE). PROPORCIONALIDADE OBSERVADA. RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1. Apelações criminais interpostas pelo Ministério Público do Estado do Ceará e por Wanderson Mendes da Silva contra sentença que, após troca de tiros entre policiais militares e indivíduos armados em comunidade dominada por facção criminosa, impronunciou o acusado quanto à imputação de tentativa de homicídio qualificado contra quatro policiais (art. 121, §2º, I, III, IV e V c/c art. 14, II, CP), desclassificou a conduta para o crime de porte ilegal de arma de fogo (art. 14 da Lei nº 10.826/03), condenando-o à pena de 2 anos e 6 meses de reclusão, e o absolveu do crime de organização criminosa (art. 2º da Lei nº 12.850/2013). O Ministério Público requer a pronúncia e condenação; a defesa pleiteia absolvição e revisão da pena.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se a prova produzida demonstra indícios suficientes de autoria e animus necandi na conduta de efetuar disparos contra policiais em contexto de confronto armado; (ii) estabelecer se há comprovação da integração do acusado em organização criminosa com estabilidade e divisão de tarefas; (iii) determinar se a condenação por porte ilegal de arma de fogo e a dosimetria da pena estão devidamente fundamentadas.
+III. RAZÕES DE DECIDIR
+3. Os depoimentos dos policiais militares são imprecisos quanto à identificação do autor dos disparos, pois relataram baixa visibilidade no local, ausência de iluminação e impossibilidade de reconhecer quem atirava, mencionando apenas "clarões" dos tiros.
+4. O laudo residuográfico realizado no acusado apresentou resultado negativo, enfraquecendo a hipótese de que ele tenha efetuado disparos.
+5. Nenhum policial foi atingido, e os relatos indicam que os disparos ocorreram em contexto de fuga e dispersão do grupo, sem demonstração inequívoca de direcionamento contra as vítimas.
+6. O conjunto probatório não comprova o animus necandi, sendo plausível que a conduta visasse evitar a prisão, e não produzir resultado morte.
+7. A ausência de prova judicializada robusta que confirme os elementos inquisitoriais impede o juízo de admissibilidade da acusação, impondo a impronúncia nos termos do art. 414 do CPP.
+8. A caracterização de organização criminosa exige associação de quatro ou mais pessoas com estrutura ordenada, divisão de tarefas e estabilidade, o que não foi demonstrado nos autos.
+9. As referências à facção GDE, pichações e contexto de disputa territorial não individualizam a conduta do acusado nem comprovam vínculo estável com organização criminosa.
+10. A inexistência de prova suficiente de autoria e participação justifica a absolvição pelo art. 386, VII, do CPP.
+11. A materialidade do crime de porte ilegal de arma de fogo está comprovada pelo auto de apreensão de revólver calibre .32 e munições encontradas nas proximidades do acusado.
+12. A autoria é confirmada pelos depoimentos policiais firmes e coerentes, colhidos sob contraditório, os quais possuem fé pública e são aptos a fundamentar a condenação.
+13. O delito do art. 14 da Lei nº 10.826/03 é de perigo abstrato, sendo desnecessária a demonstração de potencialidade lesiva da arma.
+14. A culpabilidade é corretamente valorada negativamente em razão da atuação armada em grupo na entrada da comunidade, gerando temor social.
+15. As circunstâncias do crime justificam maior reprovabilidade, considerando a prática noturna, em local sem iluminação e com diversidade de armas e munições.
+16. A fração de aumento da pena-base observa o critério de 1/8 entre o mínimo e o máximo legal, revelando proporcionalidade na fixação da pena.
+IV. DISPOSITIVO E TESE
+17. Recursos desprovidos.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos, nesta Comarca de Fortaleza, em que figuram as partes indicadas. ACORDAM os membros integrantes da 3ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER dos recursos interpostos para NEGAR-LHES PROVIMENTO, nos termos do voto da Relatora.
+Fortaleza, data da assinatura eletrônica.
+
+DESEMBARGADORA ANDRÉA MENDES BEZERRA DELFINO
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833928" cdForo="0" >
+										0202001-37.2025.8.06.0298
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833928" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833928);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833928" style="display: none;" >
+	<div id="textAreaDados_3833928" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TR&Aacute;FICO DE DROGAS (580G DE COCA&Iacute;NA). PRELIMINAR DE NULIDADE. ALEGADA VIOLA&Ccedil;&Atilde;O DE DOMIC&Iacute;LIO E FISHING EXPEDITION. INOCORR&Ecirc;NCIA. ABORDAGEM EM VIA P&Uacute;BLICA AP&Oacute;S DEN&Uacute;NCIA E VISUALIZA&Ccedil;&Atilde;O DE ENTREGA. FUNDADAS RAZ&Otilde;ES. FUGA DOS ACUSADOS. FLAGRANTE DELITO. CRIME PERMANENTE. MATERIALIDADE COMPROVADA POR LAUDOS. AUTORIA EVIDENCIADA POR DEPOIMENTOS POLICIAIS COERENTES. FINALIDADE MERCANTIL CONFIGURADA. REGIME INICIAL FECHADO MANTIDO. MAUS ANTECEDENTES E QUANTIDADE DE DROGA. PENA DE MULTA PROPORCIONAL. RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es criminais interpostas por Francisco Renildo Alves da Silva e Lucas Carneiro de Souza contra senten&ccedil;a condenat&oacute;ria pelo crime de tr&aacute;fico de drogas (art. 33, caput, da Lei n&ordm; 11.343/2006), ap&oacute;s serem flagrados, em via p&uacute;blica, na posse de 580g de coca&iacute;na, al&eacute;m de R$ 50,00 e cinco celulares, recebidos de ocupantes de ve&iacute;culo Hilux, pleiteando a nulidade das provas por suposta viola&ccedil;&atilde;o de domic&iacute;lio, absolvi&ccedil;&atilde;o por insufici&ecirc;ncia de provas e, subsidiariamente, altera&ccedil;&atilde;o do regime prisional e redu&ccedil;&atilde;o da pena de multa.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se houve nulidade das provas por alegada viola&ccedil;&atilde;o de domic&iacute;lio ou atua&ccedil;&atilde;o policial arbitr&aacute;ria (fishing expedition); (ii) estabelecer se o conjunto probat&oacute;rio &eacute; suficiente para comprovar a pr&aacute;tica do tr&aacute;fico de drogas; (iii) determinar se &eacute; cab&iacute;vel a altera&ccedil;&atilde;o do regime inicial fechado e a redu&ccedil;&atilde;o da pena de multa fixada.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A dilig&ecirc;ncia policial decorre de informa&ccedil;&otilde;es pr&eacute;vias espec&iacute;ficas sobre ve&iacute;culo utilizado para entrega de drogas, seguida da visualiza&ccedil;&atilde;o direta da entrega de sacola aos acusados.
+4. A abordagem ocorre em via p&uacute;blica, ap&oacute;s fuga dos r&eacute;us para um matagal, inexistindo ingresso em domic&iacute;lio, o que afasta a alega&ccedil;&atilde;o de viola&ccedil;&atilde;o &agrave; inviolabilidade domiciliar.
+5. A fuga dos acusados ao perceberem a presen&ccedil;a policial configura elemento concreto apto a gerar fundada suspeita e legitimar a busca pessoal.
+6. A apreens&atilde;o da droga em posse direta de um dos r&eacute;us, logo ap&oacute;s a entrega visualizada, caracteriza situa&ccedil;&atilde;o de flagrante delito.
+7. O tr&aacute;fico de drogas, na modalidade &quot;trazer consigo&quot; ou &quot;guardar&quot;, constitui crime permanente, prolongando a situa&ccedil;&atilde;o de flagr&acirc;ncia.
+8. A materialidade delitiva est&aacute; comprovada pelo auto de apreens&atilde;o e pelos laudos periciais (preliminar e definitivo) que confirmam se tratar de coca&iacute;na.
+9. A autoria delitiva &eacute; evidenciada pelos depoimentos harm&ocirc;nicos e convergentes dos policiais, que presenciaram a entrega, a fuga e a apreens&atilde;o da droga.
+10. Os depoimentos policiais possuem validade probat&oacute;ria quando coerentes e corroborados por outros elementos dos autos.
+11. A quantidade expressiva da droga (580g de coca&iacute;na) e a forma de aquisi&ccedil;&atilde;o evidenciam a destina&ccedil;&atilde;o mercantil do entorpecente.
+12. A configura&ccedil;&atilde;o do tr&aacute;fico independe da comprova&ccedil;&atilde;o de ato de venda, bastando a pr&aacute;tica de verbos nucleares do tipo penal.
+13. O regime inicial fechado mostra-se adequado diante do quantum da pena e da exist&ecirc;ncia de circunst&acirc;ncias judiciais desfavor&aacute;veis, notadamente maus antecedentes e quantidade da droga.
+14. A pena de multa foi fixada proporcionalmente &agrave; pena privativa de liberdade, conforme entendimento sumulado do tribunal, sendo incab&iacute;vel sua redu&ccedil;&atilde;o por alegada hipossufici&ecirc;ncia.
+IV. DISPOSITIVO
+15. Recursos desprovidos.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos, nesta Comarca de Fortaleza, em que figuram as partes indicadas. ACORDAM os membros integrantes da 3&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER dos recursos interpostos para NEGAR-LHES PROVIMENTO, nos termos do voto da Relatora.
+
+Fortaleza, data da assinatura eletr&ocirc;nica.
+
+DESEMBARGADORA ANDR&Eacute;A MENDES BEZERRA DELFINO
+Relatora  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0202001-37.2025.8.06.0298, Rel. Desembargador(a)  ANDREA MENDES BEZERRA DELFINO, 3&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ANDREA MENDES BEZERRA DELFINO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Tianguá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS (580G DE COCAÍNA). PRELIMINAR DE NULIDADE. ALEGADA VIOLAÇÃO DE DOMICÍLIO E FISHING EXPEDITION. INOCORRÊNCIA. ABORDAGEM EM VIA PÚBLICA APÓS DENÚNCIA E VISUALIZAÇÃO DE ENTREGA. FUNDADAS RAZÕES. FUGA DOS ACUSADOS. FLAGRANTE DELITO. CRIME PERMANENTE. MATERIALIDADE COMPROVADA POR LAUDOS. AUTORIA EVIDENCIADA POR DEPOIMENTOS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS (580G DE COCAÍNA). PRELIMINAR DE NULIDADE. ALEGADA VIOLAÇÃO DE DOMICÍLIO E FISHING EXPEDITION. INOCORRÊNCIA. ABORDAGEM EM VIA PÚBLICA APÓS DENÚNCIA E VISUALIZAÇÃO DE ENTREGA. FUNDADAS RAZÕES. FUGA DOS ACUSADOS. FLAGRANTE DELITO. CRIME PERMANENTE. MATERIALIDADE COMPROVADA POR LAUDOS. AUTORIA EVIDENCIADA POR DEPOIMENTOS POLICIAIS COERENTES. FINALIDADE MERCANTIL CONFIGURADA. REGIME INICIAL FECHADO MANTIDO. MAUS ANTECEDENTES E QUANTIDADE DE DROGA. PENA DE MULTA PROPORCIONAL. RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1. Apelações criminais interpostas por Francisco Renildo Alves da Silva e Lucas Carneiro de Souza contra sentença condenatória pelo crime de tráfico de drogas (art. 33, caput, da Lei nº 11.343/2006), após serem flagrados, em via pública, na posse de 580g de cocaína, além de R$ 50,00 e cinco celulares, recebidos de ocupantes de veículo Hilux, pleiteando a nulidade das provas por suposta violação de domicílio, absolvição por insuficiência de provas e, subsidiariamente, alteração do regime prisional e redução da pena de multa.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se houve nulidade das provas por alegada violação de domicílio ou atuação policial arbitrária (fishing expedition); (ii) estabelecer se o conjunto probatório é suficiente para comprovar a prática do tráfico de drogas; (iii) determinar se é cabível a alteração do regime inicial fechado e a redução da pena de multa fixada.
+III. RAZÕES DE DECIDIR
+3. A diligência policial decorre de informações prévias específicas sobre veículo utilizado para entrega de drogas, seguida da visualização direta da entrega de sacola aos acusados.
+4. A abordagem ocorre em via pública, após fuga dos réus para um matagal, inexistindo ingresso em domicílio, o que afasta a alegação de violação à inviolabilidade domiciliar.
+5. A fuga dos acusados ao perceberem a presença policial configura elemento concreto apto a gerar fundada suspeita e legitimar a busca pessoal.
+6. A apreensão da droga em posse direta de um dos réus, logo após a entrega visualizada, caracteriza situação de flagrante delito.
+7. O tráfico de drogas, na modalidade "trazer consigo" ou "guardar", constitui crime permanente, prolongando a situação de flagrância.
+8. A materialidade delitiva está comprovada pelo auto de apreensão e pelos laudos periciais (preliminar e definitivo) que confirmam se tratar de cocaína.
+9. A autoria delitiva é evidenciada pelos depoimentos harmônicos e convergentes dos policiais, que presenciaram a entrega, a fuga e a apreensão da droga.
+10. Os depoimentos policiais possuem validade probatória quando coerentes e corroborados por outros elementos dos autos.
+11. A quantidade expressiva da droga (580g de cocaína) e a forma de aquisição evidenciam a destinação mercantil do entorpecente.
+12. A configuração do tráfico independe da comprovação de ato de venda, bastando a prática de verbos nucleares do tipo penal.
+13. O regime inicial fechado mostra-se adequado diante do quantum da pena e da existência de circunstâncias judiciais desfavoráveis, notadamente maus antecedentes e quantidade da droga.
+14. A pena de multa foi fixada proporcionalmente à pena privativa de liberdade, conforme entendimento sumulado do tribunal, sendo incabível sua redução por alegada hipossuficiência.
+IV. DISPOSITIVO
+15. Recursos desprovidos.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos, nesta Comarca de Fortaleza, em que figuram as partes indicadas. ACORDAM os membros integrantes da 3ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER dos recursos interpostos para NEGAR-LHES PROVIMENTO, nos termos do voto da Relatora.
+
+Fortaleza, data da assinatura eletrônica.
+
+DESEMBARGADORA ANDRÉA MENDES BEZERRA DELFINO
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833892" cdForo="0" >
+										0622585-47.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833892" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833892);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833892" style="display: none;" >
+	<div id="textAreaDados_3833892" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL PENAL. HABEAS CORPUS. ORGANIZA&Ccedil;&Atilde;O CRIMINOSA ARMADA. EXCESSO DE PRAZO PARA FORMA&Ccedil;&Atilde;O DA CULPA. PROCESSO COMPLEXO COM PLURALIDADE DE R&Eacute;US. AUS&Ecirc;NCIA DE CONSTRANGIMENTO ILEGAL. ORDEM CONHECIDA E DENEGADA.
+I. CASO EM EXAME
+Habeas corpus impetrado com alega&ccedil;&atilde;o de excesso de prazo na forma&ccedil;&atilde;o da culpa, em raz&atilde;o da demora na instru&ccedil;&atilde;o criminal, com pedido de relaxamento da pris&atilde;o preventiva. A&ccedil;&atilde;o penal de elevada complexidade, com 32 acusados vinculados &agrave; criminalidade organizada, com procuradores distintos, e desmembramento do feito em rela&ccedil;&atilde;o a parte dos r&eacute;us. Pris&atilde;o preventiva mantida e reavaliada em 06.03.2026, nos termos do art. 316, par&aacute;grafo &uacute;nico, do CPP, com designa&ccedil;&atilde;o de audi&ecirc;ncia de instru&ccedil;&atilde;o para 09.09.2026.
+A quest&atilde;o em discuss&atilde;o consiste em saber se h&aacute; excesso de prazo na forma&ccedil;&atilde;o da culpa apto a caracterizar constrangimento ilegal e ensejar o relaxamento da pris&atilde;o preventiva, diante da dura&ccedil;&atilde;o da instru&ccedil;&atilde;o criminal.
+Os prazos processuais na instru&ccedil;&atilde;o criminal n&atilde;o possuem natureza absoluta. Devem ser analisados &agrave; luz da razoabilidade e da proporcionalidade, afastada a mera soma aritm&eacute;tica dos prazos legais.
+A complexidade do feito, evidenciada pela pluralidade de r&eacute;us e pela atua&ccedil;&atilde;o de organiza&ccedil;&atilde;o criminosa, justifica eventual dila&ccedil;&atilde;o temporal da marcha processual. Inexist&ecirc;ncia de des&iacute;dia do Estado-Juiz. O processo apresenta andamento regular, com ado&ccedil;&atilde;o de medidas para racionaliza&ccedil;&atilde;o da instru&ccedil;&atilde;o, como o desmembramento do feito e designa&ccedil;&atilde;o de audi&ecirc;ncia.
+A pris&atilde;o preventiva foi reavaliada recentemente, com fundamenta&ccedil;&atilde;o id&ocirc;nea quanto &agrave; persist&ecirc;ncia dos requisitos legais.
+Ainda que se cogitasse excesso de prazo, a gravidade concreta da conduta e o risco &agrave; ordem p&uacute;blica e &agrave; instru&ccedil;&atilde;o criminal autorizam a manuten&ccedil;&atilde;o da cust&oacute;dia, &agrave; luz do princ&iacute;pio da veda&ccedil;&atilde;o &agrave; prote&ccedil;&atilde;o deficiente.
+Ordem conhecida e denegada.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, inc. LXXVIII; CPP, art. 316, p.u.
+Jurisprud&ecirc;ncia relevante citada: STJ, RHC 92442/AL, Rel. Min. Felix Fischer, 5&ordf; Turma, j. 06.03.2018; TJCE, HC n&ordm; 0631993-96.2025.8.06.0000, Rel. Desa. &Acirc;ngela Teresa Gondim Carneiro Chaves, 4&ordf; C&acirc;mara Criminal, j. 17.03.2026.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 3&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, em CONHECER da presente ordem, para deneg&aacute;-la, tudo nos termos do voto do e.Relator.
+
+Fortaleza, 14 de abril de 2026  <br><br>(Habeas Corpus Criminal&nbsp;-  0622585-47.2026.8.06.0000, Rel. Desembargador(a)  HENRIQUE JORGE HOLANDA SILVEIRA, 3&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 14/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 14/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Habeas Corpus Criminal / Promoção, constituição, financiamento ou integração de Organização Criminosa
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> HENRIQUE JORGE HOLANDA SILVEIRA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS. ORGANIZAÇÃO CRIMINOSA ARMADA. EXCESSO DE PRAZO PARA FORMAÇÃO DA CULPA. PROCESSO COMPLEXO COM PLURALIDADE DE RÉUS. AUSÊNCIA DE CONSTRANGIMENTO ILEGAL. ORDEM CONHECIDA E DENEGADA.
+I. CASO EM EXAME
+Habeas corpus impetrado com alegação de excesso de prazo na formação da culpa, em razão da demora na instrução criminal, com pedido de relaxamento da prisão
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS. ORGANIZAÇÃO CRIMINOSA ARMADA. EXCESSO DE PRAZO PARA FORMAÇÃO DA CULPA. PROCESSO COMPLEXO COM PLURALIDADE DE RÉUS. AUSÊNCIA DE CONSTRANGIMENTO ILEGAL. ORDEM CONHECIDA E DENEGADA.
+I. CASO EM EXAME
+Habeas corpus impetrado com alegação de excesso de prazo na formação da culpa, em razão da demora na instrução criminal, com pedido de relaxamento da prisão preventiva. Ação penal de elevada complexidade, com 32 acusados vinculados à criminalidade organizada, com procuradores distintos, e desmembramento do feito em relação a parte dos réus. Prisão preventiva mantida e reavaliada em 06.03.2026, nos termos do art. 316, parágrafo único, do CPP, com designação de audiência de instrução para 09.09.2026.
+A questão em discussão consiste em saber se há excesso de prazo na formação da culpa apto a caracterizar constrangimento ilegal e ensejar o relaxamento da prisão preventiva, diante da duração da instrução criminal.
+Os prazos processuais na instrução criminal não possuem natureza absoluta. Devem ser analisados à luz da razoabilidade e da proporcionalidade, afastada a mera soma aritmética dos prazos legais.
+A complexidade do feito, evidenciada pela pluralidade de réus e pela atuação de organização criminosa, justifica eventual dilação temporal da marcha processual. Inexistência de desídia do Estado-Juiz. O processo apresenta andamento regular, com adoção de medidas para racionalização da instrução, como o desmembramento do feito e designação de audiência.
+A prisão preventiva foi reavaliada recentemente, com fundamentação idônea quanto à persistência dos requisitos legais.
+Ainda que se cogitasse excesso de prazo, a gravidade concreta da conduta e o risco à ordem pública e à instrução criminal autorizam a manutenção da custódia, à luz do princípio da vedação à proteção deficiente.
+Ordem conhecida e denegada.
+Dispositivos relevantes citados: CF/1988, art. 5º, inc. LXXVIII; CPP, art. 316, p.u.
+Jurisprudência relevante citada: STJ, RHC 92442/AL, Rel. Min. Felix Fischer, 5ª Turma, j. 06.03.2018; TJCE, HC nº 0631993-96.2025.8.06.0000, Rel. Desa. Ângela Teresa Gondim Carneiro Chaves, 4ª Câmara Criminal, j. 17.03.2026.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 3ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, em CONHECER da presente ordem, para denegá-la, tudo nos termos do voto do e.Relator.
+
+Fortaleza, 14 de abril de 2026
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833633" cdForo="0" >
+										0114293-60.2008.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833633" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833633);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833633" style="display: none;" >
+	<div id="textAreaDados_3833633" class="mensagemSemFormatacao" >
+		Direito Processual Civil. Agravo interno em recurso especial. Honor&aacute;rios sucumbenciais. Aprecia&ccedil;&atilde;o equitativa. Inadmissibilidade. Condena&ccedil;&atilde;o economicamente afer&iacute;vel. Tema 1.076/STJ. Agravo interno desprovido.
+I. Caso em exame
+Agravo interno interposto contra decis&atilde;o da Vice-Presid&ecirc;ncia que negou seguimento ao recurso especial, no cap&iacute;tulo relativo aos honor&aacute;rios sucumbenciais, por reconhecer a conformidade do ac&oacute;rd&atilde;o recorrido com o Tema 1.076/STJ.
+O ac&oacute;rd&atilde;o recorrido, proferido em a&ccedil;&atilde;o de ressarcimento por danos materiais e morais  decorrentes de acidente de tr&acirc;nsito, manteve a condena&ccedil;&atilde;o da empresa r&eacute; ao pagamento de pens&atilde;o mensal equivalente a 1/3 do sal&aacute;rio m&iacute;nimo &#150; a ser apurada em liquida&ccedil;&atilde;o de senten&ccedil;a, com determina&ccedil;&atilde;o de constitui&ccedil;&atilde;o de capital &#150; al&eacute;m do montante de R$ 40.000,00 (quarenta mil reais) a t&iacute;tulo de danos morais, j&aacute; inclusos os danos est&eacute;ticos, tendo fixado os honor&aacute;rios sucumbenciais em 10% sobre o valor da condena&ccedil;&atilde;o.
+III. Raz&otilde;es de decidir
+4.  O Tema 1.076/STJ estabelece que a aprecia&ccedil;&atilde;o equitativa &eacute; medida excepcional, admitida apenas quando o proveito econ&ocirc;mico for inestim&aacute;vel ou irris&oacute;rio, ou quando o valor da causa for muito baixo.
+5. Sendo a condena&ccedil;&atilde;o economicamente definida e quantific&aacute;vel, ainda que apur&aacute;vel em fase de&nbsp;liquida&ccedil;&atilde;o, &eacute; obrigat&oacute;ria a observ&acirc;ncia da ordem de grada&ccedil;&atilde;o prevista no art. 85, &sect;&sect; 2&ordm; e 3&ordm;, do CPC, adotando-se, prioritariamente, o valor da condena&ccedil;&atilde;o como base de c&aacute;lculo dos honor&aacute;rios sucumbenciais.
+6. O termo &quot;inestim&aacute;vel&quot; n&atilde;o abrange hip&oacute;teses em que o proveito econ&ocirc;mico &eacute; mensur&aacute;vel, ainda que a verba honor&aacute;ria resultante seja elevada.
+7. &Eacute; invi&aacute;vel, na via especial, pretender a redefini&ccedil;&atilde;o da base de c&aacute;lculo dos honor&aacute;rios sucumbenciais mediante insurg&ecirc;ncia contra os valores arbitrados a t&iacute;tulo de danos materiais e morais, pois tal provid&ecirc;ncia demandaria a revalora&ccedil;&atilde;o do contexto f&aacute;tico-probat&oacute;rio soberanamente delineado no ac&oacute;rd&atilde;o recorrido, em afronta ao &oacute;bice da S&uacute;mula 7/STJ.
+IV. Dispositivo e tese
+4. Agravo interno desprovido.
+Teses de julgamento: &quot;1. A fixa&ccedil;&atilde;o de honor&aacute;rios advocat&iacute;cios por aprecia&ccedil;&atilde;o equitativa somente &eacute; admiss&iacute;vel nas hip&oacute;teses excepcionais previstas no Tema 1.076/STJ. 2. Existindo condena&ccedil;&atilde;o economicamente afer&iacute;vel, os honor&aacute;rios devem ser fixados com observ&acirc;ncia dos percentuais do art. 85, &sect;&sect; 2&ordm; e 3&ordm;, do CPC, adotando-se, prioritariamente, o valor da condena&ccedil;&atilde;o como base de c&aacute;lculo. 3. &Eacute; invi&aacute;vel, na via especial, rediscutir a base de c&aacute;lculo dos honor&aacute;rios sucumbenciais a partir de insurg&ecirc;ncia contra os valores indenizat&oacute;rios fixados pelas inst&acirc;ncias ordin&aacute;rias, quando isso demandar revalora&ccedil;&atilde;o de fatos e provas, ante o &oacute;bice da S&uacute;mula 7/STJ.&quot;
+________________________
+Dispositivos relevantes citados: CPC, art. 85, &sect;&sect; 2&ordm;, 3&ordm; e 8&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, Tema 1.076; S&uacute;mula 7/STJ.
+
+
+AC&Oacute;RD&Atilde;O
+
+Acordam os Desembargadores integrantes do &Oacute;rg&atilde;o Especial do Egr&eacute;gio Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, nos autos deste Agravo Interno, por unanimidade, em conhecer do recurso e negar-lhe provimento, tudo de conformidade com o voto do eminente Relator.
+
+Fortaleza, data e hora indicadas no sistema.
+
+
+Desembargador FRANCISCO MAURO FERREIRA LIBERATO
+Vice-Presidente/Relator <br><br>(Agravo Interno C&iacute;vel&nbsp;-  0114293-60.2008.8.06.0001, Rel. Desembargador(a)  VICE PRESIDENTE TJCE, &Oacute;rg&atilde;o Especial, data do julgamento:&nbsp; 09/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 10/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> VICE PRESIDENTE TJCE
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Órgão Especial
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									09/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									114293602008806000150001
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Direito Processual Civil. Agravo interno em recurso especial. Honorários sucumbenciais. Apreciação equitativa. Inadmissibilidade. Condenação economicamente aferível. Tema 1.076/STJ. Agravo interno desprovido.
+I. Caso em exame
+Agravo interno interposto contra decisão da Vice-Presidência que negou seguimento ao recurso especial, no capítulo relativo aos honorários sucumbenciais, por reconhecer a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Direito Processual Civil. Agravo interno em recurso especial. Honorários sucumbenciais. Apreciação equitativa. Inadmissibilidade. Condenação economicamente aferível. Tema 1.076/STJ. Agravo interno desprovido.
+I. Caso em exame
+Agravo interno interposto contra decisão da Vice-Presidência que negou seguimento ao recurso especial, no capítulo relativo aos honorários sucumbenciais, por reconhecer a conformidade do acórdão recorrido com o Tema 1.076/STJ.
+O acórdão recorrido, proferido em ação de ressarcimento por <em>danos</em> materiais e <em>morais</em>  decorrentes de acidente de trânsito, manteve a condenação da empresa ré ao pagamento de pensão mensal equivalente a 1/3 do salário mínimo  a ser apurada em liquidação de sentença, com determinação de constituição de capital  além do montante de R$ 40.000,00 (quarenta mil reais) a título de <em>danos</em> <em>morais</em>, já inclusos os <em>danos</em> estéticos, tendo fixado os honorários sucumbenciais em 10% sobre o valor da condenação.
+III. Razões de decidir
+4.  O Tema 1.076/STJ estabelece que a apreciação equitativa é medida excepcional, admitida apenas quando o proveito econômico for inestimável ou irrisório, ou quando o valor da causa for muito baixo.
+5. Sendo a condenação economicamente definida e quantificável, ainda que apurável em fase de liquidação, é obrigatória a observância da ordem de gradação prevista no art. 85, §§ 2º e 3º, do CPC, adotando-se, prioritariamente, o valor da condenação como base de cálculo dos honorários sucumbenciais.
+6. O termo "inestimável" não abrange hipóteses em que o proveito econômico é mensurável, ainda que a verba honorária resultante seja elevada.
+7. É inviável, na via especial, pretender a redefinição da base de cálculo dos honorários sucumbenciais mediante insurgência contra os valores arbitrados a título de <em>danos</em> materiais e <em>morais</em>, pois tal providência demandaria a revaloração do contexto fático-probatório soberanamente delineado no acórdão recorrido, em afronta ao óbice da Súmula 7/STJ.
+IV. Dispositivo e tese
+4. Agravo interno desprovido.
+Teses de julgamento: "1. A fixação de honorários advocatícios por apreciação equitativa somente é admissível nas hipóteses excepcionais previstas no Tema 1.076/STJ. 2. Existindo condenação economicamente aferível, os honorários devem ser fixados com observância dos percentuais do art. 85, §§ 2º e 3º, do CPC, adotando-se, prioritariamente, o valor da condenação como base de cálculo. 3. É inviável, na via especial, rediscutir a base de cálculo dos honorários sucumbenciais a partir de insurgência contra os valores indenizatórios fixados pelas instâncias ordinárias, quando isso demandar revaloração de fatos e provas, ante o óbice da Súmula 7/STJ."
+________________________
+Dispositivos relevantes citados: CPC, art. 85, §§ 2º, 3º e 8º.
+Jurisprudência relevante citada: STJ, Tema 1.076; Súmula 7/STJ.
+
+
+ACÓRDÃO
+
+Acordam os Desembargadores integrantes do Órgão Especial do Egrégio Tribunal de Justiça do Estado do Ceará, nos autos deste Agravo Interno, por unanimidade, em conhecer do recurso e negar-lhe provimento, tudo de conformidade com o voto do eminente Relator.
+
+Fortaleza, data e hora indicadas no sistema.
+
+
+Desembargador FRANCISCO MAURO FERREIRA LIBERATO
+Vice-Presidente/Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="Tribunal">
+									<label for="ckTermo1">
+										Tribunal
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="Justiça">
+									<label for="ckTermo2">
+										Justiça
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="Câmara">
+									<label for="ckTermo3">
+										Câmara
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="Ceará">
+									<label for="ckTermo4">
+										Ceará
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="autos">
+									<label for="ckTermo5">
+										autos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="voto">
+									<label for="ckTermo6">
+										voto
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="ACÓRDÃO">
+									<label for="ckTermo7">
+										ACÓRDÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="Direito">
+									<label for="ckTermo8">
+										Direito
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="Estado">
+									<label for="ckTermo9">
+										Estado
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="EMENTA">
+									<label for="ckTermo10">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="termos">
+									<label for="ckTermo11">
+										termos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="discutidos">
+									<label for="ckTermo12">
+										discutidos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="relatados">
+									<label for="ckTermo13">
+										relatados
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="Vistos">
+									<label for="ckTermo14">
+										Vistos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="Fortaleza">
+									<label for="ckTermo15">
+										Fortaleza
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 20
+			</strong>
+			de 100860
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjce/samples/cjsg/results_normal_page_02.html
+++ b/tests/tjce/samples/cjsg/results_normal_page_02.html
@@ -1,0 +1,4347 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(100860)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="100860" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>21&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833474" cdForo="0" >
+										0023290-38.2019.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833474" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833474);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833474" style="display: none;" >
+	<div id="textAreaDados_3833474" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. AGRAVO EM EXECU&Ccedil;&Atilde;O PENAL. PEDIDO DE RECONHECIMENTO DE CONTINUIDADE DELITIVA. N&Atilde;O ACOLHIMENTO. VERIFICADA A HABITUALIDADE CRIMINOSA E A AUS&Ecirc;NCIA DE UNIDADE DE DES&Iacute;GNIOS. RECURSO CONHECIDO E DESPROVIDO.
+
+I. CASO EM EXAME
+
+1. Agravo em execu&ccedil;&atilde;o penal interposto contra decis&atilde;o do Ju&iacute;zo da 3&ordf; Vara de Execu&ccedil;&atilde;o Penal de Fortaleza/CE, que indeferiu o pedido de reconhecimento de continuidade delitiva entre condena&ccedil;&otilde;es das a&ccedil;&otilde;es penais n&ordm; 0181706-75.2017.8.06.0001, 0153925-10.2019.8.06.0001 e 0153411-28.2017.8.06.0001. O agravante sustenta a exist&ecirc;ncia de semelhan&ccedil;a nas condi&ccedil;&otilde;es de tempo, lugar e modo de execu&ccedil;&atilde;o dos delitos de roubo e furto.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+2. A quest&atilde;o em discuss&atilde;o consiste em saber se o apenado preenche os requisitos do art. 71 do C&oacute;digo Penal para a aplica&ccedil;&atilde;o do crime continuado.
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+3. Para a caracteriza&ccedil;&atilde;o da continuidade delitiva, a jurisprud&ecirc;ncia dos Tribunais Superiores adota a teoria objetivo-subjetiva, exigindo-se, cumulativamente, requisitos objetivos (tempo, lugar e modo de execu&ccedil;&atilde;o) e o requisito subjetivo (unidade de des&iacute;gnios).
+
+4. Embora presentes os aspectos objetivos (delitos ocorridos em curto espa&ccedil;o de tempo e com modus operandi similar), n&atilde;o restou configurada a unidade de des&iacute;gnios, uma vez que o acusado agiu com dolo aut&ocirc;nomo em cada conduta, buscando resultados distintos.
+
+5. O instituto da continuidade delitiva &eacute; um benef&iacute;cio legal que n&atilde;o se aplica ao criminoso habitual ou profissional. O agravante possui extensa ficha criminal com outras cinco condena&ccedil;&otilde;es al&eacute;m das analisadas, o que demonstra que faz do crime seu meio de vida, evidenciando reitera&ccedil;&atilde;o delitiva e n&atilde;o continuidade.
+
+IV. DISPOSITIVO E TESE
+
+6. Recurso conhecido e desprovido.
+
+Teses de julgamento: &quot;1. A caracteriza&ccedil;&atilde;o da continuidade delitiva exige o preenchimento de requisitos objetivos e do elemento subjetivo da unidade de des&iacute;gnios. 2. A habitualidade criminosa, demonstrada por extensa ficha de antecedentes, afasta a aplica&ccedil;&atilde;o do benef&iacute;cio previsto no art. 71 do C&oacute;digo Penal.&quot;
+
+Dispositivos relevantes citados: CP, arts. 69, 71, 155, 157, 180 e 288.
+
+Jurisprud&ecirc;ncias relevantes citadas: STF, HC 110.002, Rel. Min. Teori Zavascki, Segunda Turma, j. 09.12.2014; STJ, AgRg no REsp 1.666.714/SC, Rel. Min. Felix Fischer, Quinta Turma, j. 12.12.2017.
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Agravo em Execu&ccedil;&atilde;o Penal n&ordm; 0023290-38.2019.8.06.0001, ACORDAM os Desembargadores integrantes desta 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por vota&ccedil;&atilde;o un&acirc;nime, em CONHECER do recurso para NEGAR-LHE PROVIMENTO, nos termos do voto do eminente Relator.&nbsp;
+
+Fortaleza/CE, 8 de abril de 2026.
+
+FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+Presidente do &Oacute;rg&atilde;o Julgador
+
+DESEMBARGADOR S&Eacute;RGIO LUIZ ARRUDA PARENTE
+Relator  <br><br>(Agravo de Execu&ccedil;&atilde;o Penal&nbsp;-  0023290-38.2019.8.06.0001, Rel. Desembargador(a)  SERGIO LUIZ ARRUDA PARENTE, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 08/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 08/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Execução Penal / Promoção, constituição, financiamento ou integração de Organização Criminosa
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> SERGIO LUIZ ARRUDA PARENTE
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. AGRAVO EM EXECUÇÃO PENAL. PEDIDO DE RECONHECIMENTO DE CONTINUIDADE DELITIVA. NÃO ACOLHIMENTO. VERIFICADA A HABITUALIDADE CRIMINOSA E A AUSÊNCIA DE UNIDADE DE DESÍGNIOS. RECURSO CONHECIDO E DESPROVIDO.
+
+I. CASO EM EXAME
+
+1. Agravo em execução penal interposto contra decisão do Juízo da 3ª Vara de Execução Penal de Fortaleza/CE, que indeferiu o pedido de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. AGRAVO EM EXECUÇÃO PENAL. PEDIDO DE RECONHECIMENTO DE CONTINUIDADE DELITIVA. NÃO ACOLHIMENTO. VERIFICADA A HABITUALIDADE CRIMINOSA E A AUSÊNCIA DE UNIDADE DE DESÍGNIOS. RECURSO CONHECIDO E DESPROVIDO.
+
+I. CASO EM EXAME
+
+1. Agravo em execução penal interposto contra decisão do Juízo da 3ª Vara de Execução Penal de Fortaleza/CE, que indeferiu o pedido de reconhecimento de continuidade delitiva entre condenações das ações penais nº 0181706-75.2017.8.06.0001, 0153925-10.2019.8.06.0001 e 0153411-28.2017.8.06.0001. O agravante sustenta a existência de semelhança nas condições de tempo, lugar e modo de execução dos delitos de roubo e furto.
+
+II. QUESTÃO EM DISCUSSÃO
+
+2. A questão em discussão consiste em saber se o apenado preenche os requisitos do art. 71 do Código Penal para a aplicação do crime continuado.
+
+III. RAZÕES DE DECIDIR
+
+3. Para a caracterização da continuidade delitiva, a jurisprudência dos Tribunais Superiores adota a teoria objetivo-subjetiva, exigindo-se, cumulativamente, requisitos objetivos (tempo, lugar e modo de execução) e o requisito subjetivo (unidade de desígnios).
+
+4. Embora presentes os aspectos objetivos (delitos ocorridos em curto espaço de tempo e com modus operandi similar), não restou configurada a unidade de desígnios, uma vez que o acusado agiu com dolo autônomo em cada conduta, buscando resultados distintos.
+
+5. O instituto da continuidade delitiva é um benefício legal que não se aplica ao criminoso habitual ou profissional. O agravante possui extensa ficha criminal com outras cinco condenações além das analisadas, o que demonstra que faz do crime seu meio de vida, evidenciando reiteração delitiva e não continuidade.
+
+IV. DISPOSITIVO E TESE
+
+6. Recurso conhecido e desprovido.
+
+Teses de julgamento: "1. A caracterização da continuidade delitiva exige o preenchimento de requisitos objetivos e do elemento subjetivo da unidade de desígnios. 2. A habitualidade criminosa, demonstrada por extensa ficha de antecedentes, afasta a aplicação do benefício previsto no art. 71 do Código Penal."
+
+Dispositivos relevantes citados: CP, arts. 69, 71, 155, 157, 180 e 288.
+
+Jurisprudências relevantes citadas: STF, HC 110.002, Rel. Min. Teori Zavascki, Segunda Turma, j. 09.12.2014; STJ, AgRg no REsp 1.666.714/SC, Rel. Min. Felix Fischer, Quinta Turma, j. 12.12.2017.
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Agravo em Execução Penal nº 0023290-38.2019.8.06.0001, ACORDAM os Desembargadores integrantes desta 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por votação unânime, em CONHECER do recurso para NEGAR-LHE PROVIMENTO, nos termos do voto do eminente Relator. 
+
+Fortaleza/CE, 8 de abril de 2026.
+
+FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+Presidente do Órgão Julgador
+
+DESEMBARGADOR SÉRGIO LUIZ ARRUDA PARENTE
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>22&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833437" cdForo="0" >
+										0252247-94.2021.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833437" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833437);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833437" style="display: none;" >
+	<div id="textAreaDados_3833437" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. CRIMES CONTRA O PATRIM&Ocirc;NIO. FURTO SIMPLES E ROUBO MAJORADO. SUBTRA&Ccedil;&Atilde;O DE BENS MEDIANTE GRAVE AMEA&Ccedil;A. EMPREGO DE ARMA DE FOGO. DISPARO PARA INTIMIDA&Ccedil;&Atilde;O DURANTE A FUGA. CONCURSO DE AGENTES. ATUA&Ccedil;&Atilde;O CONJUNTA ENTRE A R&Eacute; E COMPARSA N&Atilde;O IDENTIFICADO. PRIS&Atilde;O EM FLAGRANTE POR POPULARES. RECUPERA&Ccedil;&Atilde;O DOS BENS SUBTRA&Iacute;DOS. PALAVRA DA V&Iacute;TIMA EM CONSON&Acirc;NCIA COM PROVAS TESTEMUNHAIS. RELEV&Acirc;NCIA PROBAT&Oacute;RIA EM CRIMES PATRIMONIAIS. COMPROVA&Ccedil;&Atilde;O DA AUTORIA E MATERIALIDADE. INAPLICABILIDADE DO PRINC&Iacute;PIO DO IN DUBIO PRO REO. TEORIA DA APPREHENSIO. CONSUMA&Ccedil;&Atilde;O DO ROUBO COM A INVERS&Atilde;O DA POSSE. DESNECESSIDADE DE POSSE MANSA E PAC&Iacute;FICA. MANUTEN&Ccedil;&Atilde;O DA CONDENA&Ccedil;&Atilde;O PELO CRIME DE ROUBO. MAJORANTE DO EMPREGO DE ARMA DE FOGO. PRESCINDIBILIDADE DE APREENS&Atilde;O E PER&Iacute;CIA DO ARTEFATO. COMPROVA&Ccedil;&Atilde;O POR PROVA ORAL ID&Ocirc;NEA. MAJORANTE DO CONCURSO DE AGENTES. DESNECESSIDADE DE IDENTIFICA&Ccedil;&Atilde;O DO CORR&Eacute;U. V&Iacute;NCULO SUBJETIVO DEMONSTRADO. DOSIMETRIA DA PENA. OBSERV&Acirc;NCIA DO SISTEMA TRIF&Aacute;SICO E DOS PRINC&Iacute;PIOS DA PROPORCIONALIDADE E RAZOABILIDADE. FURTO SIMPLES. PENA CONCRETIZADA. PRESCRI&Ccedil;&Atilde;O RETROATIVA DA PRETENS&Atilde;O PUNITIVA. ACOLHIMENTO. LAPSO TEMPORAL SUPERIOR AO PRAZO LEGAL ENTRE O RECEBIMENTO DA DEN&Uacute;NCIA E A SENTEN&Ccedil;A CONDENAT&Oacute;RIA. MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA. RECONHECIMENTO. EXTIN&Ccedil;&Atilde;O DA PUNIBILIDADE. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o criminal interposta pela defesa de Gl&oacute;ria Regina Alves Ara&uacute;jo contra senten&ccedil;a que a condenou pelos crimes de furto (art. 155 do CP) e roubo majorado (art. 157, &sect;2&ordm;, II, e &sect;2&ordm;-A, I, do CP), &agrave; pena de 7 anos e 8 meses de reclus&atilde;o, em regime inicial semiaberto, al&eacute;m de dias-multa, em raz&atilde;o de subtra&ccedil;&atilde;o de bens mediante grave amea&ccedil;a com arma de fogo, em concurso com terceiro n&atilde;o identificado, sendo a r&eacute; presa em flagrante por populares.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se ocorreu a prescri&ccedil;&atilde;o da pretens&atilde;o punitiva quanto ao crime de furto; (ii) estabelecer se h&aacute; provas suficientes para a absolvi&ccedil;&atilde;o da r&eacute; quanto ao crime de roubo; (iii) determinar se devem ser afastadas as causas de aumento referentes ao emprego de arma de fogo e ao concurso de agentes.
+III. RAZ&Otilde;ES DE DECIDIR
+Reconhece-se a prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa quanto ao crime de furto, pois, considerada a pena aplicada e o lapso temporal superior a 4 anos entre o recebimento da den&uacute;ncia e a publica&ccedil;&atilde;o da senten&ccedil;a, resta configurada a extin&ccedil;&atilde;o da punibilidade, nos termos dos arts. 109 e 110, &sect;1&ordm;, do C&oacute;digo Penal e da S&uacute;mula 146 do STF.
+Afirma-se que a prescri&ccedil;&atilde;o &eacute; mat&eacute;ria de ordem p&uacute;blica e pode ser declarada de of&iacute;cio em qualquer fase processual, conforme art. 61 do CPP.
+Mant&eacute;m-se a condena&ccedil;&atilde;o pelo crime de roubo majorado, pois a autoria e materialidade est&atilde;o comprovadas por depoimentos firmes e coerentes das v&iacute;timas, corroborados por testemunhas e demais elementos probat&oacute;rios.
+Reconhece-se a especial relev&acirc;ncia da palavra da v&iacute;tima em crimes patrimoniais, sobretudo quando harm&ocirc;nica com o conjunto probat&oacute;rio e ausente qualquer ind&iacute;cio de m&aacute;-f&eacute;.
+Considera-se configurada a grave amea&ccedil;a pelo emprego de arma de fogo, sendo desnecess&aacute;ria sua apreens&atilde;o ou per&iacute;cia para incid&ecirc;ncia da majorante, desde que comprovada por prova testemunhal id&ocirc;nea.
+Mant&eacute;m-se a majorante do concurso de agentes, pois evidenciada a atua&ccedil;&atilde;o conjunta e o v&iacute;nculo subjetivo entre os agentes, ainda que o corr&eacute;u n&atilde;o tenha sido identificado.
+Rejeita-se o pedido de absolvi&ccedil;&atilde;o por insufici&ecirc;ncia de provas, pois o acervo probat&oacute;rio &eacute; robusto e apto a sustentar o decreto condenat&oacute;rio.
+Ratifica-se a dosimetria da pena do crime de roubo, por observar o sistema trif&aacute;sico e os princ&iacute;pios da proporcionalidade e razoabilidade.
+IV. DISPOSITIVO E TESE
+Recurso conhecido e parcialmente provido.
+Tese de julgamento: A prescri&ccedil;&atilde;o da pretens&atilde;o punitiva retroativa deve ser reconhecida quando, considerada a pena aplicada, o lapso temporal entre marcos processuais supera o prazo legal; A palavra da v&iacute;tima, corroborada por outros elementos de prova, &eacute; suficiente para fundamentar condena&ccedil;&atilde;o em crimes patrimoniais; A incid&ecirc;ncia da majorante do emprego de arma de fogo prescinde da apreens&atilde;o e per&iacute;cia do artefato quando comprovada por prova testemunhal id&ocirc;nea; A majorante do concurso de agentes se configura pela atua&ccedil;&atilde;o conjunta, independentemente da identifica&ccedil;&atilde;o do corr&eacute;u.
+Dispositivos relevantes citados: CP, arts. 109, 110, &sect;1&ordm;, 155 e 157, &sect;2&ordm;, II, e &sect;2&ordm;-A, I; CPP, arts. 61 e 386, V e VII.
+Jurisprud&ecirc;ncia relevante citada: STF, S&uacute;mula 146; STJ, HC 883.483/MG, Rel. Min. Daniela Teixeira, 5&ordf; Turma, j. 10.12.2024; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0144658-14.2019.8.06.0001, Rel. Des. Benedito Helder Afonso Ibiapina, j. 24.09.2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0029083-94.2015.8.06.0001, Rel. Des. S&eacute;rgio Luiz Arruda Parente, j. 18.06.2025.  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0252247-94.2021.8.06.0001, Rel. Desembargador(a)  MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 08/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 08/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Roubo
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIA ILNA LIMA DE CASTRO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. CRIMES CONTRA O PATRIMÔNIO. FURTO SIMPLES E ROUBO MAJORADO. SUBTRAÇÃO DE BENS MEDIANTE GRAVE AMEAÇA. EMPREGO DE ARMA DE FOGO. DISPARO PARA INTIMIDAÇÃO DURANTE A FUGA. CONCURSO DE AGENTES. ATUAÇÃO CONJUNTA ENTRE A RÉ E COMPARSA NÃO IDENTIFICADO. PRISÃO EM FLAGRANTE POR POPULARES. RECUPERAÇÃO DOS BENS SUBTRAÍDOS. PALAVRA DA VÍTIMA EM CONSONÂNCIA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. CRIMES CONTRA O PATRIMÔNIO. FURTO SIMPLES E ROUBO MAJORADO. SUBTRAÇÃO DE BENS MEDIANTE GRAVE AMEAÇA. EMPREGO DE ARMA DE FOGO. DISPARO PARA INTIMIDAÇÃO DURANTE A FUGA. CONCURSO DE AGENTES. ATUAÇÃO CONJUNTA ENTRE A RÉ E COMPARSA NÃO IDENTIFICADO. PRISÃO EM FLAGRANTE POR POPULARES. RECUPERAÇÃO DOS BENS SUBTRAÍDOS. PALAVRA DA VÍTIMA EM CONSONÂNCIA COM PROVAS TESTEMUNHAIS. RELEVÂNCIA PROBATÓRIA EM CRIMES PATRIMONIAIS. COMPROVAÇÃO DA AUTORIA E MATERIALIDADE. INAPLICABILIDADE DO PRINCÍPIO DO IN DUBIO PRO REO. TEORIA DA APPREHENSIO. CONSUMAÇÃO DO ROUBO COM A INVERSÃO DA POSSE. DESNECESSIDADE DE POSSE MANSA E PACÍFICA. MANUTENÇÃO DA CONDENAÇÃO PELO CRIME DE ROUBO. MAJORANTE DO EMPREGO DE ARMA DE FOGO. PRESCINDIBILIDADE DE APREENSÃO E PERÍCIA DO ARTEFATO. COMPROVAÇÃO POR PROVA ORAL IDÔNEA. MAJORANTE DO CONCURSO DE AGENTES. DESNECESSIDADE DE IDENTIFICAÇÃO DO CORRÉU. VÍNCULO SUBJETIVO DEMONSTRADO. DOSIMETRIA DA PENA. OBSERVÂNCIA DO SISTEMA TRIFÁSICO E DOS PRINCÍPIOS DA PROPORCIONALIDADE E RAZOABILIDADE. FURTO SIMPLES. PENA CONCRETIZADA. PRESCRIÇÃO RETROATIVA DA PRETENSÃO PUNITIVA. ACOLHIMENTO. LAPSO TEMPORAL SUPERIOR AO PRAZO LEGAL ENTRE O RECEBIMENTO DA DENÚNCIA E A SENTENÇA CONDENATÓRIA. MATÉRIA DE ORDEM PÚBLICA. RECONHECIMENTO. EXTINÇÃO DA PUNIBILIDADE. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+Apelação criminal interposta pela defesa de Glória Regina Alves Araújo contra sentença que a condenou pelos crimes de furto (art. 155 do CP) e roubo majorado (art. 157, §2º, II, e §2º-A, I, do CP), à pena de 7 anos e 8 meses de reclusão, em regime inicial semiaberto, além de dias-multa, em razão de subtração de bens mediante grave ameaça com arma de fogo, em concurso com terceiro não identificado, sendo a ré presa em flagrante por populares.
+II. QUESTÃO EM DISCUSSÃO
+Há três questões em discussão: (i) definir se ocorreu a prescrição da pretensão punitiva quanto ao crime de furto; (ii) estabelecer se há provas suficientes para a absolvição da ré quanto ao crime de roubo; (iii) determinar se devem ser afastadas as causas de aumento referentes ao emprego de arma de fogo e ao concurso de agentes.
+III. RAZÕES DE DECIDIR
+Reconhece-se a prescrição da pretensão punitiva retroativa quanto ao crime de furto, pois, considerada a pena aplicada e o lapso temporal superior a 4 anos entre o recebimento da denúncia e a publicação da sentença, resta configurada a extinção da punibilidade, nos termos dos arts. 109 e 110, §1º, do Código Penal e da Súmula 146 do STF.
+Afirma-se que a prescrição é matéria de ordem pública e pode ser declarada de ofício em qualquer fase processual, conforme art. 61 do CPP.
+Mantém-se a condenação pelo crime de roubo majorado, pois a autoria e materialidade estão comprovadas por depoimentos firmes e coerentes das vítimas, corroborados por testemunhas e demais elementos probatórios.
+Reconhece-se a especial relevância da palavra da vítima em crimes patrimoniais, sobretudo quando harmônica com o conjunto probatório e ausente qualquer indício de má-fé.
+Considera-se configurada a grave ameaça pelo emprego de arma de fogo, sendo desnecessária sua apreensão ou perícia para incidência da majorante, desde que comprovada por prova testemunhal idônea.
+Mantém-se a majorante do concurso de agentes, pois evidenciada a atuação conjunta e o vínculo subjetivo entre os agentes, ainda que o corréu não tenha sido identificado.
+Rejeita-se o pedido de absolvição por insuficiência de provas, pois o acervo probatório é robusto e apto a sustentar o decreto condenatório.
+Ratifica-se a dosimetria da pena do crime de roubo, por observar o sistema trifásico e os princípios da proporcionalidade e razoabilidade.
+IV. DISPOSITIVO E TESE
+Recurso conhecido e parcialmente provido.
+Tese de julgamento: A prescrição da pretensão punitiva retroativa deve ser reconhecida quando, considerada a pena aplicada, o lapso temporal entre marcos processuais supera o prazo legal; A palavra da vítima, corroborada por outros elementos de prova, é suficiente para fundamentar condenação em crimes patrimoniais; A incidência da majorante do emprego de arma de fogo prescinde da apreensão e perícia do artefato quando comprovada por prova testemunhal idônea; A majorante do concurso de agentes se configura pela atuação conjunta, independentemente da identificação do corréu.
+Dispositivos relevantes citados: CP, arts. 109, 110, §1º, 155 e 157, §2º, II, e §2º-A, I; CPP, arts. 61 e 386, V e VII.
+Jurisprudência relevante citada: STF, Súmula 146; STJ, HC 883.483/MG, Rel. Min. Daniela Teixeira, 5ª Turma, j. 10.12.2024; TJCE, Apelação Criminal nº 0144658-14.2019.8.06.0001, Rel. Des. Benedito Helder Afonso Ibiapina, j. 24.09.2025; TJCE, Apelação Criminal nº 0029083-94.2015.8.06.0001, Rel. Des. Sérgio Luiz Arruda Parente, j. 18.06.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>23&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833370" cdForo="0" >
+										0205103-04.2024.8.06.0298
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833370" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833370);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833370" style="display: none;" >
+	<div id="textAreaDados_3833370" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSO PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. PORTE ILEGAL DE ARMA DE FOGO DE USO PERMITIDO. ADULTERA&Ccedil;&Atilde;O DE SINAL IDENTIFICADOR DE VE&Iacute;CULO AUTOMOTOR. CORRUP&Ccedil;&Atilde;O DE MENORES. AUTORIA E MATERIALIDADE COMPROVADAS. VALIDADE DO DEPOIMENTO DE POLICIAIS. CRIMES DE PERIGO ABSTRATO E FORMAL. AUS&Ecirc;NCIA DE NULIDADE NA DOSIMETRIA. MANUTEN&Ccedil;&Atilde;O DA CONDENA&Ccedil;&Atilde;O. RECURSOS DESPROVIDOS.
+
+I. DO CASO EM EXAME
+1. Apela&ccedil;&otilde;es criminais interpostas por Filipe de Castro Uch&ocirc;a e Antonio Jos&eacute; Alves de Sousa contra senten&ccedil;a do Ju&iacute;zo da Vara &Uacute;nica Criminal da Comarca de Itapipoca/CE que os condenou pela pr&aacute;tica dos crimes previstos no art. 14 da Lei n&ordm; 10.826/2003, art. 311, &sect;2&ordm;, III, do C&oacute;digo Penal, e art. 244-B da Lei n&ordm; 8.069/1990.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2.H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se a senten&ccedil;a &eacute; nula por aus&ecirc;ncia de fundamenta&ccedil;&atilde;o na dosimetria da pena; (ii) estabelecer se h&aacute; prova suficiente de autoria e materialidade quanto aos crimes de porte ilegal de arma de fogo, adultera&ccedil;&atilde;o de sinal identificador de ve&iacute;culo automotor e corrup&ccedil;&atilde;o de menores; e (iii) determinar se &eacute; cab&iacute;vel a absolvi&ccedil;&atilde;o ou a readequa&ccedil;&atilde;o do concurso de crimes.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3.A dosimetria da pena apresenta fundamenta&ccedil;&atilde;o suficiente, observando os crit&eacute;rios do art. 59 do C&oacute;digo Penal, sendo mat&eacute;ria inserida na discricionariedade regrada do julgador, inexistindo arbitrariedade ou aus&ecirc;ncia de motiva&ccedil;&atilde;o apta a ensejar nulidade.
+4. A materialidade dos delitos resta comprovada pelo auto de apresenta&ccedil;&atilde;o e apreens&atilde;o, registros fotogr&aacute;ficos e depoimentos testemunhais, que demonstram a apreens&atilde;o de armas de fogo, muni&ccedil;&otilde;es e motocicleta com placa adulterada.
+5. A autoria delitiva evidencia-se pelos depoimentos harm&ocirc;nicos dos policiais militares respons&aacute;veis pela abordagem, prestados sob contradit&oacute;rio judicial, os quais constituem meio de prova id&ocirc;neo quando coerentes com o conjunto probat&oacute;rio.
+6. O crime de porte ilegal de arma de fogo de uso permitido configura delito de perigo abstrato, sendo desnecess&aacute;ria a comprova&ccedil;&atilde;o de potencialidade lesiva concreta, bastando a pr&aacute;tica da conduta de portar ou transportar arma ou muni&ccedil;&atilde;o em desacordo com a lei.
+7. A coautoria no porte de arma de fogo pode ser reconhecida quando evidenciada atua&ccedil;&atilde;o conjunta e dom&iacute;nio funcional do fato entre os agentes, ainda que a arma esteja fisicamente em poder de apenas um deles.
+8. O delito de corrup&ccedil;&atilde;o de menores previsto no art. 244-B do ECA possui natureza formal, consumando-se com a pr&aacute;tica de infra&ccedil;&atilde;o penal em companhia de menor de idade, independentemente da prova de efetiva corrup&ccedil;&atilde;o ou de antecedentes infracionais do adolescente.
+9. A adultera&ccedil;&atilde;o de sinal identificador de ve&iacute;culo automotor resta caracterizada pela utiliza&ccedil;&atilde;o de motocicleta com placa alterada mediante fita adesiva, circunst&acirc;ncia confirmada pelos policiais e por registro fotogr&aacute;fico, sendo dispens&aacute;vel prova pericial quando a adultera&ccedil;&atilde;o &eacute; percept&iacute;vel.
+10. Demonstrada a posse do ve&iacute;culo adulterado pelos acusados, incumbe &agrave; defesa demonstrar a aus&ecirc;ncia de conhecimento da irregularidade, &ocirc;nus do qual n&atilde;o se desincumbiu, permanecendo isolada a vers&atilde;o exculpat&oacute;ria apresentada.
+11. As circunst&acirc;ncias da abordagem &#150; condu&ccedil;&atilde;o de ve&iacute;culo adulterado, transporte de armas de fogo, utiliza&ccedil;&atilde;o de balaclavas e fuga inicial da abordagem policial &#150; evidenciam o contexto de atua&ccedil;&atilde;o criminosa conjunta, afastando as teses absolut&oacute;rias e a alega&ccedil;&atilde;o de desconhecimento da adultera&ccedil;&atilde;o.
+
+IV. DISPOSITIVO
+12. Recursos conhecidos e desprovidos, com o redimensionamento, de of&iacute;cio, da san&ccedil;&atilde;o pecuni&aacute;ria aplic&aacute;vel ao r&eacute;u Filipe de Castro Uch&ocirc;a.
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Apela&ccedil;&atilde;o Criminal n.&ordm; 0205103-04.2024.8.06.0298, em que figuram como recorrentes Filipe de Castro Uch&ocirc;a e Antonio Jos&eacute; Alves de Sousa, e recorrido o Minist&eacute;rio P&uacute;blico do Estado do Cear&aacute;.
+
+ACORDAM os Desembargadores integrantes da 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em CONHECER dos recursos e NEGAR-LHES PROVIMENTO, com o redimensionamento, de of&iacute;cio, da san&ccedil;&atilde;o pecuni&aacute;ria aplic&aacute;vel ao r&eacute;u Filipe de Castro Uch&ocirc;a, nos termos do voto do eminente Relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0205103-04.2024.8.06.0298, Rel. Desembargador(a)  FRANCISCO EDUARDO TORQUATO SCORSAFAVA, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 08/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 08/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Crimes do Sistema Nacional de Armas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Itapipoca
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSO PENAL. APELAÇÃO CRIMINAL. PORTE ILEGAL DE ARMA DE FOGO DE USO PERMITIDO. ADULTERAÇÃO DE SINAL IDENTIFICADOR DE VEÍCULO AUTOMOTOR. CORRUPÇÃO DE MENORES. AUTORIA E MATERIALIDADE COMPROVADAS. VALIDADE DO DEPOIMENTO DE POLICIAIS. CRIMES DE PERIGO ABSTRATO E FORMAL. AUSÊNCIA DE NULIDADE NA DOSIMETRIA. MANUTENÇÃO DA CONDENAÇÃO. RECURSOS DESPROVIDOS.
+
+I. DO CASO EM EXAME
+1.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSO PENAL. APELAÇÃO CRIMINAL. PORTE ILEGAL DE ARMA DE FOGO DE USO PERMITIDO. ADULTERAÇÃO DE SINAL IDENTIFICADOR DE VEÍCULO AUTOMOTOR. CORRUPÇÃO DE MENORES. AUTORIA E MATERIALIDADE COMPROVADAS. VALIDADE DO DEPOIMENTO DE POLICIAIS. CRIMES DE PERIGO ABSTRATO E FORMAL. AUSÊNCIA DE NULIDADE NA DOSIMETRIA. MANUTENÇÃO DA CONDENAÇÃO. RECURSOS DESPROVIDOS.
+
+I. DO CASO EM EXAME
+1. Apelações criminais interpostas por Filipe de Castro Uchôa e Antonio José Alves de Sousa contra sentença do Juízo da Vara Única Criminal da Comarca de Itapipoca/CE que os condenou pela prática dos crimes previstos no art. 14 da Lei nº 10.826/2003, art. 311, §2º, III, do Código Penal, e art. 244-B da Lei nº 8.069/1990.
+
+II. QUESTÃO EM DISCUSSÃO
+2.Há três questões em discussão: (i) definir se a sentença é nula por ausência de fundamentação na dosimetria da pena; (ii) estabelecer se há prova suficiente de autoria e materialidade quanto aos crimes de porte ilegal de arma de fogo, adulteração de sinal identificador de veículo automotor e corrupção de menores; e (iii) determinar se é cabível a absolvição ou a readequação do concurso de crimes.
+
+III. RAZÕES DE DECIDIR
+3.A dosimetria da pena apresenta fundamentação suficiente, observando os critérios do art. 59 do Código Penal, sendo matéria inserida na discricionariedade regrada do julgador, inexistindo arbitrariedade ou ausência de motivação apta a ensejar nulidade.
+4. A materialidade dos delitos resta comprovada pelo auto de apresentação e apreensão, registros fotográficos e depoimentos testemunhais, que demonstram a apreensão de armas de fogo, munições e motocicleta com placa adulterada.
+5. A autoria delitiva evidencia-se pelos depoimentos harmônicos dos policiais militares responsáveis pela abordagem, prestados sob contraditório judicial, os quais constituem meio de prova idôneo quando coerentes com o conjunto probatório.
+6. O crime de porte ilegal de arma de fogo de uso permitido configura delito de perigo abstrato, sendo desnecessária a comprovação de potencialidade lesiva concreta, bastando a prática da conduta de portar ou transportar arma ou munição em desacordo com a lei.
+7. A coautoria no porte de arma de fogo pode ser reconhecida quando evidenciada atuação conjunta e domínio funcional do fato entre os agentes, ainda que a arma esteja fisicamente em poder de apenas um deles.
+8. O delito de corrupção de menores previsto no art. 244-B do ECA possui natureza formal, consumando-se com a prática de infração penal em companhia de menor de idade, independentemente da prova de efetiva corrupção ou de antecedentes infracionais do adolescente.
+9. A adulteração de sinal identificador de veículo automotor resta caracterizada pela utilização de motocicleta com placa alterada mediante fita adesiva, circunstância confirmada pelos policiais e por registro fotográfico, sendo dispensável prova pericial quando a adulteração é perceptível.
+10. Demonstrada a posse do veículo adulterado pelos acusados, incumbe à defesa demonstrar a ausência de conhecimento da irregularidade, ônus do qual não se desincumbiu, permanecendo isolada a versão exculpatória apresentada.
+11. As circunstâncias da abordagem  condução de veículo adulterado, transporte de armas de fogo, utilização de balaclavas e fuga inicial da abordagem policial  evidenciam o contexto de atuação criminosa conjunta, afastando as teses absolutórias e a alegação de desconhecimento da adulteração.
+
+IV. DISPOSITIVO
+12. Recursos conhecidos e desprovidos, com o redimensionamento, de ofício, da sanção pecuniária aplicável ao réu Filipe de Castro Uchôa.
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Apelação Criminal n.º 0205103-04.2024.8.06.0298, em que figuram como recorrentes Filipe de Castro Uchôa e Antonio José Alves de Sousa, e recorrido o Ministério Público do Estado do Ceará.
+
+ACORDAM os Desembargadores integrantes da 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em CONHECER dos recursos e NEGAR-LHES PROVIMENTO, com o redimensionamento, de ofício, da sanção pecuniária aplicável ao réu Filipe de Castro Uchôa, nos termos do voto do eminente Relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>24&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833457" cdForo="0" >
+										0621884-86.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833457" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833457);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833457" style="display: none;" >
+	<div id="textAreaDados_3833457" class="mensagemSemFormatacao" >
+		HABEAS CORPUS. PENAL E PROCESSUAL PENAL. LES&Atilde;O CORPORAL. ASSOCIA&Ccedil;&Atilde;O CRIMINOSA. DESOBEDI&Ecirc;NCIA. DANO QUALIFICADO. CORRUP&Ccedil;&Atilde;O DE MENORES. CRIME DA LEI GERAL DO ESPORTE. PRIS&Atilde;O PREVENTIVA. 1. PLEITO DE CAR&Ecirc;NCIA DE FUNDAMENTA&Ccedil;&Atilde;O V&Aacute;LIDA PARA A DECRETA&Ccedil;&Atilde;O DA PRIS&Atilde;O PREVENTIVA E AUS&Ecirc;NCIA DOS REQUISITOS DO ART. 312 DO CPP. DECIS&Otilde;ES SUFICIENTEMENTE ALICER&Ccedil;ADAS PELOS SEUS PRESSUPOSTOS, FUNDAMENTOS E CONDI&Ccedil;&Otilde;ES DE ADMISSIBILIDADE. INEXIST&Ecirc;NCIA DE ILEGALIDADE ID&Ocirc;NEA A JUSTIFICAR A CONCESS&Atilde;O DA ORDEM. GARANTIA DA ORDEM P&Uacute;BLICA. PERICULOSIDADE. GRAVIDADE IN CONCRETO DOS DELITOS. MODUS OPERANDI. S&Uacute;MULA 52 TJCE. CONSTRANGIMENTO ILEGAL N&Atilde;O CONFIGURADO. 2. CONDI&Ccedil;&Otilde;ES PESSOAIS FAVOR&Aacute;VEIS. IRRELEV&Acirc;NCIA. APLICA&Ccedil;&Atilde;O DE MEDIDAS CAUTELARES DIVERSAS. INSUFICI&Ecirc;NCIA. PRESENTES OS REQUISITOS AUTORIZADORES DA CUST&Oacute;DIA CAUTELAR. PRECEDENTES. 3. PEDIDO DE EXTENS&Atilde;O DE BENEF&Iacute;CIO. INEXIST&Ecirc;NCIA DE SIMILITUDE F&Aacute;TICO-PROCESSUAL.
+
+I. CASO EM EXAME
+1. Trata-se de Habeas Corpus, com pedido em car&aacute;ter liminar, impetrado por Mauro J&uacute;nior Rios, em favor de Carlos Gabriel Rodrigues da Concei&ccedil;&atilde;o, contra ato do Ju&iacute;zo de Direito da 11&ordf; Vara Criminal da Comarca de Fortaleza/CE, no bojo do processo n&ordm; 0012485-79.2026.8.06.0001.
+
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) avaliar se est&atilde;o presentes os requisitos e fundamentos da pris&atilde;o preventiva da paciente; (ii) aferir a alega&ccedil;&atilde;o da presen&ccedil;a de condi&ccedil;&otilde;es pessoais favor&aacute;veis &agrave; soltura; (iii) subsidiariamente, examinar a possibilidade de aplica&ccedil;&atilde;o de medidas cautelares diversas da pris&atilde;o. (iv) conferir a viabilidade do pedido de extens&atilde;o do benef&iacute;cio concedido a corr&eacute;us, nos termos do art. 580 do CPP.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3. No que tange &agrave;s teses de car&ecirc;ncia de fundamenta&ccedil;&atilde;o e de aus&ecirc;ncia dos requisitos para a decreta&ccedil;&atilde;o da cust&oacute;dia cautelar, n&atilde;o h&aacute; ofensa, at&eacute; aqui, aos pressupostos, fundamentos e/ou condi&ccedil;&otilde;es de admissibilidade da pris&atilde;o preventiva imputada, n&atilde;o havendo que se falar em restri&ccedil;&atilde;o ilegal ao direito constitucional de locomo&ccedil;&atilde;o.
+4. Os motivos postos no decreto constritivo est&atilde;o devidamente alicer&ccedil;ados em elementos vinculados &agrave; realidade, tendo a autoridade impetrada feito refer&ecirc;ncia &agrave;s circunst&acirc;ncias f&aacute;ticas e jur&iacute;dicas envoltas no caso, de maneira que n&atilde;o h&aacute; ilegalidade a ser reconhecida quanto a este ponto, estando respeitado o disposto nos arts. 282, inc. I e II, 311, 312 e 313 do C&oacute;digo de Ritos Penais p&aacute;trio.
+5. Tendo em vista o risco concreto de reitera&ccedil;&atilde;o delitiva do paciente, &eacute; certo que sua soltura representa um s&eacute;rio risco &agrave; preserva&ccedil;&atilde;o da ordem p&uacute;blica, devendo a pris&atilde;o preventiva ser mantida, conforme enunciado de n.&ordm; 52 da S&uacute;mula deste eg. Tribunal de Justi&ccedil;a.
+6. O fato de o agente ostentar condi&ccedil;&otilde;es favor&aacute;veis n&atilde;o &eacute; garantidor da liberdade provis&oacute;ria, pois elas devem ser avaliadas conjuntamente com as peculiaridades do caso concreto, n&atilde;o podendo, per si, afastar a necessidade da manuten&ccedil;&atilde;o da preventiva, ou de outras cautelares mais severas, quando presentes os requisitos legais, como &eacute; o caso dos autos.
+7. Verifica-se que, demonstrada a referida imprescindibilidade da segrega&ccedil;&atilde;o preventiva, resta clara a insufici&ecirc;ncia das medidas cautelares alternativas (art. 319 do C&oacute;digo de Processo Penal), uma vez que al&eacute;m de haver motiva&ccedil;&atilde;o apta a justificar a cust&oacute;dia cautelar, a sua aplica&ccedil;&atilde;o n&atilde;o se mostraria adequada e suficiente para garantir a ordem p&uacute;blica.
+8. O art. 580 do CPP prev&ecirc; a possibilidade de extens&atilde;o de benef&iacute;cio a corr&eacute;u quando presentes situa&ccedil;&otilde;es f&aacute;ticas id&ecirc;nticas, desde que n&atilde;o envolvam fundamentos exclusivamente pessoais. Inobstante, no caso, ap&oacute;s detida an&aacute;lise, restou claro que a situa&ccedil;&atilde;o f&aacute;tico-processual do paciente &eacute; notavelmente distinta, obstando que a este sejam aproveitados os efeitos do mencionado benef&iacute;cio concedido a seus corr&eacute;us.
+
+IV. DISPOSITIVO
+9. Habeas corpus conhecido e ordem denegada.
+
+________________________________________________________
+Dispositivos relevantes citados: CPP, arts. 282, I e II, 312, 313 e 319.
+
+Jurisprud&ecirc;ncias relevantes citadas: HC n. 879.305/RR, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 27/11/2024; RHC n. 91896/BA, relator Ministro Felix Fischer, Quinta Turma, julgado em 15/3/2018; AgRg no HC n. 941.276/MG, relator Ministro Og Fernandes, Sexta Turma, julgado em 4/11/2024; AgRg no HC n. 957.701/SC, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 10/12/2024; AgRg no HC n. 811.826/MG, relator Ministro Ribeiro Dantas, Quinta Turma, julgado em 12/6/2023; Habeas Corpus Criminal&nbsp;- 0632861-11.2024.8.06.0000, Rel. Desembargador(a) Marl&uacute;cia de Ara&uacute;jo Bezerra, 3&ordf; C&acirc;mara Criminal, data do julgamento&nbsp; 10/12/2024; Habeas Corpus Criminal &#150;  0624893-61.2023.8.06.0000, Relator(a): Maria Ilna Lima de Castro, 2&ordf; C&acirc;mara Criminal, Data do julgamento 31/05/2023; AgRg no RHC n. 194.147/MS, relator Ministro Ot&aacute;vio de Almeida Toledo (Desembargador Convocado do TJSP), Sexta Turma, julgado em 19/8/2024; AgRg no HC n. 854.089/SP, relator Ministro Joel Ilan Paciornik, Quinta Turma, julgado em 29/4/2024; Habeas Corpus Criminal&nbsp;- 0629044-70.2023.8.06.0000, Rel. Desembargador(a) Henrique Jorge Holanda Silveira, 3&ordf; C&acirc;mara Criminal, data do julgamento&nbsp; 18/07/2023; Habeas Corpus Criminal - 0633714-54.2023.8.06.0000, Rel. Desembargador(a) Maria Ilna Lima de Castro, 2&ordf; C&acirc;mara Criminal, data do julgamento:  25/10/2023.
+
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Habeas Corpus n&ordm; 0621884-86.2026.8.06.0000, formulado por Mauro J&uacute;nior Rios, em favor de Carlos Gabriel Rodrigues da Concei&ccedil;&atilde;o, contra ato do Juiz de Direito da 11&ordf; Vara Criminal da Comarca de Fortaleza, nos autos do processo de n.&ordm; 0012485-79.2026.8.06.0001.
+
+Acordam os Desembargadores integrantes da 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em conhecer do presente habeas corpus, para denegar a ordem.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator <br><br>(Habeas Corpus Criminal&nbsp;-  0621884-86.2026.8.06.0000, Rel. Desembargador(a)  FRANCISCO EDUARDO TORQUATO SCORSAFAVA, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 08/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 08/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Habeas Corpus Criminal / Habeas Corpus - Liberatório
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>HABEAS CORPUS. PENAL E PROCESSUAL PENAL. LESÃO CORPORAL. ASSOCIAÇÃO CRIMINOSA. DESOBEDIÊNCIA. <em>DANO</em> QUALIFICADO. CORRUPÇÃO DE MENORES. CRIME DA LEI GERAL DO ESPORTE. PRISÃO PREVENTIVA. 1. PLEITO DE CARÊNCIA DE FUNDAMENTAÇÃO VÁLIDA PARA A DECRETAÇÃO DA PRISÃO PREVENTIVA E AUSÊNCIA DOS REQUISITOS DO ART. 312 DO CPP. DECISÕES SUFICIENTEMENTE ALICERÇADAS PELOS SEUS PRESSUPOSTOS, FUNDAMENTOS E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>HABEAS CORPUS. PENAL E PROCESSUAL PENAL. LESÃO CORPORAL. ASSOCIAÇÃO CRIMINOSA. DESOBEDIÊNCIA. <em>DANO</em> QUALIFICADO. CORRUPÇÃO DE MENORES. CRIME DA LEI GERAL DO ESPORTE. PRISÃO PREVENTIVA. 1. PLEITO DE CARÊNCIA DE FUNDAMENTAÇÃO VÁLIDA PARA A DECRETAÇÃO DA PRISÃO PREVENTIVA E AUSÊNCIA DOS REQUISITOS DO ART. 312 DO CPP. DECISÕES SUFICIENTEMENTE ALICERÇADAS PELOS SEUS PRESSUPOSTOS, FUNDAMENTOS E CONDIÇÕES DE ADMISSIBILIDADE. INEXISTÊNCIA DE ILEGALIDADE IDÔNEA A JUSTIFICAR A CONCESSÃO DA ORDEM. GARANTIA DA ORDEM PÚBLICA. PERICULOSIDADE. GRAVIDADE IN CONCRETO DOS DELITOS. MODUS OPERANDI. SÚMULA 52 TJCE. CONSTRANGIMENTO ILEGAL NÃO CONFIGURADO. 2. CONDIÇÕES PESSOAIS FAVORÁVEIS. IRRELEVÂNCIA. APLICAÇÃO DE MEDIDAS CAUTELARES DIVERSAS. INSUFICIÊNCIA. PRESENTES OS REQUISITOS AUTORIZADORES DA CUSTÓDIA CAUTELAR. PRECEDENTES. 3. PEDIDO DE EXTENSÃO DE BENEFÍCIO. INEXISTÊNCIA DE SIMILITUDE FÁTICO-PROCESSUAL.
+
+I. CASO EM EXAME
+1. Trata-se de Habeas Corpus, com pedido em caráter liminar, impetrado por Mauro Júnior Rios, em favor de Carlos Gabriel Rodrigues da Conceição, contra ato do Juízo de Direito da 11ª Vara Criminal da Comarca de Fortaleza/CE, no bojo do processo nº 0012485-79.2026.8.06.0001.
+
+II. QUESTÕES EM DISCUSSÃO
+2. Há quatro questões em discussão: (i) avaliar se estão presentes os requisitos e fundamentos da prisão preventiva da paciente; (ii) aferir a alegação da presença de condições pessoais favoráveis à soltura; (iii) subsidiariamente, examinar a possibilidade de aplicação de medidas cautelares diversas da prisão. (iv) conferir a viabilidade do pedido de extensão do benefício concedido a corréus, nos termos do art. 580 do CPP.
+
+III. RAZÕES DE DECIDIR
+3. No que tange às teses de carência de fundamentação e de ausência dos requisitos para a decretação da custódia cautelar, não há ofensa, até aqui, aos pressupostos, fundamentos e/ou condições de admissibilidade da prisão preventiva imputada, não havendo que se falar em restrição ilegal ao direito constitucional de locomoção.
+4. Os motivos postos no decreto constritivo estão devidamente alicerçados em elementos vinculados à realidade, tendo a autoridade impetrada feito referência às circunstâncias fáticas e jurídicas envoltas no caso, de maneira que não há ilegalidade a ser reconhecida quanto a este ponto, estando respeitado o disposto nos arts. 282, inc. I e II, 311, 312 e 313 do Código de Ritos Penais pátrio.
+5. Tendo em vista o risco concreto de reiteração delitiva do paciente, é certo que sua soltura representa um sério risco à preservação da ordem pública, devendo a prisão preventiva ser mantida, conforme enunciado de n.º 52 da Súmula deste eg. Tribunal de Justiça.
+6. O fato de o agente ostentar condições favoráveis não é garantidor da liberdade provisória, pois elas devem ser avaliadas conjuntamente com as peculiaridades do caso concreto, não podendo, per si, afastar a necessidade da manutenção da preventiva, ou de outras cautelares mais severas, quando presentes os requisitos legais, como é o caso dos autos.
+7. Verifica-se que, demonstrada a referida imprescindibilidade da segregação preventiva, resta clara a insuficiência das medidas cautelares alternativas (art. 319 do Código de Processo Penal), uma vez que além de haver motivação apta a justificar a custódia cautelar, a sua aplicação não se mostraria adequada e suficiente para garantir a ordem pública.
+8. O art. 580 do CPP prevê a possibilidade de extensão de benefício a corréu quando presentes situações fáticas idênticas, desde que não envolvam fundamentos exclusivamente pessoais. Inobstante, no caso, após detida análise, restou claro que a situação fático-processual do paciente é notavelmente distinta, obstando que a este sejam aproveitados os efeitos do mencionado benefício concedido a seus corréus.
+
+IV. DISPOSITIVO
+9. Habeas corpus conhecido e ordem denegada.
+
+________________________________________________________
+Dispositivos relevantes citados: CPP, arts. 282, I e II, 312, 313 e 319.
+
+Jurisprudências relevantes citadas: HC n. 879.305/RR, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 27/11/2024; RHC n. 91896/BA, relator Ministro Felix Fischer, Quinta Turma, julgado em 15/3/2018; AgRg no HC n. 941.276/MG, relator Ministro Og Fernandes, Sexta Turma, julgado em 4/11/2024; AgRg no HC n. 957.701/SC, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 10/12/2024; AgRg no HC n. 811.826/MG, relator Ministro Ribeiro Dantas, Quinta Turma, julgado em 12/6/2023; Habeas Corpus Criminal - 0632861-11.2024.8.06.0000, Rel. Desembargador(a) Marlúcia de Araújo Bezerra, 3ª Câmara Criminal, data do julgamento  10/12/2024; Habeas Corpus Criminal   0624893-61.2023.8.06.0000, Relator(a): Maria Ilna Lima de Castro, 2ª Câmara Criminal, Data do julgamento 31/05/2023; AgRg no RHC n. 194.147/MS, relator Ministro Otávio de Almeida Toledo (Desembargador Convocado do TJSP), Sexta Turma, julgado em 19/8/2024; AgRg no HC n. 854.089/SP, relator Ministro Joel Ilan Paciornik, Quinta Turma, julgado em 29/4/2024; Habeas Corpus Criminal - 0629044-70.2023.8.06.0000, Rel. Desembargador(a) Henrique Jorge Holanda Silveira, 3ª Câmara Criminal, data do julgamento  18/07/2023; Habeas Corpus Criminal - 0633714-54.2023.8.06.0000, Rel. Desembargador(a) Maria Ilna Lima de Castro, 2ª Câmara Criminal, data do julgamento:  25/10/2023.
+
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Habeas Corpus nº 0621884-86.2026.8.06.0000, formulado por Mauro Júnior Rios, em favor de Carlos Gabriel Rodrigues da Conceição, contra ato do Juiz de Direito da 11ª Vara Criminal da Comarca de Fortaleza, nos autos do processo de n.º 0012485-79.2026.8.06.0001.
+
+Acordam os Desembargadores integrantes da 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em conhecer do presente habeas corpus, para denegar a ordem.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>25&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833455" cdForo="0" >
+										0224422-39.2025.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833455" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833455);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833455" style="display: none;" >
+	<div id="textAreaDados_3833455" class="mensagemSemFormatacao" >
+		PENAL. PROCESSO PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TR&Aacute;FICO DE DROGAS. CRIMES DO ESTATUTO DO DESARMAMENTO (ART. 33 DA LEI N.&ordm; 11.343/2006 E ARTS. 14 E 16 DA LEI N.&ordm;10.0826/2003). SENTEN&Ccedil;A CONDENAT&Oacute;RIA. RECURSOS DEFENSIVOS.   1. PRELIMINAR DE NULIDADE POR AUS&Ecirc;NCIA DE FUNDAMENTA&Ccedil;&Atilde;O. AUS&Ecirc;NCIA DE APRECIA&Ccedil;&Atilde;O DE TESES DEFENSIVAS. REJEI&Ccedil;&Atilde;O. DECIS&Atilde;O MOTIVADA EM CONFORMIDADE COM O ART. 93, IX, DA CF/88. 2. ABORDAGEM POLICIAL. BUSCA PESSOAL. FUNDADA SUSPEITA. LICITUDE DA PROVA. 3. PEDIDO DE ABSOLVI&Ccedil;&Atilde;O PELO ART. 33. IMPOSSIBILIDADE. DEPOIMENTOS QUE APONTAM PARA O ENVOLVIMENTO DO APELANTE COM AS DROGAS. DEPOIMENTO DOS POLICIAIS QUE S&Atilde;O COERENTES COM O RESTANTE DO FEITO. APREENS&Atilde;O DE ELEMENTOS INDICATIVOS DO TR&Aacute;FICO (BALAN&Ccedil;A DE PRECIS&Atilde;O, SACOS PL&Aacute;STICOS, CANIVETE E DINHEIRO EM ESP&Eacute;CIE). R&Eacute;U QUE CONFIRMOU TR&Aacute;FICO DURANTE INQU&Eacute;RITO POLICIAL. ART. 155 DO CPP. 4. PRETENS&Atilde;O ABSOLUT&Oacute;RIA DO DELITO DE PORTE ILEGAL DE MUNI&Ccedil;&Atilde;O DE USO RESTRITO. DESCABIMENTO. CRIME DE MERA CONDUTA E DE PERIGO ABSTRATO. CONDENA&Ccedil;&Atilde;O MANTIDA. 5. PLEITO ABSOLUT&Oacute;RIO DO CRIME PREVISTO NO ART. 14 DA LEI N.&ordm; 10.826/2003. ALEGA&Ccedil;&Atilde;O DE INSUFICI&Ecirc;NCIA DE PROVAS DA AUTORIA DELITIVA. IMPOSSIBILIDADE. CONJUNTO PROBAT&Oacute;RIO PRODUZIDO EM JU&Iacute;ZO QUE SE REVELA BASTANTE PARA A CONDENA&Ccedil;&Atilde;O. DEPOIMENTOS DOS POLICIAIS RESPONS&Aacute;VEIS PELA OCORR&Ecirc;NCIA EM CONSON&Acirc;NCIA COM OS DEMAIS ELEMENTOS DO FEITO. VALIDADE. SISTEMA DO LIVRE CONVENCIMENTO MOTIVADO OU DA PERSUAS&Atilde;O RACIONAL. 6. DOSIMETRIA EFETUADA NA FORMA LEGALMENTE PREVISTA.
+
+I. CASO EM EXAME
+1. Trata-se os autos de Recursos de Apela&ccedil;&atilde;o interpostos por Francisco Anderson Pereira do Esp&iacute;rito Santo e Samuel Lucas Lima Barros, insurgindo-se contra a senten&ccedil;a prolatada &agrave;s fls. 273/293, pelo Ju&iacute;zo da 3&ordf; Vara de Delitos de Tr&aacute;fico de Drogas da Comarca de Fortaleza.
+
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; seis quest&otilde;es em discuss&atilde;o: (i) verificar se deve ser reconhecida a nulidade da senten&ccedil;a, em raz&atilde;o de alegada aus&ecirc;ncia de fundamenta&ccedil;&atilde;o; (ii) definir se a busca pessoal realizada pela pol&iacute;cia enseja a nulidade das provas obtidas; (iii) analisar o pleito de absolvi&ccedil;&atilde;o pelo crime de tr&aacute;fico de drogas; (iv) avaliar a poss&iacute;vel absolvi&ccedil;&atilde;o quanto ao delito previsto no art. 16 da Lei n.&ordm; 10.826/2003; (v) aferir o pedido absolut&oacute;rio do crime do art. 14 do Estatuto do Desarmamento; (vi) examinar a dosimetria.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3. Cumpre salientar que n&atilde;o h&aacute; obrigatoriedade de o magistrado enfrentar, ponto a ponto, todas as teses levantadas pelas partes. O que se exige, em conformidade com o art. 93, inciso IX, da Constitui&ccedil;&atilde;o Federal e com o art. 315, &sect; 2&ordm;, do C&oacute;digo de Processo Penal, &eacute; que a decis&atilde;o seja devidamente motivada, revelando de forma clara as raz&otilde;es de convencimento adotadas, como ocorreu no caso em tela.
+4. A busca pessoal justifica-se quando h&aacute; fundada suspeita de que a pessoa esteja na posse de arma proibida ou de objetos que constituam corpo de delito, nos termos do art. 244 do C&oacute;digo de Processo Penal.
+5. Houve um conjunto de fatores que levaram &agrave; forma&ccedil;&atilde;o da suspeita por parte dos policiais e, consequentemente, &agrave; realiza&ccedil;&atilde;o da busca pessoal, pois, al&eacute;m de estar o acusado em local conhecido pelo tr&aacute;fico de drogas, os acusados fugiram ao avistar os policiais e um deles teve um volume na cintura identificada por um dos agentes. Conforme os termos da jurisprud&ecirc;ncia p&aacute;tria, nesse caso n&atilde;o h&aacute; ilegalidade de provas nem nulidade processual apta a ser reconhecida.
+6. N&atilde;o h&aacute; nenhuma raz&atilde;o para acoimar de inid&ocirc;neos os testemunhos dos policiais que efetuaram a pris&atilde;o em flagrante e a apreens&atilde;o das drogas, os quais constituem meios de prova l&iacute;citos e ostentam a confiabilidade necess&aacute;ria para dar margem &agrave; condena&ccedil;&atilde;o, mormente quando consent&acirc;neos com os demais elementos angariados na instru&ccedil;&atilde;o.
+7. Quanto ao pleito de absolvi&ccedil;&atilde;o do recorrente pelo delito de tr&aacute;fico de drogas, nota-se que, a despeito dos argumentos defensivos, as informa&ccedil;&otilde;es dos autos demonstram a presen&ccedil;a de elementos suficientes para embasar a condena&ccedil;&atilde;o imposta ao insurgente, n&atilde;o assistindo, pois, raz&atilde;o para absolvi&ccedil;&atilde;o na forma pretendida. &Eacute; isso que se dessume da senten&ccedil;a guerreada, a qual reflete, com fidedignidade, as provas dos fatos constantes dos autos.
+8. Em rela&ccedil;&atilde;o aos pedidos absolut&oacute;rios quantos aos delitos dos arts. 14 e 16 do Estatuto do Desarmamento, observa-se que as provas colhidas ao longo do feito, sobretudo na instru&ccedil;&atilde;o processual, elucidativas, restando demonstradas as referidas condutas delitivas.
+9. A dosimetria foi efetuada na forma legalmente prevista.
+
+IV. DISPOSITIVO
+10. Recursos conhecidos e desprovidos.
+________________________________________________________
+Dispositivos relevantes citados: CPP, arts. 155, 157 e 244; Lei n.&ordm; 11.343/2006, art. 33; Lei n.&ordm; 10.826/2003, arts. 14 e 16.
+
+Jurisprud&ecirc;ncias relevantes citadas: Apela&ccedil;&atilde;o Criminal&nbsp;- 0800041-80.2024.8.06.0120, Rel. Desembargador(a) LIGIA ANDRADE DE ALENCAR MAGALH&Atilde;ES, 1&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 08/07/2025, data da publica&ccedil;&atilde;o:&nbsp; 09/07/2025;  AgRg no HC n. 973.806/RJ, relator Ministro Carlos Cini Marchionatti (Desembargador Convocado TJRS), Quinta Turma, julgado em 1/7/2025, DJEN de 4/7/2025;  Apela&ccedil;&atilde;o Criminal&nbsp;- 0200678-80.2023.8.06.0293, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 06/03/2024, data da publica&ccedil;&atilde;o:&nbsp; 06/03/2024;  AgRg no AREsp n. 2.703.590/RJ, relator Ministro Reynaldo Soares da Fonseca, Quinta Turma, julgado em 17/12/2024, DJe de 23/12/2024;  HC n. 966.086/MG, relator Ministro Sebasti&atilde;o Reis J&uacute;nior, Sexta Turma, julgado em 19/3/2025, DJEN de 27/3/2025.
+
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Apela&ccedil;&atilde;o Criminal n.&ordm; 0224422-39.2025.8.06.0001, em que figuram como recorrentes Francisco Anderson Pereira do Esp&iacute;rito Santo e Samuel Lucas Lima Barros e recorrido o Minist&eacute;rio P&uacute;blico do Estado do Cear&aacute;.
+
+ACORDAM os Desembargadores integrantes da 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em CONHECER dos recursos, para NEGAR-LHES PROVIMENTO, nos termos do voto do eminente Relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0224422-39.2025.8.06.0001, Rel. Desembargador(a)  FRANCISCO EDUARDO TORQUATO SCORSAFAVA, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 08/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 08/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>PENAL. PROCESSO PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. CRIMES DO ESTATUTO DO DESARMAMENTO (ART. 33 DA LEI N.º 11.343/2006 E ARTS. 14 E 16 DA LEI N.º10.0826/2003). SENTENÇA CONDENATÓRIA. RECURSOS DEFENSIVOS.   1. PRELIMINAR DE NULIDADE POR AUSÊNCIA DE FUNDAMENTAÇÃO. AUSÊNCIA DE APRECIAÇÃO DE TESES DEFENSIVAS. REJEIÇÃO. DECISÃO MOTIVADA EM CONFORMIDADE COM O ART. 93, IX, DA CF/88. 2.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>PENAL. PROCESSO PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. CRIMES DO ESTATUTO DO DESARMAMENTO (ART. 33 DA LEI N.º 11.343/2006 E ARTS. 14 E 16 DA LEI N.º10.0826/2003). SENTENÇA CONDENATÓRIA. RECURSOS DEFENSIVOS.   1. PRELIMINAR DE NULIDADE POR AUSÊNCIA DE FUNDAMENTAÇÃO. AUSÊNCIA DE APRECIAÇÃO DE TESES DEFENSIVAS. REJEIÇÃO. DECISÃO MOTIVADA EM CONFORMIDADE COM O ART. 93, IX, DA CF/88. 2. ABORDAGEM POLICIAL. BUSCA PESSOAL. FUNDADA SUSPEITA. LICITUDE DA PROVA. 3. PEDIDO DE ABSOLVIÇÃO PELO ART. 33. IMPOSSIBILIDADE. DEPOIMENTOS QUE APONTAM PARA O ENVOLVIMENTO DO APELANTE COM AS DROGAS. DEPOIMENTO DOS POLICIAIS QUE SÃO COERENTES COM O RESTANTE DO FEITO. APREENSÃO DE ELEMENTOS INDICATIVOS DO TRÁFICO (BALANÇA DE PRECISÃO, SACOS PLÁSTICOS, CANIVETE E DINHEIRO EM ESPÉCIE). RÉU QUE CONFIRMOU TRÁFICO DURANTE INQUÉRITO POLICIAL. ART. 155 DO CPP. 4. PRETENSÃO ABSOLUTÓRIA DO DELITO DE PORTE ILEGAL DE MUNIÇÃO DE USO RESTRITO. DESCABIMENTO. CRIME DE MERA CONDUTA E DE PERIGO ABSTRATO. CONDENAÇÃO MANTIDA. 5. PLEITO ABSOLUTÓRIO DO CRIME PREVISTO NO ART. 14 DA LEI N.º 10.826/2003. ALEGAÇÃO DE INSUFICIÊNCIA DE PROVAS DA AUTORIA DELITIVA. IMPOSSIBILIDADE. CONJUNTO PROBATÓRIO PRODUZIDO EM JUÍZO QUE SE REVELA BASTANTE PARA A CONDENAÇÃO. DEPOIMENTOS DOS POLICIAIS RESPONSÁVEIS PELA OCORRÊNCIA EM CONSONÂNCIA COM OS DEMAIS ELEMENTOS DO FEITO. VALIDADE. SISTEMA DO LIVRE CONVENCIMENTO MOTIVADO OU DA PERSUASÃO RACIONAL. 6. DOSIMETRIA EFETUADA NA FORMA LEGALMENTE PREVISTA.
+
+I. CASO EM EXAME
+1. Trata-se os autos de Recursos de Apelação interpostos por Francisco Anderson Pereira do Espírito Santo e Samuel Lucas Lima Barros, insurgindo-se contra a sentença prolatada às fls. 273/293, pelo Juízo da 3ª Vara de Delitos de Tráfico de Drogas da Comarca de Fortaleza.
+
+II. QUESTÕES EM DISCUSSÃO
+2. Há seis questões em discussão: (i) verificar se deve ser reconhecida a nulidade da sentença, em razão de alegada ausência de fundamentação; (ii) definir se a busca pessoal realizada pela polícia enseja a nulidade das provas obtidas; (iii) analisar o pleito de absolvição pelo crime de tráfico de drogas; (iv) avaliar a possível absolvição quanto ao delito previsto no art. 16 da Lei n.º 10.826/2003; (v) aferir o pedido absolutório do crime do art. 14 do Estatuto do Desarmamento; (vi) examinar a dosimetria.
+
+III. RAZÕES DE DECIDIR
+3. Cumpre salientar que não há obrigatoriedade de o magistrado enfrentar, ponto a ponto, todas as teses levantadas pelas partes. O que se exige, em conformidade com o art. 93, inciso IX, da Constituição Federal e com o art. 315, § 2º, do Código de Processo Penal, é que a decisão seja devidamente motivada, revelando de forma clara as razões de convencimento adotadas, como ocorreu no caso em tela.
+4. A busca pessoal justifica-se quando há fundada suspeita de que a pessoa esteja na posse de arma proibida ou de objetos que constituam corpo de delito, nos termos do art. 244 do Código de Processo Penal.
+5. Houve um conjunto de fatores que levaram à formação da suspeita por parte dos policiais e, consequentemente, à realização da busca pessoal, pois, além de estar o acusado em local conhecido pelo tráfico de drogas, os acusados fugiram ao avistar os policiais e um deles teve um volume na cintura identificada por um dos agentes. Conforme os termos da jurisprudência pátria, nesse caso não há ilegalidade de provas nem nulidade processual apta a ser reconhecida.
+6. Não há nenhuma razão para acoimar de inidôneos os testemunhos dos policiais que efetuaram a prisão em flagrante e a apreensão das drogas, os quais constituem meios de prova lícitos e ostentam a confiabilidade necessária para dar margem à condenação, mormente quando consentâneos com os demais elementos angariados na instrução.
+7. Quanto ao pleito de absolvição do recorrente pelo delito de tráfico de drogas, nota-se que, a despeito dos argumentos defensivos, as informações dos autos demonstram a presença de elementos suficientes para embasar a condenação imposta ao insurgente, não assistindo, pois, razão para absolvição na forma pretendida. É isso que se dessume da sentença guerreada, a qual reflete, com fidedignidade, as provas dos fatos constantes dos autos.
+8. Em relação aos pedidos absolutórios quantos aos delitos dos arts. 14 e 16 do Estatuto do Desarmamento, observa-se que as provas colhidas ao longo do feito, sobretudo na instrução processual, elucidativas, restando demonstradas as referidas condutas delitivas.
+9. A dosimetria foi efetuada na forma legalmente prevista.
+
+IV. DISPOSITIVO
+10. Recursos conhecidos e desprovidos.
+________________________________________________________
+Dispositivos relevantes citados: CPP, arts. 155, 157 e 244; Lei n.º 11.343/2006, art. 33; Lei n.º 10.826/2003, arts. 14 e 16.
+
+Jurisprudências relevantes citadas: Apelação Criminal - 0800041-80.2024.8.06.0120, Rel. Desembargador(a) LIGIA ANDRADE DE ALENCAR MAGALHÃES, 1ª Câmara Criminal, data do julgamento:  08/07/2025, data da publicação:  09/07/2025;  AgRg no HC n. 973.806/RJ, relator Ministro Carlos Cini Marchionatti (Desembargador Convocado TJRS), Quinta Turma, julgado em 1/7/2025, DJEN de 4/7/2025;  Apelação Criminal - 0200678-80.2023.8.06.0293, Rel. Desembargador(a) MARIA ILNA LIMA DE CASTRO, 2ª Câmara Criminal, data do julgamento:  06/03/2024, data da publicação:  06/03/2024;  AgRg no AREsp n. 2.703.590/RJ, relator Ministro Reynaldo Soares da Fonseca, Quinta Turma, julgado em 17/12/2024, DJe de 23/12/2024;  HC n. 966.086/MG, relator Ministro Sebastião Reis Júnior, Sexta Turma, julgado em 19/3/2025, DJEN de 27/3/2025.
+
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Apelação Criminal n.º 0224422-39.2025.8.06.0001, em que figuram como recorrentes Francisco Anderson Pereira do Espírito Santo e Samuel Lucas Lima Barros e recorrido o Ministério Público do Estado do Ceará.
+
+ACORDAM os Desembargadores integrantes da 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em CONHECER dos recursos, para NEGAR-LHES PROVIMENTO, nos termos do voto do eminente Relator.
+
+Fortaleza, data e hora indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>26&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833395" cdForo="0" >
+										0202023-94.2022.8.06.0300
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833395" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833395);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833395" style="display: none;" >
+	<div id="textAreaDados_3833395" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TRIBUNAL DO J&Uacute;RI. TENTATIVA DE HOMIC&Iacute;DIO QUALIFICADO. ALEGA&Ccedil;&Atilde;O DE DECIS&Atilde;O MANIFESTAMENTE CONTR&Aacute;RIA &Agrave; PROVA DOS AUTOS. SOBERANIA DOS VEREDICTOS. MANUTEN&Ccedil;&Atilde;O DAS QUALIFICADORAS. DOSIMETRIA DA PENA. CONSEQU&Ecirc;NCIAS DO CRIME. SEQUELAS NA V&Iacute;TIMA. REGIME MANTIDO. RECURSO DESPROVIDO.
+
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta por Pablo Ramon Ferreira Morais contra senten&ccedil;a proferida pelo Juiz Presidente do Tribunal do J&uacute;ri da 1&ordf; Vara da Comarca de Caucaia/CE que, em conformidade com o veredicto do Conselho de Senten&ccedil;a, condenou o r&eacute;u &agrave; pena de 7 anos e 8 meses de reclus&atilde;o pela pr&aacute;tica do crime de tentativa de homic&iacute;dio qualificado (art. 121, &sect;2&ordm;, II e IV, c/c art. 14, II, do C&oacute;digo Penal).
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se a decis&atilde;o do Conselho de Senten&ccedil;a &eacute; manifestamente contr&aacute;ria &agrave; prova dos autos, a justificar a anula&ccedil;&atilde;o do julgamento; (ii) estabelecer se deve ser afastada a qualificadora do recurso que dificultou ou impossibilitou a defesa da v&iacute;tima; (iii) determinar se a dosimetria da pena aplicada pelo ju&iacute;zo de origem merece reforma.
+
+III. RAZ&Otilde;ES DE DECIDIR
+3. A apela&ccedil;&atilde;o interposta contra decis&atilde;o do Tribunal do J&uacute;ri possui fundamenta&ccedil;&atilde;o vinculada, limitando-se o efeito devolutivo aos fundamentos apresentados pela parte, nos termos da S&uacute;mula n&ordm; 713 do STF.
+4. A soberania dos veredictos, assegurada pelo art. 5&ordm;, XXXVIII, &quot;c&quot;, da Constitui&ccedil;&atilde;o Federal, impede a desconstitui&ccedil;&atilde;o da decis&atilde;o dos jurados quando esta encontra suporte no conjunto probat&oacute;rio, ainda que exista vers&atilde;o divergente nos autos.
+5 A anula&ccedil;&atilde;o do julgamento por decis&atilde;o manifestamente contr&aacute;ria &agrave; prova dos autos somente &eacute; cab&iacute;vel quando o veredicto for completamente dissociado do acervo probat&oacute;rio, inexistindo qualquer elemento que o sustente.
+
+6. A materialidade do delito e a prova de autoria encontram respaldo no prontu&aacute;rio m&eacute;dico da v&iacute;tima, nos depoimentos testemunhais colhidos na fase inquisitorial e em ju&iacute;zo, bem como no relat&oacute;rio de monitoramento eletr&ocirc;nico que indica a presen&ccedil;a do r&eacute;u nas proximidades do local do crime no momento dos fatos.
+7. O reconhecimento da qualificadora do recurso que dificultou a defesa da v&iacute;tima mostra-se adequado quando o ataque ocorre de forma s&uacute;bita e inesperada, mediante disparos de arma de fogo, circunst&acirc;ncia apta a reduzir a capacidade de rea&ccedil;&atilde;o do ofendido.
+8. A valora&ccedil;&atilde;o negativa das consequ&ecirc;ncias do crime na primeira fase da dosimetria da pena revela-se leg&iacute;tima quando evidenciado que a v&iacute;tima sofreu sequelas f&iacute;sicas e psicol&oacute;gicas decorrentes dos disparos de arma de fogo, circunst&acirc;ncia que extrapola os efeitos ordin&aacute;rios do delito.
+9. A dosimetria e o regime da pena foram realizados com base em elementos concretos constantes dos autos, observando os crit&eacute;rios previstos nos arts. 33 e 59 do C&oacute;digo Penal e o princ&iacute;pio do livre convencimento motivado do julgador.
+
+IV. DISPOSITIVO E TESE.
+10. Apela&ccedil;&atilde;o criminal conhecida e desprovida.
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Apela&ccedil;&atilde;o Criminal n.&ordm; 0202023-94.2022.8.06.0300, em que figura como recorrente Pablo Ramon Ferreira Morais  e recorrido o Minist&eacute;rio P&uacute;blico do Estado do Cear&aacute;.
+
+ACORDAM os Desembargadores integrantes da 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em CONHECER do recurso para negar-lhe provimento, nos termos do voto do eminente Relator.
+
+Fortaleza, hora e data indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0202023-94.2022.8.06.0300, Rel. Desembargador(a)  FRANCISCO EDUARDO TORQUATO SCORSAFAVA, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 08/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 08/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Crime Tentado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO EDUARDO TORQUATO SCORSAFAVA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Caucaia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									08/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRIBUNAL DO JÚRI. TENTATIVA DE HOMICÍDIO QUALIFICADO. ALEGAÇÃO DE DECISÃO MANIFESTAMENTE CONTRÁRIA À PROVA DOS AUTOS. SOBERANIA DOS VEREDICTOS. MANUTENÇÃO DAS QUALIFICADORAS. DOSIMETRIA DA PENA. CONSEQUÊNCIAS DO CRIME. SEQUELAS NA VÍTIMA. REGIME MANTIDO. RECURSO DESPROVIDO.
+
+I. CASO EM EXAME
+1. Apelação criminal interposta por Pablo Ramon
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRIBUNAL DO JÚRI. TENTATIVA DE HOMICÍDIO QUALIFICADO. ALEGAÇÃO DE DECISÃO MANIFESTAMENTE CONTRÁRIA À PROVA DOS AUTOS. SOBERANIA DOS VEREDICTOS. MANUTENÇÃO DAS QUALIFICADORAS. DOSIMETRIA DA PENA. CONSEQUÊNCIAS DO CRIME. SEQUELAS NA VÍTIMA. REGIME MANTIDO. RECURSO DESPROVIDO.
+
+I. CASO EM EXAME
+1. Apelação criminal interposta por Pablo Ramon Ferreira <em>Morais</em> contra sentença proferida pelo Juiz Presidente do Tribunal do Júri da 1ª Vara da Comarca de Caucaia/CE que, em conformidade com o veredicto do Conselho de Sentença, condenou o réu à pena de 7 anos e 8 meses de reclusão pela prática do crime de tentativa de homicídio qualificado (art. 121, §2º, II e IV, c/c art. 14, II, do Código Penal).
+
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se a decisão do Conselho de Sentença é manifestamente contrária à prova dos autos, a justificar a anulação do julgamento; (ii) estabelecer se deve ser afastada a qualificadora do recurso que dificultou ou impossibilitou a defesa da vítima; (iii) determinar se a dosimetria da pena aplicada pelo juízo de origem merece reforma.
+
+III. RAZÕES DE DECIDIR
+3. A apelação interposta contra decisão do Tribunal do Júri possui fundamentação vinculada, limitando-se o efeito devolutivo aos fundamentos apresentados pela parte, nos termos da Súmula nº 713 do STF.
+4. A soberania dos veredictos, assegurada pelo art. 5º, XXXVIII, "c", da Constituição Federal, impede a desconstituição da decisão dos jurados quando esta encontra suporte no conjunto probatório, ainda que exista versão divergente nos autos.
+5 A anulação do julgamento por decisão manifestamente contrária à prova dos autos somente é cabível quando o veredicto for completamente dissociado do acervo probatório, inexistindo qualquer elemento que o sustente.
+
+6. A materialidade do delito e a prova de autoria encontram respaldo no prontuário médico da vítima, nos depoimentos testemunhais colhidos na fase inquisitorial e em juízo, bem como no relatório de monitoramento eletrônico que indica a presença do réu nas proximidades do local do crime no momento dos fatos.
+7. O reconhecimento da qualificadora do recurso que dificultou a defesa da vítima mostra-se adequado quando o ataque ocorre de forma súbita e inesperada, mediante disparos de arma de fogo, circunstância apta a reduzir a capacidade de reação do ofendido.
+8. A valoração negativa das consequências do crime na primeira fase da dosimetria da pena revela-se legítima quando evidenciado que a vítima sofreu sequelas físicas e psicológicas decorrentes dos disparos de arma de fogo, circunstância que extrapola os efeitos ordinários do delito.
+9. A dosimetria e o regime da pena foram realizados com base em elementos concretos constantes dos autos, observando os critérios previstos nos arts. 33 e 59 do Código Penal e o princípio do livre convencimento motivado do julgador.
+
+IV. DISPOSITIVO E TESE.
+10. Apelação criminal conhecida e desprovida.
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Apelação Criminal n.º 0202023-94.2022.8.06.0300, em que figura como recorrente Pablo Ramon Ferreira <em>Morais</em>  e recorrido o Ministério Público do Estado do Ceará.
+
+ACORDAM os Desembargadores integrantes da 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em CONHECER do recurso para negar-lhe provimento, nos termos do voto do eminente Relator.
+
+Fortaleza, hora e data indicadas pelo sistema.
+
+Des. Francisco Eduardo Torquato Scorsafava
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>27&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833314" cdForo="0" >
+										0053450-62.2021.8.06.0167
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833314" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833314);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833314" style="display: none;" >
+	<div id="textAreaDados_3833314" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. ROUBO MAJORADO. EMPREGO DE ARMA DE FOGO E CONCURSO DE AGENTES. DOSIMETRIA DA PENA. CONSEQU&Ecirc;NCIAS DO CRIME. PREJU&Iacute;ZO INERENTE AO TIPO PENAL. MAJORANTE SOBEJANTE. REGIME INICIAL DE CUMPRIMENTO DE PENA.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta pela defesa contra senten&ccedil;a que condenou o r&eacute;u pela pr&aacute;tica do crime de roubo majorado pelo emprego de arma de fogo e concurso de agentes (art. 157, &sect; 2&ordm;, II, e &sect; 2&ordm;-A, I, do CP), &agrave; pena de 6 anos e 8 meses de reclus&atilde;o, em regime inicial fechado, al&eacute;m de 16 dias-multa. O recorrente pleiteia o afastamento da circunst&acirc;ncia judicial negativa referente &agrave;s consequ&ecirc;ncias do crime e a modifica&ccedil;&atilde;o do regime inicial para o semiaberto.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em saber: (i) se a n&atilde;o restitui&ccedil;&atilde;o dos bens subtra&iacute;dos e a perda de documentos pessoais autorizam a valora&ccedil;&atilde;o negativa das consequ&ecirc;ncias do crime na primeira fase da dosimetria do roubo; e (ii) se a exist&ecirc;ncia de uma &uacute;nica circunst&acirc;ncia judicial desfavor&aacute;vel &#150; decorrente do deslocamento de majorante sobejante &#150; justifica a imposi&ccedil;&atilde;o de regime inicial mais gravoso do que o legalmente previsto para a pena aplicada.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A utiliza&ccedil;&atilde;o de majorante sobejante (concurso de agentes) para exasperar a pena-base na primeira fase da dosimetria &eacute; admitida pela jurisprud&ecirc;ncia consolidada do Superior Tribunal de Justi&ccedil;a e do TJCE, desde que a mesma causa de aumento n&atilde;o tenha sido empregada na terceira fase, inexistindo, nessa hip&oacute;tese, viola&ccedil;&atilde;o ao princ&iacute;pio do &quot;ne bis in idem&quot;.
+4. A valora&ccedil;&atilde;o negativa das consequ&ecirc;ncias do crime com base na mera perda patrimonial e na n&atilde;o restitui&ccedil;&atilde;o dos bens subtra&iacute;dos &eacute; inid&ocirc;nea no delito de roubo, por tratar-se de circunst&acirc;ncia inerente ao tipo penal, j&aacute; considerada pelo legislador na fixa&ccedil;&atilde;o da pena m&iacute;nima cominada no preceito secund&aacute;rio do tipo incriminador.
+5. A perda de documentos pessoais, embora gere transtornos &agrave; v&iacute;tima, n&atilde;o configura, por si s&oacute;, consequ&ecirc;ncia que extrapole os efeitos ordin&aacute;rios do tipo penal de roubo, de modo que n&atilde;o autoriza a exaspera&ccedil;&atilde;o da pena-base.
+6. A imposi&ccedil;&atilde;o de regime inicial mais gravoso exige a presen&ccedil;a de mais de uma circunst&acirc;ncia judicial negativa ou de vetores com gravidade superior, sob pena de viola&ccedil;&atilde;o aos princ&iacute;pios da razoabilidade e da proporcionalidade. No caso, remanescendo apenas uma circunst&acirc;ncia judicial desfavor&aacute;vel, e sendo o r&eacute;u prim&aacute;rio com pena na faixa do art. 33, &sect; 2&ordm;, &quot;b&quot;, do C&oacute;digo Penal, imp&otilde;e-se a fixa&ccedil;&atilde;o do regime semiaberto.
+7. O concurso de dois agentes no crime de roubo n&atilde;o autoriza, por si s&oacute;, a fixa&ccedil;&atilde;o de regime prisional mais gravoso do que o legalmente previsto, quando o r&eacute;u for prim&aacute;rio e a pena aplicada permitir regime menos severo.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e parcialmente provido para: (a) afastar a valora&ccedil;&atilde;o negativa da vetorial das consequ&ecirc;ncias do crime na primeira fase da dosimetria; e (b) fixar o regime inicial semiaberto para o cumprimento da pena privativa de liberdade, mantidas as demais disposi&ccedil;&otilde;es da senten&ccedil;a, inclusive a pena definitiva de 6 anos e 8 meses de reclus&atilde;o e 16 dias-multa.
+Teses: 1. A n&atilde;o restitui&ccedil;&atilde;o dos bens subtra&iacute;dos e a perda de documentos pessoais constituem consequ&ecirc;ncias inerentes ao tipo penal de roubo, n&atilde;o autorizando a exaspera&ccedil;&atilde;o da pena-base na primeira fase da dosimetria. 2. A exist&ecirc;ncia de uma &uacute;nica circunst&acirc;ncia judicial desfavor&aacute;vel n&atilde;o justifica, por si s&oacute;, a imposi&ccedil;&atilde;o de regime inicial mais gravoso do que o legalmente previsto para r&eacute;u prim&aacute;rio.
+Legisla&ccedil;&atilde;o citada: CP/1940, arts. 33, &sect; 2&ordm;, &quot;b&quot;, &sect; 3&ordm;, 59, 68 e 157, &sect; 2&ordm;, II, e &sect; 2&ordm;-A, I; CPP/1941, art. 387, &sect; 2&ordm;.
+Jurisprud&ecirc;ncia citada: STJ, AgRg no REsp 2.142.363/SP, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, julgado em 26/02/2025; STJ, EDcl no REsp 2.226.292/MG, Rel. Min. Rog&eacute;rio Schietti Cruz, Sexta Turma, julgado em 21/10/2025; STJ, REsp 2.018.433/PA, Rel. Min. Daniela Teixeira, Quinta Turma, DJEN de 10/02/2025; STJ, REsp 2.182.311/MG, Rel. Min. OG Fernandes, Sexta Turma, DJEN de 01/09/2025; STJ, AgRg no HC 863.871/PE, Rel. Min. Daniela Teixeira, Quinta Turma, DJE de 02/12/2024.
+
+ACORD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de apela&ccedil;&atilde;o criminal n&ordm; 0053450-62.2021.8.06.0167, ACORDAM os desembargadores da 1&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, &agrave; unanimidade, em CONHECER do recurso de apela&ccedil;&atilde;o e DAR-LHE PARCIAL PROVIMENTO, nos termos do voto do Relator.
+
+Fortaleza, 07 de abril de 2026
+
+DESEMBARGADOR M&Aacute;RIO PARENTE TE&Oacute;FILO NETO
+Relator
+  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0053450-62.2021.8.06.0167, Rel. Desembargador(a)  MARIO PARENTE  TE&Oacute;FILO  NETO, 1&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 07/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Roubo Majorado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIO PARENTE  TEÓFILO  NETO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sobral
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. ROUBO MAJORADO. EMPREGO DE ARMA DE FOGO E CONCURSO DE AGENTES. DOSIMETRIA DA PENA. CONSEQUÊNCIAS DO CRIME. PREJUÍZO INERENTE AO TIPO PENAL. MAJORANTE SOBEJANTE. REGIME INICIAL DE CUMPRIMENTO DE PENA.
+I. CASO EM EXAME
+1. Apelação criminal interposta pela defesa contra sentença que condenou o réu pela prática do crime de roubo majorado pelo
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. ROUBO MAJORADO. EMPREGO DE ARMA DE FOGO E CONCURSO DE AGENTES. DOSIMETRIA DA PENA. CONSEQUÊNCIAS DO CRIME. PREJUÍZO INERENTE AO TIPO PENAL. MAJORANTE SOBEJANTE. REGIME INICIAL DE CUMPRIMENTO DE PENA.
+I. CASO EM EXAME
+1. Apelação criminal interposta pela defesa contra sentença que condenou o réu pela prática do crime de roubo majorado pelo emprego de arma de fogo e concurso de agentes (art. 157, § 2º, II, e § 2º-A, I, do CP), à pena de 6 anos e 8 meses de reclusão, em regime inicial fechado, além de 16 dias-multa. O recorrente pleiteia o afastamento da circunstância judicial negativa referente às consequências do crime e a modificação do regime inicial para o semiaberto.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em saber: (i) se a não restituição dos bens subtraídos e a perda de documentos pessoais autorizam a valoração negativa das consequências do crime na primeira fase da dosimetria do roubo; e (ii) se a existência de uma única circunstância judicial desfavorável  decorrente do deslocamento de majorante sobejante  justifica a imposição de regime inicial mais gravoso do que o legalmente previsto para a pena aplicada.
+III. RAZÕES DE DECIDIR
+3. A utilização de majorante sobejante (concurso de agentes) para exasperar a pena-base na primeira fase da dosimetria é admitida pela jurisprudência consolidada do Superior Tribunal de Justiça e do TJCE, desde que a mesma causa de aumento não tenha sido empregada na terceira fase, inexistindo, nessa hipótese, violação ao princípio do "ne bis in idem".
+4. A valoração negativa das consequências do crime com base na mera perda patrimonial e na não restituição dos bens subtraídos é inidônea no delito de roubo, por tratar-se de circunstância inerente ao tipo penal, já considerada pelo legislador na fixação da pena mínima cominada no preceito secundário do tipo incriminador.
+5. A perda de documentos pessoais, embora gere transtornos à vítima, não configura, por si só, consequência que extrapole os efeitos ordinários do tipo penal de roubo, de modo que não autoriza a exasperação da pena-base.
+6. A imposição de regime inicial mais gravoso exige a presença de mais de uma circunstância judicial negativa ou de vetores com gravidade superior, sob pena de violação aos princípios da razoabilidade e da proporcionalidade. No caso, remanescendo apenas uma circunstância judicial desfavorável, e sendo o réu primário com pena na faixa do art. 33, § 2º, "b", do Código Penal, impõe-se a fixação do regime semiaberto.
+7. O concurso de dois agentes no crime de roubo não autoriza, por si só, a fixação de regime prisional mais gravoso do que o legalmente previsto, quando o réu for primário e a pena aplicada permitir regime menos severo.
+IV. DISPOSITIVO E TESE
+8. Recurso conhecido e parcialmente provido para: (a) afastar a valoração negativa da vetorial das consequências do crime na primeira fase da dosimetria; e (b) fixar o regime inicial semiaberto para o cumprimento da pena privativa de liberdade, mantidas as demais disposições da sentença, inclusive a pena definitiva de 6 anos e 8 meses de reclusão e 16 dias-multa.
+Teses: 1. A não restituição dos bens subtraídos e a perda de documentos pessoais constituem consequências inerentes ao tipo penal de roubo, não autorizando a exasperação da pena-base na primeira fase da dosimetria. 2. A existência de uma única circunstância judicial desfavorável não justifica, por si só, a imposição de regime inicial mais gravoso do que o legalmente previsto para réu primário.
+Legislação citada: CP/1940, arts. 33, § 2º, "b", § 3º, 59, 68 e 157, § 2º, II, e § 2º-A, I; CPP/1941, art. 387, § 2º.
+Jurisprudência citada: STJ, AgRg no REsp 2.142.363/SP, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, julgado em 26/02/2025; STJ, EDcl no REsp 2.226.292/MG, Rel. Min. Rogério Schietti Cruz, Sexta Turma, julgado em 21/10/2025; STJ, REsp 2.018.433/PA, Rel. Min. Daniela Teixeira, Quinta Turma, DJEN de 10/02/2025; STJ, REsp 2.182.311/MG, Rel. Min. OG Fernandes, Sexta Turma, DJEN de 01/09/2025; STJ, AgRg no HC 863.871/PE, Rel. Min. Daniela Teixeira, Quinta Turma, DJE de 02/12/2024.
+
+ACORDÃO
+
+Vistos, relatados e discutidos estes autos de apelação criminal nº 0053450-62.2021.8.06.0167, ACORDAM os desembargadores da 1ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, à unanimidade, em CONHECER do recurso de apelação e DAR-LHE PARCIAL PROVIMENTO, nos termos do voto do Relator.
+
+Fortaleza, 07 de abril de 2026
+
+DESEMBARGADOR MÁRIO PARENTE TEÓFILO NETO
+Relator
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>28&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833283" cdForo="0" >
+										0622508-38.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833283" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833283);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833283" style="display: none;" >
+	<div id="textAreaDados_3833283" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL PENAL. HABEAS CORPUS. PRIS&Atilde;O PREVENTIVA. FUNDAMENTA&Ccedil;&Atilde;O ID&Ocirc;NEA. GARANTIA DA ORDEM P&Uacute;BLICA. ORGANIZA&Ccedil;&Atilde;O CRIMINOSA. BONS ANTECEDENTES. INSUFICI&Ecirc;NCIA PARA REVOGA&Ccedil;&Atilde;O. PRIS&Atilde;O DOMICILIAR. GENITORA DE FILHO MENOR DE DOZE ANOS. SITUA&Ccedil;&Atilde;O EXCEPCIONAL. EXPOSI&Ccedil;&Atilde;O DO MENOR A AMBIENTE CRIMINOSO. INTERESSE SUPERIOR DA CRIAN&Ccedil;A. ORDEM DENEGADA.
+I. Caso em exame
+1. Habeas corpus, com pedido liminar, impetrado em favor de paciente presa preventivamente pela suposta pr&aacute;tica de associa&ccedil;&atilde;o criminosa armada e infra&ccedil;&otilde;es ao Estatuto do Desarmamento. O impetrante sustenta aus&ecirc;ncia de fundamenta&ccedil;&atilde;o id&ocirc;nea para a cust&oacute;dia cautelar e requer, subsidiariamente, a substitui&ccedil;&atilde;o pela pris&atilde;o domiciliar, ao argumento de ser a paciente genitora de filhos menores e &uacute;nica respons&aacute;vel pelos seus cuidados.
+II. Quest&atilde;o em discuss&atilde;o
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) saber se a decis&atilde;o que decretou a pris&atilde;o preventiva da paciente apresenta fundamenta&ccedil;&atilde;o id&ocirc;nea, apta a demonstrar a necessidade da cust&oacute;dia cautelar para a garantia da ordem p&uacute;blica; e (ii) saber se &eacute; cab&iacute;vel a substitui&ccedil;&atilde;o da pris&atilde;o preventiva por pris&atilde;o domiciliar em raz&atilde;o de a paciente ser genitora de filho menor de doze anos, nos termos do art. 318, V, do CPP. .
+III. Raz&otilde;es de decidir
+3. A pris&atilde;o preventiva foi decretada com base na comprova&ccedil;&atilde;o da materialidade delitiva e na presen&ccedil;a de ind&iacute;cios suficientes de autoria, consubstanciados nos elementos colhidos no auto de pris&atilde;o em flagrante, mostrando-se devidamente motivada em observ&acirc;ncia ao art. 93, IX, da Constitui&ccedil;&atilde;o Federal..
+4. A medida cautelar mostrou-se necess&aacute;ria &agrave; garantia da ordem p&uacute;blica, diante da gravidade concreta da conduta, evidenciada pela atua&ccedil;&atilde;o da paciente em concurso de agentes com finalidade criminosa e pelos ind&iacute;cios de integra&ccedil;&atilde;o &agrave; organiza&ccedil;&atilde;o criminosa denominada &quot;CV&quot;, circunst&acirc;ncias que revelam periculosidade social acentuada.
+5. O fato de a paciente ser propriet&aacute;ria do im&oacute;vel onde se realizou o flagrante &#150; apontado como poss&iacute;vel ponto de apoio da organiza&ccedil;&atilde;o criminosa &#150; e de os agentes terem recebido a composi&ccedil;&atilde;o policial a disparos de arma de fogo refor&ccedil;a a gravidade concreta dos fatos e a inadequa&ccedil;&atilde;o das medidas cautelares alternativas.
+6. No que concerne ao pedido de pris&atilde;o domiciliar, a mera condi&ccedil;&atilde;o de genitora de filho menor de doze anos n&atilde;o confere direito autom&aacute;tico ao benef&iacute;cio, sendo necess&aacute;ria a an&aacute;lise das circunst&acirc;ncias concretas do caso. A jurisprud&ecirc;ncia reconhece a possibilidade de denega&ccedil;&atilde;o do benef&iacute;cio em situa&ccedil;&otilde;es excepcionais.
+7. No caso, o interesse superior da crian&ccedil;a &#150; valor que a norma visa a tutelar &#150; conduz a conclus&atilde;o contr&aacute;ria ao pleito: o menor se encontrava exposto a ambiente de acentuada vulnerabilidade social e moral na pr&oacute;pria resid&ecirc;ncia da paciente, utilizada como ponto de atua&ccedil;&atilde;o de organiza&ccedil;&atilde;o criminosa, circunst&acirc;ncia incompat&iacute;vel com a prote&ccedil;&atilde;o integral assegurada a crian&ccedil;as e adolescentes pelo ordenamento jur&iacute;dico.
+8. As condi&ccedil;&otilde;es pessoais favor&aacute;veis da paciente, como a primariedade, n&atilde;o t&ecirc;m o cond&atilde;o de, por si s&oacute;s, impedir a manuten&ccedil;&atilde;o da pris&atilde;o preventiva quando presentes os requisitos legais autorizadores e devidamente demonstrada a sua necessidade.
+IV. Dispositivo e tese
+9. Ordem conhecida e negada.
+
+Tese de julgamento:
+1. A condi&ccedil;&atilde;o de genitora de filho menor de doze anos n&atilde;o assegura automaticamente a substitui&ccedil;&atilde;o da pris&atilde;o preventiva por pris&atilde;o domiciliar quando configurada situa&ccedil;&atilde;o excepcional, evidenciada pela exposi&ccedil;&atilde;o da crian&ccedil;a a ambiente de acentuada vulnerabilidade moral e social decorrente da atua&ccedil;&atilde;o da acusada em contexto de organiza&ccedil;&atilde;o criminosa, hip&oacute;tese em que o pr&oacute;prio interesse superior do menor imp&otilde;e a manuten&ccedil;&atilde;o da cust&oacute;dia cautelar devidamente fundamentada.
+2. A necessidade de interromper ou diminuir a atua&ccedil;&atilde;o de integrantes de organiza&ccedil;&atilde;o criminosa enquadra-se no conceito de garantia da ordem p&uacute;blica, constituindo fundamenta&ccedil;&atilde;o cautelar id&ocirc;nea e suficiente para a pris&atilde;o preventiva.
+
+
+Legisla&ccedil;&atilde;o citada: CF/1988, art. 93, IX; CPP, arts. 318, IV, V e 318-A.
+Jurisprud&ecirc;ncia citada: STJ, AgRg no RHC n. 226.146/CE, rel. Min. Ribeiro Dantas, Quinta Turma, julgado em 25/02/2026, DJEN de 12/03/2026; STJ, AgRg no HC n. 939.644/SC, rel. Min. Og Fernandes, Sexta Turma, julgado em 12/02/2025, DJEN de 18/02/2025; TJCE, HC 0630344-96.2025.8.06.0000, Rel. Des.&ordf; Maria Edna Martins, 3&ordf; C&acirc;mara Criminal, julgado em 10/02/2026.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 1&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;,&agrave; unanimidade, em CONHECER do writ, mas para DENEGAR a ordem, nos exatos termos do voto do relator.
+
+Fortaleza, 7 de abril de 2026
+
+
+
+M&Aacute;RIO PARENTE TE&Oacute;FILO NETO
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR M&Aacute;RIO PARENTE TE&Oacute;FILO NETO
+Relator <br><br>(Habeas Corpus Criminal&nbsp;-  0622508-38.2026.8.06.0000, Rel. Desembargador(a)  MARIO PARENTE  TE&Oacute;FILO  NETO, 1&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 07/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Habeas Corpus Criminal / Crimes do Sistema Nacional de Armas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIO PARENTE  TEÓFILO  NETO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Solonópole
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS. PRISÃO PREVENTIVA. FUNDAMENTAÇÃO IDÔNEA. GARANTIA DA ORDEM PÚBLICA. ORGANIZAÇÃO CRIMINOSA. BONS ANTECEDENTES. INSUFICIÊNCIA PARA REVOGAÇÃO. PRISÃO DOMICILIAR. GENITORA DE FILHO MENOR DE DOZE ANOS. SITUAÇÃO EXCEPCIONAL. EXPOSIÇÃO DO MENOR A AMBIENTE CRIMINOSO. INTERESSE SUPERIOR DA CRIANÇA. ORDEM DENEGADA.
+I. Caso em exame
+1. Habeas corpus, com pedido
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS. PRISÃO PREVENTIVA. FUNDAMENTAÇÃO IDÔNEA. GARANTIA DA ORDEM PÚBLICA. ORGANIZAÇÃO CRIMINOSA. BONS ANTECEDENTES. INSUFICIÊNCIA PARA REVOGAÇÃO. PRISÃO DOMICILIAR. GENITORA DE FILHO MENOR DE DOZE ANOS. SITUAÇÃO EXCEPCIONAL. EXPOSIÇÃO DO MENOR A AMBIENTE CRIMINOSO. INTERESSE SUPERIOR DA CRIANÇA. ORDEM DENEGADA.
+I. Caso em exame
+1. Habeas corpus, com pedido liminar, impetrado em favor de paciente presa preventivamente pela suposta prática de associação criminosa armada e infrações ao Estatuto do Desarmamento. O impetrante sustenta ausência de fundamentação idônea para a custódia cautelar e requer, subsidiariamente, a substituição pela prisão domiciliar, ao argumento de ser a paciente genitora de filhos menores e única responsável pelos seus cuidados.
+II. Questão em discussão
+2. Há duas questões em discussão: (i) saber se a decisão que decretou a prisão preventiva da paciente apresenta fundamentação idônea, apta a demonstrar a necessidade da custódia cautelar para a garantia da ordem pública; e (ii) saber se é cabível a substituição da prisão preventiva por prisão domiciliar em razão de a paciente ser genitora de filho menor de doze anos, nos termos do art. 318, V, do CPP. .
+III. Razões de decidir
+3. A prisão preventiva foi decretada com base na comprovação da materialidade delitiva e na presença de indícios suficientes de autoria, consubstanciados nos elementos colhidos no auto de prisão em flagrante, mostrando-se devidamente motivada em observância ao art. 93, IX, da Constituição Federal..
+4. A medida cautelar mostrou-se necessária à garantia da ordem pública, diante da gravidade concreta da conduta, evidenciada pela atuação da paciente em concurso de agentes com finalidade criminosa e pelos indícios de integração à organização criminosa denominada "CV", circunstâncias que revelam periculosidade social acentuada.
+5. O fato de a paciente ser proprietária do imóvel onde se realizou o flagrante  apontado como possível ponto de apoio da organização criminosa  e de os agentes terem recebido a composição policial a disparos de arma de fogo reforça a gravidade concreta dos fatos e a inadequação das medidas cautelares alternativas.
+6. No que concerne ao pedido de prisão domiciliar, a mera condição de genitora de filho menor de doze anos não confere direito automático ao benefício, sendo necessária a análise das circunstâncias concretas do caso. A jurisprudência reconhece a possibilidade de denegação do benefício em situações excepcionais.
+7. No caso, o interesse superior da criança  valor que a norma visa a tutelar  conduz a conclusão contrária ao pleito: o menor se encontrava exposto a ambiente de acentuada vulnerabilidade social e <em>moral</em> na própria residência da paciente, utilizada como ponto de atuação de organização criminosa, circunstância incompatível com a proteção integral assegurada a crianças e adolescentes pelo ordenamento jurídico.
+8. As condições pessoais favoráveis da paciente, como a primariedade, não têm o condão de, por si sós, impedir a manutenção da prisão preventiva quando presentes os requisitos legais autorizadores e devidamente demonstrada a sua necessidade.
+IV. Dispositivo e tese
+9. Ordem conhecida e negada.
+
+Tese de julgamento:
+1. A condição de genitora de filho menor de doze anos não assegura automaticamente a substituição da prisão preventiva por prisão domiciliar quando configurada situação excepcional, evidenciada pela exposição da criança a ambiente de acentuada vulnerabilidade <em>moral</em> e social decorrente da atuação da acusada em contexto de organização criminosa, hipótese em que o próprio interesse superior do menor impõe a manutenção da custódia cautelar devidamente fundamentada.
+2. A necessidade de interromper ou diminuir a atuação de integrantes de organização criminosa enquadra-se no conceito de garantia da ordem pública, constituindo fundamentação cautelar idônea e suficiente para a prisão preventiva.
+
+
+Legislação citada: CF/1988, art. 93, IX; CPP, arts. 318, IV, V e 318-A.
+Jurisprudência citada: STJ, AgRg no RHC n. 226.146/CE, rel. Min. Ribeiro Dantas, Quinta Turma, julgado em 25/02/2026, DJEN de 12/03/2026; STJ, AgRg no HC n. 939.644/SC, rel. Min. Og Fernandes, Sexta Turma, julgado em 12/02/2025, DJEN de 18/02/2025; TJCE, HC 0630344-96.2025.8.06.0000, Rel. Des.ª Maria Edna Martins, 3ª Câmara Criminal, julgado em 10/02/2026.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 1ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará,à unanimidade, em CONHECER do writ, mas para DENEGAR a ordem, nos exatos termos do voto do relator.
+
+Fortaleza, 7 de abril de 2026
+
+
+
+MÁRIO PARENTE TEÓFILO NETO
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR MÁRIO PARENTE TEÓFILO NETO
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>29&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833231" cdForo="0" >
+										0204528-74.2025.8.06.0293
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833231" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833231);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833231" style="display: none;" >
+	<div id="textAreaDados_3833231" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O. ROUBO MAJORADO. RECURSO DA DEFESA. 1. INSURG&Ecirc;NCIA QUANTO &Agrave; INOBSERV&Acirc;NCIA DO ART. 226 DO CPP. 2. PEDIDO DE REFORMA DA  DOSIMETRIA. 2.1. AFASTAMENTO DAS CONSEQU&Ecirc;NCIAS DO CRIME. 2.2. DECOTE DA SENILIDADE POR DESCONHECIMENTO DA IDADE DA V&Iacute;TIMA. 2.3. PLEITO DE EXCLUS&Atilde;O DA MAJORANTE POR AUS&Ecirc;NCIA DE APREENS&Atilde;O DA ARMA BRANCA. 2.4. PEDIDO DE ALTERA&Ccedil;&Atilde;O DE REGIME. RECURSO CONHECIDO E PARCIALMENTE PROVIDO COM REDIMENSIONAMENTO DA PENA.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a proferida pela Ju&iacute;za de Direito da 2&ordf; Vara Criminal da Comarca de Iguatu que condenou o r&eacute;u pela pr&aacute;tica do crime de roubo majorado, &agrave; pena de 10 (dez) anos, 2 (dois) meses e 20 (vinte) dias de reclus&atilde;o, em regime inicial fechado, em raz&atilde;o da subtra&ccedil;&atilde;o de R$ 670,00 mediante grave amea&ccedil;a com uso de canivete e viol&ecirc;ncia f&iacute;sica contra a v&iacute;tima.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2. H&aacute; quatro quest&otilde;es em discuss&atilde;o: (i) aferir se a aus&ecirc;ncia de observ&acirc;ncia do procedimento previsto no CPP invalida o reconhecimento do acusado; (ii) verificar se h&aacute; provas suficientes de autoria e materialidade para manuten&ccedil;&atilde;o da condena&ccedil;&atilde;o; (iii) determinar a corre&ccedil;&atilde;o da dosimetria da pena, especialmente quanto &agrave; valora&ccedil;&atilde;o das circunst&acirc;ncias judiciais, agravantes e causa de aumento; (iv) examinar a possibilidade de modifica&ccedil;&atilde;o do regime inicial e concess&atilde;o do direito de recorrer em liberdade.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A inobserv&acirc;ncia do procedimento no CPP n&atilde;o invalida, automaticamente, a condena&ccedil;&atilde;o quando a autoria delitiva est&aacute; demonstrada por provas aut&ocirc;nomas e independentes, como registros de videomonitoramento e depoimentos testemunhais. O reconhecimento pessoal formal &eacute; dispens&aacute;vel quando n&atilde;o constitui a base da identifica&ccedil;&atilde;o do acusado, mas apenas confirma&ccedil;&atilde;o de autoria j&aacute; estabelecida por outros elementos probat&oacute;rios.
+4. A materialidade e autoria do delito restam comprovadas por boletim de ocorr&ecirc;ncia, laudo pericial, relat&oacute;rio policial com imagens e relatos firmes e coerentes de v&iacute;tima e testemunhas. A palavra da v&iacute;tima, em crimes patrimoniais, possui especial relev&acirc;ncia probat&oacute;ria quando corroborada por outros elementos de prova.
+5. Dosimetria. A valora&ccedil;&atilde;o negativa das consequ&ecirc;ncias do crime &eacute; indevida quando fundamentada em elemento inerente ao tipo penal, impondo a redu&ccedil;&atilde;o da pena-base ao m&iacute;nimo legal.
+6. A agravante da senilidade possui natureza objetiva, incidindo independentemente do conhecimento da idade da v&iacute;tima pelo agente.
+7. A n&atilde;o apreens&atilde;o da arma branca n&atilde;o impede o reconhecimento da causa de aumento, quando sua utiliza&ccedil;&atilde;o &eacute; comprovada por outros meios de prova.
+8. A pena definitiva foi reduzida para  7 (sete) anos, 1 (um) m&ecirc;s e 10 (dez) dias de reclus&atilde;o e 17 (dezessete) dias-multa. A manuten&ccedil;&atilde;o do regime inicial fechado &eacute; adequada diante da reincid&ecirc;ncia e do montante da pena.
+9. A cust&oacute;dia cautelar deve ser mantida em raz&atilde;o da periculosidade concreta do agente e do risco de reitera&ccedil;&atilde;o delitiva, evidenciado pelos antecedentes e processos em curso.
+IV. DISPOSITIVO
+10. Recurso conhecido e parcialmente provido.
+
+Teses de julgamento: 1. A inobserv&acirc;ncia do art. 226 do CPP n&atilde;o impede a condena&ccedil;&atilde;o quando a autoria &eacute; comprovada por provas independentes e id&ocirc;neas. 2. A palavra da v&iacute;tima, corroborada por outros elementos, &eacute; suficiente para sustentar condena&ccedil;&atilde;o em crimes patrimoniais. 3. &Eacute; indevida a exaspera&ccedil;&atilde;o da pena-base com fundamento em circunst&acirc;ncias inerentes ao tipo penal. 4. A agravante do art. 61, II, &quot;h&quot;, do C&oacute;digo Penal possui natureza objetiva e independe do conhecimento da idade da v&iacute;tima, pelo agente. 5. A n&atilde;o apreens&atilde;o da arma branca n&atilde;o afasta a causa de aumento quando comprovado seu uso por outros meios de prova.
+
+Dispositivos relevantes citados: CP, arts. 33, 44, 60, 61, II, &quot;h&quot;, 77 e 157, &sect; 2&ordm;, VII; CPP, arts. 226 e 312; S&uacute;mula 582 do STJ.
+
+Jurisprud&ecirc;ncia relevante citada: STJ, Tema Repetitivo n&ordm; 1.258; STJ, AgRg no REsp 2.095.884/PR, Rel. Min. Rogerio Schietti Cruz, 6&ordf; Turma, j. 12.12.2023; STJ -   TJCE - Apela&ccedil;&atilde;o Criminal&nbsp;- 0050900-16.2020.8.06.0075, Rel. Desembargador(a) FRANCISCO JAIME MEDEIROS NETO, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 25/11/2025, data da publica&ccedil;&atilde;o:&nbsp; 25/11/2025; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0202815-49.2025.8.06.0298, Rel. Des. Francisco Jaime Medeiros Neto, j. 03.02.2026; TJCE, Apela&ccedil;&atilde;o Criminal n&ordm; 0041040-92.2015.8.06.0001, Rel. Des. Vanja Fontenele Pontes, j. 03.02.2026.TJCE, S&uacute;mula 52.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos, ACORDAM os Desembargadores integrantes da 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Cear&aacute;, por unanimidade, em CONHECER do recurso PARA DAR-LHE PARCIAL PROVIMENTO e, por consequ&ecirc;ncia, redimensionar a pena, nos termos do voto da Relatora.
+Fortaleza, 07 de abril de 2026.
+
+DESEMBARGADORA &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0204528-74.2025.8.06.0293, Rel. Desembargador(a)  &Acirc;NGELA TERESA GONDIM CARNEIRO CHAVES, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 07/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Roubo Majorado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Iguatu
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO. ROUBO MAJORADO. RECURSO DA DEFESA. 1. INSURGÊNCIA QUANTO À INOBSERVÂNCIA DO ART. 226 DO CPP. 2. PEDIDO DE REFORMA DA  DOSIMETRIA. 2.1. AFASTAMENTO DAS CONSEQUÊNCIAS DO CRIME. 2.2. DECOTE DA SENILIDADE POR DESCONHECIMENTO DA IDADE DA VÍTIMA. 2.3. PLEITO DE EXCLUSÃO DA MAJORANTE POR AUSÊNCIA DE APREENSÃO DA ARMA BRANCA. 2.4. PEDIDO DE ALTERAÇÃO DE REGIME.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO. ROUBO MAJORADO. RECURSO DA DEFESA. 1. INSURGÊNCIA QUANTO À INOBSERVÂNCIA DO ART. 226 DO CPP. 2. PEDIDO DE REFORMA DA  DOSIMETRIA. 2.1. AFASTAMENTO DAS CONSEQUÊNCIAS DO CRIME. 2.2. DECOTE DA SENILIDADE POR DESCONHECIMENTO DA IDADE DA VÍTIMA. 2.3. PLEITO DE EXCLUSÃO DA MAJORANTE POR AUSÊNCIA DE APREENSÃO DA ARMA BRANCA. 2.4. PEDIDO DE ALTERAÇÃO DE REGIME. RECURSO CONHECIDO E PARCIALMENTE PROVIDO COM REDIMENSIONAMENTO DA PENA.
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença proferida pela Juíza de Direito da 2ª Vara Criminal da Comarca de Iguatu que condenou o réu pela prática do crime de roubo majorado, à pena de 10 (dez) anos, 2 (dois) meses e 20 (vinte) dias de reclusão, em regime inicial fechado, em razão da subtração de R$ 670,00 mediante grave ameaça com uso de canivete e violência física contra a vítima.
+II. QUESTÕES EM DISCUSSÃO
+2. Há quatro questões em discussão: (i) aferir se a ausência de observância do procedimento previsto no CPP invalida o reconhecimento do acusado; (ii) verificar se há provas suficientes de autoria e materialidade para manutenção da condenação; (iii) determinar a correção da dosimetria da pena, especialmente quanto à valoração das circunstâncias judiciais, agravantes e causa de aumento; (iv) examinar a possibilidade de modificação do regime inicial e concessão do direito de recorrer em liberdade.
+III. RAZÕES DE DECIDIR
+3. A inobservância do procedimento no CPP não invalida, automaticamente, a condenação quando a autoria delitiva está demonstrada por provas autônomas e independentes, como registros de videomonitoramento e depoimentos testemunhais. O reconhecimento pessoal formal é dispensável quando não constitui a base da identificação do acusado, mas apenas confirmação de autoria já estabelecida por outros elementos probatórios.
+4. A materialidade e autoria do delito restam comprovadas por boletim de ocorrência, laudo pericial, relatório policial com imagens e relatos firmes e coerentes de vítima e testemunhas. A palavra da vítima, em crimes patrimoniais, possui especial relevância probatória quando corroborada por outros elementos de prova.
+5. Dosimetria. A valoração negativa das consequências do crime é indevida quando fundamentada em elemento inerente ao tipo penal, impondo a redução da pena-base ao mínimo legal.
+6. A agravante da senilidade possui natureza objetiva, incidindo independentemente do conhecimento da idade da vítima pelo agente.
+7. A não apreensão da arma branca não impede o reconhecimento da causa de aumento, quando sua utilização é comprovada por outros meios de prova.
+8. A pena definitiva foi reduzida para  7 (sete) anos, 1 (um) mês e 10 (dez) dias de reclusão e 17 (dezessete) dias-multa. A manutenção do regime inicial fechado é adequada diante da reincidência e do montante da pena.
+9. A custódia cautelar deve ser mantida em razão da periculosidade concreta do agente e do risco de reiteração delitiva, evidenciado pelos antecedentes e processos em curso.
+IV. DISPOSITIVO
+10. Recurso conhecido e parcialmente provido.
+
+Teses de julgamento: 1. A inobservância do art. 226 do CPP não impede a condenação quando a autoria é comprovada por provas independentes e idôneas. 2. A palavra da vítima, corroborada por outros elementos, é suficiente para sustentar condenação em crimes patrimoniais. 3. É indevida a exasperação da pena-base com fundamento em circunstâncias inerentes ao tipo penal. 4. A agravante do art. 61, II, "h", do Código Penal possui natureza objetiva e independe do conhecimento da idade da vítima, pelo agente. 5. A não apreensão da arma branca não afasta a causa de aumento quando comprovado seu uso por outros meios de prova.
+
+Dispositivos relevantes citados: CP, arts. 33, 44, 60, 61, II, "h", 77 e 157, § 2º, VII; CPP, arts. 226 e 312; Súmula 582 do STJ.
+
+Jurisprudência relevante citada: STJ, Tema Repetitivo nº 1.258; STJ, AgRg no REsp 2.095.884/PR, Rel. Min. Rogerio Schietti Cruz, 6ª Turma, j. 12.12.2023; STJ -   TJCE - Apelação Criminal - 0050900-16.2020.8.06.0075, Rel. Desembargador(a) FRANCISCO JAIME MEDEIROS NETO, 4ª Câmara Criminal, data do julgamento:  25/11/2025, data da publicação:  25/11/2025; TJCE, Apelação Criminal nº 0202815-49.2025.8.06.0298, Rel. Des. Francisco Jaime Medeiros Neto, j. 03.02.2026; TJCE, Apelação Criminal nº 0041040-92.2015.8.06.0001, Rel. Des. Vanja Fontenele Pontes, j. 03.02.2026.TJCE, Súmula 52.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos, ACORDAM os Desembargadores integrantes da 4ª Câmara Criminal do Tribunal de Justiça do Ceará, por unanimidade, em CONHECER do recurso PARA DAR-LHE PARCIAL PROVIMENTO e, por consequência, redimensionar a pena, nos termos do voto da Relatora.
+Fortaleza, 07 de abril de 2026.
+
+DESEMBARGADORA ÂNGELA TERESA GONDIM CARNEIRO CHAVES
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>30&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833249" cdForo="0" >
+										0621648-37.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833249" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833249);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833249" style="display: none;" >
+	<div id="textAreaDados_3833249" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL PENAL. HABEAS CORPUS CRIMINAL. ROUBO MAJORADO. INVAS&Atilde;O DE DOMIC&Iacute;LIO. EMPREGO DE ARMA DE FOGO. CONCURSO DE AGENTES. ADULTERA&Ccedil;&Atilde;O DE SINAL IDENTIFICADOR DE VE&Iacute;CULO AUTOMOTOR. CONDENA&Ccedil;&Atilde;O. DIREITO DE RECORRER EM LIBERDADE. PRIS&Atilde;O PREVENTIVA MANTIDA NA SENTEN&Ccedil;A. FUNDAMENTA&Ccedil;&Atilde;O PER RELATIONEM. VALIDADE. FUMUS COMMISSI DELICTI E PERICULUM LIBERTATIS CONFIGURADOS. GRAVIDADE CONCRETA DO DELITO. MODUS OPERANDI. REITERA&Ccedil;&Atilde;O DELITIVA. EXIST&Ecirc;NCIA DE OUTRAS A&Ccedil;&Otilde;ES PENAIS E INVESTIGA&Ccedil;&Otilde;ES EM CURSO. S&Uacute;MULA 52 DO TJCE. CONTEMPORANEIDADE DA MEDIDA CAUTELAR. CONDI&Ccedil;&Otilde;ES PESSOAIS FAVOR&Aacute;VEIS IRRELEVANTES. MEDIDAS CAUTELARES DIVERSAS INSUFICIENTES. ORDEM DENEGADA.
+I. CASO EM EXAME
+1) Habeas corpus impetrado em favor de paciente condenado pela pr&aacute;tica dos crimes previstos no art. 157, &sect;2&ordm;, inciso II e &sect;2&ordm;-A, inciso I, c/c art. 70, bem como art. 311, &sect;2&ordm;, inciso III, c/c art. 69, todos do C&oacute;digo Penal, em raz&atilde;o de roubo majorado praticado mediante invas&atilde;o de resid&ecirc;ncia, com emprego de arma de fogo e concurso de agentes, al&eacute;m de adultera&ccedil;&atilde;o de sinal identificador de ve&iacute;culo automotor. A defesa sustenta constrangimento ilegal decorrente da manuten&ccedil;&atilde;o da pris&atilde;o preventiva na senten&ccedil;a condenat&oacute;ria, ao argumento de aus&ecirc;ncia de fundamenta&ccedil;&atilde;o concreta, inexist&ecirc;ncia de contemporaneidade e possibilidade de substitui&ccedil;&atilde;o por medidas cautelares diversas da pris&atilde;o.
+II. QUEST&Otilde;ES EM DISCUSS&Atilde;O
+2) As quest&otilde;es em discuss&atilde;o consistem em verificar se a decis&atilde;o que manteve a pris&atilde;o preventiva do paciente por ocasi&atilde;o da senten&ccedil;a condenat&oacute;ria apresenta fundamenta&ccedil;&atilde;o id&ocirc;nea e contempor&acirc;nea, nos termos dos arts. 312 e 387, &sect;1&ordm;, do C&oacute;digo de Processo Penal e definir se, diante das circunst&acirc;ncias do caso concreto, seria cab&iacute;vel a substitui&ccedil;&atilde;o da cust&oacute;dia cautelar por medidas cautelares diversas da pris&atilde;o.
+III. RAZ&Otilde;ES DE DECIDIR
+3) A decis&atilde;o que manteve a pris&atilde;o preventiva por ocasi&atilde;o da senten&ccedil;a condenat&oacute;ria encontra-se devidamente fundamentada, sendo v&aacute;lida a utiliza&ccedil;&atilde;o da t&eacute;cnica de motiva&ccedil;&atilde;o per relationem, quando evidenciada a perman&ecirc;ncia dos fundamentos anteriormente expostos no decreto prisional, conforme entendimento consolidado do Superior Tribunal de Justi&ccedil;a.
+4) O fumus commissi delicti encontra-se demonstrado pela prova da materialidade e pelos ind&iacute;cios suficientes de autoria extra&iacute;dos da investiga&ccedil;&atilde;o policial, consistentes nos depoimentos das v&iacute;timas e testemunhas, nos termos de reconhecimento, na an&aacute;lise de imagens de c&acirc;meras de seguran&ccedil;a e na pr&oacute;pria confiss&atilde;o do paciente em sede policial.
+5) O periculum libertatis revela-se na gravidade concreta do delito e no modus operandi empregado, consistente na invas&atilde;o de resid&ecirc;ncia por grupo de indiv&iacute;duos encapuzados, mediante grave amea&ccedil;a com emprego de arma de fogo, com restri&ccedil;&atilde;o da liberdade das v&iacute;timas e subtra&ccedil;&atilde;o de diversos bens avaliados em aproximadamente R$ 350.000,00.
+6) Evidencia-se, ainda, risco concreto de reitera&ccedil;&atilde;o delitiva, diante da exist&ecirc;ncia de outras a&ccedil;&otilde;es penais e investiga&ccedil;&otilde;es em curso em desfavor do paciente, circunst&acirc;ncia apta a justificar a manuten&ccedil;&atilde;o da cust&oacute;dia cautelar para garantia da ordem p&uacute;blica, nos termos da S&uacute;mula 52 do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;.
+7) A contemporaneidade da pris&atilde;o preventiva n&atilde;o se limita &agrave; data da pr&aacute;tica delitiva, mas relaciona-se &agrave; persist&ecirc;ncia dos motivos que justificam a medida cautelar, especialmente quando demonstrado o risco atual de reitera&ccedil;&atilde;o criminosa e de comprometimento da ordem p&uacute;blica.
+8) Condi&ccedil;&otilde;es pessoais favor&aacute;veis, como primariedade, resid&ecirc;ncia fixa ou aus&ecirc;ncia de condena&ccedil;&atilde;o definitiva, n&atilde;o impedem a decreta&ccedil;&atilde;o ou manuten&ccedil;&atilde;o da pris&atilde;o preventiva quando presentes fundamentos concretos que evidenciem a necessidade da medida extrema.As medidas cautelares diversas previstas no art. 319 do C&oacute;digo de Processo Penal mostram-se inadequadas e insuficientes diante da gravidade concreta da conduta e da periculosidade evidenciada pelo comportamento do paciente, inclusive porque, &agrave; &eacute;poca dos fatos, encontrava-se submetido a monitora&ccedil;&atilde;o eletr&ocirc;nica em outro processo.
+IV. DISPOSITIVO
+9) Ordem parcialmente conhecida e denegada.
+
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 3&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER parcialmente do writ, para na extens&atilde;o cognosc&iacute;vel, DENEGAR a ordem, nos termos do voto da Relatora.
+
+Fortaleza, data da assinatura eletr&ocirc;nica.
+
+
+DESEMBARGADORA ANDR&Eacute;A MENDES BEZERRA DELFINO
+Relatora  <br><br>(Habeas Corpus Criminal&nbsp;-  0621648-37.2026.8.06.0000, Rel. Desembargador(a)  ANDREA MENDES BEZERRA DELFINO, 3&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 07/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Habeas Corpus Criminal / Roubo Majorado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ANDREA MENDES BEZERRA DELFINO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS CRIMINAL. ROUBO MAJORADO. INVASÃO DE DOMICÍLIO. EMPREGO DE ARMA DE FOGO. CONCURSO DE AGENTES. ADULTERAÇÃO DE SINAL IDENTIFICADOR DE VEÍCULO AUTOMOTOR. CONDENAÇÃO. DIREITO DE RECORRER EM LIBERDADE. PRISÃO PREVENTIVA MANTIDA NA SENTENÇA. FUNDAMENTAÇÃO PER RELATIONEM. VALIDADE. FUMUS COMMISSI DELICTI E PERICULUM LIBERTATIS CONFIGURADOS. GRAVIDADE CONCRETA DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS CRIMINAL. ROUBO MAJORADO. INVASÃO DE DOMICÍLIO. EMPREGO DE ARMA DE FOGO. CONCURSO DE AGENTES. ADULTERAÇÃO DE SINAL IDENTIFICADOR DE VEÍCULO AUTOMOTOR. CONDENAÇÃO. DIREITO DE RECORRER EM LIBERDADE. PRISÃO PREVENTIVA MANTIDA NA SENTENÇA. FUNDAMENTAÇÃO PER RELATIONEM. VALIDADE. FUMUS COMMISSI DELICTI E PERICULUM LIBERTATIS CONFIGURADOS. GRAVIDADE CONCRETA DO DELITO. MODUS OPERANDI. REITERAÇÃO DELITIVA. EXISTÊNCIA DE OUTRAS AÇÕES PENAIS E INVESTIGAÇÕES EM CURSO. SÚMULA 52 DO TJCE. CONTEMPORANEIDADE DA MEDIDA CAUTELAR. CONDIÇÕES PESSOAIS FAVORÁVEIS IRRELEVANTES. MEDIDAS CAUTELARES DIVERSAS INSUFICIENTES. ORDEM DENEGADA.
+I. CASO EM EXAME
+1) Habeas corpus impetrado em favor de paciente condenado pela prática dos crimes previstos no art. 157, §2º, inciso II e §2º-A, inciso I, c/c art. 70, bem como art. 311, §2º, inciso III, c/c art. 69, todos do Código Penal, em razão de roubo majorado praticado mediante invasão de residência, com emprego de arma de fogo e concurso de agentes, além de adulteração de sinal identificador de veículo automotor. A defesa sustenta constrangimento ilegal decorrente da manutenção da prisão preventiva na sentença condenatória, ao argumento de ausência de fundamentação concreta, inexistência de contemporaneidade e possibilidade de substituição por medidas cautelares diversas da prisão.
+II. QUESTÕES EM DISCUSSÃO
+2) As questões em discussão consistem em verificar se a decisão que manteve a prisão preventiva do paciente por ocasião da sentença condenatória apresenta fundamentação idônea e contemporânea, nos termos dos arts. 312 e 387, §1º, do Código de Processo Penal e definir se, diante das circunstâncias do caso concreto, seria cabível a substituição da custódia cautelar por medidas cautelares diversas da prisão.
+III. RAZÕES DE DECIDIR
+3) A decisão que manteve a prisão preventiva por ocasião da sentença condenatória encontra-se devidamente fundamentada, sendo válida a utilização da técnica de motivação per relationem, quando evidenciada a permanência dos fundamentos anteriormente expostos no decreto prisional, conforme entendimento consolidado do Superior Tribunal de Justiça.
+4) O fumus commissi delicti encontra-se demonstrado pela prova da materialidade e pelos indícios suficientes de autoria extraídos da investigação policial, consistentes nos depoimentos das vítimas e testemunhas, nos termos de reconhecimento, na análise de imagens de câmeras de segurança e na própria confissão do paciente em sede policial.
+5) O periculum libertatis revela-se na gravidade concreta do delito e no modus operandi empregado, consistente na invasão de residência por grupo de indivíduos encapuzados, mediante grave ameaça com emprego de arma de fogo, com restrição da liberdade das vítimas e subtração de diversos bens avaliados em aproximadamente R$ 350.000,00.
+6) Evidencia-se, ainda, risco concreto de reiteração delitiva, diante da existência de outras ações penais e investigações em curso em desfavor do paciente, circunstância apta a justificar a manutenção da custódia cautelar para garantia da ordem pública, nos termos da Súmula 52 do Tribunal de Justiça do Estado do Ceará.
+7) A contemporaneidade da prisão preventiva não se limita à data da prática delitiva, mas relaciona-se à persistência dos motivos que justificam a medida cautelar, especialmente quando demonstrado o risco atual de reiteração criminosa e de comprometimento da ordem pública.
+8) Condições pessoais favoráveis, como primariedade, residência fixa ou ausência de condenação definitiva, não impedem a decretação ou manutenção da prisão preventiva quando presentes fundamentos concretos que evidenciem a necessidade da medida extrema.As medidas cautelares diversas previstas no art. 319 do Código de Processo Penal mostram-se inadequadas e insuficientes diante da gravidade concreta da conduta e da periculosidade evidenciada pelo comportamento do paciente, inclusive porque, à época dos fatos, encontrava-se submetido a monitoração eletrônica em outro processo.
+IV. DISPOSITIVO
+9) Ordem parcialmente conhecida e denegada.
+
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 3ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER parcialmente do writ, para na extensão cognoscível, DENEGAR a ordem, nos termos do voto da Relatora.
+
+Fortaleza, data da assinatura eletrônica.
+
+
+DESEMBARGADORA ANDRÉA MENDES BEZERRA DELFINO
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>31&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833147" cdForo="0" >
+										0621976-64.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833147" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833147);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833147" style="display: none;" >
+	<div id="textAreaDados_3833147" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL PENAL. HABEAS CORPUS. TR&Aacute;FICO DE DROGAS E POSSE DE ARMA DE FOGO DE USO RESTRITO. PRIS&Atilde;O PREVENTIVA. GARANTIA DA ORDEM P&Uacute;BLICA. GRAVIDADE CONCRETA. REITERA&Ccedil;&Atilde;O DELITIVA. FUNDAMENTA&Ccedil;&Atilde;O ID&Ocirc;NEA E REQUISITOS DA PRIS&Atilde;O DEMONSTRADOS. EXCESSO DE PRAZO NA FORMA&Ccedil;&Atilde;O DA CULPA. INOCORR&Ecirc;NCIA. CONTRIBUI&Ccedil;&Atilde;O DA DEFESA PARA A MORA PROCESSUAL. S&Uacute;MULA 64 DO STJ. RECOMENDA&Ccedil;&Atilde;O DE CELERIDADE MEDIANTE ANTECIPA&Ccedil;&Atilde;O DE AUDI&Ecirc;NCIA REDESIGNADA. ORDEM CONHECIDA E DENEGADA.
+1. Caso em Exame: Habeas corpus impetrado pela Defensoria P&uacute;blica do Estado do Cear&aacute; em favor de Francisco Anderson de Almeida Cunha, apontando como autoridade coatora o Ju&iacute;zo da 2&ordf; Vara Criminal da Comarca de Caucaia/CE, nos autos do processo n&ordm; 0201137-90.2025.8.06.0300, em que o paciente responde por crimes de tr&aacute;fico de drogas e posse de arma de fogo de uso restrito. O paciente foi preso em flagrante em 31/03/2025, tendo a cust&oacute;dia sido convertida em pris&atilde;o preventiva em audi&ecirc;ncia de cust&oacute;dia realizada em 01/04/2025, sob o fundamento da garantia da ordem p&uacute;blica. A den&uacute;ncia foi oferecida e recebida, com designa&ccedil;&atilde;o de audi&ecirc;ncia de instru&ccedil;&atilde;o e julgamento, a qual sofreu redesigna&ccedil;&otilde;es, culminando na remarca&ccedil;&atilde;o para 11/08/2026, sem in&iacute;cio da instru&ccedil;&atilde;o criminal. A impetra&ccedil;&atilde;o sustenta aus&ecirc;ncia dos requisitos da pris&atilde;o preventiva e ocorr&ecirc;ncia de excesso de prazo na forma&ccedil;&atilde;o da culpa, diante da prolongada segrega&ccedil;&atilde;o cautelar.
+2. Quest&atilde;o em Discuss&atilde;o: (i) Verificar a presen&ccedil;a dos requisitos autorizadores da pris&atilde;o preventiva; (ii) Analisar a ocorr&ecirc;ncia de constrangimento ilegal por excesso de prazo na forma&ccedil;&atilde;o da culpa.
+3. Raz&otilde;es de Decidir: A pris&atilde;o preventiva encontra-se devidamente fundamentada na garantia da ordem p&uacute;blica, evidenciada pela gravidade concreta da conduta, consubstanciada na apreens&atilde;o de diversidade de entorpecentes, arma de fogo de uso restrito e apetrechos t&iacute;picos do tr&aacute;fico, bem como na exist&ecirc;ncia de antecedentes criminais, indicativos de reitera&ccedil;&atilde;o delitiva. Presentes o fumus comissi delicti, demonstrado pela materialidade delitiva e ind&iacute;cios de autoria, inclusive com confiss&atilde;o, e o periculum libertatis, evidenciado pela periculosidade do agente, justifica-se a manuten&ccedil;&atilde;o da cust&oacute;dia cautelar, sendo insuficientes as medidas cautelares diversas da pris&atilde;o. No tocante ao alegado excesso de prazo, embora o paciente esteja preso h&aacute; lapso temporal significativo sem in&iacute;cio da instru&ccedil;&atilde;o, a an&aacute;lise deve observar o princ&iacute;pio da razoabilidade, n&atilde;o sendo aferida por mera soma aritm&eacute;tica de prazos. No caso concreto, a demora n&atilde;o decorre exclusivamente de in&eacute;rcia estatal, mas tamb&eacute;m da contribui&ccedil;&atilde;o da defesa, em raz&atilde;o da aus&ecirc;ncia de testemunhas por ela arroladas e da n&atilde;o apresenta&ccedil;&atilde;o tempestiva da resposta &agrave; acusa&ccedil;&atilde;o. Ademais, h&aacute; pluralidade de r&eacute;us e imputa&ccedil;&atilde;o de m&uacute;ltiplos delitos, circunst&acirc;ncias que conferem maior complexidade ao feito. Aplica-se, portanto, o entendimento consolidado na S&uacute;mula 64 do STJ, segundo o qual n&atilde;o h&aacute; constrangimento ilegal quando o atraso &eacute; provocado pela defesa. Todavia, reconhece-se a necessidade de evitar prolongamento excessivo da pris&atilde;o cautelar, recomendando-se ao ju&iacute;zo de origem a readequa&ccedil;&atilde;o da pauta para antecipa&ccedil;&atilde;o da audi&ecirc;ncia de instru&ccedil;&atilde;o, redesignada para o dia 11/08/2026.
+4. Dispositivo e Tese: Ordem conhecida e denegada. Tese: N&atilde;o configura constrangimento ilegal por excesso de prazo na forma&ccedil;&atilde;o da culpa quando a demora processual decorre, ainda que parcialmente, da atua&ccedil;&atilde;o da defesa e da complexidade do feito, estando presentes os requisitos da pris&atilde;o preventiva.
+Dispositivos Relevantes Citados
+Constitui&ccedil;&atilde;o Federal, art. 5&ordm;, incisos LVII, LXVIII e LXXVIII
+C&oacute;digo de Processo Penal, arts. 312, 313 e 319
+Lei n&ordm; 11.343/06, art. 33
+Lei n&ordm; 10.826/03, art. 16
+Jurisprud&ecirc;ncia Relevante Citada
+STF, HC 244.886/SP
+STJ, RHC 132.191/BA
+STJ, AgRg no RHC 195.136/RS
+STJ, RHC 92.442/AL
+STJ, S&uacute;mula 64
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER da ordem impetrada em Habeas Corpus, mas para DENEG&Aacute;-LA, nos termos do voto do e. Relator.
+Fortaleza, data e hora do sistema.
+
+S&Iacute;LVIA SOARES DE S&Aacute; N&Oacute;BREGA
+Presidente do &Oacute;rg&atilde;o Julgador
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator  <br><br>(Habeas Corpus Criminal&nbsp;-  0621976-64.2026.8.06.0000, Rel. Desembargador(a)  FRANCISCO  JAIME MEDEIROS NETO, 4&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 07/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Habeas Corpus Criminal / Crimes do Sistema Nacional de Armas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO  JAIME MEDEIROS NETO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Caucaia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS. TRÁFICO DE DROGAS E POSSE DE ARMA DE FOGO DE USO RESTRITO. PRISÃO PREVENTIVA. GARANTIA DA ORDEM PÚBLICA. GRAVIDADE CONCRETA. REITERAÇÃO DELITIVA. FUNDAMENTAÇÃO IDÔNEA E REQUISITOS DA PRISÃO DEMONSTRADOS. EXCESSO DE PRAZO NA FORMAÇÃO DA CULPA. INOCORRÊNCIA. CONTRIBUIÇÃO DA DEFESA PARA A MORA PROCESSUAL. SÚMULA 64 DO STJ. RECOMENDAÇÃO DE CELERIDADE MEDIANTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL. HABEAS CORPUS. TRÁFICO DE DROGAS E POSSE DE ARMA DE FOGO DE USO RESTRITO. PRISÃO PREVENTIVA. GARANTIA DA ORDEM PÚBLICA. GRAVIDADE CONCRETA. REITERAÇÃO DELITIVA. FUNDAMENTAÇÃO IDÔNEA E REQUISITOS DA PRISÃO DEMONSTRADOS. EXCESSO DE PRAZO NA FORMAÇÃO DA CULPA. INOCORRÊNCIA. CONTRIBUIÇÃO DA DEFESA PARA A MORA PROCESSUAL. SÚMULA 64 DO STJ. RECOMENDAÇÃO DE CELERIDADE MEDIANTE ANTECIPAÇÃO DE AUDIÊNCIA REDESIGNADA. ORDEM CONHECIDA E DENEGADA.
+1. Caso em Exame: Habeas corpus impetrado pela Defensoria Pública do Estado do Ceará em favor de Francisco Anderson de Almeida Cunha, apontando como autoridade coatora o Juízo da 2ª Vara Criminal da Comarca de Caucaia/CE, nos autos do processo nº 0201137-90.2025.8.06.0300, em que o paciente responde por crimes de tráfico de drogas e posse de arma de fogo de uso restrito. O paciente foi preso em flagrante em 31/03/2025, tendo a custódia sido convertida em prisão preventiva em audiência de custódia realizada em 01/04/2025, sob o fundamento da garantia da ordem pública. A denúncia foi oferecida e recebida, com designação de audiência de instrução e julgamento, a qual sofreu redesignações, culminando na remarcação para 11/08/2026, sem início da instrução criminal. A impetração sustenta ausência dos requisitos da prisão preventiva e ocorrência de excesso de prazo na formação da culpa, diante da prolongada segregação cautelar.
+2. Questão em Discussão: (i) Verificar a presença dos requisitos autorizadores da prisão preventiva; (ii) Analisar a ocorrência de constrangimento ilegal por excesso de prazo na formação da culpa.
+3. Razões de Decidir: A prisão preventiva encontra-se devidamente fundamentada na garantia da ordem pública, evidenciada pela gravidade concreta da conduta, consubstanciada na apreensão de diversidade de entorpecentes, arma de fogo de uso restrito e apetrechos típicos do tráfico, bem como na existência de antecedentes criminais, indicativos de reiteração delitiva. Presentes o fumus comissi delicti, demonstrado pela materialidade delitiva e indícios de autoria, inclusive com confissão, e o periculum libertatis, evidenciado pela periculosidade do agente, justifica-se a manutenção da custódia cautelar, sendo insuficientes as medidas cautelares diversas da prisão. No tocante ao alegado excesso de prazo, embora o paciente esteja preso há lapso temporal significativo sem início da instrução, a análise deve observar o princípio da razoabilidade, não sendo aferida por mera soma aritmética de prazos. No caso concreto, a demora não decorre exclusivamente de inércia estatal, mas também da contribuição da defesa, em razão da ausência de testemunhas por ela arroladas e da não apresentação tempestiva da resposta à acusação. Ademais, há pluralidade de réus e imputação de múltiplos delitos, circunstâncias que conferem maior complexidade ao feito. Aplica-se, portanto, o entendimento consolidado na Súmula 64 do STJ, segundo o qual não há constrangimento ilegal quando o atraso é provocado pela defesa. Todavia, reconhece-se a necessidade de evitar prolongamento excessivo da prisão cautelar, recomendando-se ao juízo de origem a readequação da pauta para antecipação da audiência de instrução, redesignada para o dia 11/08/2026.
+4. Dispositivo e Tese: Ordem conhecida e denegada. Tese: Não configura constrangimento ilegal por excesso de prazo na formação da culpa quando a demora processual decorre, ainda que parcialmente, da atuação da defesa e da complexidade do feito, estando presentes os requisitos da prisão preventiva.
+Dispositivos Relevantes Citados
+Constituição Federal, art. 5º, incisos LVII, LXVIII e LXXVIII
+Código de Processo Penal, arts. 312, 313 e 319
+Lei nº 11.343/06, art. 33
+Lei nº 10.826/03, art. 16
+Jurisprudência Relevante Citada
+STF, HC 244.886/SP
+STJ, RHC 132.191/BA
+STJ, AgRg no RHC 195.136/RS
+STJ, RHC 92.442/AL
+STJ, Súmula 64
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER da ordem impetrada em Habeas Corpus, mas para DENEGÁ-LA, nos termos do voto do e. Relator.
+Fortaleza, data e hora do sistema.
+
+SÍLVIA SOARES DE SÁ NÓBREGA
+Presidente do Órgão Julgador
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>32&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833263" cdForo="0" >
+										0282752-63.2024.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833263" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833263);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833263" style="display: none;" >
+	<div id="textAreaDados_3833263" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. ROUBO MAJORADO. CONCURSO DE AGENTES. EMPREGO DE ARMA DE FOGO. RESTRI&Ccedil;&Atilde;O DA LIBERDADE DAS V&Iacute;TIMAS. UTILIZA&Ccedil;&Atilde;O DE VE&Iacute;CULO ADULTERADO. INVAS&Atilde;O DE RESID&Ecirc;NCIA DURANTE A MADRUGADA. SUBTRA&Ccedil;&Atilde;O DE BENS DE ELEVADO VALOR. PROVAS ROBUSTAS. CONFISS&Atilde;O EXTRAJUDICIAL. PALAVRA DAS V&Iacute;TIMAS CORROBORADA. TEORIA DA AMOTIO. CONSUMA&Ccedil;&Atilde;O. DESCLASSIFICA&Ccedil;&Atilde;O PARA FURTO. IMPOSSIBILIDADE. DOSIMETRIA FUNDAMENTADA. REGIME FECHADO. MANUTEN&Ccedil;&Atilde;O DA CONDENA&Ccedil;&Atilde;O. RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es criminais interpostas por Gabriel Levi Aires Pantale&atilde;o de Abreu, Wivison Castelo Rodrigues e Jonathan Jansen da Silva Sousa contra senten&ccedil;a que os condenou por roubo majorado (art. 157, &sect;2&ordm;, II e V, &sect;2&ordm;-A, I, do CP) e adultera&ccedil;&atilde;o de sinal identificador de ve&iacute;culo (art. 311, &sect;2&ordm;, III, do CP), ap&oacute;s invadirem resid&ecirc;ncia durante a madrugada, renderem as v&iacute;timas com arma de fogo, mant&ecirc;-las amarradas por cerca de uma hora e subtra&iacute;rem diversos bens (armas, eletr&ocirc;nicos, joias e dinheiro), utilizando ve&iacute;culo com placa adulterada, sendo posteriormente identificados por imagens, dilig&ecirc;ncias policiais e apreens&atilde;o de objetos.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se o conjunto probat&oacute;rio &eacute; suficiente para sustentar a condena&ccedil;&atilde;o; (ii) estabelecer se &eacute; cab&iacute;vel a desclassifica&ccedil;&atilde;o do roubo para furto simples tentado; (iii) determinar se a dosimetria da pena e o regime prisional comportam altera&ccedil;&atilde;o.
+III. RAZ&Otilde;ES DE DECIDIR
+3. As provas colhidas em ju&iacute;zo e na fase inquisitorial s&atilde;o convergentes e consistentes, incluindo depoimentos firmes das v&iacute;timas, relatos de policiais, imagens de seguran&ccedil;a e apreens&atilde;o de bens subtra&iacute;dos, demonstrando autoria e materialidade com grau de certeza.
+4. A identifica&ccedil;&atilde;o dos r&eacute;us decorre de investiga&ccedil;&atilde;o baseada no rastreamento do ve&iacute;culo utilizado, alugado por familiar de um dos acusados, e posterior localiza&ccedil;&atilde;o dos envolvidos com parte dos objetos roubados.
+5. A confiss&atilde;o extrajudicial de dois acusados, aliada aos demais elementos probat&oacute;rios, refor&ccedil;a a responsabilidade penal.
+6. A palavra das v&iacute;timas possui especial relev&acirc;ncia, sobretudo porque descreve detalhadamente a din&acirc;mica do crime e encontra respaldo nas demais provas.
+7. Restou comprovado o emprego de arma de fogo, a atua&ccedil;&atilde;o em concurso de agentes e a restri&ccedil;&atilde;o da liberdade das v&iacute;timas, circunst&acirc;ncias que caracterizam o roubo majorado e afastam a tese de furto.
+8. A desclassifica&ccedil;&atilde;o para furto tentado &eacute; invi&aacute;vel, pois houve grave amea&ccedil;a e efetiva invers&atilde;o da posse dos bens, ainda que por curto per&iacute;odo.
+9. Aplica-se a teoria da amotio, segundo a qual a consuma&ccedil;&atilde;o do roubo ocorre com a simples invers&atilde;o da posse, independentemente de posse mansa e pac&iacute;fica.
+10. A dosimetria da pena observa fundamenta&ccedil;&atilde;o id&ocirc;nea, sendo leg&iacute;tima a valora&ccedil;&atilde;o negativa da culpabilidade (em raz&atilde;o do concurso de majorantes) e das consequ&ecirc;ncias do crime (elevado preju&iacute;zo e abalo psicol&oacute;gico).
+11. A utiliza&ccedil;&atilde;o de majorantes excedentes na primeira fase da dosimetria &eacute; admitida pela jurisprud&ecirc;ncia do STJ.
+12. As atenuantes de confiss&atilde;o espont&acirc;nea e menoridade relativa s&atilde;o afastadas, pois os r&eacute;us negaram os fatos em ju&iacute;zo e possu&iacute;am mais de 21 anos &agrave; &eacute;poca do crime.
+13. A causa de diminui&ccedil;&atilde;o da tentativa &eacute; inaplic&aacute;vel diante da consuma&ccedil;&atilde;o do delito.
+14. O regime inicial fechado &eacute; adequado em raz&atilde;o do elevado quantum da pena e das circunst&acirc;ncias judiciais desfavor&aacute;veis.
+15. A detra&ccedil;&atilde;o penal deve ser analisada pelo ju&iacute;zo da execu&ccedil;&atilde;o, e n&atilde;o em sede de apela&ccedil;&atilde;o.
+IV. DISPOSITIVO
+16. Recursos desprovidos.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos, nesta Comarca de Fortaleza, em que figuram as partes indicadas. ACORDAM os membros integrantes da 3&ordf; C&acirc;mara Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER do recurso apresentado para NEGAR-LHES PROVIMENTO, nos termos do voto da Relatora.
+
+Fortaleza, data da assinatura eletr&ocirc;nica.
+
+DESEMBARGADORA ANDR&Eacute;A MENDES BEZERRA DELFINO
+Relatora  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0282752-63.2024.8.06.0001, Rel. Desembargador(a)  ANDREA MENDES BEZERRA DELFINO, 3&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 07/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ANDREA MENDES BEZERRA DELFINO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. ROUBO MAJORADO. CONCURSO DE AGENTES. EMPREGO DE ARMA DE FOGO. RESTRIÇÃO DA LIBERDADE DAS VÍTIMAS. UTILIZAÇÃO DE VEÍCULO ADULTERADO. INVASÃO DE RESIDÊNCIA DURANTE A MADRUGADA. SUBTRAÇÃO DE BENS DE ELEVADO VALOR. PROVAS ROBUSTAS. CONFISSÃO EXTRAJUDICIAL. PALAVRA DAS VÍTIMAS CORROBORADA. TEORIA DA AMOTIO. CONSUMAÇÃO. DESCLASSIFICAÇÃO PARA FURTO.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. ROUBO MAJORADO. CONCURSO DE AGENTES. EMPREGO DE ARMA DE FOGO. RESTRIÇÃO DA LIBERDADE DAS VÍTIMAS. UTILIZAÇÃO DE VEÍCULO ADULTERADO. INVASÃO DE RESIDÊNCIA DURANTE A MADRUGADA. SUBTRAÇÃO DE BENS DE ELEVADO VALOR. PROVAS ROBUSTAS. CONFISSÃO EXTRAJUDICIAL. PALAVRA DAS VÍTIMAS CORROBORADA. TEORIA DA AMOTIO. CONSUMAÇÃO. DESCLASSIFICAÇÃO PARA FURTO. IMPOSSIBILIDADE. DOSIMETRIA FUNDAMENTADA. REGIME FECHADO. MANUTENÇÃO DA CONDENAÇÃO. RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1. Apelações criminais interpostas por Gabriel Levi Aires Pantaleão de Abreu, Wivison Castelo Rodrigues e Jonathan Jansen da Silva Sousa contra sentença que os condenou por roubo majorado (art. 157, §2º, II e V, §2º-A, I, do CP) e adulteração de sinal identificador de veículo (art. 311, §2º, III, do CP), após invadirem residência durante a madrugada, renderem as vítimas com arma de fogo, mantê-las amarradas por cerca de uma hora e subtraírem diversos bens (armas, eletrônicos, joias e dinheiro), utilizando veículo com placa adulterada, sendo posteriormente identificados por imagens, diligências policiais e apreensão de objetos.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se o conjunto probatório é suficiente para sustentar a condenação; (ii) estabelecer se é cabível a desclassificação do roubo para furto simples tentado; (iii) determinar se a dosimetria da pena e o regime prisional comportam alteração.
+III. RAZÕES DE DECIDIR
+3. As provas colhidas em juízo e na fase inquisitorial são convergentes e consistentes, incluindo depoimentos firmes das vítimas, relatos de policiais, imagens de segurança e apreensão de bens subtraídos, demonstrando autoria e materialidade com grau de certeza.
+4. A identificação dos réus decorre de investigação baseada no rastreamento do veículo utilizado, alugado por familiar de um dos acusados, e posterior localização dos envolvidos com parte dos objetos roubados.
+5. A confissão extrajudicial de dois acusados, aliada aos demais elementos probatórios, reforça a responsabilidade penal.
+6. A palavra das vítimas possui especial relevância, sobretudo porque descreve detalhadamente a dinâmica do crime e encontra respaldo nas demais provas.
+7. Restou comprovado o emprego de arma de fogo, a atuação em concurso de agentes e a restrição da liberdade das vítimas, circunstâncias que caracterizam o roubo majorado e afastam a tese de furto.
+8. A desclassificação para furto tentado é inviável, pois houve grave ameaça e efetiva inversão da posse dos bens, ainda que por curto período.
+9. Aplica-se a teoria da amotio, segundo a qual a consumação do roubo ocorre com a simples inversão da posse, independentemente de posse mansa e pacífica.
+10. A dosimetria da pena observa fundamentação idônea, sendo legítima a valoração negativa da culpabilidade (em razão do concurso de majorantes) e das consequências do crime (elevado prejuízo e abalo psicológico).
+11. A utilização de majorantes excedentes na primeira fase da dosimetria é admitida pela jurisprudência do STJ.
+12. As atenuantes de confissão espontânea e menoridade relativa são afastadas, pois os réus negaram os fatos em juízo e possuíam mais de 21 anos à época do crime.
+13. A causa de diminuição da tentativa é inaplicável diante da consumação do delito.
+14. O regime inicial fechado é adequado em razão do elevado quantum da pena e das circunstâncias judiciais desfavoráveis.
+15. A detração penal deve ser analisada pelo juízo da execução, e não em sede de apelação.
+IV. DISPOSITIVO
+16. Recursos desprovidos.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos, nesta Comarca de Fortaleza, em que figuram as partes indicadas. ACORDAM os membros integrantes da 3ª Câmara Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER do recurso apresentado para NEGAR-LHES PROVIMENTO, nos termos do voto da Relatora.
+
+Fortaleza, data da assinatura eletrônica.
+
+DESEMBARGADORA ANDRÉA MENDES BEZERRA DELFINO
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>33&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833261" cdForo="0" >
+										0620408-13.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833261" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833261);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833261" style="display: none;" >
+	<div id="textAreaDados_3833261" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL PENAL E PENAL. REVIS&Atilde;O CRIMINAL. HOMIC&Iacute;DIO QUALIFICADO (DUAS VEZES). ROUBO MAJORADO. ART. 621, I, DO CPP. REDISCUSS&Atilde;O DE MAT&Eacute;RIA J&Aacute; APRECIADA EM APELA&Ccedil;&Atilde;O. S&Uacute;MULA 56 DO TJCE. AUS&Ecirc;NCIA DE PROVA NOVA OU CONTRARIEDADE &Agrave; EVID&Ecirc;NCIA DOS AUTOS. CONDUTA PROCESSUAL CONTRADIT&Oacute;RIA. N&Atilde;O CONHECIMENTO.
+I. CASO EM EXAME
+1. Revis&atilde;o Criminal ajuizada com fundamento no art. 621, I, do C&oacute;digo de Processo Penal contra ac&oacute;rd&atilde;o que manteve condena&ccedil;&atilde;o pelos crimes previstos nos arts. 121, &sect; 2&ordm;, IV (por duas vezes), e 157, &sect; 2&ordm;-A, I, do C&oacute;digo Penal, com pena fixada em 43 anos, 8 meses e 20 dias de reclus&atilde;o, em regime inicial fechado. Sustenta-se que a condena&ccedil;&atilde;o pelo roubo majorado seria manifestamente contr&aacute;ria &agrave; evid&ecirc;ncia dos autos, por aus&ecirc;ncia de prova id&ocirc;nea de materialidade e autoria, bem como ilegalidades na dosimetria da pena, pleiteando absolvi&ccedil;&atilde;o quanto ao roubo ou readequa&ccedil;&atilde;o da reprimenda.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se a revis&atilde;o criminal pode ser conhecida quando fundada na mera rediscuss&atilde;o de teses j&aacute; apreciadas em apela&ccedil;&atilde;o; (ii) estabelecer se a condena&ccedil;&atilde;o pelo crime de roubo majorado &eacute; manifestamente contr&aacute;ria &agrave; evid&ecirc;ncia dos autos, nos termos do art. 621, I, do CPP; (iii) determinar se h&aacute; ilegalidade flagrante na dosimetria da pena apta a justificar a via revisional.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A revis&atilde;o criminal possui natureza excepcional e somente &eacute; cab&iacute;vel nas hip&oacute;teses taxativas do art. 621 do CPP, n&atilde;o se prestando como suced&acirc;neo recursal ou segunda apela&ccedil;&atilde;o.
+4. A pretens&atilde;o revisional limita-se &agrave; reaprecia&ccedil;&atilde;o do conjunto probat&oacute;rio e &agrave; rediscuss&atilde;o da dosimetria j&aacute; examinada pelo Tribunal do J&uacute;ri e por esta Corte em sede de apela&ccedil;&atilde;o, hip&oacute;tese vedada pela S&uacute;mula 56 do TJCE.
+5. N&atilde;o se verifica condena&ccedil;&atilde;o destitu&iacute;da de suporte probat&oacute;rio, pois o &eacute;dito condenat&oacute;rio encontra amparo em elementos analisados pelo Conselho de Senten&ccedil;a, cuja soberania &eacute; garantia constitucional, e validados pelo Tribunal em grau recursal.
+6. A confiss&atilde;o judicial, utilizada inclusive pela pr&oacute;pria defesa em apela&ccedil;&atilde;o como elemento argumentativo, constitui meio de prova id&ocirc;neo quando corroborada por outros elementos, afastando a alega&ccedil;&atilde;o de aus&ecirc;ncia de prova quanto ao roubo.
+7. A ado&ccedil;&atilde;o, em sede revisional, de tese incompat&iacute;vel com a estrat&eacute;gia defensiva anteriormente sustentada caracteriza conduta processual contradit&oacute;ria (venire contra factum proprium), incompat&iacute;vel com a boa-f&eacute; objetiva e com a estabilidade da coisa julgada.
+8. A dosimetria da pena foi integralmente reexaminada em apela&ccedil;&atilde;o, com corre&ccedil;&atilde;o de equ&iacute;voco aritm&eacute;tico e fundamenta&ccedil;&atilde;o concreta quanto &agrave; negativa&ccedil;&atilde;o das vetoriais do art. 59 do C&oacute;digo Penal, n&atilde;o se evidenciando error in judicando, ilegalidade flagrante ou bis in idem.
+9. O mero inconformismo com a conclus&atilde;o anteriormente adotada n&atilde;o autoriza o manejo da revis&atilde;o criminal, sob pena de esvaziamento da coisa julgada e de afronta &agrave; natureza excepcional da a&ccedil;&atilde;o.
+IV. DISPOSITIVO E TESE
+10. Revis&atilde;o criminal n&atilde;o conhecida.
+Tese de julgamento:
+1. A revis&atilde;o criminal n&atilde;o pode ser utilizada como suced&acirc;neo recursal para rediscutir teses j&aacute; apreciadas e rejeitadas em apela&ccedil;&atilde;o, nos termos do art. 621 do CPP e da S&uacute;mula 56 do TJCE.
+2. A configura&ccedil;&atilde;o da hip&oacute;tese do art. 621, I, do CPP exige condena&ccedil;&atilde;o manifestamente destitu&iacute;da de suporte probat&oacute;rio, n&atilde;o se admitindo nova valora&ccedil;&atilde;o de provas regularmente examinadas pelo Tribunal do J&uacute;ri e pelo &oacute;rg&atilde;o revisor.
+3. A rediscuss&atilde;o da dosimetria da pena na via revisional somente &eacute; admiss&iacute;vel diante de ilegalidade flagrante ou teratologia, inexistentes quando a exaspera&ccedil;&atilde;o das vetoriais do art. 59 do CP est&aacute; fundamentada em elementos concretos dos autos.
+Dispositivos relevantes citados: CPP, art. 621, I; CP, arts. 59, 69, 121, &sect; 2&ordm;, IV, 157, &sect; 2&ordm;-A, I; CP, art. 33, &sect; 2&ordm;, &quot;a&quot;; CP, art. 61, II, &quot;b&quot;.
+Jurisprud&ecirc;ncia relevante citada: TJCE, S&uacute;mula 56; STJ - AgRg no AREsp: 2267393 SP 2022/0394962-0; STJ - AgRg no AREsp: 1855618 AC 2021/0080149-0; STJ - AgRg no AREsp: 2467664 SP 2023/0339019-7.
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos, acorda a Se&ccedil;&atilde;o Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em deixar de conhecer da presente revis&atilde;o criminal, nos termos do voto do Relator.
+Fortaleza, data constante no sistema.
+
+
+HENRIQUE JORGE HOLANDA SILVEIRA
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator  <br><br>(Revis&atilde;o Criminal&nbsp;-  0620408-13.2026.8.06.0000, Rel. Desembargador(a)  FRANCISCO  JAIME MEDEIROS NETO, Se&ccedil;&atilde;o Criminal, data do julgamento:&nbsp; 06/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Revisão Criminal / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO  JAIME MEDEIROS NETO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Iguatu
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									06/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL E PENAL. REVISÃO CRIMINAL. HOMICÍDIO QUALIFICADO (DUAS VEZES). ROUBO MAJORADO. ART. 621, I, DO CPP. REDISCUSSÃO DE MATÉRIA JÁ APRECIADA EM APELAÇÃO. SÚMULA 56 DO TJCE. AUSÊNCIA DE PROVA NOVA OU CONTRARIEDADE À EVIDÊNCIA DOS AUTOS. CONDUTA PROCESSUAL CONTRADITÓRIA. NÃO CONHECIMENTO.
+I. CASO EM EXAME
+1. Revisão Criminal ajuizada com fundamento no art. 621, I, do Código de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL PENAL E PENAL. REVISÃO CRIMINAL. HOMICÍDIO QUALIFICADO (DUAS VEZES). ROUBO MAJORADO. ART. 621, I, DO CPP. REDISCUSSÃO DE MATÉRIA JÁ APRECIADA EM APELAÇÃO. SÚMULA 56 DO TJCE. AUSÊNCIA DE PROVA NOVA OU CONTRARIEDADE À EVIDÊNCIA DOS AUTOS. CONDUTA PROCESSUAL CONTRADITÓRIA. NÃO CONHECIMENTO.
+I. CASO EM EXAME
+1. Revisão Criminal ajuizada com fundamento no art. 621, I, do Código de Processo Penal contra acórdão que manteve condenação pelos crimes previstos nos arts. 121, § 2º, IV (por duas vezes), e 157, § 2º-A, I, do Código Penal, com pena fixada em 43 anos, 8 meses e 20 dias de reclusão, em regime inicial fechado. Sustenta-se que a condenação pelo roubo majorado seria manifestamente contrária à evidência dos autos, por ausência de prova idônea de materialidade e autoria, bem como ilegalidades na dosimetria da pena, pleiteando absolvição quanto ao roubo ou readequação da reprimenda.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se a revisão criminal pode ser conhecida quando fundada na mera rediscussão de teses já apreciadas em apelação; (ii) estabelecer se a condenação pelo crime de roubo majorado é manifestamente contrária à evidência dos autos, nos termos do art. 621, I, do CPP; (iii) determinar se há ilegalidade flagrante na dosimetria da pena apta a justificar a via revisional.
+III. RAZÕES DE DECIDIR
+3. A revisão criminal possui natureza excepcional e somente é cabível nas hipóteses taxativas do art. 621 do CPP, não se prestando como sucedâneo recursal ou segunda apelação.
+4. A pretensão revisional limita-se à reapreciação do conjunto probatório e à rediscussão da dosimetria já examinada pelo Tribunal do Júri e por esta Corte em sede de apelação, hipótese vedada pela Súmula 56 do TJCE.
+5. Não se verifica condenação destituída de suporte probatório, pois o édito condenatório encontra amparo em elementos analisados pelo Conselho de Sentença, cuja soberania é garantia constitucional, e validados pelo Tribunal em grau recursal.
+6. A confissão judicial, utilizada inclusive pela própria defesa em apelação como elemento argumentativo, constitui meio de prova idôneo quando corroborada por outros elementos, afastando a alegação de ausência de prova quanto ao roubo.
+7. A adoção, em sede revisional, de tese incompatível com a estratégia defensiva anteriormente sustentada caracteriza conduta processual contraditória (venire contra factum proprium), incompatível com a boa-fé objetiva e com a estabilidade da coisa julgada.
+8. A dosimetria da pena foi integralmente reexaminada em apelação, com correção de equívoco aritmético e fundamentação concreta quanto à negativação das vetoriais do art. 59 do Código Penal, não se evidenciando error in judicando, ilegalidade flagrante ou bis in idem.
+9. O mero inconformismo com a conclusão anteriormente adotada não autoriza o manejo da revisão criminal, sob pena de esvaziamento da coisa julgada e de afronta à natureza excepcional da ação.
+IV. DISPOSITIVO E TESE
+10. Revisão criminal não conhecida.
+Tese de julgamento:
+1. A revisão criminal não pode ser utilizada como sucedâneo recursal para rediscutir teses já apreciadas e rejeitadas em apelação, nos termos do art. 621 do CPP e da Súmula 56 do TJCE.
+2. A configuração da hipótese do art. 621, I, do CPP exige condenação manifestamente destituída de suporte probatório, não se admitindo nova valoração de provas regularmente examinadas pelo Tribunal do Júri e pelo órgão revisor.
+3. A rediscussão da dosimetria da pena na via revisional somente é admissível diante de ilegalidade flagrante ou teratologia, inexistentes quando a exasperação das vetoriais do art. 59 do CP está fundamentada em elementos concretos dos autos.
+Dispositivos relevantes citados: CPP, art. 621, I; CP, arts. 59, 69, 121, § 2º, IV, 157, § 2º-A, I; CP, art. 33, § 2º, "a"; CP, art. 61, II, "b".
+Jurisprudência relevante citada: TJCE, Súmula 56; STJ - AgRg no AREsp: 2267393 SP 2022/0394962-0; STJ - AgRg no AREsp: 1855618 AC 2021/0080149-0; STJ - AgRg no AREsp: 2467664 SP 2023/0339019-7.
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos, acorda a Seção Criminal do Tribunal de Justiça do Estado do Ceará, por unanimidade, em deixar de conhecer da presente revisão criminal, nos termos do voto do Relator.
+Fortaleza, data constante no sistema.
+
+
+HENRIQUE JORGE HOLANDA SILVEIRA
+Presidente do Órgão Julgador
+
+
+DESEMBARGADOR FRANCISCO JAIME MEDEIROS NETO
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>34&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833269" cdForo="0" >
+										0202630-69.2022.8.06.0151
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833269" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833269);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833269" style="display: none;" >
+	<div id="textAreaDados_3833269" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. VIOL&Ecirc;NCIA DOM&Eacute;STICA. PERSEGUI&Ccedil;&Atilde;O E VIAS DE FATO. PROVA SUFICIENTE. PALAVRA DA V&Iacute;TIMA. BIS IN IDEM NA DOSIMETRIA. REDIMENSIONAMENTO DA PENA. DANOS MORAIS. REDU&Ccedil;&Atilde;O. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a que condenou o r&eacute;u pela pr&aacute;tica dos crimes de persegui&ccedil;&atilde;o (art. 147-A, &sect; 1&ordm;, II, do CP) e contraven&ccedil;&atilde;o de vias de fato (art. 21 da Lei n. 3.688/1941), no contexto de viol&ecirc;ncia dom&eacute;stica, &agrave; pena de reclus&atilde;o, pris&atilde;o simples e multa, al&eacute;m de indeniza&ccedil;&atilde;o por danos morais, em raz&atilde;o de condutas reiteradas de agress&atilde;o f&iacute;sica, amea&ccedil;a e persegui&ccedil;&atilde;o contra ex-companheira.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se h&aacute; insufici&ecirc;ncia probat&oacute;ria a ensejar a absolvi&ccedil;&atilde;o do r&eacute;u; (ii) estabelecer se a dosimetria da pena comporta redu&ccedil;&atilde;o, especialmente diante da presen&ccedil;a de bis in idem; (iii) determinar se &eacute; cab&iacute;vel o afastamento ou a redu&ccedil;&atilde;o da indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O conjunto probat&oacute;rio demonstra de forma suficiente a materialidade e autoria dos delitos, com base em depoimentos firmes e coerentes da v&iacute;tima, corroborados por prova testemunhal e elementos documentais. A palavra da v&iacute;tima possui especial relev&acirc;ncia nos crimes praticados no contexto de viol&ecirc;ncia dom&eacute;stica, sobretudo quando harm&ocirc;nica com os demais elementos probat&oacute;rios.
+4. A conduta do r&eacute;u caracteriza o crime de persegui&ccedil;&atilde;o, diante da reitera&ccedil;&atilde;o de atos de vigil&acirc;ncia, aproxima&ccedil;&atilde;o indevida e tentativas insistentes de contato, aptos a causar temor e abalo psicol&oacute;gico &agrave; v&iacute;tima.
+5. A pr&aacute;tica de vias de fato resta comprovada pela descri&ccedil;&atilde;o detalhada da agress&atilde;o f&iacute;sica e pela confirma&ccedil;&atilde;o testemunhal, al&eacute;m de admiss&atilde;o indireta do r&eacute;u.
+6. A valora&ccedil;&atilde;o negativa da culpabilidade e dos motivos do crime na primeira fase da dosimetria mostra-se id&ocirc;nea, considerando o hist&oacute;rico de viol&ecirc;ncia e a motiva&ccedil;&atilde;o relacionada &agrave; n&atilde;o aceita&ccedil;&atilde;o do t&eacute;rmino do relacionamento.
+7. A incid&ecirc;ncia concomitante da agravante do art. 61, II, &quot;f&quot;, do CP e da causa de aumento do art. 147-A, &sect; 1&ordm;, II, do CP configura bis in idem, por se basearem na mesma circunst&acirc;ncia de viol&ecirc;ncia dom&eacute;stica contra a mulher. A exclus&atilde;o da agravante imp&otilde;e o redimensionamento da pena do crime de persegui&ccedil;&atilde;o, mantendo-se h&iacute;gida a dosimetria quanto &agrave; contraven&ccedil;&atilde;o penal.
+8. A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais &eacute; cab&iacute;vel nos termos do art. 387, IV, do CPP e da tese firmada no Tema 983 do STJ, independentemente de instru&ccedil;&atilde;o probat&oacute;ria espec&iacute;fica. No entanto, a redu&ccedil;&atilde;o do valor da indeniza&ccedil;&atilde;o mostra-se adequada diante das condi&ccedil;&otilde;es econ&ocirc;micas do r&eacute;u e dos princ&iacute;pios da razoabilidade e proporcionalidade.
+IV. DISPOSITIVO
+9. Recurso conhecido e parcialmente provido. <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0202630-69.2022.8.06.0151, Rel. Desembargador(a)  ANDREA MENDES BEZERRA DELFINO, 3&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 07/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Leve
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> ANDREA MENDES BEZERRA DELFINO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Quixadá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. VIOLÊNCIA DOMÉSTICA. PERSEGUIÇÃO E VIAS DE FATO. PROVA SUFICIENTE. PALAVRA DA VÍTIMA. BIS IN IDEM NA DOSIMETRIA. REDIMENSIONAMENTO DA PENA. <em>DANOS</em> <em>MORAIS</em>. REDUÇÃO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença que condenou o réu pela prática dos crimes de perseguição (art.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. VIOLÊNCIA DOMÉSTICA. PERSEGUIÇÃO E VIAS DE FATO. PROVA SUFICIENTE. PALAVRA DA VÍTIMA. BIS IN IDEM NA DOSIMETRIA. REDIMENSIONAMENTO DA PENA. <em>DANOS</em> <em>MORAIS</em>. REDUÇÃO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação criminal interposta contra sentença que condenou o réu pela prática dos crimes de perseguição (art. 147-A, § 1º, II, do CP) e contravenção de vias de fato (art. 21 da Lei n. 3.688/1941), no contexto de violência doméstica, à pena de reclusão, prisão simples e multa, além de indenização por <em>danos</em> <em>morais</em>, em razão de condutas reiteradas de agressão física, ameaça e perseguição contra ex-companheira.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se há insuficiência probatória a ensejar a absolvição do réu; (ii) estabelecer se a dosimetria da pena comporta redução, especialmente diante da presença de bis in idem; (iii) determinar se é cabível o afastamento ou a redução da indenização por <em>danos</em> <em>morais</em>.
+III. RAZÕES DE DECIDIR
+3. O conjunto probatório demonstra de forma suficiente a materialidade e autoria dos delitos, com base em depoimentos firmes e coerentes da vítima, corroborados por prova testemunhal e elementos documentais. A palavra da vítima possui especial relevância nos crimes praticados no contexto de violência doméstica, sobretudo quando harmônica com os demais elementos probatórios.
+4. A conduta do réu caracteriza o crime de perseguição, diante da reiteração de atos de vigilância, aproximação indevida e tentativas insistentes de contato, aptos a causar temor e abalo psicológico à vítima.
+5. A prática de vias de fato resta comprovada pela descrição detalhada da agressão física e pela confirmação testemunhal, além de admissão indireta do réu.
+6. A valoração negativa da culpabilidade e dos motivos do crime na primeira fase da dosimetria mostra-se idônea, considerando o histórico de violência e a motivação relacionada à não aceitação do término do relacionamento.
+7. A incidência concomitante da agravante do art. 61, II, "f", do CP e da causa de aumento do art. 147-A, § 1º, II, do CP configura bis in idem, por se basearem na mesma circunstância de violência doméstica contra a mulher. A exclusão da agravante impõe o redimensionamento da pena do crime de perseguição, mantendo-se hígida a dosimetria quanto à contravenção penal.
+8. A fixação de indenização por <em>danos</em> <em>morais</em> é cabível nos termos do art. 387, IV, do CPP e da tese firmada no Tema 983 do STJ, independentemente de instrução probatória específica. No entanto, a redução do valor da indenização mostra-se adequada diante das condições econômicas do réu e dos princípios da razoabilidade e proporcionalidade.
+IV. DISPOSITIVO
+9. Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>35&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3833062" cdForo="0" >
+										0213826-69.2020.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3833062" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3833062);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3833062" style="display: none;" >
+	<div id="textAreaDados_3833062" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O. VALOR DA CAUSA. IRRESIGNA&Ccedil;&Atilde;O APRESENTADA EM CONTRARRAZ&Otilde;ES DE APELO. DECIS&Atilde;O ANULADA PELO STJ. REJULGAMENTO. ANULA&Ccedil;&Atilde;O DE TESTAMENTO. VALOR DA CAUSA DEVE CORRESPONDER AO PROVEITO ECON&Ocirc;MICO. MONTANTE APRESENTADO EM PRIMEIRAS DECLARA&Ccedil;&Otilde;ES DE INVENT&Aacute;RIO. DECLARAT&Oacute;RIOS PARCIALMENTE PROVIDOS.
+
+1. Considerando que consta de forma expressa o provimento do recurso especial para cassar o ac&oacute;rd&atilde;o recorrido, determinando o retorno dos autos para que este Tribunal examine a quest&atilde;o referente a impugna&ccedil;&atilde;o ao valor da causa atribu&iacute;do &agrave; causa.
+2. Insta esclarecer que os artigos 292 e 293 do C&oacute;digo de Processo Civil estabelecem os crit&eacute;rios para indica&ccedil;&atilde;o do valor da causa na peti&ccedil;&atilde;o inicial nos seguintes termos:
+Art. 292. O valor da causa constar&aacute; da peti&ccedil;&atilde;o inicial ou da reconven&ccedil;&atilde;o e ser&aacute;:
+I - na a&ccedil;&atilde;o de cobran&ccedil;a de d&iacute;vida, a soma monetariamente corrigida do principal, dos juros de mora vencidos e de outras penalidades, se houver, at&eacute; a data de propositura da a&ccedil;&atilde;o;
+II - na a&ccedil;&atilde;o que tiver por objeto a exist&ecirc;ncia, a validade, o cumprimento, a modifica&ccedil;&atilde;o, a resolu&ccedil;&atilde;o, a resili&ccedil;&atilde;o ou a rescis&atilde;o de ato jur&iacute;dico, o valor do ato ou o de sua parte controvertida;
+III - na a&ccedil;&atilde;o de alimentos, a soma de 12 (doze) presta&ccedil;&otilde;es mensais pedidas pelo autor;
+IV - na a&ccedil;&atilde;o de divis&atilde;o, de demarca&ccedil;&atilde;o e de reivindica&ccedil;&atilde;o, o valor de avalia&ccedil;&atilde;o da &aacute;rea ou do bem objeto do pedido;
+V - na a&ccedil;&atilde;o indenizat&oacute;ria, inclusive a fundada em dano moral, o valor pretendido;
+VI - na a&ccedil;&atilde;o em que h&aacute; cumula&ccedil;&atilde;o de pedidos, a quantia correspondente &agrave; soma dos valores de todos eles;
+VII - na a&ccedil;&atilde;o em que os pedidos s&atilde;o alternativos, o de maior valor;
+VIII - na a&ccedil;&atilde;o em que houver pedido subsidi&aacute;rio, o valor do pedido principal.
+&sect; 1&ordm; Quando se pedirem presta&ccedil;&otilde;es vencidas e vincendas, considerar-se-&aacute; o valor de umas e outras.
+&sect; 2&ordm; O valor das presta&ccedil;&otilde;es vincendas ser&aacute; igual a uma presta&ccedil;&atilde;o anual, se a obriga&ccedil;&atilde;o for por tempo indeterminado ou por tempo superior a 1 (um) ano, e, se por tempo inferior, ser&aacute; igual &agrave; soma das presta&ccedil;&otilde;es.
+&sect; 3&ordm; O juiz corrigir&aacute;, de of&iacute;cio e por arbitramento, o valor da causa quando verificar que n&atilde;o corresponde ao conte&uacute;do patrimonial em discuss&atilde;o ou ao proveito econ&ocirc;mico perseguido pelo autor, caso em que se proceder&aacute; ao recolhimento das custas correspondentes.
+&nbsp;Art. 293. O r&eacute;u poder&aacute; impugnar, em preliminar da contesta&ccedil;&atilde;o, o valor atribu&iacute;do &agrave; causa pelo autor, sob pena de preclus&atilde;o, e o juiz decidir&aacute; a respeito, impondo, se for o caso, a complementa&ccedil;&atilde;o das custas.
+3. Observa-se, pois, da exegese dos dispositivos acima transcritos que o valor da causa, nas a&ccedil;&otilde;es de anula&ccedil;&atilde;o de testamento, como &eacute; o caso posto a exame, deve corresponder ao montante perquirido na inicial, baseado no valor l&iacute;quido do acervo patrimonial do testador.
+4. Contudo, no caso exposto, analisando de forma detida a peti&ccedil;&atilde;o inicial da demanda origin&aacute;ria, verifica-se que a recorrida indicou R$ 1.000,00 (um mil reais) como valor da causa, o que de fato n&atilde;o corresponde ao proveito econ&ocirc;mico perquirido.
+5. Dessa maneira, o valor indicado &eacute; equivocado devendo ser retificado para o quantum apresentado nas primeiras declara&ccedil;&otilde;es do invent&aacute;rio do Esp&oacute;lio de Maria N&uacute;bia Sousa Noronha, m&atilde;e da recorrida, conforme entendimento do STJ, acima indicado, motivo pelo qual fixo o valor da causa, de of&iacute;cio, em R$ 1.951.387,90 (um milh&atilde;o, novecentos e cinquenta e um mil, trezentos e oitenta e sete reais e noventa centavos), resultado da diferen&ccedil;a entre o total de bens e o total das d&iacute;vidas apresentado na planilha de fl. 145.
+6. Declarat&oacute;rios parcialmente providos.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos dos embargos de declara&ccedil;&atilde;o n&ordm; 0213826-69.2020.8.06.0001, em que figuram as partes acima indicadas, acordam os Desembargadores integrantes da 2&ordf; C&acirc;mara Direito Privado do egr&eacute;gio Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, conhecer do recurso,  para dar-lhe parcial provimento, nos termos do voto do Relator.
+
+Fortaleza, 01 de abril de 2026
+
+
+
+MARIA DE F&Aacute;TIMA DE MELO LOUREIRO
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR CARLOS ALBERTO MENDES FORTE
+Relator  <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0213826-69.2020.8.06.0001, Rel. Desembargador(a)  CARLOS ALBERTO MENDES FORTE, 2&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 01/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 07/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Nulidade e Anulação de Testamento
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> CARLOS ALBERTO MENDES FORTE
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									07/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO. VALOR DA CAUSA. IRRESIGNAÇÃO APRESENTADA EM CONTRARRAZÕES DE APELO. DECISÃO ANULADA PELO STJ. REJULGAMENTO. ANULAÇÃO DE TESTAMENTO. VALOR DA CAUSA DEVE CORRESPONDER AO PROVEITO ECONÔMICO. MONTANTE APRESENTADO EM PRIMEIRAS DECLARAÇÕES DE INVENTÁRIO. DECLARATÓRIOS PARCIALMENTE PROVIDOS.
+
+1. Considerando que consta de forma expressa o provimento do recurso
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO. VALOR DA CAUSA. IRRESIGNAÇÃO APRESENTADA EM CONTRARRAZÕES DE APELO. DECISÃO ANULADA PELO STJ. REJULGAMENTO. ANULAÇÃO DE TESTAMENTO. VALOR DA CAUSA DEVE CORRESPONDER AO PROVEITO ECONÔMICO. MONTANTE APRESENTADO EM PRIMEIRAS DECLARAÇÕES DE INVENTÁRIO. DECLARATÓRIOS PARCIALMENTE PROVIDOS.
+
+1. Considerando que consta de forma expressa o provimento do recurso especial para cassar o acórdão recorrido, determinando o retorno dos autos para que este Tribunal examine a questão referente a impugnação ao valor da causa atribuído à causa.
+2. Insta esclarecer que os artigos 292 e 293 do Código de Processo Civil estabelecem os critérios para indicação do valor da causa na petição inicial nos seguintes termos:
+Art. 292. O valor da causa constará da petição inicial ou da reconvenção e será:
+I - na ação de cobrança de dívida, a soma monetariamente corrigida do principal, dos juros de mora vencidos e de outras penalidades, se houver, até a data de propositura da ação;
+II - na ação que tiver por objeto a existência, a validade, o cumprimento, a modificação, a resolução, a resilição ou a rescisão de ato jurídico, o valor do ato ou o de sua parte controvertida;
+III - na ação de alimentos, a soma de 12 (doze) prestações mensais pedidas pelo autor;
+IV - na ação de divisão, de demarcação e de reivindicação, o valor de avaliação da área ou do bem objeto do pedido;
+V - na ação indenizatória, inclusive a fundada em <em>dano</em> <em>moral</em>, o valor pretendido;
+VI - na ação em que há cumulação de pedidos, a quantia correspondente à soma dos valores de todos eles;
+VII - na ação em que os pedidos são alternativos, o de maior valor;
+VIII - na ação em que houver pedido subsidiário, o valor do pedido principal.
+§ 1º Quando se pedirem prestações vencidas e vincendas, considerar-se-á o valor de umas e outras.
+§ 2º O valor das prestações vincendas será igual a uma prestação anual, se a obrigação for por tempo indeterminado ou por tempo superior a 1 (um) ano, e, se por tempo inferior, será igual à soma das prestações.
+§ 3º O juiz corrigirá, de ofício e por arbitramento, o valor da causa quando verificar que não corresponde ao conteúdo patrimonial em discussão ou ao proveito econômico perseguido pelo autor, caso em que se procederá ao recolhimento das custas correspondentes.
+ Art. 293. O réu poderá impugnar, em preliminar da contestação, o valor atribuído à causa pelo autor, sob pena de preclusão, e o juiz decidirá a respeito, impondo, se for o caso, a complementação das custas.
+3. Observa-se, pois, da exegese dos dispositivos acima transcritos que o valor da causa, nas ações de anulação de testamento, como é o caso posto a exame, deve corresponder ao montante perquirido na inicial, baseado no valor líquido do acervo patrimonial do testador.
+4. Contudo, no caso exposto, analisando de forma detida a petição inicial da demanda originária, verifica-se que a recorrida indicou R$ 1.000,00 (um mil reais) como valor da causa, o que de fato não corresponde ao proveito econômico perquirido.
+5. Dessa maneira, o valor indicado é equivocado devendo ser retificado para o quantum apresentado nas primeiras declarações do inventário do Espólio de Maria Núbia Sousa Noronha, mãe da recorrida, conforme entendimento do STJ, acima indicado, motivo pelo qual fixo o valor da causa, de ofício, em R$ 1.951.387,90 (um milhão, novecentos e cinquenta e um mil, trezentos e oitenta e sete reais e noventa centavos), resultado da diferença entre o total de bens e o total das dívidas apresentado na planilha de fl. 145.
+6. Declaratórios parcialmente providos.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos dos embargos de declaração nº 0213826-69.2020.8.06.0001, em que figuram as partes acima indicadas, acordam os Desembargadores integrantes da 2ª Câmara Direito Privado do egrégio Tribunal de Justiça do Estado do Ceará, por unanimidade, conhecer do recurso,  para dar-lhe parcial provimento, nos termos do voto do Relator.
+
+Fortaleza, 01 de abril de 2026
+
+
+
+MARIA DE FÁTIMA DE MELO LOUREIRO
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR CARLOS ALBERTO MENDES FORTE
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>36&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3832953" cdForo="0" >
+										0620932-10.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3832953" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3832953);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3832953" style="display: none;" >
+	<div id="textAreaDados_3832953" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. REVIS&Atilde;O CRIMINAL. art. 129, &sect; 3&ordm;, do CP. HIP&Oacute;TESES DE CABIMENTO DA REVIS&Atilde;O CRIMINAL N&Atilde;O DEMONSTRADAS. PRETENS&Atilde;O DE REEXAME DA MAT&Eacute;RIA. INADMISSIBILIDADE. S&Uacute;MULA 56 DO TJCE. MANEJO INADEQUADO DA REVISIONAL. INEXIST&Ecirc;NCIA, NA DOSIMETRIA DA PENA, DE FLAGRANTE ILEGALIDADE, DE ERRO T&Eacute;CNICO OU DE EVIDENTE INJUSTI&Ccedil;A NA APLICA&Ccedil;&Atilde;O DA REPRIMENDA. REVIS&Atilde;O CRIMINAL N&Atilde;O CONHECIDA.
+I. CASO EM EXAME.
+1. A senten&ccedil;a proferida pelo Ju&iacute;zo da 1&ordf; Vara da comarca de Quixad&aacute;/CE condenou o Requerente a 10 (dez) anos de reclus&atilde;o, em regime inicialmente fechado, por infra&ccedil;&atilde;o ao art. 129, &sect; 3&ordm;, do CP, havendo a 2&ordf; C&acirc;mara Criminal deste Tribunal, por unanimidade e sob a relatoria do, &agrave; &eacute;poca, Juiz convocado e hoje Des. Francisco Jaime Medeiros Neto, negado provimento ao recurso apelat&oacute;rio manejado pelo Requerente, ac&oacute;rd&atilde;o contra o qual o Requerente op&ocirc;s embargos de declara&ccedil;&atilde;o, havendo a 2&ordf; C&acirc;mara Criminal desta Corte, por unanimidade e sob a relatoria do Des. Benedito Helder Afonso Ibiapina, acolhido os aclarat&oacute;rios, redimensionando a pena do Requerente para 7 (sete) anos de reclus&atilde;o, em regime inicialmente fechado (a&ccedil;&atilde;o penal de n&ordm; 0023859-21.2012.8.06.0151).
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O.
+2. O Requerente postula a revis&atilde;o da dosimetria da pena, sustentando que a san&ccedil;&atilde;o deve ser fixada em 4 (quatro) anos de reclus&atilde;o, em regime inicialmente aberto.
+III. RAZ&Otilde;ES DE DECIDIR.
+3. A 2&ordf; C&acirc;mara Criminal deste Tribunal, por unanimidade e sob a relatoria do Des. Benedito Helder Afonso Ibiapina, acolheu os embargos de declara&ccedil;&atilde;o opostos pelo Requerente contra o ac&oacute;rd&atilde;o que negou provimento ao recurso apelat&oacute;rio interposto pelo Requerente (ac&oacute;rd&atilde;o de fls. 537/548 da a&ccedil;&atilde;o penal de n&ordm; 0023859-21.2012.8.06.0151 &#150; SAJSG), ocasi&atilde;o em que reexaminou a dosimetria da pena do Requerente e redimensionou a san&ccedil;&atilde;o do Requerente para 7 (sete) anos de reclus&atilde;o, em regime inicialmente fechado.
+4. Dessa forma, a fundamenta&ccedil;&atilde;o utilizada pelo Requerente n&atilde;o encontra amparo no art. 621 do CPP. Com efeito, n&atilde;o restou demonstrada nenhuma das hip&oacute;teses previstas no art. 621 do CPP, cabendo destacar que a revis&atilde;o criminal n&atilde;o constitui meio apto &agrave; reaprecia&ccedil;&atilde;o da prova dos autos, por mero inconformismo da parte Requerente, sob pena de se transformar a revisional em uma apela&ccedil;&atilde;o criminal, de tal sorte que a presente Revis&atilde;o Criminal, por ser manifestamente incab&iacute;vel, n&atilde;o deve ser conhecida, havendo este Tribunal editado, a respeito da mat&eacute;ria, a S&uacute;mula 56 (&quot;N&atilde;o se conhece de revis&atilde;o criminal com fulcro no art. 621, I, do C&oacute;digo de Processo Penal, quando esta se fundamenta em teses j&aacute; recha&ccedil;adas em recurso de apela&ccedil;&atilde;o&quot;). Ademais, n&atilde;o se desconhece que a doutrina e a jurisprud&ecirc;ncia passaram a admitir, em car&aacute;ter excepcional e diante das particularidades do caso concreto, a revis&atilde;o criminal para fins de altera&ccedil;&atilde;o da dosimetria da pena transitada em julgado, mas somente quando comprovada a exist&ecirc;ncia de flagrante ilegalidade, erro t&eacute;cnico ou evidente injusti&ccedil;a na aplica&ccedil;&atilde;o da reprimenda, circunst&acirc;ncias que caracterizam, ainda que indiretamente, viola&ccedil;&atilde;o ao texto da lei, n&atilde;o se verificando nenhuma dessas hip&oacute;teses nos autos da a&ccedil;&atilde;o penal de n&ordm; 0023859-21.2012.8.06.0151, importando ressaltar, ainda, que a revis&atilde;o criminal n&atilde;o pode ser usada como instrumento para se adotar a corrente doutrin&aacute;ria ou jurisprudencial mais favor&aacute;vel ao condenado. Assim sendo, a presente Revis&atilde;o Criminal, por ser manifestamente incab&iacute;vel, n&atilde;o deve ser conhecida.
+IV. DISPOSITIVO E TESE.
+5. Revis&atilde;o Criminal n&atilde;o conhecida.
+
+______________
+
+Dispositivos relevantes citados: art. 621 do CPP; art. 66, I, da Lei 7.210/1984 (Lei de Execu&ccedil;&atilde;o Penal).
+
+Jurisprud&ecirc;ncia relevante citada: S&uacute;mula 611 do STF (&quot;Transitada em julgado a senten&ccedil;a condenat&oacute;ria, compete ao ju&iacute;zo das execu&ccedil;&otilde;es a aplica&ccedil;&atilde;o de lei mais benigna&quot;); STJ, AgRg no AREsp 2759668/SP, Rel. Min. Reynaldo Soares da Fonseca, 5&ordf; Turma, julgamento em 03.12.2024, DJEN 09.12.2024; STJ, AgRg no REsp 1985567/RS, Rel. Min. Joel Ilan Paciornik, 5&ordf; Turma, julgamento em 19.06.2023, DJe 22.06.2023; STJ, AgRg no HC 707839/RS, Rel. Min. Messod Azulay Neto, 5&ordf; Turma, julgamento em 24.04.2023, DJe 28.04.2023; STJ, AgRg no REsp 2043108/DF, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, 6&ordf; Turma, julgamento em 17.04.2023, DJe 20.04.2023; S&uacute;mula 56 do TJCE (&quot;N&atilde;o se conhece de revis&atilde;o criminal com fulcro no art. 621, I, do C&oacute;digo de Processo Penal, quando esta se fundamenta em teses j&aacute; recha&ccedil;adas em recurso de apela&ccedil;&atilde;o&quot;).
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a Se&ccedil;&atilde;o Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute; em n&atilde;o conhecer da Revis&atilde;o Criminal, nos termos do voto do Relator.
+
+Fortaleza, 06 de abril de 2026.
+
+
+DESEMBARGADOR HENRIQUE JORGE HOLANDA SILVEIRA
+Relator
+
+  <br><br>(Revis&atilde;o Criminal&nbsp;-  0620932-10.2026.8.06.0000, Rel. Desembargador(a)  HENRIQUE JORGE HOLANDA SILVEIRA, Se&ccedil;&atilde;o Criminal, data do julgamento:&nbsp; 06/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 06/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Revisão Criminal / Seguida de Morte
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> HENRIQUE JORGE HOLANDA SILVEIRA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Quixadá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									06/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									06/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. REVISÃO CRIMINAL. art. 129, § 3º, do CP. HIPÓTESES DE CABIMENTO DA REVISÃO CRIMINAL NÃO DEMONSTRADAS. PRETENSÃO DE REEXAME DA MATÉRIA. INADMISSIBILIDADE. SÚMULA 56 DO TJCE. MANEJO INADEQUADO DA REVISIONAL. INEXISTÊNCIA, NA DOSIMETRIA DA PENA, DE FLAGRANTE ILEGALIDADE, DE ERRO TÉCNICO OU DE EVIDENTE INJUSTIÇA NA APLICAÇÃO DA REPRIMENDA. REVISÃO CRIMINAL NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. REVISÃO CRIMINAL. art. 129, § 3º, do CP. HIPÓTESES DE CABIMENTO DA REVISÃO CRIMINAL NÃO DEMONSTRADAS. PRETENSÃO DE REEXAME DA MATÉRIA. INADMISSIBILIDADE. SÚMULA 56 DO TJCE. MANEJO INADEQUADO DA REVISIONAL. INEXISTÊNCIA, NA DOSIMETRIA DA PENA, DE FLAGRANTE ILEGALIDADE, DE ERRO TÉCNICO OU DE EVIDENTE INJUSTIÇA NA APLICAÇÃO DA REPRIMENDA. REVISÃO CRIMINAL NÃO CONHECIDA.
+I. CASO EM EXAME.
+1. A sentença proferida pelo Juízo da 1ª Vara da comarca de Quixadá/CE condenou o Requerente a 10 (dez) anos de reclusão, em regime inicialmente fechado, por infração ao art. 129, § 3º, do CP, havendo a 2ª Câmara Criminal deste Tribunal, por unanimidade e sob a relatoria do, à época, Juiz convocado e hoje Des. Francisco Jaime Medeiros Neto, negado provimento ao recurso apelatório manejado pelo Requerente, acórdão contra o qual o Requerente opôs embargos de declaração, havendo a 2ª Câmara Criminal desta Corte, por unanimidade e sob a relatoria do Des. Benedito Helder Afonso Ibiapina, acolhido os aclaratórios, redimensionando a pena do Requerente para 7 (sete) anos de reclusão, em regime inicialmente fechado (ação penal de nº 0023859-21.2012.8.06.0151).
+II. QUESTÃO EM DISCUSSÃO.
+2. O Requerente postula a revisão da dosimetria da pena, sustentando que a sanção deve ser fixada em 4 (quatro) anos de reclusão, em regime inicialmente aberto.
+III. RAZÕES DE DECIDIR.
+3. A 2ª Câmara Criminal deste Tribunal, por unanimidade e sob a relatoria do Des. Benedito Helder Afonso Ibiapina, acolheu os embargos de declaração opostos pelo Requerente contra o acórdão que negou provimento ao recurso apelatório interposto pelo Requerente (acórdão de fls. 537/548 da ação penal de nº 0023859-21.2012.8.06.0151  SAJSG), ocasião em que reexaminou a dosimetria da pena do Requerente e redimensionou a sanção do Requerente para 7 (sete) anos de reclusão, em regime inicialmente fechado.
+4. Dessa forma, a fundamentação utilizada pelo Requerente não encontra amparo no art. 621 do CPP. Com efeito, não restou demonstrada nenhuma das hipóteses previstas no art. 621 do CPP, cabendo destacar que a revisão criminal não constitui meio apto à reapreciação da prova dos autos, por mero inconformismo da parte Requerente, sob pena de se transformar a revisional em uma apelação criminal, de tal sorte que a presente Revisão Criminal, por ser manifestamente incabível, não deve ser conhecida, havendo este Tribunal editado, a respeito da matéria, a Súmula 56 ("Não se conhece de revisão criminal com fulcro no art. 621, I, do Código de Processo Penal, quando esta se fundamenta em teses já rechaçadas em recurso de apelação"). Ademais, não se desconhece que a doutrina e a jurisprudência passaram a admitir, em caráter excepcional e diante das particularidades do caso concreto, a revisão criminal para fins de alteração da dosimetria da pena transitada em julgado, mas somente quando comprovada a existência de flagrante ilegalidade, erro técnico ou evidente injustiça na aplicação da reprimenda, circunstâncias que caracterizam, ainda que indiretamente, violação ao texto da lei, não se verificando nenhuma dessas hipóteses nos autos da ação penal de nº 0023859-21.2012.8.06.0151, importando ressaltar, ainda, que a revisão criminal não pode ser usada como instrumento para se adotar a corrente doutrinária ou jurisprudencial mais favorável ao condenado. Assim sendo, a presente Revisão Criminal, por ser manifestamente incabível, não deve ser conhecida.
+IV. DISPOSITIVO E TESE.
+5. Revisão Criminal não conhecida.
+
+______________
+
+Dispositivos relevantes citados: art. 621 do CPP; art. 66, I, da Lei 7.210/1984 (Lei de Execução Penal).
+
+Jurisprudência relevante citada: Súmula 611 do STF ("Transitada em julgado a sentença condenatória, compete ao juízo das execuções a aplicação de lei mais benigna"); STJ, AgRg no AREsp 2759668/SP, Rel. Min. Reynaldo Soares da Fonseca, 5ª Turma, julgamento em 03.12.2024, DJEN 09.12.2024; STJ, AgRg no REsp 1985567/RS, Rel. Min. Joel Ilan Paciornik, 5ª Turma, julgamento em 19.06.2023, DJe 22.06.2023; STJ, AgRg no HC 707839/RS, Rel. Min. Messod Azulay Neto, 5ª Turma, julgamento em 24.04.2023, DJe 28.04.2023; STJ, AgRg no REsp 2043108/DF, Rel. Min. Sebastião Reis Júnior, 6ª Turma, julgamento em 17.04.2023, DJe 20.04.2023; Súmula 56 do TJCE ("Não se conhece de revisão criminal com fulcro no art. 621, I, do Código de Processo Penal, quando esta se fundamenta em teses já rechaçadas em recurso de apelação").
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a Seção Criminal do Tribunal de Justiça do Estado do Ceará em não conhecer da Revisão Criminal, nos termos do voto do Relator.
+
+Fortaleza, 06 de abril de 2026.
+
+
+DESEMBARGADOR HENRIQUE JORGE HOLANDA SILVEIRA
+Relator
+
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>37&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3832952" cdForo="0" >
+										0620688-81.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3832952" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3832952);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3832952" style="display: none;" >
+	<div id="textAreaDados_3832952" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. REVIS&Atilde;O CRIMINAL. art. 157, &sect; 3&ordm;, do CP. HIP&Oacute;TESES DE CABIMENTO DA REVIS&Atilde;O CRIMINAL N&Atilde;O DEMONSTRADAS. PRETENS&Atilde;O DE REEXAME DA MAT&Eacute;RIA. INADMISSIBILIDADE. S&Uacute;MULA 56 DO TJCE. MANEJO INADEQUADO DA REVISIONAL. INEXIST&Ecirc;NCIA, NA DOSIMETRIA DA PENA, DE FLAGRANTE ILEGALIDADE, DE ERRO T&Eacute;CNICO OU DE EVIDENTE INJUSTI&Ccedil;A NA APLICA&Ccedil;&Atilde;O DA REPRIMENDA. REVIS&Atilde;O CRIMINAL N&Atilde;O CONHECIDA.
+I. CASO EM EXAME.
+1. A senten&ccedil;a proferida pelo Ju&iacute;zo da 2&ordf; Vara Criminal da comarca de Caucaia/CE condenou o Requerente a 25 (vinte e cinco) anos de reclus&atilde;o e 250 (duzentos e cinquenta) dias-multa, em regime inicialmente fechado, por infra&ccedil;&atilde;o ao art. 157, &sect; 3&ordm;, do CP, havendo a 1&ordf; C&acirc;mara Criminal deste Tribunal, por unanimidade e sob a relatoria da Desa. S&iacute;lvia Soares de S&aacute; N&oacute;brega, dado parcial provimento ao recurso apelat&oacute;rio manejado pelo Requerente, redimensionando a pena do Requerente para 18 (dezoito) anos e 9 (nove) meses de reclus&atilde;o e 96 (noventa e seis) dias-multa, ac&oacute;rd&atilde;o contra o qual o Requerente op&ocirc;s embargos de declara&ccedil;&atilde;o, havendo a 1&ordf; C&acirc;mara Criminal desta Corte, por unanimidade e sob a relatoria da Desa. S&iacute;lvia Soares de S&aacute; N&oacute;brega, rejeitado os aclarat&oacute;rios opostos pelo Requerente, com o posterior tr&acirc;nsito em julgado (a&ccedil;&atilde;o penal de n&ordm; 0006308-76.2004.8.06.0064).
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O.
+2. O Requerente postula a revis&atilde;o da dosimetria da pena, aplicando-se, na segunda fase da dosimetria da pena, a circunst&acirc;ncia atenuante da menoridade relativa (art. 65, I, do CP).
+III. RAZ&Otilde;ES DE DECIDIR.
+3. A 1&ordf; C&acirc;mara Criminal deste Tribunal, por unanimidade e sob a relatoria da Desa. S&iacute;lvia Soares de S&aacute; N&oacute;brega, julgando o recurso apelat&oacute;rio interposto pelo Requerente (ac&oacute;rd&atilde;o de fls. 638/655 da a&ccedil;&atilde;o penal de n&ordm; 0006308-76.2004.8.06.0064 &#150; SAJSG), reexaminou a dosimetria da pena do Requerente e redimensionou a san&ccedil;&atilde;o do Requerente para 18 (dezoito) anos e 9 (nove) meses de reclus&atilde;o e 96 (noventa e seis) dias-multa, ocasi&atilde;o em que aplicou, em favor do Requerente, na segunda fase da dosimetria da pena, a circunst&acirc;ncia atenuante da menoridade relativa (art. 65, I, do CP).
+4. Dessa forma, a fundamenta&ccedil;&atilde;o utilizada pelo Requerente n&atilde;o encontra amparo no art. 621 do CPP. Com efeito, n&atilde;o restou demonstrada nenhuma das hip&oacute;teses previstas no art. 621 do CPP, cabendo destacar que a revis&atilde;o criminal n&atilde;o constitui meio apto &agrave; reaprecia&ccedil;&atilde;o da prova dos autos, por mero inconformismo da parte Requerente, sob pena de se transformar a revisional em uma apela&ccedil;&atilde;o criminal, de tal sorte que a presente Revis&atilde;o Criminal, por ser manifestamente incab&iacute;vel, n&atilde;o deve ser conhecida, havendo este Tribunal editado, a respeito da mat&eacute;ria, a S&uacute;mula 56 (&quot;N&atilde;o se conhece de revis&atilde;o criminal com fulcro no art. 621, I, do C&oacute;digo de Processo Penal, quando esta se fundamenta em teses j&aacute; recha&ccedil;adas em recurso de apela&ccedil;&atilde;o&quot;). Ademais, n&atilde;o se desconhece que a doutrina e a jurisprud&ecirc;ncia passaram a admitir, em car&aacute;ter excepcional e diante das particularidades do caso concreto, a revis&atilde;o criminal para fins de altera&ccedil;&atilde;o da dosimetria da pena transitada em julgado, mas somente quando comprovada a exist&ecirc;ncia de flagrante ilegalidade, erro t&eacute;cnico ou evidente injusti&ccedil;a na aplica&ccedil;&atilde;o da reprimenda, circunst&acirc;ncias que caracterizam, ainda que indiretamente, viola&ccedil;&atilde;o ao texto da lei, n&atilde;o se verificando nenhuma dessas hip&oacute;teses nos autos da a&ccedil;&atilde;o penal de n&ordm; 0006308-76.2004.8.06.0064, importando ressaltar, ainda, que a revis&atilde;o criminal n&atilde;o pode ser usada como instrumento para se adotar a corrente doutrin&aacute;ria ou jurisprudencial mais favor&aacute;vel ao condenado. Assim sendo, a presente Revis&atilde;o Criminal, por ser manifestamente incab&iacute;vel, n&atilde;o deve ser conhecida.
+IV. DISPOSITIVO E TESE.
+5. Revis&atilde;o Criminal n&atilde;o conhecida.
+
+______________
+
+Dispositivos relevantes citados: art. 621 do CPP; art. 66, I, da Lei 7.210/1984 (Lei de Execu&ccedil;&atilde;o Penal).
+
+Jurisprud&ecirc;ncia relevante citada: S&uacute;mula 611 do STF (&quot;Transitada em julgado a senten&ccedil;a condenat&oacute;ria, compete ao ju&iacute;zo das execu&ccedil;&otilde;es a aplica&ccedil;&atilde;o de lei mais benigna&quot;); STJ, AgRg no AREsp 2759668/SP, Rel. Min. Reynaldo Soares da Fonseca, 5&ordf; Turma, julgamento em 03.12.2024, DJEN 09.12.2024; STJ, AgRg no REsp 1985567/RS, Rel. Min. Joel Ilan Paciornik, 5&ordf; Turma, julgamento em 19.06.2023, DJe 22.06.2023; STJ, AgRg no HC 707839/RS, Rel. Min. Messod Azulay Neto, 5&ordf; Turma, julgamento em 24.04.2023, DJe 28.04.2023; STJ, AgRg no REsp 2043108/DF, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, 6&ordf; Turma, julgamento em 17.04.2023, DJe 20.04.2023; S&uacute;mula 56 do TJCE (&quot;N&atilde;o se conhece de revis&atilde;o criminal com fulcro no art. 621, I, do C&oacute;digo de Processo Penal, quando esta se fundamenta em teses j&aacute; recha&ccedil;adas em recurso de apela&ccedil;&atilde;o&quot;).
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a Se&ccedil;&atilde;o Criminal do Tribunal de Justi&ccedil;a do Estado do Cear&aacute; em n&atilde;o conhecer da Revis&atilde;o Criminal, nos termos do voto do Relator.
+
+Fortaleza, 06 de abril de 2026.
+
+
+DESEMBARGADOR HENRIQUE JORGE HOLANDA SILVEIRA
+Relator
+
+  <br><br>(Revis&atilde;o Criminal&nbsp;-  0620688-81.2026.8.06.0000, Rel. Desembargador(a)  HENRIQUE JORGE HOLANDA SILVEIRA, Se&ccedil;&atilde;o Criminal, data do julgamento:&nbsp; 06/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 06/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Revisão Criminal / Latrocínio
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> HENRIQUE JORGE HOLANDA SILVEIRA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Caucaia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									Seção Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									06/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									06/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. REVISÃO CRIMINAL. art. 157, § 3º, do CP. HIPÓTESES DE CABIMENTO DA REVISÃO CRIMINAL NÃO DEMONSTRADAS. PRETENSÃO DE REEXAME DA MATÉRIA. INADMISSIBILIDADE. SÚMULA 56 DO TJCE. MANEJO INADEQUADO DA REVISIONAL. INEXISTÊNCIA, NA DOSIMETRIA DA PENA, DE FLAGRANTE ILEGALIDADE, DE ERRO TÉCNICO OU DE EVIDENTE INJUSTIÇA NA APLICAÇÃO DA REPRIMENDA. REVISÃO CRIMINAL NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. REVISÃO CRIMINAL. art. 157, § 3º, do CP. HIPÓTESES DE CABIMENTO DA REVISÃO CRIMINAL NÃO DEMONSTRADAS. PRETENSÃO DE REEXAME DA MATÉRIA. INADMISSIBILIDADE. SÚMULA 56 DO TJCE. MANEJO INADEQUADO DA REVISIONAL. INEXISTÊNCIA, NA DOSIMETRIA DA PENA, DE FLAGRANTE ILEGALIDADE, DE ERRO TÉCNICO OU DE EVIDENTE INJUSTIÇA NA APLICAÇÃO DA REPRIMENDA. REVISÃO CRIMINAL NÃO CONHECIDA.
+I. CASO EM EXAME.
+1. A sentença proferida pelo Juízo da 2ª Vara Criminal da comarca de Caucaia/CE condenou o Requerente a 25 (vinte e cinco) anos de reclusão e 250 (duzentos e cinquenta) dias-multa, em regime inicialmente fechado, por infração ao art. 157, § 3º, do CP, havendo a 1ª Câmara Criminal deste Tribunal, por unanimidade e sob a relatoria da Desa. Sílvia Soares de Sá Nóbrega, dado parcial provimento ao recurso apelatório manejado pelo Requerente, redimensionando a pena do Requerente para 18 (dezoito) anos e 9 (nove) meses de reclusão e 96 (noventa e seis) dias-multa, acórdão contra o qual o Requerente opôs embargos de declaração, havendo a 1ª Câmara Criminal desta Corte, por unanimidade e sob a relatoria da Desa. Sílvia Soares de Sá Nóbrega, rejeitado os aclaratórios opostos pelo Requerente, com o posterior trânsito em julgado (ação penal de nº 0006308-76.2004.8.06.0064).
+II. QUESTÃO EM DISCUSSÃO.
+2. O Requerente postula a revisão da dosimetria da pena, aplicando-se, na segunda fase da dosimetria da pena, a circunstância atenuante da menoridade relativa (art. 65, I, do CP).
+III. RAZÕES DE DECIDIR.
+3. A 1ª Câmara Criminal deste Tribunal, por unanimidade e sob a relatoria da Desa. Sílvia Soares de Sá Nóbrega, julgando o recurso apelatório interposto pelo Requerente (acórdão de fls. 638/655 da ação penal de nº 0006308-76.2004.8.06.0064  SAJSG), reexaminou a dosimetria da pena do Requerente e redimensionou a sanção do Requerente para 18 (dezoito) anos e 9 (nove) meses de reclusão e 96 (noventa e seis) dias-multa, ocasião em que aplicou, em favor do Requerente, na segunda fase da dosimetria da pena, a circunstância atenuante da menoridade relativa (art. 65, I, do CP).
+4. Dessa forma, a fundamentação utilizada pelo Requerente não encontra amparo no art. 621 do CPP. Com efeito, não restou demonstrada nenhuma das hipóteses previstas no art. 621 do CPP, cabendo destacar que a revisão criminal não constitui meio apto à reapreciação da prova dos autos, por mero inconformismo da parte Requerente, sob pena de se transformar a revisional em uma apelação criminal, de tal sorte que a presente Revisão Criminal, por ser manifestamente incabível, não deve ser conhecida, havendo este Tribunal editado, a respeito da matéria, a Súmula 56 ("Não se conhece de revisão criminal com fulcro no art. 621, I, do Código de Processo Penal, quando esta se fundamenta em teses já rechaçadas em recurso de apelação"). Ademais, não se desconhece que a doutrina e a jurisprudência passaram a admitir, em caráter excepcional e diante das particularidades do caso concreto, a revisão criminal para fins de alteração da dosimetria da pena transitada em julgado, mas somente quando comprovada a existência de flagrante ilegalidade, erro técnico ou evidente injustiça na aplicação da reprimenda, circunstâncias que caracterizam, ainda que indiretamente, violação ao texto da lei, não se verificando nenhuma dessas hipóteses nos autos da ação penal de nº 0006308-76.2004.8.06.0064, importando ressaltar, ainda, que a revisão criminal não pode ser usada como instrumento para se adotar a corrente doutrinária ou jurisprudencial mais favorável ao condenado. Assim sendo, a presente Revisão Criminal, por ser manifestamente incabível, não deve ser conhecida.
+IV. DISPOSITIVO E TESE.
+5. Revisão Criminal não conhecida.
+
+______________
+
+Dispositivos relevantes citados: art. 621 do CPP; art. 66, I, da Lei 7.210/1984 (Lei de Execução Penal).
+
+Jurisprudência relevante citada: Súmula 611 do STF ("Transitada em julgado a sentença condenatória, compete ao juízo das execuções a aplicação de lei mais benigna"); STJ, AgRg no AREsp 2759668/SP, Rel. Min. Reynaldo Soares da Fonseca, 5ª Turma, julgamento em 03.12.2024, DJEN 09.12.2024; STJ, AgRg no REsp 1985567/RS, Rel. Min. Joel Ilan Paciornik, 5ª Turma, julgamento em 19.06.2023, DJe 22.06.2023; STJ, AgRg no HC 707839/RS, Rel. Min. Messod Azulay Neto, 5ª Turma, julgamento em 24.04.2023, DJe 28.04.2023; STJ, AgRg no REsp 2043108/DF, Rel. Min. Sebastião Reis Júnior, 6ª Turma, julgamento em 17.04.2023, DJe 20.04.2023; Súmula 56 do TJCE ("Não se conhece de revisão criminal com fulcro no art. 621, I, do Código de Processo Penal, quando esta se fundamenta em teses já rechaçadas em recurso de apelação").
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a Seção Criminal do Tribunal de Justiça do Estado do Ceará em não conhecer da Revisão Criminal, nos termos do voto do Relator.
+
+Fortaleza, 06 de abril de 2026.
+
+
+DESEMBARGADOR HENRIQUE JORGE HOLANDA SILVEIRA
+Relator
+
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>38&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3832724" cdForo="0" >
+										0208312-93.2024.8.06.0293
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3832724" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3832724);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3832724" style="display: none;" >
+	<div id="textAreaDados_3832724" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. TR&Aacute;FICO DE DROGAS. BUSCA DOMICILIAR. DEN&Uacute;NCIA AN&Ocirc;NIMA SOMADA A CONFISS&Atilde;O E CONSENTIMENTO. FUNDADAS RAZ&Otilde;ES. LICITUDE DA PROVA. DESCLASSIFICA&Ccedil;&Atilde;O PARA USO PESSOAL. IMPOSSIBILIDADE. TR&Aacute;FICO PRIVILEGIADO. CABIMENTO. REDIMENSIONAMENTO DA PENA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apela&ccedil;&atilde;o criminal interposta por Rodrigo Rangel Cardoso contra senten&ccedil;a proferida pelo Ju&iacute;zo da 4&ordf; Vara Criminal da Comarca de Caucaia que o condenou pela pr&aacute;tica do crime previsto no art. 33 da Lei n&ordm; 11.343/2006, fixando a pena em 6 anos e 3 meses de reclus&atilde;o, em regime inicial semiaberto, e 625 dias-multa. A defesa suscita nulidade da busca domiciliar por viola&ccedil;&atilde;o ao art. 5&ordm;, XI, da CF/1988, pleiteia a desclassifica&ccedil;&atilde;o para o art. 28 da Lei de Drogas e, subsidiariamente, o reconhecimento da causa especial de diminui&ccedil;&atilde;o do &sect;4&ordm; do art. 33.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se o ingresso policial no domic&iacute;lio do r&eacute;u, sem mandado judicial, foi l&iacute;cito diante de den&uacute;ncia an&ocirc;nima e alegado consentimento; (ii) estabelecer se o conjunto probat&oacute;rio &eacute; suficiente para manter a condena&ccedil;&atilde;o por tr&aacute;fico, afastando a desclassifica&ccedil;&atilde;o para uso pessoal; e (iii) determinar se est&atilde;o presentes os requisitos para aplica&ccedil;&atilde;o da causa de diminui&ccedil;&atilde;o prevista no art. 33, &sect;4&ordm;, da Lei n&ordm; 11.343/2006, com redimensionamento da pena.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O ingresso em domic&iacute;lio sem mandado judicial &eacute; l&iacute;cito quando amparado em fundadas raz&otilde;es que indiquem situa&ccedil;&atilde;o de flagrante delito, nos termos do Tema 280 da repercuss&atilde;o geral do STF (RE 603.616/RO).
+4. A den&uacute;ncia an&ocirc;nima, aliada &agrave; abordagem do acusado na frente da resid&ecirc;ncia e &agrave; sua admiss&atilde;o de que havia droga no interior do im&oacute;vel, seguida de autoriza&ccedil;&atilde;o para ingresso, constitui substrato objetivo suficiente para legitimar a dilig&ecirc;ncia.
+5. O pr&oacute;prio r&eacute;u, na audi&ecirc;ncia de cust&oacute;dia, afirmou ter autorizado a entrada dos policiais e indicado a exist&ecirc;ncia de 80 pinos de coca&iacute;na, vers&atilde;o posteriormente alterada apenas em ju&iacute;zo, o que fragiliza a alega&ccedil;&atilde;o de coa&ccedil;&atilde;o.
+6. O crime de tr&aacute;fico, nas modalidades de guardar ou ter em dep&oacute;sito, possui natureza permanente, o que autoriza o ingresso domiciliar diante de situa&ccedil;&atilde;o de flagr&acirc;ncia, conforme precedentes do STJ.
+
+7. A apreens&atilde;o de 84 pinos de coca&iacute;na (64g), balan&ccedil;a de precis&atilde;o e material para embalagem evidencia aparato t&iacute;pico de mercancia, afastando a tese de posse para consumo pr&oacute;prio.
+8. A forma de fracionamento e acondicionamento da droga constitui elemento relevante para caracterizar o tr&aacute;fico, n&atilde;o sendo a condi&ccedil;&atilde;o de eventual usu&aacute;rio suficiente para descaracterizar a trafic&acirc;ncia.
+
+9. A exist&ecirc;ncia de a&ccedil;&atilde;o penal em curso, sem tr&acirc;nsito em julgado, n&atilde;o autoriza o afastamento autom&aacute;tico do tr&aacute;fico privilegiado, sob pena de viola&ccedil;&atilde;o ao princ&iacute;pio da presun&ccedil;&atilde;o de inoc&ecirc;ncia, conforme precedentes do STJ.
+10. Presentes a primariedade e a aus&ecirc;ncia de elementos concretos que demonstrem dedica&ccedil;&atilde;o a atividades criminosas ou integra&ccedil;&atilde;o a organiza&ccedil;&atilde;o criminosa, &eacute; cab&iacute;vel a incid&ecirc;ncia da minorante do art. 33, &sect;4&ordm;, da Lei n&ordm; 11.343/2006.
+11. Reconhecido o tr&aacute;fico privilegiado e inexistindo vetores negativos na primeira fase, imp&otilde;e-se a fixa&ccedil;&atilde;o do regime inicial aberto.
+IV. DISPOSITIVO
+12. Recurso conhecido e parcialmente provido.  <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0208312-93.2024.8.06.0293, Rel. Desembargador(a)  MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 01/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 01/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIA ILNA LIMA DE CASTRO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Caucaia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									01/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. BUSCA DOMICILIAR. DENÚNCIA ANÔNIMA SOMADA A CONFISSÃO E CONSENTIMENTO. FUNDADAS RAZÕES. LICITUDE DA PROVA. DESCLASSIFICAÇÃO PARA USO PESSOAL. IMPOSSIBILIDADE. TRÁFICO PRIVILEGIADO. CABIMENTO. REDIMENSIONAMENTO DA PENA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apelação criminal interposta
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. TRÁFICO DE DROGAS. BUSCA DOMICILIAR. DENÚNCIA ANÔNIMA SOMADA A CONFISSÃO E CONSENTIMENTO. FUNDADAS RAZÕES. LICITUDE DA PROVA. DESCLASSIFICAÇÃO PARA USO PESSOAL. IMPOSSIBILIDADE. TRÁFICO PRIVILEGIADO. CABIMENTO. REDIMENSIONAMENTO DA PENA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Trata-se de Apelação criminal interposta por Rodrigo Rangel Cardoso contra sentença proferida pelo Juízo da 4ª Vara Criminal da Comarca de Caucaia que o condenou pela prática do crime previsto no art. 33 da Lei nº 11.343/2006, fixando a pena em 6 anos e 3 meses de reclusão, em regime inicial semiaberto, e 625 dias-multa. A defesa suscita nulidade da busca domiciliar por violação ao art. 5º, XI, da CF/1988, pleiteia a desclassificação para o art. 28 da Lei de Drogas e, subsidiariamente, o reconhecimento da causa especial de diminuição do §4º do art. 33.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se o ingresso policial no domicílio do réu, sem mandado judicial, foi lícito diante de denúncia anônima e alegado consentimento; (ii) estabelecer se o conjunto probatório é suficiente para manter a condenação por tráfico, afastando a desclassificação para uso pessoal; e (iii) determinar se estão presentes os requisitos para aplicação da causa de diminuição prevista no art. 33, §4º, da Lei nº 11.343/2006, com redimensionamento da pena.
+III. RAZÕES DE DECIDIR
+3. O ingresso em domicílio sem mandado judicial é lícito quando amparado em fundadas razões que indiquem situação de flagrante delito, nos termos do Tema 280 da repercussão geral do STF (RE 603.616/RO).
+4. A denúncia anônima, aliada à abordagem do acusado na frente da residência e à sua admissão de que havia droga no interior do imóvel, seguida de autorização para ingresso, constitui substrato objetivo suficiente para legitimar a diligência.
+5. O próprio réu, na audiência de custódia, afirmou ter autorizado a entrada dos policiais e indicado a existência de 80 pinos de cocaína, versão posteriormente alterada apenas em juízo, o que fragiliza a alegação de coação.
+6. O crime de tráfico, nas modalidades de guardar ou ter em depósito, possui natureza permanente, o que autoriza o ingresso domiciliar diante de situação de flagrância, conforme precedentes do STJ.
+
+7. A apreensão de 84 pinos de cocaína (64g), balança de precisão e material para embalagem evidencia aparato típico de mercancia, afastando a tese de posse para consumo próprio.
+8. A forma de fracionamento e acondicionamento da droga constitui elemento relevante para caracterizar o tráfico, não sendo a condição de eventual usuário suficiente para descaracterizar a traficância.
+
+9. A existência de ação penal em curso, sem trânsito em julgado, não autoriza o afastamento automático do tráfico privilegiado, sob pena de violação ao princípio da presunção de inocência, conforme precedentes do STJ.
+10. Presentes a primariedade e a ausência de elementos concretos que demonstrem dedicação a atividades criminosas ou integração a organização criminosa, é cabível a incidência da minorante do art. 33, §4º, da Lei nº 11.343/2006.
+11. Reconhecido o tráfico privilegiado e inexistindo vetores negativos na primeira fase, impõe-se a fixação do regime inicial aberto.
+IV. DISPOSITIVO
+12. Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>39&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3832886" cdForo="0" >
+										0201107-57.2022.8.06.0301
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3832886" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3832886);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3832886" style="display: none;" >
+	<div id="textAreaDados_3832886" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. RECURSO DE APELA&Ccedil;&Atilde;O. IRRESIGNA&Ccedil;&Atilde;O DA DEFESA. ESTATUTO DO IDOSO. CRIME DE EXPOSI&Ccedil;&Atilde;O A PERIGO DA INTEGRIDADE F&Iacute;SICA E PS&Iacute;QUICA DO IDOSO (LEI N&ordm; 10.741/2003, ART. 99, CAPUT). CRIME DE APROPRIA&Ccedil;&Atilde;O/DESVIO DE BENS OU RENDIMENTOS (LEI N&ordm; 10.741/2003, ART. 102). PEDIDO DE ABSOLVI&Ccedil;&Atilde;O POR AUS&Ecirc;NCIA DE DOLO E INSUFICI&Ecirc;NCIA PROBAT&Oacute;RIA. REJEI&Ccedil;&Atilde;O. R&Eacute; QUE MANTINHA A M&Atilde;E, DE 88 ANOS, EM SITUA&Ccedil;&Atilde;O DE ABANDONO, SEM ALIMENTA&Ccedil;&Atilde;O ADEQUADA, HIGIENE E VIGIL&Acirc;NCIA. RELAT&Oacute;RIO SOCIAL E DEPOIMENTOS CONFIRMAM VULNERABILIDADE, RISCO E DESVIO DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. MATERIALIDADE E AUTORIA COMPROVADAS. ALEGADA AUS&Ecirc;NCIA DE DOLO AFASTADA. PROVA DOCUMENTAL E TESTEMUNHAL ROBUSTA. CONDUTA QUE EXTRAPOLA A MERA PRECARIEDADE FINANCEIRA. MANUTEN&Ccedil;&Atilde;O DA CONDENA&Ccedil;&Atilde;O. PEDIDO DE REFORMA DA DOSIMETRIA. PLEITO DE EXCLUS&Atilde;O DE AGRAVANTES (ART. 61, II, &quot;E&quot;, &quot;F&quot; E &quot;G&quot;, CP). ALEGA&Ccedil;&Atilde;O DE BIS IN IDEM. DESCABIMENTO. FUNDAMENTOS AUT&Ocirc;NOMOS. RECURSO CONHECIDO E DESPROVIDO.
+
+I. CASO EM EXAME
+
+1. Apela&ccedil;&atilde;o Criminal interposta por Josefa Maria da Concei&ccedil;&atilde;o Costa contra senten&ccedil;a que a condenou &agrave;s penas dos arts. 99 e 102 da Lei n&ordm; 10.741/2003 (Estatuto do Idoso). A acusada, na condi&ccedil;&atilde;o de curadora da pr&oacute;pria genitora (88 anos), exp&ocirc;s a sa&uacute;de da idosa a perigo em ambiente insalubre e sem assist&ecirc;ncia, al&eacute;m de desviar seus proventos previdenci&aacute;rios para finalidades diversas. A defesa pleiteia a absolvi&ccedil;&atilde;o por falta de provas e aus&ecirc;ncia de dolo, ou, subsidiariamente, o afastamento de agravantes na dosimetria.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) saber se o conjunto probat&oacute;rio &eacute; suficiente para demonstrar o dolo e a autoria dos crimes de exposi&ccedil;&atilde;o a perigo e desvio de rendimentos da idosa; e (ii) saber se a aplica&ccedil;&atilde;o cumulativa das agravantes do art. 61, II, al&iacute;neas &quot;e&quot; (parentesco), &quot;f&quot; (rela&ccedil;&otilde;es dom&eacute;sticas) e &quot;g&quot; (abuso de autoridade/m&uacute;nus de curadora) configura bis in idem.
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+3. A materialidade e a autoria delitivas restaram comprovadas pelo laudo social e depoimentos testemunhais que descreveram cen&aacute;rio de extrema vulnerabilidade, com a idosa trancada sozinha, em condi&ccedil;&otilde;es de higiene f&eacute;tidas e alimenta&ccedil;&atilde;o prec&aacute;ria, enquanto a r&eacute; se ausentava da cidade ap&oacute;s sacar o benef&iacute;cio previdenci&aacute;rio da v&iacute;tima.
+
+4. O dolo direto &eacute; evidenciado pelo abandono deliberado e pela utiliza&ccedil;&atilde;o dos recursos da idosa para fins pessoais da r&eacute;, n&atilde;o subsistindo a tese de &quot;precariedade financeira&quot; quando os valores destinados &agrave; subsist&ecirc;ncia da v&iacute;tima n&atilde;o eram a ela revertidos.
+
+5. Inexiste bis in idem na aplica&ccedil;&atilde;o das agravantes do art. 61, II, CP, uma vez que possuem fatos geradores distintos: o v&iacute;nculo de parentesco (al&iacute;nea &quot;e&quot;), a facilita&ccedil;&atilde;o pelo conv&iacute;vio dom&eacute;stico (al&iacute;nea &quot;f&quot;) e a viola&ccedil;&atilde;o do dever jur&iacute;dico espec&iacute;fico decorrente da curatela (al&iacute;nea &quot;g&quot;).
+
+6. A fra&ccedil;&atilde;o de aumento na dosimetria mostrou-se proporcional ao n&uacute;mero de agravantes e &agrave; gravidade concreta das condutas, inexistindo ilegalidade a ser sanada.
+
+IV. DISPOSITIVO E TESE
+
+7. Recurso conhecido e desprovido.
+
+Tese de julgamento:
+
+&quot;1. A configura&ccedil;&atilde;o dos crimes previstos nos arts. 99 e 102 do Estatuto do Idoso prescinde de dolo espec&iacute;fico de dano quando demonstrada a exposi&ccedil;&atilde;o a perigo por neglig&ecirc;ncia deliberada e o desvio de finalidade dos proventos da v&iacute;tima.&quot;;
+
+&quot;2. N&atilde;o configura bis in idem a incid&ecirc;ncia cumulativa das agravantes de parentesco, rela&ccedil;&otilde;es dom&eacute;sticas e abuso de autoridade decorrente de curatela, pois amparadas em fundamentos f&aacute;ticos e jur&iacute;dicos aut&ocirc;nomos.&quot;
+
+Dispositivos relevantes citados: CP, arts. 59 e 61, II, &quot;e&quot;, &quot;f&quot; e &quot;g&quot;; Lei n&ordm; 10.741/2003, arts. 99 e 102.
+
+Jurisprud&ecirc;ncia relevante citada: TJ-PR, Apela&ccedil;&atilde;o 00004731720188160007, Rel. Des. Carvilio da Silveira Filho, 4&ordf; C&acirc;mara Criminal, j. 22.09.2025.
+
+
+
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos estes autos de Apela&ccedil;&atilde;o n&ordm; 0201107-57.2022.8.06.0301, ACORDAM os Desembargadores integrantes da 2&ordf; C&acirc;mara Criminal deste Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em conhecer do recurso para JULG&Aacute;-LO DESPROVIDO, nos termos do voto do Relator.
+
+Fortaleza, 1&ordm; de abril de 2026.
+
+
+Des. Francisco Eduardo Torquato Scorsafava
+Presidente do &Oacute;rg&atilde;o Julgador
+
+Des. S&eacute;rgio Luiz Arruda Parente
+Relator
+ <br><br>(Apela&ccedil;&atilde;o Criminal&nbsp;-  0201107-57.2022.8.06.0301, Rel. Desembargador(a)  SERGIO LUIZ ARRUDA PARENTE, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 01/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 01/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Crime / Contravenção contra Idoso
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> SERGIO LUIZ ARRUDA PARENTE
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Lavras da Mangabeira
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									01/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. RECURSO DE APELAÇÃO. IRRESIGNAÇÃO DA DEFESA. ESTATUTO DO IDOSO. CRIME DE EXPOSIÇÃO A PERIGO DA INTEGRIDADE FÍSICA E PSÍQUICA DO IDOSO (LEI Nº 10.741/2003, ART. 99, CAPUT). CRIME DE APROPRIAÇÃO/DESVIO DE BENS OU RENDIMENTOS (LEI Nº 10.741/2003, ART. 102). PEDIDO DE ABSOLVIÇÃO POR AUSÊNCIA DE DOLO E INSUFICIÊNCIA PROBATÓRIA. REJEIÇÃO. RÉ QUE MANTINHA A MÃE, DE 88
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. RECURSO DE APELAÇÃO. IRRESIGNAÇÃO DA DEFESA. ESTATUTO DO IDOSO. CRIME DE EXPOSIÇÃO A PERIGO DA INTEGRIDADE FÍSICA E PSÍQUICA DO IDOSO (LEI Nº 10.741/2003, ART. 99, CAPUT). CRIME DE APROPRIAÇÃO/DESVIO DE BENS OU RENDIMENTOS (LEI Nº 10.741/2003, ART. 102). PEDIDO DE ABSOLVIÇÃO POR AUSÊNCIA DE DOLO E INSUFICIÊNCIA PROBATÓRIA. REJEIÇÃO. RÉ QUE MANTINHA A MÃE, DE 88 ANOS, EM SITUAÇÃO DE ABANDONO, SEM ALIMENTAÇÃO ADEQUADA, HIGIENE E VIGILÂNCIA. RELATÓRIO SOCIAL E DEPOIMENTOS CONFIRMAM VULNERABILIDADE, RISCO E DESVIO DE BENEFÍCIO PREVIDENCIÁRIO. MATERIALIDADE E AUTORIA COMPROVADAS. ALEGADA AUSÊNCIA DE DOLO AFASTADA. PROVA DOCUMENTAL E TESTEMUNHAL ROBUSTA. CONDUTA QUE EXTRAPOLA A MERA PRECARIEDADE FINANCEIRA. MANUTENÇÃO DA CONDENAÇÃO. PEDIDO DE REFORMA DA DOSIMETRIA. PLEITO DE EXCLUSÃO DE AGRAVANTES (ART. 61, II, "E", "F" E "G", CP). ALEGAÇÃO DE BIS IN IDEM. DESCABIMENTO. FUNDAMENTOS AUTÔNOMOS. RECURSO CONHECIDO E DESPROVIDO.
+
+I. CASO EM EXAME
+
+1. Apelação Criminal interposta por Josefa Maria da Conceição Costa contra sentença que a condenou às penas dos arts. 99 e 102 da Lei nº 10.741/2003 (Estatuto do Idoso). A acusada, na condição de curadora da própria genitora (88 anos), expôs a saúde da idosa a perigo em ambiente insalubre e sem assistência, além de desviar seus proventos previdenciários para finalidades diversas. A defesa pleiteia a absolvição por falta de provas e ausência de dolo, ou, subsidiariamente, o afastamento de agravantes na dosimetria.
+
+II. QUESTÃO EM DISCUSSÃO
+
+2. Há duas questões em discussão: (i) saber se o conjunto probatório é suficiente para demonstrar o dolo e a autoria dos crimes de exposição a perigo e desvio de rendimentos da idosa; e (ii) saber se a aplicação cumulativa das agravantes do art. 61, II, alíneas "e" (parentesco), "f" (relações domésticas) e "g" (abuso de autoridade/múnus de curadora) configura bis in idem.
+
+III. RAZÕES DE DECIDIR
+
+3. A materialidade e a autoria delitivas restaram comprovadas pelo laudo social e depoimentos testemunhais que descreveram cenário de extrema vulnerabilidade, com a idosa trancada sozinha, em condições de higiene fétidas e alimentação precária, enquanto a ré se ausentava da cidade após sacar o benefício previdenciário da vítima.
+
+4. O dolo direto é evidenciado pelo abandono deliberado e pela utilização dos recursos da idosa para fins pessoais da ré, não subsistindo a tese de "precariedade financeira" quando os valores destinados à subsistência da vítima não eram a ela revertidos.
+
+5. Inexiste bis in idem na aplicação das agravantes do art. 61, II, CP, uma vez que possuem fatos geradores distintos: o vínculo de parentesco (alínea "e"), a facilitação pelo convívio doméstico (alínea "f") e a violação do dever jurídico específico decorrente da curatela (alínea "g").
+
+6. A fração de aumento na dosimetria mostrou-se proporcional ao número de agravantes e à gravidade concreta das condutas, inexistindo ilegalidade a ser sanada.
+
+IV. DISPOSITIVO E TESE
+
+7. Recurso conhecido e desprovido.
+
+Tese de julgamento:
+
+"1. A configuração dos crimes previstos nos arts. 99 e 102 do Estatuto do Idoso prescinde de dolo específico de <em>dano</em> quando demonstrada a exposição a perigo por negligência deliberada e o desvio de finalidade dos proventos da vítima.";
+
+"2. Não configura bis in idem a incidência cumulativa das agravantes de parentesco, relações domésticas e abuso de autoridade decorrente de curatela, pois amparadas em fundamentos fáticos e jurídicos autônomos."
+
+Dispositivos relevantes citados: CP, arts. 59 e 61, II, "e", "f" e "g"; Lei nº 10.741/2003, arts. 99 e 102.
+
+Jurisprudência relevante citada: TJ-PR, Apelação 00004731720188160007, Rel. Des. Carvilio da Silveira Filho, 4ª Câmara Criminal, j. 22.09.2025.
+
+
+
+ACÓRDÃO
+
+Vistos, relatados e discutidos estes autos de Apelação nº 0201107-57.2022.8.06.0301, ACORDAM os Desembargadores integrantes da 2ª Câmara Criminal deste Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em conhecer do recurso para JULGÁ-LO DESPROVIDO, nos termos do voto do Relator.
+
+Fortaleza, 1º de abril de 2026.
+
+
+Des. Francisco Eduardo Torquato Scorsafava
+Presidente do Órgão Julgador
+
+Des. Sérgio Luiz Arruda Parente
+Relator
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>40&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3832765" cdForo="0" >
+										0622369-86.2026.8.06.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3832765" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3832765);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3832765" style="display: none;" >
+	<div id="textAreaDados_3832765" class="mensagemSemFormatacao" >
+		HABEAS CORPUS. PENAL E PROCESSUAL PENAL. EXTORS&Atilde;O QUALIFICADA, ASSOCIA&Ccedil;&Atilde;O CRIMINOSA QUALIFICADA E CONTRAVEN&Ccedil;&Atilde;O DE JOGOS DE AZAR (ART. 158, &sect; 1&ordm;, E ART. 288, &sect; 1&ordm;, DO C&Oacute;DIGO PENAL, AL&Eacute;M DO ART. 50 DO DECRETO-LEI N&ordm; 3.688/41). PRIS&Atilde;O PREVENTIVA. ALEGADA FRAGILIDADE PROBAT&Oacute;RIA QUE TERIA CULMINADO NA PRIS&Atilde;O DO PACIENTE. MAT&Eacute;RIA INCOMPAT&Iacute;VEL COM A VIA ESTREITA DO HABEAS CORPUS. N&Atilde;O CONHECIMENTO, NO PONTO. TESE DE CAR&Ecirc;NCIA DE FUNDAMENTA&Ccedil;&Atilde;O ID&Ocirc;NEA E AUS&Ecirc;NCIA DOS REQUISITOS DO ART. 312 DO CPP. N&Atilde;O ACOLHIMENTO. DECIS&Atilde;O DEVIDAMENTE FUNDAMENTADA NA GARANTIA DA ORDEM P&Uacute;BLICA, COM BASE NA GRAVIDADE CONCRETA DA CONDUTA. MODUS OPERANDI VIOLENTO, CONSISTENTE NA COA&Ccedil;&Atilde;O DE OPERADORES DE APOSTAS MEDIANTE AMEA&Ccedil;AS DE AGRESS&Otilde;ES E INC&Ecirc;NDIOS. SUPOSTO DOM&Iacute;NIO TERRITORIAL ATRIBU&Iacute;DO A FAC&Ccedil;&Atilde;O CRIMINOSA. CONDI&Ccedil;&Otilde;ES PESSOAIS FAVOR&Aacute;VEIS. IRRELEV&Acirc;NCIA, POR SI S&Oacute;S. MEDIDAS CAUTELARES DIVERSAS DA PRIS&Atilde;O. INADEQUA&Ccedil;&Atilde;O E INSUFICI&Ecirc;NCIA NO CASO CONCRETO. ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE CONTEMPORANEIDADE. INOCORR&Ecirc;NCIA. PERSIST&Ecirc;NCIA DOS MOTIVOS ENSEJADORES DA CUST&Oacute;DIA CAUTELAR. DELITO PERMANENTE, EM CONTEXTO DE ORGANIZA&Ccedil;&Atilde;O CRIMINOSA. ORDEM PARCIALMENTE CONHECIDA E, NESSA EXTENS&Atilde;O, DENEGADA.
+
+CASO EM EXAME
+
+Trata-se de habeas corpus liberat&oacute;rio, com pedido liminar, impetrado em favor de Francisco Gildevan, contra ato do Juiz de Direito do 3&ordm; N&uacute;cleo Regional de Cust&oacute;dia e das Garantias &#150; sede em Quixad&aacute;/CE. O feito de origem apura suposto esquema criminoso em Quixeramobim/CE voltado &agrave; coa&ccedil;&atilde;o de operadores de apostas esportivas, mediante amea&ccedil;as violentas, para que aderissem &agrave;s plataformas &quot;Ouro Bets&quot; e &quot;Pitaco Bets&quot;, pr&aacute;tica atribu&iacute;da a integrantes de fac&ccedil;&atilde;o criminosa.
+
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+H&aacute; cinco quest&otilde;es em discuss&atilde;o: (i) analisar a fragilidade probat&oacute;ria que culminou na pris&atilde;o do paciente; (ii) verificar se o decreto de pris&atilde;o preventiva carece de fundamenta&ccedil;&atilde;o id&ocirc;nea ou dos requisitos do art. 312 do CPP; (iii) aferir se a medida extrema observa o requisito da contemporaneidade, diante da persist&ecirc;ncia do risco &agrave; ordem p&uacute;blica; (iv) avaliar se medidas cautelares diversas da pris&atilde;o seriam suficientes para resguardar o meio social, diante da periculosidade demonstrada; (v) aferir as condi&ccedil;&otilde;es pessoais favor&aacute;veis do paciente.
+
+RAZ&Otilde;ES DE DECIDIR
+
+A alega&ccedil;&atilde;o de fragilidade do conjunto probat&oacute;rio que culminou na pris&atilde;o do suplicante demanda revolvimento aprofundado do conjunto f&aacute;tico-probat&oacute;rio, provid&ecirc;ncia incompat&iacute;vel com a via estreita do habeas corpus, destinada apenas ao controle de ilegalidade manifesta.
+
+A pris&atilde;o preventiva encontra-se devidamente fundamentada na necessidade de garantia da ordem p&uacute;blica, alicer&ccedil;ada em elementos concretos que demonstram a gravidade da conduta. As condutas atribu&iacute;das ao paciente indicam que, segundo se alega, ele manteria estabelecimento que funcionaria como base de apoio ao grupo, promovendo a plataforma &quot;Pitaco Bets&quot;, captando apostadores, operando sistemas de recebimento e contribuindo para a expans&atilde;o da marca no munic&iacute;pio.
+
+Tais circunst&acirc;ncias evidenciam sua participa&ccedil;&atilde;o ativa e relevante na estrutura do esquema criminoso, bem como sua capacidade log&iacute;stica para a manuten&ccedil;&atilde;o e expans&atilde;o das atividades il&iacute;citas, voltadas ao dom&iacute;nio territorial da explora&ccedil;&atilde;o de jogos de azar no interior do Estado do Cear&aacute;.
+
+Ademais, observa-se que as condutas atribu&iacute;das aos investigados n&atilde;o se apresentam como fatos isolados, mas inseridas em um contexto de atua&ccedil;&atilde;o estruturada e permanente, direcionada &agrave; intimida&ccedil;&atilde;o reiterada de operadores de apostas, &agrave; supress&atilde;o da concorr&ecirc;ncia e &agrave; concentra&ccedil;&atilde;o dos lucros em benef&iacute;cio da organiza&ccedil;&atilde;o criminosa (PCC). Tal cen&aacute;rio revela a habitualidade delitiva e evidencia o risco concreto de continuidade das pr&aacute;ticas il&iacute;citas.
+
+Verifica-se, ainda, conforme bem trouxe a autoridade apontada como coatora, &quot;que os fatos foram praticados mediante grave amea&ccedil;a, consubstanciada em intimida&ccedil;&otilde;es reiteradas, inclusive com refer&ecirc;ncia a repres&aacute;lias violentas, como inc&ecirc;ndios de estabelecimentos e amea&ccedil;as de morte, elevando a gravidade concreta das condutas e o potencial lesivo &agrave; ordem p&uacute;blica&quot;.
+
+A fundamenta&ccedil;&atilde;o observa, ainda, as inova&ccedil;&otilde;es da Lei n&ordm; 15.272/2025, que orienta a aferi&ccedil;&atilde;o da periculosidade do agente a partir do modus operandi violento e do fundado receio de reitera&ccedil;&atilde;o.
+
+No tocante &agrave; contemporaneidade, esta n&atilde;o se limita ao lapso temporal entre o fato e a pris&atilde;o, mas &agrave; perpetua&ccedil;&atilde;o da necessidade da medida. Tratando-se de condutas praticadas no &acirc;mbito de organiza&ccedil;&atilde;o criminosa, resta evidenciada a atualidade do perigo gerado pelo estado de liberdade do acusado.
+
+Demonstrada a imprescindibilidade da segrega&ccedil;&atilde;o cautelar para interromper a atua&ccedil;&atilde;o criminosa, as medidas cautelares diversas do art. 319 do CPP revelam-se insuficientes e inadequadas. Eventuais condi&ccedil;&otilde;es pessoais favor&aacute;veis n&atilde;o autorizam, isoladamente, a soltura quando presentes os requisitos legais da cust&oacute;dia antecipada.
+
+IV. DISPOSITIVO E TESE
+
+Ordem parcialmente conhecida e, nessa extens&atilde;o, denegada.  <br><br>(Habeas Corpus Criminal&nbsp;-  0622369-86.2026.8.06.0000, Rel. Desembargador(a)  MARIA ILNA LIMA DE CASTRO, 2&ordf; C&acirc;mara Criminal, data do julgamento:&nbsp; 01/04/2026, data da publica&ccedil;&atilde;o:&nbsp; 01/04/2026)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Habeas Corpus Criminal / Associação Criminosa
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIA ILNA LIMA DE CASTRO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Quixeramobim
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									01/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>HABEAS CORPUS. PENAL E PROCESSUAL PENAL. EXTORSÃO QUALIFICADA, ASSOCIAÇÃO CRIMINOSA QUALIFICADA E CONTRAVENÇÃO DE JOGOS DE AZAR (ART. 158, § 1º, E ART. 288, § 1º, DO CÓDIGO PENAL, ALÉM DO ART. 50 DO DECRETO-LEI Nº 3.688/41). PRISÃO PREVENTIVA. ALEGADA FRAGILIDADE PROBATÓRIA QUE TERIA CULMINADO NA PRISÃO DO PACIENTE. MATÉRIA INCOMPATÍVEL COM A VIA ESTREITA DO HABEAS CORPUS. NÃO CONHECIMENTO, NO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>HABEAS CORPUS. PENAL E PROCESSUAL PENAL. EXTORSÃO QUALIFICADA, ASSOCIAÇÃO CRIMINOSA QUALIFICADA E CONTRAVENÇÃO DE JOGOS DE AZAR (ART. 158, § 1º, E ART. 288, § 1º, DO CÓDIGO PENAL, ALÉM DO ART. 50 DO DECRETO-LEI Nº 3.688/41). PRISÃO PREVENTIVA. ALEGADA FRAGILIDADE PROBATÓRIA QUE TERIA CULMINADO NA PRISÃO DO PACIENTE. MATÉRIA INCOMPATÍVEL COM A VIA ESTREITA DO HABEAS CORPUS. NÃO CONHECIMENTO, NO PONTO. TESE DE CARÊNCIA DE FUNDAMENTAÇÃO IDÔNEA E AUSÊNCIA DOS REQUISITOS DO ART. 312 DO CPP. NÃO ACOLHIMENTO. DECISÃO DEVIDAMENTE FUNDAMENTADA NA GARANTIA DA ORDEM PÚBLICA, COM BASE NA GRAVIDADE CONCRETA DA CONDUTA. MODUS OPERANDI VIOLENTO, CONSISTENTE NA COAÇÃO DE OPERADORES DE APOSTAS MEDIANTE AMEAÇAS DE AGRESSÕES E INCÊNDIOS. SUPOSTO DOMÍNIO TERRITORIAL ATRIBUÍDO A FACÇÃO CRIMINOSA. CONDIÇÕES PESSOAIS FAVORÁVEIS. IRRELEVÂNCIA, POR SI SÓS. MEDIDAS CAUTELARES DIVERSAS DA PRISÃO. INADEQUAÇÃO E INSUFICIÊNCIA NO CASO CONCRETO. ALEGAÇÃO DE AUSÊNCIA DE CONTEMPORANEIDADE. INOCORRÊNCIA. PERSISTÊNCIA DOS MOTIVOS ENSEJADORES DA CUSTÓDIA CAUTELAR. DELITO PERMANENTE, EM CONTEXTO DE ORGANIZAÇÃO CRIMINOSA. ORDEM PARCIALMENTE CONHECIDA E, NESSA EXTENSÃO, DENEGADA.
+
+CASO EM EXAME
+
+Trata-se de habeas corpus liberatório, com pedido liminar, impetrado em favor de Francisco Gildevan, contra ato do Juiz de Direito do 3º Núcleo Regional de Custódia e das Garantias  sede em Quixadá/CE. O feito de origem apura suposto esquema criminoso em Quixeramobim/CE voltado à coação de operadores de apostas esportivas, mediante ameaças violentas, para que aderissem às plataformas "Ouro Bets" e "Pitaco Bets", prática atribuída a integrantes de facção criminosa.
+
+QUESTÃO EM DISCUSSÃO
+
+Há cinco questões em discussão: (i) analisar a fragilidade probatória que culminou na prisão do paciente; (ii) verificar se o decreto de prisão preventiva carece de fundamentação idônea ou dos requisitos do art. 312 do CPP; (iii) aferir se a medida extrema observa o requisito da contemporaneidade, diante da persistência do risco à ordem pública; (iv) avaliar se medidas cautelares diversas da prisão seriam suficientes para resguardar o meio social, diante da periculosidade demonstrada; (v) aferir as condições pessoais favoráveis do paciente.
+
+RAZÕES DE DECIDIR
+
+A alegação de fragilidade do conjunto probatório que culminou na prisão do suplicante demanda revolvimento aprofundado do conjunto fático-probatório, providência incompatível com a via estreita do habeas corpus, destinada apenas ao controle de ilegalidade manifesta.
+
+A prisão preventiva encontra-se devidamente fundamentada na necessidade de garantia da ordem pública, alicerçada em elementos concretos que demonstram a gravidade da conduta. As condutas atribuídas ao paciente indicam que, segundo se alega, ele manteria estabelecimento que funcionaria como base de apoio ao grupo, promovendo a plataforma "Pitaco Bets", captando apostadores, operando sistemas de recebimento e contribuindo para a expansão da marca no município.
+
+Tais circunstâncias evidenciam sua participação ativa e relevante na estrutura do esquema criminoso, bem como sua capacidade logística para a manutenção e expansão das atividades ilícitas, voltadas ao domínio territorial da exploração de jogos de azar no interior do Estado do Ceará.
+
+Ademais, observa-se que as condutas atribuídas aos investigados não se apresentam como fatos isolados, mas inseridas em um contexto de atuação estruturada e permanente, direcionada à intimidação reiterada de operadores de apostas, à supressão da concorrência e à concentração dos lucros em benefício da organização criminosa (PCC). Tal cenário revela a habitualidade delitiva e evidencia o risco concreto de continuidade das práticas ilícitas.
+
+Verifica-se, ainda, conforme bem trouxe a autoridade apontada como coatora, "que os fatos foram praticados mediante grave ameaça, consubstanciada em intimidações reiteradas, inclusive com referência a represálias violentas, como incêndios de estabelecimentos e ameaças de morte, elevando a gravidade concreta das condutas e o potencial lesivo à ordem pública".
+
+A fundamentação observa, ainda, as inovações da Lei nº 15.272/2025, que orienta a aferição da periculosidade do agente a partir do modus operandi violento e do fundado receio de reiteração.
+
+No tocante à contemporaneidade, esta não se limita ao lapso temporal entre o fato e a prisão, mas à perpetuação da necessidade da medida. Tratando-se de condutas praticadas no âmbito de organização criminosa, resta evidenciada a atualidade do perigo gerado pelo estado de liberdade do acusado.
+
+Demonstrada a imprescindibilidade da segregação cautelar para interromper a atuação criminosa, as medidas cautelares diversas do art. 319 do CPP revelam-se insuficientes e inadequadas. Eventuais condições pessoais favoráveis não autorizam, isoladamente, a soltura quando presentes os requisitos legais da custódia antecipada.
+
+IV. DISPOSITIVO E TESE
+
+Ordem parcialmente conhecida e, nessa extensão, denegada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="Tribunal">
+									<label for="ckTermo1">
+										Tribunal
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="Justiça">
+									<label for="ckTermo2">
+										Justiça
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="Câmara">
+									<label for="ckTermo3">
+										Câmara
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="Ceará">
+									<label for="ckTermo4">
+										Ceará
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="autos">
+									<label for="ckTermo5">
+										autos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="voto">
+									<label for="ckTermo6">
+										voto
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="ACÓRDÃO">
+									<label for="ckTermo7">
+										ACÓRDÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="Direito">
+									<label for="ckTermo8">
+										Direito
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="Estado">
+									<label for="ckTermo9">
+										Estado
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="EMENTA">
+									<label for="ckTermo10">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="termos">
+									<label for="ckTermo11">
+										termos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="discutidos">
+									<label for="ckTermo12">
+										discutidos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="relatados">
+									<label for="ckTermo13">
+										relatados
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="Vistos">
+									<label for="ckTermo14">
+										Vistos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="Fortaleza">
+									<label for="ckTermo15">
+										Fortaleza
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				21 a 40
+			</strong>
+			de 100860
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+			<a name="A1" title="Página anterior">
+				&lt;
+			</a>
+
+
+
+
+
+
+
+
+
+
+
+					<a name="A1" style="padding-left:4px" >
+						1
+					</a>
+
+
+
+
+
+					<span class="paginaAtual" >
+						2
+					</span>
+
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A3" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjce/samples/cjsg/single_page.html
+++ b/tests/tjce/samples/cjsg/single_page.html
@@ -1,0 +1,3285 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(16)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="16" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3811239" cdForo="0" >
+										0000353-76.2005.8.06.0178
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3811239" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3811239);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3811239" style="display: none;" >
+	<div id="textAreaDados_3811239" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIA. POSSE DECORRENTE DE MERA TOLER&Acirc;NCIA. AUS&Ecirc;NCIA DE ANIMUS DOMINI. IMPROCED&Ecirc;NCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel contra senten&ccedil;a proferida pelo Ju&iacute;zo da 2&ordf; Vara da Comarca de Uruburetama/CE, que julgou improcedente a&ccedil;&atilde;o de usucapi&atilde;o extraordin&aacute;ria proposta pelos autores, sob o fundamento de aus&ecirc;ncia dos requisitos legais previstos no art. 1.238 do CC, especialmente o animus domini.
+2. Os autores alegam posse mansa, pac&iacute;fica e ininterrupta desde 1980 sobre im&oacute;vel urbano, pleiteando a declara&ccedil;&atilde;o de dom&iacute;nio por usucapi&atilde;o extraordin&aacute;ria. O im&oacute;vel, no entanto, &eacute; registrado em nome da Federa&ccedil;&atilde;o de Trabalhadores Crist&atilde;os do Cear&aacute;, atual Federa&ccedil;&atilde;o dos C&iacute;rculos Oper&aacute;rios do Estado do Cear&aacute; (FECOECE), que apresentou contesta&ccedil;&atilde;o apontando a posse como prec&aacute;ria.
+3. A senten&ccedil;a de primeiro grau foi mantida por ac&oacute;rd&atilde;o, que concluiu pela inexist&ecirc;ncia de animus domini, diante de prova de que a ocupa&ccedil;&atilde;o se deu por mera permiss&atilde;o de uso, caracterizando posse prec&aacute;ria.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. A quest&atilde;o em discuss&atilde;o consiste em saber se a posse exercida pelos autores sobre o im&oacute;vel urbano re&uacute;ne os requisitos necess&aacute;rios &agrave; configura&ccedil;&atilde;o da usucapi&atilde;o extraordin&aacute;ria, com &ecirc;nfase na an&aacute;lise da exist&ecirc;ncia de animus domini, nos termos do art. 1.238 do CC.
+III. RAZ&Otilde;ES DE DECIDIR
+5. A usucapi&atilde;o extraordin&aacute;ria exige posse mansa, pac&iacute;fica, ininterrupta e com animus domini por 15 anos, ou 10 anos no caso de moradia habitual ou realiza&ccedil;&atilde;o de obras produtivas (CC, art. 1.238 e par&aacute;grafo &uacute;nico).
+6. O im&oacute;vel est&aacute; regularmente registrado em nome da FECOECE, conforme matr&iacute;cula n&ordm; 5.370 do Cart&oacute;rio de Registro de Im&oacute;veis.
+7. A prova testemunhal &eacute; un&iacute;ssona em reconhecer que os autores ingressaram no im&oacute;vel com anu&ecirc;ncia da Federa&ccedil;&atilde;o, por meio de permiss&atilde;o de uso, afastando a inten&ccedil;&atilde;o de exercer posse como se propriet&aacute;rios fossem.
+8. O contrato de m&uacute;tuo juntado aos autos tamb&eacute;m refor&ccedil;a o car&aacute;ter prec&aacute;rio da posse.
+9. A perman&ecirc;ncia prolongada no im&oacute;vel e a realiza&ccedil;&atilde;o de benfeitorias n&atilde;o configuram, por si s&oacute;s, animus domini quando a posse tem origem em mera toler&acirc;ncia ou comodato verbal, conforme art. 1.208 do CC.
+10. Aus&ecirc;ncia de comprova&ccedil;&atilde;o de altera&ccedil;&atilde;o da natureza da posse para ad usucapionem.
+IV. DISPOSITIVO E TESE
+11. Recurso de apela&ccedil;&atilde;o conhecido e desprovido.
+Tese de julgamento: &iquest;1. N&atilde;o configura animus domini a posse exercida por mera toler&acirc;ncia do propriet&aacute;rio, ainda que prolongada no tempo. 2. A posse prec&aacute;ria, originada de permiss&atilde;o de uso, n&atilde;o &eacute; apta a fundamentar aquisi&ccedil;&atilde;o da propriedade por usucapi&atilde;o extraordin&aacute;ria.&iquest;
+Dispositivos relevantes citados: CC, arts. 1.208 e 1.238; CPC, art. 373, I.
+Jurisprud&ecirc;ncia relevante citada: TJCE, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0000711-98.2009.8.06.0146, Rel. Des. Jos&eacute; Ricardo Vidal Patroc&iacute;nio, 1&ordf; C&acirc;mara de Direito Privado, j. 26.03.2025; TJCE, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0142109-65.2018.8.06.0001, Rel. Des. Francisco Bezerra Cavalcante, 4&ordf; C&acirc;mara de Direito Privado, j. 18.03.2025; TJCE, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0040055-36.2012.8.06.0064, Rel. Des. Francisco Mauro Ferreira Liberato, 1&ordf; C&acirc;mara de Direito Privado, j. 03.07.2024.
+AC&Oacute;RD&Atilde;O
+Vistos, relatados e discutidos estes autos, acorda a 3&ordf; C&acirc;mara Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, &agrave; unanimidade, pelo conhecimento e desprovimento do apelo, nos termos do voto do eminente Relator.
+Fortaleza, 4 de agosto de 2025
+
+MARCOS WILLIAM LEITE DE OLIVEIRA
+Presidente do &Oacute;rg&atilde;o Julgador
+
+DESEMBARGADOR MARCOS WILLIAM LEITE DE OLIVEIRA
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0000353-76.2005.8.06.0178, Rel. Desembargador(a)  MARCOS WILLIAM LEITE DE OLIVEIRA, 3&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 20/08/2025, data da publica&ccedil;&atilde;o:&nbsp; 20/08/2025)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(70 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Ordinária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARCOS WILLIAM LEITE DE OLIVEIRA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Uruburetama
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									20/08/2025
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									20/08/2025
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. POSSE DECORRENTE DE MERA TOLERÂNCIA. AUSÊNCIA DE ANIMUS DOMINI. IMPROCEDÊNCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível contra sentença proferida pelo Juízo da 2ª Vara da Comarca de Uruburetama/CE, que julgou improcedente ação de <em>usucapião</em> <em>extraordinária</em> proposta pelos
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. POSSE DECORRENTE DE MERA TOLERÂNCIA. AUSÊNCIA DE ANIMUS DOMINI. IMPROCEDÊNCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível contra sentença proferida pelo Juízo da 2ª Vara da Comarca de Uruburetama/CE, que julgou improcedente ação de <em>usucapião</em> <em>extraordinária</em> proposta pelos autores, sob o fundamento de ausência dos requisitos legais previstos no art. 1.238 do CC, especialmente o animus domini.
+2. Os autores alegam posse mansa, pacífica e ininterrupta desde 1980 sobre imóvel urbano, pleiteando a declaração de domínio por <em>usucapião</em> <em>extraordinária</em>. O imóvel, no entanto, é registrado em nome da Federação de Trabalhadores Cristãos do Ceará, atual Federação dos Círculos Operários do Estado do Ceará (FECOECE), que apresentou contestação apontando a posse como precária.
+3. A sentença de primeiro grau foi mantida por acórdão, que concluiu pela inexistência de animus domini, diante de prova de que a ocupação se deu por mera permissão de uso, caracterizando posse precária.
+II. QUESTÃO EM DISCUSSÃO
+4. A questão em discussão consiste em saber se a posse exercida pelos autores sobre o imóvel urbano reúne os requisitos necessários à configuração da <em>usucapião</em> <em>extraordinária</em>, com ênfase na análise da existência de animus domini, nos termos do art. 1.238 do CC.
+III. RAZÕES DE DECIDIR
+5. A <em>usucapião</em> <em>extraordinária</em> exige posse mansa, pacífica, ininterrupta e com animus domini por 15 anos, ou 10 anos no caso de moradia habitual ou realização de obras produtivas (CC, art. 1.238 e parágrafo único).
+6. O imóvel está regularmente registrado em nome da FECOECE, conforme matrícula nº 5.370 do Cartório de Registro de Imóveis.
+7. A prova testemunhal é uníssona em reconhecer que os autores ingressaram no imóvel com anuência da Federação, por meio de permissão de uso, afastando a intenção de exercer posse como se proprietários fossem.
+8. O contrato de mútuo juntado aos autos também reforça o caráter precário da posse.
+9. A permanência prolongada no imóvel e a realização de benfeitorias não configuram, por si sós, animus domini quando a posse tem origem em mera tolerância ou comodato verbal, conforme art. 1.208 do CC.
+10. Ausência de comprovação de alteração da natureza da posse para ad usucapionem.
+IV. DISPOSITIVO E TESE
+11. Recurso de apelação conhecido e desprovido.
+Tese de julgamento: ¿1. Não configura animus domini a posse exercida por mera tolerância do proprietário, ainda que prolongada no tempo. 2. A posse precária, originada de permissão de uso, não é apta a fundamentar aquisição da propriedade por <em>usucapião</em> <em>extraordinária</em>.¿
+Dispositivos relevantes citados: CC, arts. 1.208 e 1.238; CPC, art. 373, I.
+Jurisprudência relevante citada: TJCE, Apelação Cível nº 0000711-98.2009.8.06.0146, Rel. Des. José Ricardo Vidal Patrocínio, 1ª Câmara de Direito Privado, j. 26.03.2025; TJCE, Apelação Cível nº 0142109-65.2018.8.06.0001, Rel. Des. Francisco Bezerra Cavalcante, 4ª Câmara de Direito Privado, j. 18.03.2025; TJCE, Apelação Cível nº 0040055-36.2012.8.06.0064, Rel. Des. Francisco Mauro Ferreira Liberato, 1ª Câmara de Direito Privado, j. 03.07.2024.
+ACÓRDÃO
+Vistos, relatados e discutidos estes autos, acorda a 3ª Câmara Direito Privado do Tribunal de Justiça do Estado do Ceará, à unanimidade, pelo conhecimento e desprovimento do apelo, nos termos do voto do eminente Relator.
+Fortaleza, 4 de agosto de 2025
+
+MARCOS WILLIAM LEITE DE OLIVEIRA
+Presidente do Órgão Julgador
+
+DESEMBARGADOR MARCOS WILLIAM LEITE DE OLIVEIRA
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3760533" cdForo="0" >
+										0419237-61.2010.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3760533" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3760533);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3760533" style="display: none;" >
+	<div id="textAreaDados_3760533" class="mensagemSemFormatacao" >
+		direito civil. Recurso de apela&ccedil;&atilde;o. Usucapi&atilde;o especial urbano. Julgamento antecipado da lide. Aus&ecirc;ncia de audi&ecirc;ncia instrut&oacute;ria e de intima&ccedil;&atilde;o do minist&eacute;rio p&uacute;blico. Cerceamento de defesa. Nulidade da senten&ccedil;a.
+I. Caso em exame
+1. O recurso foi interposto pela autora em face de senten&ccedil;a da 4&ordf; Vara C&iacute;vel de Fortaleza/CE, que julgou improcedente a A&ccedil;&atilde;o de Usucapi&atilde;o Especial Urbano. A decis&atilde;o considerou ausentes provas robustas da posse mansa, pac&iacute;fica e ininterrupta desde 2001.
+2. A apelante argumenta que o magistrado desconsiderou a posse exercida por mais de 20 (vinte) anos, contando-se o tempo decorrido durante o tr&acirc;mite do processo, defendendo a sufici&ecirc;ncia das provas juntadas, incluindo contrato particular de compra e venda.
+II. Quest&atilde;o em discuss&atilde;o
+3. H&aacute; duas quest&otilde;es em discuss&atilde;o:
+(i) se a improced&ecirc;ncia do pedido de usucapi&atilde;o especial urbano decorreu de erro na an&aacute;lise do &ocirc;nus probat&oacute;rio sobre a posse;
+(ii) se eventuais falhas procedimentais identificadas ensejam a anula&ccedil;&atilde;o da senten&ccedil;a para reabertura do processo.
+III. Raz&otilde;es de decidir
+4. O julgamento antecipado da lide, sem realiza&ccedil;&atilde;o de audi&ecirc;ncia instrut&oacute;ria para oitiva de testemunhas, violou os princ&iacute;pios do contradit&oacute;rio e da ampla defesa. A prova do tempo de posse &eacute; essencial em a&ccedil;&otilde;es de usucapi&atilde;o, o que torna indispens&aacute;vel a audi&ecirc;ncia instrut&oacute;ria, conforme reiterada jurisprud&ecirc;ncia.
+5. A aus&ecirc;ncia de intima&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico para manifesta&ccedil;&atilde;o como fiscal da ordem jur&iacute;dica, em conformidade com o art. 178, I, do CPC, e o art. 12, &sect; 1&ordm;, do Estatuto da Cidade, constitui v&iacute;cio insan&aacute;vel, especialmente em demandas de usucapi&atilde;o especial urbano que envolvem interesse social relevante.
+6. A interven&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico poderia ter influenciado decisivamente o curso do processo, seja requisitando audi&ecirc;ncia de instru&ccedil;&atilde;o, analisando novos fatos trazidos no curso da a&ccedil;&atilde;o em conformidade com o art. 493 do CPC, a exemplo do prazo decorrido durante a marcha processual, ou avaliando a fungibilidade entre modalidades de usucapi&atilde;o.
+7. A condu&ccedil;&atilde;o processual incorreta, ao indeferir a instru&ccedil;&atilde;o probat&oacute;ria requerida pela autora e omitir a intima&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico, comprometeu a regularidade do processo e resultou na nulidade da senten&ccedil;a de improced&ecirc;ncia.
+8. A aus&ecirc;ncia de maturidade da causa para julgamento final demanda a reabertura da instru&ccedil;&atilde;o probat&oacute;ria, especialmente para a oitiva de testemunhas, al&eacute;m da retomada dos atos processuais com a participa&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico.
+IV. Dispositivo e tese
+9. Apela&ccedil;&atilde;o conhecida e provida, em parte. Senten&ccedil;a anulada para o regular processamento do feito, com a reabertura da instru&ccedil;&atilde;o e intima&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico.
+    Tese de julgamento: &quot;Em a&ccedil;&otilde;es de usucapi&atilde;o especial urbano, a aus&ecirc;ncia de audi&ecirc;ncia instrut&oacute;ria para comprova&ccedil;&atilde;o da posse mansa, pac&iacute;fica e ininterrupta, bem como a falta de intima&ccedil;&atilde;o do Minist&eacute;rio P&uacute;blico como fiscal da ordem jur&iacute;dica, constitui cerceamento de defesa e enseja a nulidade da senten&ccedil;a.&quot;
+______________
+
+Dispositivos relevantes citados:  Constitui&ccedil;&atilde;o Federal, art. 183;   C&oacute;digo Civil, arts. 1.240 e 1.238;  C&oacute;digo de Processo Civil, arts. 178, 355, 357, &sect;4&ordm;, 370, 371, 493;   Estatuto da Cidade (Lei 10.257/2001), arts. 9&ordm;, 11 e 12, &sect; 1&ordm;.
+
+Jurisprud&ecirc;ncia relevante citada:
+
+STJ: REsp n. 1.969.217/SP, rel. Min. Nancy Andrighi, 08/03/2022; AgInt no REsp n. 2.075.558/SP, rel. Min. Regina Helena Costa, 09/10/2023 e REsp n. 1.361.226/MG, rel. Min. Raul Ara&uacute;jo, julgado em 22/10/2013. TJCE: Apela&ccedil;&atilde;o C&iacute;vel - 0139558-83.2016.8.06.0001, rel. Des. Heraclito Vieira de Sousa Neto, 06/10/2021; Apela&ccedil;&atilde;o C&iacute;vel - 0151262-93.2016.8.06.0001, rel. Des. Jane Ruth Maia de Queiroga, 07/02/2024; Apela&ccedil;&atilde;o C&iacute;vel - 0189879-88.2017.8.06.0001, rel. Des. Everardo Lucena Segundo, 09/11/2022; Apela&ccedil;&atilde;o C&iacute;vel - 0170938-66.2012.8.06.0001, rel. Des. Jos&eacute; Evandro Nogueira Lima Filho, 07/05/2024; Apela&ccedil;&atilde;o C&iacute;vel - 0193739-34.2016.8.06.0001, rel. Des. Jos&eacute; Ricardo Vidal Patroc&iacute;nio, 26/07/2023; Apela&ccedil;&atilde;o C&iacute;vel - 0026239-08.2010.8.06.0112, rel. Des. Francisco Luciano Lima Rodrigues, 04/11/2020 e Apela&ccedil;&atilde;o C&iacute;vel - 0000287-53.2010.8.06.0071, rel. Des. Francisco Mauro Ferreira Liberato. TJRS: Apela&ccedil;&atilde;o C&iacute;vel, n&ordm; 5073135-29.2022.8.21.0001, rel. Des. Dilso Domingos Pereira, 27/03/2024. TJRJ: e Apela&ccedil;&atilde;o, n&ordm; 0004261-77.2003.8.19.0202, rel. Des. Hor&aacute;cio dos Santos Ribeiro Neto, 21/06/2022. TJMG: Apel. C&iacute;vel, n&ordm; 1.0000.24.184267-3/001, rel. Des. Tiago Gomes de C. Pinto, 17/06/2024.
+
+AC&Oacute;RD&Atilde;O
+	&nbsp;
+Visto, relatado e discutido o presente recurso, acorda a Primeira C&acirc;mara de Direito Privado do Egr&eacute;gio Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, em conhecer do recurso para, por fundamenta&ccedil;&atilde;o diversa, dar-lhe parcial provimento, no sentido de anular a senten&ccedil;a atacada; nos termos do relat&oacute;rio e voto que passam a integrar o presente ac&oacute;rd&atilde;o.&nbsp;
+
+Fortaleza/CE, data da assinatura digital.
+&nbsp;
+DESEMBARGADOR FRANCISCO MAURO FERREIRA LIBERATO
+Presidente do &Oacute;rg&atilde;o Julgador
+
+DESEMBARGADORA MARIA REGINA DE OLIVEIRA C&Acirc;MARA
+Relatora <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0419237-61.2010.8.06.0001, Rel. Desembargador(a)  MARIA REGINA OLIVEIRA CAMARA, 1&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 04/12/2024, data da publica&ccedil;&atilde;o:&nbsp; 04/12/2024)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(117 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Especial (Constitucional)
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> MARIA REGINA OLIVEIRA CAMARA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									04/12/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									04/12/2024
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>direito civil. Recurso de apelação. <em>Usucapião</em> especial urbano. Julgamento antecipado da lide. Ausência de audiência instrutória e de intimação do ministério público. Cerceamento de defesa. Nulidade da sentença.
+I. Caso em exame
+1. O recurso foi interposto pela autora em face de sentença da 4ª Vara Cível de Fortaleza/CE, que julgou improcedente a Ação de <em>Usucapião</em> Especial
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>direito civil. Recurso de apelação. <em>Usucapião</em> especial urbano. Julgamento antecipado da lide. Ausência de audiência instrutória e de intimação do ministério público. Cerceamento de defesa. Nulidade da sentença.
+I. Caso em exame
+1. O recurso foi interposto pela autora em face de sentença da 4ª Vara Cível de Fortaleza/CE, que julgou improcedente a Ação de <em>Usucapião</em> Especial Urbano. A decisão considerou ausentes provas robustas da posse mansa, pacífica e ininterrupta desde 2001.
+2. A apelante argumenta que o magistrado desconsiderou a posse exercida por mais de 20 (vinte) anos, contando-se o tempo decorrido durante o trâmite do processo, defendendo a suficiência das provas juntadas, incluindo contrato particular de compra e venda.
+II. Questão em discussão
+3. Há duas questões em discussão:
+(i) se a improcedência do pedido de <em>usucapião</em> especial urbano decorreu de erro na análise do ônus probatório sobre a posse;
+(ii) se eventuais falhas procedimentais identificadas ensejam a anulação da sentença para reabertura do processo.
+III. Razões de decidir
+4. O julgamento antecipado da lide, sem realização de audiência instrutória para oitiva de testemunhas, violou os princípios do contraditório e da ampla defesa. A prova do tempo de posse é essencial em ações de <em>usucapião</em>, o que torna indispensável a audiência instrutória, conforme reiterada jurisprudência.
+5. A ausência de intimação do Ministério Público para manifestação como fiscal da ordem jurídica, em conformidade com o art. 178, I, do CPC, e o art. 12, § 1º, do Estatuto da Cidade, constitui vício insanável, especialmente em demandas de <em>usucapião</em> especial urbano que envolvem interesse social relevante.
+6. A intervenção do Ministério Público poderia ter influenciado decisivamente o curso do processo, seja requisitando audiência de instrução, analisando novos fatos trazidos no curso da ação em conformidade com o art. 493 do CPC, a exemplo do prazo decorrido durante a marcha processual, ou avaliando a fungibilidade entre modalidades de <em>usucapião</em>.
+7. A condução processual incorreta, ao indeferir a instrução probatória requerida pela autora e omitir a intimação do Ministério Público, comprometeu a regularidade do processo e resultou na nulidade da sentença de improcedência.
+8. A ausência de maturidade da causa para julgamento final demanda a reabertura da instrução probatória, especialmente para a oitiva de testemunhas, além da retomada dos atos processuais com a participação do Ministério Público.
+IV. Dispositivo e tese
+9. Apelação conhecida e provida, em parte. Sentença anulada para o regular processamento do feito, com a reabertura da instrução e intimação do Ministério Público.
+    Tese de julgamento: "Em ações de <em>usucapião</em> especial urbano, a ausência de audiência instrutória para comprovação da posse mansa, pacífica e ininterrupta, bem como a falta de intimação do Ministério Público como fiscal da ordem jurídica, constitui cerceamento de defesa e enseja a nulidade da sentença."
+______________
+
+Dispositivos relevantes citados:  Constituição Federal, art. 183;   Código Civil, arts. 1.240 e 1.238;  Código de Processo Civil, arts. 178, 355, 357, §4º, 370, 371, 493;   Estatuto da Cidade (Lei 10.257/2001), arts. 9º, 11 e 12, § 1º.
+
+Jurisprudência relevante citada:
+
+STJ: REsp n. 1.969.217/SP, rel. Min. Nancy Andrighi, 08/03/2022; AgInt no REsp n. 2.075.558/SP, rel. Min. Regina Helena Costa, 09/10/2023 e REsp n. 1.361.226/MG, rel. Min. Raul Araújo, julgado em 22/10/2013. TJCE: Apelação Cível - 0139558-83.2016.8.06.0001, rel. Des. Heraclito Vieira de Sousa Neto, 06/10/2021; Apelação Cível - 0151262-93.2016.8.06.0001, rel. Des. Jane Ruth Maia de Queiroga, 07/02/2024; Apelação Cível - 0189879-88.2017.8.06.0001, rel. Des. Everardo Lucena Segundo, 09/11/2022; Apelação Cível - 0170938-66.2012.8.06.0001, rel. Des. José Evandro Nogueira Lima Filho, 07/05/2024; Apelação Cível - 0193739-34.2016.8.06.0001, rel. Des. José Ricardo Vidal Patrocínio, 26/07/2023; Apelação Cível - 0026239-08.2010.8.06.0112, rel. Des. Francisco Luciano Lima Rodrigues, 04/11/2020 e Apelação Cível - 0000287-53.2010.8.06.0071, rel. Des. Francisco Mauro Ferreira Liberato. TJRS: Apelação Cível, nº 5073135-29.2022.8.21.0001, rel. Des. Dilso Domingos Pereira, 27/03/2024. TJRJ: e Apelação, nº 0004261-77.2003.8.19.0202, rel. Des. Horácio dos Santos Ribeiro Neto, 21/06/2022. TJMG: Apel. Cível, nº 1.0000.24.184267-3/001, rel. Des. Tiago Gomes de C. Pinto, 17/06/2024.
+
+ACÓRDÃO
+	 
+Visto, relatado e discutido o presente recurso, acorda a Primeira Câmara de Direito Privado do Egrégio Tribunal de Justiça do Estado do Ceará, em conhecer do recurso para, por fundamentação diversa, dar-lhe parcial provimento, no sentido de anular a sentença atacada; nos termos do relatório e voto que passam a integrar o presente acórdão. 
+
+Fortaleza/CE, data da assinatura digital.
+ 
+DESEMBARGADOR FRANCISCO MAURO FERREIRA LIBERATO
+Presidente do Órgão Julgador
+
+DESEMBARGADORA MARIA REGINA DE OLIVEIRA CÂMARA
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3745320" cdForo="0" >
+										0129032-86.2018.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3745320" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3745320);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3745320" style="display: none;" >
+	<div id="textAreaDados_3745320" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O REIVINDICAT&Oacute;RIA DA POSSE. REQUISITOS DO ART. 1.228 DO C&Oacute;DIGO CIVIL. POSSE INJUSTA N&Atilde;O COMPROVADA. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO CONHECIDO E DESPROVIDO.
+O cerne da quest&atilde;o em apre&ccedil;o consiste na prova da posse injusta por parte dos r&eacute;us nos termos do art. 1.228 do C&oacute;digo Civil que fundamenta a pretens&atilde;o reivindicat&oacute;ria.
+S&atilde;o pressupostos para a obten&ccedil;&atilde;o da tutela reclamada, a comprova&ccedil;&atilde;o do dom&iacute;nio atual sobre a coisa reivindicanda; a individualiza&ccedil;&atilde;o da coisa pretendida (limites e confronta&ccedil;&otilde;es do im&oacute;vel); e a demonstra&ccedil;&atilde;o de que o r&eacute;u est&aacute; exercendo a posse sobre a coisa de forma injusta.
+Consoante se percebe dos autos, o que se verifica no caso em apre&ccedil;o &eacute; que a parte autora alega ser propriet&aacute;ria do im&oacute;vel objeto da lide, tendo juntado aos autos documentos capazes de comprovar o alegado por si. Do mesmo modo, quanto &agrave; individualiza&ccedil;&atilde;o do im&oacute;vel, restou claramente identificado e caracterizado o bem objeto do pedido reivindicat&oacute;rio.
+O cerne da quest&atilde;o em apre&ccedil;o consiste na prova da posse injusta por parte dos r&eacute;us nos termos do art. 1.228 do C&oacute;digo Civil que fundamenta a pretens&atilde;o reivindicat&oacute;ria. Referida posse injusta, segundo a conclus&atilde;o da r. senten&ccedil;a, n&atilde;o estaria comprovada.
+Analisando os documentos juntados pela parte autora para alicer&ccedil;ar seu pedido, verifica-se que n&atilde;o assiste raz&atilde;o &agrave; sua irresigna&ccedil;&atilde;o, posto que n&atilde;o conseguiu provar, por meio h&aacute;bil, a ocorr&ecirc;ncia do terceiro requisito acima analisado (posse injusta).
+Ao contr&aacute;rio, os Recorridos, muito embora n&atilde;o tenham apresentado o registro do im&oacute;vel no Cart&oacute;rio competente, demonstraram que o bem fora adquirido de boa-f&eacute;, o que inclui, consequentemente, a sua posse de boa-f&eacute;, porquanto denota-se que o im&oacute;vel objeto da lide foi adquirido pelos r&eacute;us por quem se apresentava como dono.
+Embora os autores se apresentem, at&eacute; o momento, como propriet&aacute;rios, uma vez que a compra e venda n&atilde;o foi registrada na matr&iacute;cula do im&oacute;vel, e aleguem que as constru&ccedil;&otilde;es foram realizadas pelos r&eacute;us sem seu conhecimento e consentimento, &eacute; importante reconhecer, com base nas testemunhas ouvidas, que os promoventes sempre tiveram ci&ecirc;ncia do processo de compra e venda e das obras realizadas pelos r&eacute;us.
+Ainda, observa-se que, conforme reconhecido na senten&ccedil;a, as testemunhas relataram que, desde 2008, os promovidos exercem a posse mansa, pac&iacute;fica e ininterrupta do bem, inexistindo, at&eacute; o ajuizamento desta a&ccedil;&atilde;o, qualquer contesta&ccedil;&atilde;o ou oposi&ccedil;&atilde;o por parte de terceiros, especialmente dos demandantes, sendo de conhecimento da popula&ccedil;&atilde;o local que o im&oacute;vel pertence aos requeridos, que o utilizam com animus domini.
+Diante do exposto, comprovado o exerc&iacute;cio da posse qualificada sobre o im&oacute;vel objurgado, imp&otilde;e-se a manuten&ccedil;&atilde;o da senten&ccedil;a com rejei&ccedil;&atilde;o da pretens&atilde;o reivindicat&oacute;ria, porquanto h&aacute; que se considerar que a posse dos r&eacute;us n&atilde;o se encontra eivada de injusti&ccedil;a.
+&Eacute; importante asseverar, por oportuno, que n&atilde;o se deve confundir v&iacute;cio ou injusti&ccedil;a da posse com mera impossibilidade de registro formal da &aacute;rea possu&iacute;da/adquirida.
+Recurso CONHECIDO E DESPROVIDO.
+
+AC&Oacute;RD&Atilde;O:
+Vistos, relatados e discutidos estes acorda a 2&ordf; C&acirc;mara de Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, em conhecer do recurso de apela&ccedil;&atilde;o n&ordm; 0129032-86.2018.8.06.0001 para negar-lhe provimento, nos termos do voto proferido pelo Excelent&iacute;ssimo Desembargador Relator.
+
+Fortaleza, data indicada no sistema.
+
+DESEMBARGADOR EVERARDO LUCENA SEGUNDO
+Relator
+(assinado digitalmente)  <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0129032-86.2018.8.06.0001, Rel. Desembargador(a)  EVERARDO LUCENA SEGUNDO, 2&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 16/10/2024, data da publica&ccedil;&atilde;o:&nbsp; 16/10/2024)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Reivindicação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> EVERARDO LUCENA SEGUNDO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/10/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/10/2024
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO REIVINDICATÓRIA DA POSSE. REQUISITOS DO ART. 1.228 DO CÓDIGO CIVIL. POSSE INJUSTA NÃO COMPROVADA. MANUTENÇÃO DA SENTENÇA. RECURSO CONHECIDO E DESPROVIDO.
+O cerne da questão em apreço consiste na prova da posse injusta por parte dos réus nos termos do art. 1.228 do Código Civil que fundamenta a pretensão reivindicatória.
+São pressupostos para a obtenção da tutela reclamada,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO REIVINDICATÓRIA DA POSSE. REQUISITOS DO ART. 1.228 DO CÓDIGO CIVIL. POSSE INJUSTA NÃO COMPROVADA. MANUTENÇÃO DA SENTENÇA. RECURSO CONHECIDO E DESPROVIDO.
+O cerne da questão em apreço consiste na prova da posse injusta por parte dos réus nos termos do art. 1.228 do Código Civil que fundamenta a pretensão reivindicatória.
+São pressupostos para a obtenção da tutela reclamada, a comprovação do domínio atual sobre a coisa reivindicanda; a individualização da coisa pretendida (limites e confrontações do imóvel); e a demonstração de que o réu está exercendo a posse sobre a coisa de forma injusta.
+Consoante se percebe dos autos, o que se verifica no caso em apreço é que a parte autora alega ser proprietária do imóvel objeto da lide, tendo juntado aos autos documentos capazes de comprovar o alegado por si. Do mesmo modo, quanto à individualização do imóvel, restou claramente identificado e caracterizado o bem objeto do pedido reivindicatório.
+O cerne da questão em apreço consiste na prova da posse injusta por parte dos réus nos termos do art. 1.228 do Código Civil que fundamenta a pretensão reivindicatória. Referida posse injusta, segundo a conclusão da r. sentença, não estaria comprovada.
+Analisando os documentos juntados pela parte autora para alicerçar seu pedido, verifica-se que não assiste razão à sua irresignação, posto que não conseguiu provar, por meio hábil, a ocorrência do terceiro requisito acima analisado (posse injusta).
+Ao contrário, os Recorridos, muito embora não tenham apresentado o registro do imóvel no Cartório competente, demonstraram que o bem fora adquirido de boa-fé, o que inclui, consequentemente, a sua posse de boa-fé, porquanto denota-se que o imóvel objeto da lide foi adquirido pelos réus por quem se apresentava como dono.
+Embora os autores se apresentem, até o momento, como proprietários, uma vez que a compra e venda não foi registrada na matrícula do imóvel, e aleguem que as construções foram realizadas pelos réus sem seu conhecimento e consentimento, é importante reconhecer, com base nas testemunhas ouvidas, que os promoventes sempre tiveram ciência do processo de compra e venda e das obras realizadas pelos réus.
+Ainda, observa-se que, conforme reconhecido na sentença, as testemunhas relataram que, desde 2008, os promovidos exercem a posse mansa, pacífica e ininterrupta do bem, inexistindo, até o ajuizamento desta ação, qualquer contestação ou oposição por parte de terceiros, especialmente dos demandantes, sendo de conhecimento da população local que o imóvel pertence aos requeridos, que o utilizam com animus domini.
+Diante do exposto, comprovado o exercício da posse qualificada sobre o imóvel objurgado, impõe-se a manutenção da sentença com rejeição da pretensão reivindicatória, porquanto há que se considerar que a posse dos réus não se encontra eivada de injustiça.
+É importante asseverar, por oportuno, que não se deve confundir vício ou injustiça da posse com mera impossibilidade de registro formal da área possuída/adquirida.
+Recurso CONHECIDO E DESPROVIDO.
+
+ACÓRDÃO:
+Vistos, relatados e discutidos estes acorda a 2ª Câmara de Direito Privado do Tribunal de Justiça do Estado do Ceará, em conhecer do recurso de apelação nº 0129032-86.2018.8.06.0001 para negar-lhe provimento, nos termos do voto proferido pelo Excelentíssimo Desembargador Relator.
+
+Fortaleza, data indicada no sistema.
+
+DESEMBARGADOR EVERARDO LUCENA SEGUNDO
+Relator
+(assinado digitalmente)
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3691004" cdForo="0" >
+										0915638-18.2014.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3691004" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3691004);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3691004" style="display: none;" >
+	<div id="textAreaDados_3691004" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. USUCAPI&Atilde;O ESPECIAL URBANO. PROCED&Ecirc;NCIA NA ORIGEM. RECURSO DA R&Eacute;.  TESE DEFENSIVA DEVIDAMENTE ANALISADA, FUNDAMENTADA E REJEITADA PELO JU&Iacute;ZO A QUO. PROVA PERICIAL. T&Oacute;PICO DO RECURSO N&Atilde;O DEDUZIDO NA INICIAL E CONTRARRAZ&Otilde;ES. INOVA&Ccedil;&Atilde;O RECURSAL. REQUISITOS DA PRESCRI&Ccedil;&Atilde;O AQUISITIVA CONSISTENTE A POSSE DA AUTORA MANSA, PAC&Iacute;FICA E ININTERRUPTA DA &Aacute;REA POR MAIS DE 25 (VINTE E CINCO) ANOS, SOMADA A POSSE CONTINUADA. PROVA TESTEMUNHAL QUE CORROBORA O RECONHECIMENTO DA AUTORA COMO LEG&Iacute;TIMA POSSUIDORA. TESE DO R&Eacute;U INCONCEB&Iacute;VEL. AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DO FATO IMPEDITIVO, MODIFICATIVO OU EXTINTIVO DO DIREITO DA AUTORA, ART. 373, II DO CPC. REQUISITOS DOS ARTIGOS 183, DA CONSTITUI&Ccedil;&Atilde;O FEDERAL E 1.240, DO C&Oacute;DIGO CIVIL. PREENCHIDOS: 1) POSSE ININTERRUPTA, SEM OPOSI&Ccedil;&Atilde;O E COM &Acirc;NIMO DE DONO PELO PRAZO DE 5 (CINCO) ANOS; 2) IM&Oacute;VEL LOCALIZADO EM &Aacute;REA URBANA; 3) UTILIZA&Ccedil;&Atilde;O PARA MORADIA PR&Oacute;PRIA OU DE SUA FAM&Iacute;LIA; 4) TERRENO COM SUPERF&Iacute;CIE DE AT&Eacute; 250M&sup2;; 5) AUS&Ecirc;NCIA DE PROPRIEDADE SOBRE OUTRO IM&Oacute;VEL URBANO OU RURAL. EXEGESE DOS ARTIGOS SUPRACITADOS PREENCHIDOS. RECURSO PARCIALMENTE CONHECIDO E NA PARTE CONHECIDA DESPROVIDO. SENTEN&Ccedil;A MANTIDA.
+I. A a&ccedil;&atilde;o de usucapi&atilde;o &eacute; forma origin&aacute;ria de aquisi&ccedil;&atilde;o de propriedade prevista no livro Direito das coisas, do C&oacute;digo Civil/2002.
+II. &Eacute; vedada a inova&ccedil;&atilde;o recursal com mat&eacute;ria n&atilde;o deduzida na peti&ccedil;&atilde;o inicial ou na contesta&ccedil;&atilde;o, sob pena de viola&ccedil;&atilde;o aos princ&iacute;pios constitucionais da ampla defesa e do contradit&oacute;rio. Assim, patenteada a referida inova&ccedil;&atilde;o, o t&oacute;pico relacionado a prova t&eacute;cnica ou pericial n&atilde;o merece conhecimento, visto que n&atilde;o arguido em nenhum momento antes da senten&ccedil;a, sendo defendido, t&atilde;o somente, no recurso apelat&oacute;rio.
+III. O conjunto probat&oacute;rio anexado aos autos apresenta-se coerente no sentido de demonstrar que a apelada Mairyane da Silva Fernandes &eacute; a leg&iacute;tima possuidora do im&oacute;vel objeto da A&ccedil;&atilde;o de Usucapi&atilde;o Urbano, pois detinha a posse mansa e pac&iacute;fica h&aacute; mais de duas d&eacute;cadas, somada a posse continuada, sem interveni&ecirc;ncia de qualquer parte que seja, caracterizando, assim, o animus domini necess&aacute;rio para o presente caso.
+IV. Em rela&ccedil;&atilde;o &agrave; aus&ecirc;ncia dos requisitos esculpidos no artigo 1.240 do CC/2002, a empresa apelante n&atilde;o se desincumbiu de comprovar os fatos impeditivos, modificativo ou extintivos do direito da autora/apelada, &ocirc;nus da prova que lhe cabia, a teor do disposto no art. 373, inciso II do CPC.
+V. Assim, conclui-se que o conjunto probat&oacute;rio f&aacute;tico dos autos revela motivos consider&aacute;veis que autorizem o reconhecimento da pretens&atilde;o aqui deduzida, qual seja, a confirma&ccedil;&atilde;o do t&iacute;tulo de dom&iacute;nio da apelada, sobre o im&oacute;vel usucapiendo, confirmando a senten&ccedil;a em todos os seus termos
+VI. Recurso parcialmente conhecido e, na parte conhecida, desprovido. Senten&ccedil;a mantida.
+
+
+
+
+AC&Oacute;RD&Atilde;O
+
+	Visto, relatado e discutido o Recurso Apelat&oacute;rio n&ordm; 0915638-18.2014.8.06.0001, em que figuram como partes as acima nominadas, acorda a Terceira C&acirc;mara de Direito Privado do Egr&eacute;gio Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER PARCIALMENTE DO RECURSO E, NA PARTE CONHECIDA, NEGAR-LHE PROVIMENTO, mantendo inalterada a senten&ccedil;a recorrida, tudo nos termos do voto do Relator, que integra esta decis&atilde;o.
+		Fortaleza, 22 de maio de 2024.
+
+DESEMBARGADORA CLEIDE ALVES DE AGUIAR
+	Presidente do &Oacute;rg&atilde;o Julgador
+
+JUIZ CONVOCADO DR. PAULO DE TARSO PIRES NOGUEIRA
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0915638-18.2014.8.06.0001, Rel. Desembargador(a)  PAULO DE TARSO PIRES NOGUEIRA - PORT. 2696/2023, 3&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 22/05/2024, data da publica&ccedil;&atilde;o:&nbsp; 22/05/2024)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(54 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Especial (Constitucional)
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> PAULO DE TARSO PIRES NOGUEIRA - PORT. 2696/2023
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									22/05/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									22/05/2024
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. <em>USUCAPIÃO</em> ESPECIAL URBANO. PROCEDÊNCIA NA ORIGEM. RECURSO DA RÉ.  TESE DEFENSIVA DEVIDAMENTE ANALISADA, FUNDAMENTADA E REJEITADA PELO JUÍZO A QUO. PROVA PERICIAL. TÓPICO DO RECURSO NÃO DEDUZIDO NA INICIAL E CONTRARRAZÕES. INOVAÇÃO RECURSAL. REQUISITOS DA PRESCRIÇÃO AQUISITIVA CONSISTENTE A POSSE DA AUTORA MANSA, PACÍFICA E ININTERRUPTA DA ÁREA POR MAIS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. <em>USUCAPIÃO</em> ESPECIAL URBANO. PROCEDÊNCIA NA ORIGEM. RECURSO DA RÉ.  TESE DEFENSIVA DEVIDAMENTE ANALISADA, FUNDAMENTADA E REJEITADA PELO JUÍZO A QUO. PROVA PERICIAL. TÓPICO DO RECURSO NÃO DEDUZIDO NA INICIAL E CONTRARRAZÕES. INOVAÇÃO RECURSAL. REQUISITOS DA PRESCRIÇÃO AQUISITIVA CONSISTENTE A POSSE DA AUTORA MANSA, PACÍFICA E ININTERRUPTA DA ÁREA POR MAIS DE 25 (VINTE E CINCO) ANOS, SOMADA A POSSE CONTINUADA. PROVA TESTEMUNHAL QUE CORROBORA O RECONHECIMENTO DA AUTORA COMO LEGÍTIMA POSSUIDORA. TESE DO RÉU INCONCEBÍVEL. AUSÊNCIA DE COMPROVAÇÃO DO FATO IMPEDITIVO, MODIFICATIVO OU EXTINTIVO DO DIREITO DA AUTORA, ART. 373, II DO CPC. REQUISITOS DOS ARTIGOS 183, DA CONSTITUIÇÃO FEDERAL E 1.240, DO CÓDIGO CIVIL. PREENCHIDOS: 1) POSSE ININTERRUPTA, SEM OPOSIÇÃO E COM ÂNIMO DE DONO PELO PRAZO DE 5 (CINCO) ANOS; 2) IMÓVEL LOCALIZADO EM ÁREA URBANA; 3) UTILIZAÇÃO PARA MORADIA PRÓPRIA OU DE SUA <em>FAMÍLIA</em>; 4) TERRENO COM SUPERFÍCIE DE ATÉ 250M²; 5) AUSÊNCIA DE PROPRIEDADE SOBRE OUTRO IMÓVEL URBANO OU <em>RURAL</em>. EXEGESE DOS ARTIGOS SUPRACITADOS PREENCHIDOS. RECURSO PARCIALMENTE CONHECIDO E NA PARTE CONHECIDA DESPROVIDO. SENTENÇA MANTIDA.
+I. A ação de <em>usucapião</em> é forma originária de aquisição de propriedade prevista no livro Direito das coisas, do Código Civil/2002.
+II. É vedada a inovação recursal com matéria não deduzida na petição inicial ou na contestação, sob pena de violação aos princípios constitucionais da ampla defesa e do contraditório. Assim, patenteada a referida inovação, o tópico relacionado a prova técnica ou pericial não merece conhecimento, visto que não arguido em nenhum momento antes da sentença, sendo defendido, tão somente, no recurso apelatório.
+III. O conjunto probatório anexado aos autos apresenta-se coerente no sentido de demonstrar que a apelada Mairyane da Silva Fernandes é a legítima possuidora do imóvel objeto da Ação de <em>Usucapião</em> Urbano, pois detinha a posse mansa e pacífica há mais de duas décadas, somada a posse continuada, sem interveniência de qualquer parte que seja, caracterizando, assim, o animus domini necessário para o presente caso.
+IV. Em relação à ausência dos requisitos esculpidos no artigo 1.240 do CC/2002, a empresa apelante não se desincumbiu de comprovar os fatos impeditivos, modificativo ou extintivos do direito da autora/apelada, ônus da prova que lhe cabia, a teor do disposto no art. 373, inciso II do CPC.
+V. Assim, conclui-se que o conjunto probatório fático dos autos revela motivos consideráveis que autorizem o reconhecimento da pretensão aqui deduzida, qual seja, a confirmação do título de domínio da apelada, sobre o imóvel usucapiendo, confirmando a sentença em todos os seus termos
+VI. Recurso parcialmente conhecido e, na parte conhecida, desprovido. Sentença mantida.
+
+
+
+
+ACÓRDÃO
+
+	Visto, relatado e discutido o Recurso Apelatório nº 0915638-18.2014.8.06.0001, em que figuram como partes as acima nominadas, acorda a Terceira Câmara de Direito Privado do Egrégio Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER PARCIALMENTE DO RECURSO E, NA PARTE CONHECIDA, NEGAR-LHE PROVIMENTO, mantendo inalterada a sentença recorrida, tudo nos termos do voto do Relator, que integra esta decisão.
+		Fortaleza, 22 de maio de 2024.
+
+DESEMBARGADORA CLEIDE ALVES DE AGUIAR
+	Presidente do Órgão Julgador
+
+JUIZ CONVOCADO DR. PAULO DE TARSO PIRES NOGUEIRA
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3673857" cdForo="0" >
+										0043522-52.2014.8.06.0064
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3673857" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3673857);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3673857" style="display: none;" >
+	<div id="textAreaDados_3673857" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL E CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O ORDIN&Aacute;RIA. SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. IRRESIGNA&Ccedil;&Atilde;O DA PARTE AUTORA. PEDIDO DE JUSTI&Ccedil;A GRATUITA E DE ANULA&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECOLHIMENTO DE CUSTAS JUDICIAIS NA ORIGEM E DO PREPARO DO RECURSO. COMPORTAMENTO CONTRADIT&Oacute;RIO VEDADO PELO ORDENAMENTO JUR&Iacute;DICO P&Aacute;TRIO. PRECLUS&Atilde;O L&Oacute;GICA. INVIABILIDADE DE DEFERIMENTO DA GRATUIDADE. TESE DO APELO COM ALEGA&Ccedil;&Atilde;O DO EXERC&Iacute;CIO DE POSSE MANSA E PAC&Iacute;FICA PELO LAPSO TEMPORAL EXIGIDO PELA LEI E DE ALTERA&Ccedil;&Atilde;O INDEVIDA DAS VIAS P&Uacute;BLICAS PELO MUNIC&Iacute;PIO DE CAUCAIA. PARTE AUTORA QUE N&Atilde;O LOGROU &Ecirc;XITO EM COMPROVAR O FATO CONSTITUTIVO DE SEU DIREITO. BEM P&Uacute;BLICO. CERTID&Atilde;O DE CONSTITUI&Ccedil;&Atilde;O DO IM&Oacute;VEL NO DOM&Iacute;NIO P&Uacute;BLICO NOS AUTOS. LEI FEDERAL N&ordm; 6.766/79. IMPOSSIBILIDADE DE PRESCRI&Ccedil;&Atilde;O AQUISITIVA. ART. 183, &sect;3&ordm;, DA CF/88 E S&Uacute;MULA &ordm; 340 DO STF. RECURSO CONHECIDO E DESPROVIDO.
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 3&ordf; C&acirc;mara Direito P&uacute;blico do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;,por unanimidade, em conhecer do recurso de apela&ccedil;&atilde;o para negar provimento, nos termos do voto do relator.
+Fortaleza, data e hora indicados pelo sistema.
+
+DESEMBARGADOR FRANCISCO LUCIANO LIMA RODRIGUES
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0043522-52.2014.8.06.0064, Rel. Desembargador(a)  FRANCISCO LUCIANO LIMA RODRIGUES, 3&ordf; C&acirc;mara Direito P&uacute;blico, data do julgamento:&nbsp; 01/04/2024, data da publica&ccedil;&atilde;o:&nbsp; 02/04/2024)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Utilização de bens públicos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO LUCIANO LIMA RODRIGUES
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Caucaia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Direito Público
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									01/04/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									02/04/2024
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E CIVIL. APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> ORDINÁRIA. SENTENÇA DE IMPROCEDÊNCIA. IRRESIGNAÇÃO DA PARTE AUTORA. PEDIDO DE JUSTIÇA GRATUITA E DE ANULAÇÃO DA SENTENÇA. RECOLHIMENTO DE CUSTAS JUDICIAIS NA ORIGEM E DO PREPARO DO RECURSO. COMPORTAMENTO CONTRADITÓRIO VEDADO PELO ORDENAMENTO JURÍDICO PÁTRIO. PRECLUSÃO LÓGICA. INVIABILIDADE DE DEFERIMENTO DA GRATUIDADE.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E CIVIL. APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> ORDINÁRIA. SENTENÇA DE IMPROCEDÊNCIA. IRRESIGNAÇÃO DA PARTE AUTORA. PEDIDO DE JUSTIÇA GRATUITA E DE ANULAÇÃO DA SENTENÇA. RECOLHIMENTO DE CUSTAS JUDICIAIS NA ORIGEM E DO PREPARO DO RECURSO. COMPORTAMENTO CONTRADITÓRIO VEDADO PELO ORDENAMENTO JURÍDICO PÁTRIO. PRECLUSÃO LÓGICA. INVIABILIDADE DE DEFERIMENTO DA GRATUIDADE. TESE DO APELO COM ALEGAÇÃO DO EXERCÍCIO DE POSSE MANSA E PACÍFICA PELO LAPSO TEMPORAL EXIGIDO PELA LEI E DE ALTERAÇÃO INDEVIDA DAS VIAS PÚBLICAS PELO MUNICÍPIO DE CAUCAIA. PARTE AUTORA QUE NÃO LOGROU ÊXITO EM COMPROVAR O FATO CONSTITUTIVO DE SEU DIREITO. BEM PÚBLICO. CERTIDÃO DE CONSTITUIÇÃO DO IMÓVEL NO DOMÍNIO PÚBLICO NOS AUTOS. LEI FEDERAL Nº 6.766/79. IMPOSSIBILIDADE DE PRESCRIÇÃO AQUISITIVA. ART. 183, §3º, DA CF/88 E SÚMULA º 340 DO STF. RECURSO CONHECIDO E DESPROVIDO.
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 3ª Câmara Direito Público do Tribunal de Justiça do Estado do Ceará,por unanimidade, em conhecer do recurso de apelação para negar provimento, nos termos do voto do relator.
+Fortaleza, data e hora indicados pelo sistema.
+
+DESEMBARGADOR FRANCISCO LUCIANO LIMA RODRIGUES
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3658383" cdForo="0" >
+										0914580-77.2014.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3658383" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3658383);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3658383" style="display: none;" >
+	<div id="textAreaDados_3658383" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIA. POSSE AD USUCAPIONEM. REQUISITOS DEMONSTRADOS. PRESEN&Ccedil;A DO ANIMUS DOMINI. &Ocirc;NUS DA PROVA DEMONSTRADO. ARTIGO 373, I, DO CPC. RECURSO CONHECIDO E PROVIDO. SENTEN&Ccedil;A REFORMADA.
+1. Cuidam os presentes autos de recurso de apela&ccedil;&atilde;o c&iacute;vel visando a reforma da senten&ccedil;a prolatada pelo M.M. Juiz de Direito da 19&ordf; Vara C&iacute;vel da Comarca de Fortaleza que julgou improcedente a A&ccedil;&atilde;o de Usucapi&atilde;o Extraordin&aacute;ria por n&atilde;o vislumbrar a implementa&ccedil;&atilde;o dos requisitos que autorizam o reconhecimento do direito almejado.
+2. A controv&eacute;rsia recursal consiste em saber se agiu corretamente o ju&iacute;zo de piso ao julgar improcedente a a&ccedil;&atilde;o de usucapi&atilde;o extraordin&aacute;ria.
+3. Feitas essas considera&ccedil;&otilde;es, como se v&ecirc;, a posse aduzida com vistas a possibilitar a aquisi&ccedil;&atilde;o da propriedade mediante a usucapi&atilde;o extraordin&aacute;ria, requer o preenchimento dos pressupostos elencados em lei, quais sejam: 1) o bem deve ser suscet&iacute;vel de ser usucapido; 2) o possuidor deve exercer a posse como se dono fosse, ou seja, com &iquest;animus domini&iquest;; 3) a posse deve se prolongar pelo decurso do prazo de quinze anos; 4) o autor da usucapi&atilde;o deve possuir o bem im&oacute;vel sem interrup&ccedil;&atilde;o e sem oposi&ccedil;&atilde;o e 5) independentemente de justo t&iacute;tulo e boa-f&eacute;, o que se verifica dos autos.
+4. Nesse sentido, depreende-se que a parte autora comprovou nos autos que exerce a posse pelo prazo exigido no C&oacute;digo Civil, assim como demonstrou fato constitutivo do seu direito, consoante disciplina o artigo 373, I, do CPC, qual seja, a comprova&ccedil;&atilde;o do lapso temporal do efetivo exerc&iacute;cio da posse.
+5. Recurso de apela&ccedil;&atilde;o conhecido e provido. Senten&ccedil;a reformada.
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 1&ordf; C&acirc;mara Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em conhecer do recurso de apela&ccedil;&atilde;o, para, no m&eacute;rito, dar-lhe provimento, nos termos do voto do Relator.
+Fortaleza, data da assinatura digital.
+
+DESEMBARGADOR FRANCISCO MAURO FERREIRA LIBERATO
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+DESEMBARGADOR CARLOS AUGUSTO GOMES CORREIA
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0914580-77.2014.8.06.0001, Rel. Desembargador(a)  CARLOS AUGUSTO GOMES CORREIA, 1&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 14/02/2024, data da publica&ccedil;&atilde;o:&nbsp; 14/02/2024)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(66 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Extraordinária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> CARLOS AUGUSTO GOMES CORREIA
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/02/2024
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/02/2024
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. POSSE AD USUCAPIONEM. REQUISITOS DEMONSTRADOS. PRESENÇA DO ANIMUS DOMINI. ÔNUS DA PROVA DEMONSTRADO. ARTIGO 373, I, DO CPC. RECURSO CONHECIDO E PROVIDO. SENTENÇA REFORMADA.
+1. Cuidam os presentes autos de recurso de apelação cível visando a reforma da sentença prolatada pelo M.M. Juiz de Direito
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. POSSE AD USUCAPIONEM. REQUISITOS DEMONSTRADOS. PRESENÇA DO ANIMUS DOMINI. ÔNUS DA PROVA DEMONSTRADO. ARTIGO 373, I, DO CPC. RECURSO CONHECIDO E PROVIDO. SENTENÇA REFORMADA.
+1. Cuidam os presentes autos de recurso de apelação cível visando a reforma da sentença prolatada pelo M.M. Juiz de Direito da 19ª Vara Cível da Comarca de Fortaleza que julgou improcedente a Ação de <em>Usucapião</em> <em>Extraordinária</em> por não vislumbrar a implementação dos requisitos que autorizam o reconhecimento do direito almejado.
+2. A controvérsia recursal consiste em saber se agiu corretamente o juízo de piso ao julgar improcedente a ação de <em>usucapião</em> <em>extraordinária</em>.
+3. Feitas essas considerações, como se vê, a posse aduzida com vistas a possibilitar a aquisição da propriedade mediante a <em>usucapião</em> <em>extraordinária</em>, requer o preenchimento dos pressupostos elencados em lei, quais sejam: 1) o bem deve ser suscetível de ser usucapido; 2) o possuidor deve exercer a posse como se dono fosse, ou seja, com ¿animus domini¿; 3) a posse deve se prolongar pelo decurso do prazo de quinze anos; 4) o autor da <em>usucapião</em> deve possuir o bem imóvel sem interrupção e sem oposição e 5) independentemente de justo título e boa-fé, o que se verifica dos autos.
+4. Nesse sentido, depreende-se que a parte autora comprovou nos autos que exerce a posse pelo prazo exigido no Código Civil, assim como demonstrou fato constitutivo do seu direito, consoante disciplina o artigo 373, I, do CPC, qual seja, a comprovação do lapso temporal do efetivo exercício da posse.
+5. Recurso de apelação conhecido e provido. Sentença reformada.
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 1ª Câmara Direito Privado do Tribunal de Justiça do Estado do Ceará, por unanimidade, em conhecer do recurso de apelação, para, no mérito, dar-lhe provimento, nos termos do voto do Relator.
+Fortaleza, data da assinatura digital.
+
+DESEMBARGADOR FRANCISCO MAURO FERREIRA LIBERATO
+Presidente do Órgão Julgador
+
+
+DESEMBARGADOR CARLOS AUGUSTO GOMES CORREIA
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3613305" cdForo="0" >
+										0022700-52.2005.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3613305" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3613305);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3613305" style="display: none;" >
+	<div id="textAreaDados_3613305" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. USUCAPI&Atilde;O ESPECIAL URBANO.  SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA, DECLARANDO A AUTORA / APELADA COMO PROPRIET&Aacute;RIA DO IM&Oacute;VEL OBJETO DOS AUTOS. CORRETA APRECIA&Ccedil;&Atilde;O. COMODATO VERBAL N&Atilde;O COMPROVADO. &Ocirc;NUS DA PROVA. REQUISITOS DO ART. 1240 DO CC E DO ART. 183 DA CF DEVIDAMENTE PREENCHIDOS. RECURSO CONHECIDO E  IMPROVIDO. SENTEN&Ccedil;A MANTIDA.
+I &iquest; Cuidam os presentes autos de Recurso de Apela&ccedil;&atilde;o C&iacute;vel, interposto por Leide Maria Alves Pinto, com intuito de reformar decis&atilde;o proferida pelo Ju&iacute;zo da 39&ordf; Vara C&iacute;vel da Comarca de Fortaleza, em sede de A&ccedil;&atilde;o de Usucapi&atilde;o Especial Urbano, a qual julgou procedente a a&ccedil;&atilde;o em curso, declarando adquirida a propriedade localizada no Bairro Joaquim T&aacute;vora, com frente para a rua Jo&atilde;o Br&iacute;gido, n&ordm; 267, que &eacute; objeto destes autos, por usucapi&atilde;o, pela autora/ora apelada, Sra. Leoneide Pereira da Silva.
+
+II - O cerne da quest&atilde;o consiste em analisar dois pontos: 1 &iquest; se o alegado comotado verbal, que afastaria a presens&atilde;o de usucapir, restara comprovado nos autos, tendo, de fato, o cond&atilde;o de descaracterizar a propriedade declarada, de modo a classificar a ocupa&ccedil;&atilde;o com esteio no art. 1.208 do CC/2002, entendendo-a como mera deten&ccedil;&atilde;o; 2 - se h&aacute; o preenchimento dos requisitos concernentes ao tipo legal de usucapi&atilde;o de que trata os autos, a saber, especial urbana, uma vez que alegada a aus&ecirc;ncia de animus domini pela parte recorrida.
+
+III - De fato, a parte apelante n&atilde;o conseguiu trazer aos autos robusto acervo probat&oacute;rio capaz de dirimir e, consequentemente, fundamentar as suas alega&ccedil;&otilde;es, nem quanto &agrave; uma poss&iacute;vel loca&ccedil;&atilde;o celebrada entre a recorrida e o seu pai, j&aacute; falecido, o que fora afastado corretamente pelo ju&iacute;zo de piso ainda em primeira inst&acirc;ncia, tampouco o alegado comodato verbal apresentado enquanto raz&atilde;o recursal.
+
+IV &iquest; Na hip&oacute;tese, restam incontroversos, havendo, inclusive, admiss&atilde;o, por parte da apelante, todos os requisitos para configura&ccedil;&atilde;o da usucapi&atilde;o especial urbana, sendo levantado apenas o concernente ao animus domini; ocorre que, novamente, a parte apelante n&atilde;o conseguiu comprovar, em nenhum momento dos autos, as amea&ccedil;as sofridas a sua fam&iacute;lia, nem qualquer tentativa de retirada da recorrida do im&oacute;vel objeto desta lide, bem como que comprovasse o abandono alegado, al&eacute;m de alus&otilde;es a informa&ccedil;&otilde;es as quais indicou como oriundas de &quot;vizinhos&quot; apenas, mas nada concretamente capaz de modificar, ou de extinguir, o direito exordialmente pleitado pela parte adversa.
+
+VI &iquest; Para al&eacute;m disso, em oposi&ccedil;&atilde;o, os documentos apresentados pela parte autora/ ora apelada, foram &iacute;ntegros no sentido de confirmar o seu pedido inaugural, que demostrou utilizar-se, at&eacute; os dias atuais, do im&oacute;vel objeto destes autos para fins de moradia, ou seja, caracterizando, claramente, o seu &acirc;nimo de dono, agindo com a evidente inten&ccedil;&atilde;o de ser dono, raz&atilde;o pela qual compartilho do entendimento do magistrado de origem, bem como do parecer ministerial, mantendo a senten&ccedil;a de piso em seu inteiro teor.
+
+VIII &iquest; Recurso de apela&ccedil;&atilde;o conhecido e improvido. Senten&ccedil;a Mantida.
+AC&Oacute;RD&Atilde;O
+
+Vistos, relatados e discutidos os presentes autos do Recurso de  Apela&ccedil;&atilde;o C&iacute;vel, em que figuram as partes acima referidas, ACORDAM os Senhores Desembargadores da 4&ordf; C&acirc;mara de Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em conhecer da apela&ccedil;&atilde;o interposta, para no m&eacute;rito NEGAR-LHE PROVIMENTO, tudo nos termos do voto do Desembargador Relator.
+
+Fortaleza, 22 de agosto de 2023
+
+
+
+MARIA DO LIVRAMENTO ALVES MAGALHAES
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR DURVAL AIRES FILHO
+Relator
+
+
+
+PROCURADOR(A) DE JUSTI&Ccedil;A <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0022700-52.2005.8.06.0001, Rel. Desembargador(a)  DURVAL AIRES FILHO, 4&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 22/08/2023, data da publica&ccedil;&atilde;o:&nbsp; 22/08/2023)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(62 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Ordinária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> DURVAL AIRES FILHO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									22/08/2023
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									22/08/2023
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> ESPECIAL URBANO.  SENTENÇA DE PROCEDÊNCIA, DECLARANDO A AUTORA / APELADA COMO PROPRIETÁRIA DO IMÓVEL OBJETO DOS AUTOS. CORRETA APRECIAÇÃO. COMODATO VERBAL NÃO COMPROVADO. ÔNUS DA PROVA. REQUISITOS DO ART. 1240 DO CC E DO ART. 183 DA CF DEVIDAMENTE PREENCHIDOS. RECURSO CONHECIDO E  IMPROVIDO. SENTENÇA MANTIDA.
+I ¿ Cuidam os presentes autos de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> ESPECIAL URBANO.  SENTENÇA DE PROCEDÊNCIA, DECLARANDO A AUTORA / APELADA COMO PROPRIETÁRIA DO IMÓVEL OBJETO DOS AUTOS. CORRETA APRECIAÇÃO. COMODATO VERBAL NÃO COMPROVADO. ÔNUS DA PROVA. REQUISITOS DO ART. 1240 DO CC E DO ART. 183 DA CF DEVIDAMENTE PREENCHIDOS. RECURSO CONHECIDO E  IMPROVIDO. SENTENÇA MANTIDA.
+I ¿ Cuidam os presentes autos de Recurso de Apelação Cível, interposto por Leide Maria Alves Pinto, com intuito de reformar decisão proferida pelo Juízo da 39ª Vara Cível da Comarca de Fortaleza, em sede de Ação de <em>Usucapião</em> Especial Urbano, a qual julgou procedente a ação em curso, declarando adquirida a propriedade localizada no Bairro Joaquim Távora, com frente para a rua João Brígido, nº 267, que é objeto destes autos, por <em>usucapião</em>, pela autora/ora apelada, Sra. Leoneide Pereira da Silva.
+
+II - O cerne da questão consiste em analisar dois pontos: 1 ¿ se o alegado comotado verbal, que afastaria a presensão de usucapir, restara comprovado nos autos, tendo, de fato, o condão de descaracterizar a propriedade declarada, de modo a classificar a ocupação com esteio no art. 1.208 do CC/2002, entendendo-a como mera detenção; 2 - se há o preenchimento dos requisitos concernentes ao tipo legal de <em>usucapião</em> de que trata os autos, a saber, especial urbana, uma vez que alegada a ausência de animus domini pela parte recorrida.
+
+III - De fato, a parte apelante não conseguiu trazer aos autos robusto acervo probatório capaz de dirimir e, consequentemente, fundamentar as suas alegações, nem quanto à uma possível locação celebrada entre a recorrida e o seu pai, já falecido, o que fora afastado corretamente pelo juízo de piso ainda em primeira instância, tampouco o alegado comodato verbal apresentado enquanto razão recursal.
+
+IV ¿ Na hipótese, restam incontroversos, havendo, inclusive, admissão, por parte da apelante, todos os requisitos para configuração da <em>usucapião</em> especial urbana, sendo levantado apenas o concernente ao animus domini; ocorre que, novamente, a parte apelante não conseguiu comprovar, em nenhum momento dos autos, as ameaças sofridas a sua <em>família</em>, nem qualquer tentativa de retirada da recorrida do imóvel objeto desta lide, bem como que comprovasse o abandono alegado, além de alusões a informações as quais indicou como oriundas de "vizinhos" apenas, mas nada concretamente capaz de modificar, ou de extinguir, o direito exordialmente pleitado pela parte adversa.
+
+VI ¿ Para além disso, em oposição, os documentos apresentados pela parte autora/ ora apelada, foram íntegros no sentido de confirmar o seu pedido inaugural, que demostrou utilizar-se, até os dias atuais, do imóvel objeto destes autos para fins de moradia, ou seja, caracterizando, claramente, o seu ânimo de dono, agindo com a evidente intenção de ser dono, razão pela qual compartilho do entendimento do magistrado de origem, bem como do parecer ministerial, mantendo a sentença de piso em seu inteiro teor.
+
+VIII ¿ Recurso de apelação conhecido e improvido. Sentença Mantida.
+ACÓRDÃO
+
+Vistos, relatados e discutidos os presentes autos do Recurso de  Apelação Cível, em que figuram as partes acima referidas, ACORDAM os Senhores Desembargadores da 4ª Câmara de Direito Privado do Tribunal de Justiça do Estado do Ceará, por unanimidade, em conhecer da apelação interposta, para no mérito NEGAR-LHE PROVIMENTO, tudo nos termos do voto do Desembargador Relator.
+
+Fortaleza, 22 de agosto de 2023
+
+
+
+MARIA DO LIVRAMENTO ALVES MAGALHAES
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR DURVAL AIRES FILHO
+Relator
+
+
+
+PROCURADOR(A) DE JUSTIÇA
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3561202" cdForo="0" >
+										0050452-56.2021.8.06.0124
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3561202" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3561202);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3561202" style="display: none;" >
+	<div id="textAreaDados_3561202" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIA. AQUISI&Ccedil;&Atilde;O DOS REQUISITOS LEGAIS. OCORR&Ecirc;NCIA. PRESEN&Ccedil;A DE PROVA DO ANIMUS DOMINI. RECURSO CONHECIDO MAS N&Atilde;O PROVIDO.
+1. &Eacute; cedi&ccedil;o que a usucapi&atilde;o &eacute; forma de aquisi&ccedil;&atilde;o origin&aacute;ria da propriedade e de outros direitos reais, pela posse prolongada da coisa, acrescida de demais requisitos legais. Nesse sentido, Caio M&aacute;rio da Silva Pereira, in Institui&ccedil;&otilde;es de Direito Civil, Editora Forense, 4&ordf; edi&ccedil;&atilde;o, v. 4, leciona que a usucapi&atilde;o &eacute; A aquisi&ccedil;&atilde;o da propriedade ou outro direito real pelo decurso do tempo estabelecido e com a observ&acirc;ncia dos requisitos em lei.
+2. Assim, a usucapi&atilde;o &eacute; o direito que o indiv&iacute;duo adquire em rela&ccedil;&atilde;o &agrave; posse de um bem m&oacute;vel ou im&oacute;vel em decorr&ecirc;ncia da utiliza&ccedil;&atilde;o do bem por determinado tempo, cont&iacute;nuo e incontestadamente. Sendo a usucapi&atilde;o sobre bens im&oacute;veis ficar&aacute; discriminada em tr&ecirc;s esp&eacute;cies: extraordin&aacute;ria, ordin&aacute;ria e especial (rural e urbana).
+3. Compulsando os autos, observa-se que a recorrida intentou a prescri&ccedil;&atilde;o aquisitiva na forma extraordin&aacute;ria, na forma prevista no art. 1.238 do C&oacute;digo Civil.
+4. Nos termos dos dispositivos legais acima colacionados, destaca-se que a posse apta a ensejar a usucapi&atilde;o &eacute; aquela exercida com &acirc;nimo de dono, ou seja, com inten&ccedil;&atilde;o de exercer em nome pr&oacute;prio o direito de propriedade.
+5. Com efeito, animus domini nada mais &eacute; do que uma contraposi&ccedil;&atilde;o ao mero possuidor a t&iacute;tulo prec&aacute;rio, &eacute; a verdadeira exterioriza&ccedil;&atilde;o daquele que tem a posse do bem em nome pr&oacute;prio, e n&atilde;o se acha em rela&ccedil;&atilde;o de depend&ecirc;ncia para quem quer que seja.
+6. O artigo 373, inciso II, do C&oacute;digo de Processo Civil, estabelece que o &ocirc;nus da prova incumbe ao r&eacute;u, quanto &agrave; exist&ecirc;ncia de fato impeditivo, modificativo ou extintivo do direito do autor.
+7. No presente caso, a mansid&atilde;o da posse da recorrida com animus domini restou devidamente comprovada, bem como o requisito inerente ao lapso temporal e ao tipo de posse exercida.
+8. &Eacute; que durante a instru&ccedil;&atilde;o processual se produziu fartas provas testemunhais que ratificam a tese autoral, n&atilde;o tendo a parte apelante apresentado qualquer prova a desconstituir o direito autoral, bem como a ratificar sua tese de que os atos narrados na demanda eram de mera permiss&atilde;o ou toler&acirc;ncia.
+9. Por sua vez, os depoimentos das testemunhas d&atilde;o conta de que o im&oacute;vel se encontra h&aacute;, no m&iacute;nimo, aproximadamente 24 anos sob posse da parte apelada, portanto, cumpridos os requisitos legais exigidos.
+10. Assim, andou bem o Ju&iacute;zo a quo ao julgar procedente o pedido exordial.
+11. Recurso conhecido mas n&atilde;o provido.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos de apela&ccedil;&atilde;o c&iacute;vel n&ordm; 0050452-56.2021.8.06.0124, acorda a 2&ordf; C&acirc;mara de Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, em por vota&ccedil;&atilde;o un&acirc;nime, em conhecer do recurso, mas para negar-lhe provimento, em conformidade com o voto do eminente relator.
+
+Fortaleza, 08 de fevereiro de 2023.
+
+
+INACIO DE ALENCAR CORTEZ NETO
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+DESEMBARGADOR CARLOS ALBERTO MENDES FORTE
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0050452-56.2021.8.06.0124, Rel. Desembargador(a)  CARLOS ALBERTO MENDES FORTE, 2&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 08/02/2023, data da publica&ccedil;&atilde;o:&nbsp; 09/02/2023)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(56 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Extraordinária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> CARLOS ALBERTO MENDES FORTE
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Milagres
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									08/02/2023
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									09/02/2023
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. AQUISIÇÃO DOS REQUISITOS LEGAIS. OCORRÊNCIA. PRESENÇA DE PROVA DO ANIMUS DOMINI. RECURSO CONHECIDO MAS NÃO PROVIDO.
+1. É cediço que a <em>usucapião</em> é forma de aquisição originária da propriedade e de outros direitos reais, pela posse prolongada da coisa, acrescida de demais requisitos legais. Nesse sentido, Caio Mário da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DE <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIA</em>. AQUISIÇÃO DOS REQUISITOS LEGAIS. OCORRÊNCIA. PRESENÇA DE PROVA DO ANIMUS DOMINI. RECURSO CONHECIDO MAS NÃO PROVIDO.
+1. É cediço que a <em>usucapião</em> é forma de aquisição originária da propriedade e de outros direitos reais, pela posse prolongada da coisa, acrescida de demais requisitos legais. Nesse sentido, Caio Mário da Silva Pereira, in Instituições de Direito Civil, Editora Forense, 4ª edição, v. 4, leciona que a <em>usucapião</em> é A aquisição da propriedade ou outro direito real pelo decurso do tempo estabelecido e com a observância dos requisitos em lei.
+2. Assim, a <em>usucapião</em> é o direito que o indivíduo adquire em relação à posse de um bem móvel ou imóvel em decorrência da utilização do bem por determinado tempo, contínuo e incontestadamente. Sendo a <em>usucapião</em> sobre bens imóveis ficará discriminada em três espécies: <em>extraordinária</em>, ordinária e especial (<em>rural</em> e urbana).
+3. Compulsando os autos, observa-se que a recorrida intentou a prescrição aquisitiva na forma <em>extraordinária</em>, na forma prevista no art. 1.238 do Código Civil.
+4. Nos termos dos dispositivos legais acima colacionados, destaca-se que a posse apta a ensejar a <em>usucapião</em> é aquela exercida com ânimo de dono, ou seja, com intenção de exercer em nome próprio o direito de propriedade.
+5. Com efeito, animus domini nada mais é do que uma contraposição ao mero possuidor a título precário, é a verdadeira exteriorização daquele que tem a posse do bem em nome próprio, e não se acha em relação de dependência para quem quer que seja.
+6. O artigo 373, inciso II, do Código de Processo Civil, estabelece que o ônus da prova incumbe ao réu, quanto à existência de fato impeditivo, modificativo ou extintivo do direito do autor.
+7. No presente caso, a mansidão da posse da recorrida com animus domini restou devidamente comprovada, bem como o requisito inerente ao lapso temporal e ao tipo de posse exercida.
+8. É que durante a instrução processual se produziu fartas provas testemunhais que ratificam a tese autoral, não tendo a parte apelante apresentado qualquer prova a desconstituir o direito autoral, bem como a ratificar sua tese de que os atos narrados na demanda eram de mera permissão ou tolerância.
+9. Por sua vez, os depoimentos das testemunhas dão conta de que o imóvel se encontra há, no mínimo, aproximadamente 24 anos sob posse da parte apelada, portanto, cumpridos os requisitos legais exigidos.
+10. Assim, andou bem o Juízo a quo ao julgar procedente o pedido exordial.
+11. Recurso conhecido mas não provido.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos de apelação cível nº 0050452-56.2021.8.06.0124, acorda a 2ª Câmara de Direito Privado do Tribunal de Justiça do Estado do Ceará, em por votação unânime, em conhecer do recurso, mas para negar-lhe provimento, em conformidade com o voto do eminente relator.
+
+Fortaleza, 08 de fevereiro de 2023.
+
+
+INACIO DE ALENCAR CORTEZ NETO
+Presidente do Órgão Julgador
+
+
+DESEMBARGADOR CARLOS ALBERTO MENDES FORTE
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3400346" cdForo="0" >
+										0209261-62.2020.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3400346" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3400346);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3400346" style="display: none;" >
+	<div id="textAreaDados_3400346" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O ORDIN&Aacute;RIO. UNIDADE EM CONDOM&Iacute;NIO EDIL&Iacute;CIO IRREGULAR. AQUISI&Ccedil;&Atilde;O ORIGIN&Aacute;RIA DA PROPRIEDADE - IMPOSSIBILIDADE. N&Atilde;O ESPECIFICA&Ccedil;&Atilde;O, INDIVIDUALIZA&Ccedil;&Atilde;O E AVERBA&Ccedil;&Atilde;O DAS UNIDADES AUT&Ocirc;NOMAS NA MATR&Iacute;CULA ORIGIN&Aacute;RIA. M&Aacute;CULA QUE N&Atilde;O PODE SER SANADA PELA LIDE QUE VISA O RECONHECIMENTO DA PRESCRI&Ccedil;&Atilde;O AQUISITIVA. EXIST&Ecirc;NCIA DE JUSTO T&Iacute;TULO. SENTEN&Ccedil;A MANTIDA. RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I - Nos termos do art. 1.242,  do C&oacute;digo Civil de 2002, para a caracteriza&ccedil;&atilde;o da usucapi&atilde;o ordin&aacute;ria, basta que haja os seguintes requisitos: a) posse ad usucapionem, classificada como aquela exercida com &acirc;nimo de dono e capaz de deferir ao seu titular a prescri&ccedil;&atilde;o aquisitiva da coisa gerando o seu dom&iacute;nio; b) inexist&ecirc;ncia de oposi&ccedil;&atilde;o ou resist&ecirc;ncia, isto &eacute;, posse mansa e pac&iacute;fica; c) justo t&iacute;tulo, compreendendo-se como tal o documento potencialmente h&aacute;bil a transferir a propriedade ou outros direitos reais, mas que n&atilde;o o faz por padecer de algum v&iacute;cio formal ou material; d) boa-f&eacute;, ou seja, a aus&ecirc;ncia de ci&ecirc;ncia de qualquer situa&ccedil;&atilde;o que poderia viciar a posse do requerente; e e) lapso temporal decen&aacute;rio. A posse ad usucapionem conjuga os requisitos da continuidade (a posse n&atilde;o pode sofrer interrup&ccedil;&otilde;es); da incontestabilidade e da pacificidade (inexist&ecirc;ncia de oposi&ccedil;&atilde;o ou resist&ecirc;ncia, isto &eacute;, posse mansa e pac&iacute;fica); e do animus domini (o possuidor deve agir como se dono fosse).
+II &#150; Al&eacute;m dos pressupostos mencionados no citado dispositivo, &eacute; mister a individualiza&ccedil;&atilde;o do im&oacute;vel e n&atilde;o ofensa aos princ&iacute;pios da continuidade registral e da unitariedade matricial, conforme previsto na Lei de Registro P&uacute;blico.
+III &#150; Na esp&eacute;cie, os usucapientes, adquirentes de unidade aut&ocirc;noma em condom&iacute;nio edil&iacute;cio, sobre o qual n&atilde;o ocorreu a averba&ccedil;&atilde;o da constru&ccedil;&atilde;o, o registro da especifica&ccedil;&atilde;o do condom&iacute;nio, com a individualiza&ccedil;&atilde;o e discrimina&ccedil;&atilde;o das unidades edificadas na matr&iacute;cula que engloba o todo do empreendimento, querem adquirir a propriedade origin&aacute;ria pela via da prescri&ccedil;&atilde;o aquisitiva.
+IV &#150; Impossibilidade, a teor das regras impostas pelos arts. 176, &sect; 1o., I, 222 e 227, da Lei 6.015/73, bem assim pela firme orienta&ccedil;&atilde;o do excelso Superior Tribunal de Justi&ccedil;a, verbatim et litteram: &quot;(...) 1. &Eacute; inadmiss&iacute;vel a utiliza&ccedil;&atilde;o da a&ccedil;&atilde;o de usucapi&atilde;o para que a parte obtenha a individualiza&ccedil;&atilde;o e o registro de fra&ccedil;&atilde;o de im&oacute;vel objeto de condom&iacute;nio em loteamento irregular. Assim, ser&aacute; &uacute;til, necess&aacute;ria e adequada a tutela jurisdicional somente quando o provimento pretendido for apto a corrigir a situa&ccedil;&atilde;o concreta, isto &eacute;, se a pretens&atilde;o de direito material tem aptid&atilde;o para solucionar a quest&atilde;o de fato objeto de controv&eacute;rsia, o que n&atilde;o se verifica na esp&eacute;cie. Precedente. 2. Agravo interno desprovido. (AgInt nos EDcl no REsp 1539964/DF, Rel. Ministro MARCO AUR&Eacute;LIO BELLIZZE, TERCEIRA TURMA, julgado em 09/12/2019, DJe 12/12/2019). Precedentes deste Sodal&iacute;cio Alencarino.
+V &#150; No caso, a matr&iacute;cula &quot;m&atilde;e&quot; n&atilde;o pode sofrer divis&atilde;o, pois sobre ela ser&aacute; averbada a totalidade da incorpora&ccedil;&atilde;o e registrada a especifica&ccedil;&atilde;o do condom&iacute;nio vertical. Outrossim, n&atilde;o &eacute; fact&iacute;vel a abertura de uma matr&iacute;cula para a fra&ccedil;&atilde;o ideal sem a pr&eacute;via observ&acirc;ncia aos ditames da Lei de Registros P&uacute;blico. E mais, ex vi o princ&iacute;pio da unitariedade da matr&iacute;cula, consagrado no artigo 176, &sect; 1o., I, e  227, da LRP,  &eacute; vedado mais de uma matr&iacute;cula para o mesmo im&oacute;vel. Por fim, n&atilde;o se pode falar em usucapi&atilde;o tabular, de livro ou de coisa pr&oacute;pria, que tem por escopo colmatar a fun&ccedil;&atilde;o social da propriedade, porque n&atilde;o h&aacute; impugna&ccedil;&atilde;o aos direitos dos adquirentes da unidade imobili&aacute;ria aut&ocirc;noma. Enfim, o meio processual eleito n&atilde;o &eacute; o adequado para a solu&ccedil;&atilde;o da controv&eacute;rsia.
+VI - Apela&ccedil;&atilde;o conhecida e n&atilde;o provida.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 2&ordf; C&acirc;mara Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em conhecer do recurso, mas para denegar-lhe provimento, nos termos do voto do Relator.
+
+Fortaleza, 23 de junho de 2021
+
+
+DESEMBARGADOR FRANCISCO  DARIVAL BESERRA PRIMO
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0209261-62.2020.8.06.0001, Rel. Desembargador(a)  FRANCISCO  DARIVAL BESERRA PRIMO, 2&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 23/06/2021, data da publica&ccedil;&atilde;o:&nbsp; 23/06/2021)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(51 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Ausência de Pressupostos de Constituição e Desenvolvimento
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO  DARIVAL BESERRA PRIMO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									23/06/2021
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									23/06/2021
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO DE <em>USUCAPIÃO</em> ORDINÁRIO. UNIDADE EM CONDOMÍNIO EDILÍCIO IRREGULAR. AQUISIÇÃO ORIGINÁRIA DA PROPRIEDADE - IMPOSSIBILIDADE. NÃO ESPECIFICAÇÃO, INDIVIDUALIZAÇÃO E AVERBAÇÃO DAS UNIDADES AUTÔNOMAS NA MATRÍCULA ORIGINÁRIA. MÁCULA QUE NÃO PODE SER SANADA PELA LIDE QUE VISA O RECONHECIMENTO DA PRESCRIÇÃO AQUISITIVA. EXISTÊNCIA DE JUSTO TÍTULO. SENTENÇA MANTIDA. RECURSO CONHECIDO E NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO DE <em>USUCAPIÃO</em> ORDINÁRIO. UNIDADE EM CONDOMÍNIO EDILÍCIO IRREGULAR. AQUISIÇÃO ORIGINÁRIA DA PROPRIEDADE - IMPOSSIBILIDADE. NÃO ESPECIFICAÇÃO, INDIVIDUALIZAÇÃO E AVERBAÇÃO DAS UNIDADES AUTÔNOMAS NA MATRÍCULA ORIGINÁRIA. MÁCULA QUE NÃO PODE SER SANADA PELA LIDE QUE VISA O RECONHECIMENTO DA PRESCRIÇÃO AQUISITIVA. EXISTÊNCIA DE JUSTO TÍTULO. SENTENÇA MANTIDA. RECURSO CONHECIDO E NÃO PROVIDO.
+I - Nos termos do art. 1.242,  do Código Civil de 2002, para a caracterização da <em>usucapião</em> ordinária, basta que haja os seguintes requisitos: a) posse ad usucapionem, classificada como aquela exercida com ânimo de dono e capaz de deferir ao seu titular a prescrição aquisitiva da coisa gerando o seu domínio; b) inexistência de oposição ou resistência, isto é, posse mansa e pacífica; c) justo título, compreendendo-se como tal o documento potencialmente hábil a transferir a propriedade ou outros direitos reais, mas que não o faz por padecer de algum vício formal ou material; d) boa-fé, ou seja, a ausência de ciência de qualquer situação que poderia viciar a posse do requerente; e e) lapso temporal decenário. A posse ad usucapionem conjuga os requisitos da continuidade (a posse não pode sofrer interrupções); da incontestabilidade e da pacificidade (inexistência de oposição ou resistência, isto é, posse mansa e pacífica); e do animus domini (o possuidor deve agir como se dono fosse).
+II  Além dos pressupostos mencionados no citado dispositivo, é mister a individualização do imóvel e não ofensa aos princípios da continuidade registral e da unitariedade matricial, conforme previsto na Lei de Registro Público.
+III  Na espécie, os usucapientes, adquirentes de unidade autônoma em condomínio edilício, sobre o qual não ocorreu a averbação da construção, o registro da especificação do condomínio, com a individualização e discriminação das unidades edificadas na matrícula que engloba o todo do empreendimento, querem adquirir a propriedade originária pela via da prescrição aquisitiva.
+IV  Impossibilidade, a teor das regras impostas pelos arts. 176, § 1o., I, 222 e 227, da Lei 6.015/73, bem assim pela firme orientação do excelso Superior Tribunal de Justiça, verbatim et litteram: "(...) 1. É inadmissível a utilização da ação de <em>usucapião</em> para que a parte obtenha a individualização e o registro de fração de imóvel objeto de condomínio em loteamento irregular. Assim, será útil, necessária e adequada a tutela jurisdicional somente quando o provimento pretendido for apto a corrigir a situação concreta, isto é, se a pretensão de direito material tem aptidão para solucionar a questão de fato objeto de controvérsia, o que não se verifica na espécie. Precedente. 2. Agravo interno desprovido. (AgInt nos EDcl no REsp 1539964/DF, Rel. Ministro MARCO AURÉLIO BELLIZZE, TERCEIRA TURMA, julgado em 09/12/2019, DJe 12/12/2019). Precedentes deste Sodalício Alencarino.
+V  No caso, a matrícula "mãe" não pode sofrer divisão, pois sobre ela será averbada a totalidade da incorporação e registrada a especificação do condomínio vertical. Outrossim, não é factível a abertura de uma matrícula para a fração ideal sem a prévia observância aos ditames da Lei de Registros Público. E mais, ex vi o princípio da unitariedade da matrícula, consagrado no artigo 176, § 1o., I, e  227, da LRP,  é vedado mais de uma matrícula para o mesmo imóvel. Por fim, não se pode falar em <em>usucapião</em> tabular, de livro ou de coisa própria, que tem por escopo colmatar a função social da propriedade, porque não há impugnação aos direitos dos adquirentes da unidade imobiliária autônoma. Enfim, o meio processual eleito não é o adequado para a solução da controvérsia.
+VI - Apelação conhecida e não provida.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 2ª Câmara Direito Privado do Tribunal de Justiça do Estado do Ceará, por unanimidade, em conhecer do recurso, mas para denegar-lhe provimento, nos termos do voto do Relator.
+
+Fortaleza, 23 de junho de 2021
+
+
+DESEMBARGADOR FRANCISCO  DARIVAL BESERRA PRIMO
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3343690" cdForo="0" >
+										0000102-18.2000.8.06.0151
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3343690" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3343690);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3343690" style="display: none;" >
+	<div id="textAreaDados_3343690" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. DIREITO ADMINISTRATIVO. INTERDITO PROIBIT&Oacute;RIO. IM&Oacute;VEL DESTINADO &Agrave; UTILIDADE P&Uacute;BLICA. CONSTRU&Ccedil;&Atilde;O DE CENTRO DE ZOONOSES E F&Oacute;RUM DA COMARCA NO IM&Oacute;VEL DO AUTOR. PRELIMINARES. NULIDADE ABSOLUTA POR AUS&Ecirc;NCIA DE INTIMA&Ccedil;&Atilde;O DO MINIST&Eacute;RIO P&Uacute;BLICO. IMPROCEDENTE. INTERESSES MERAMENTE PATRIMONIAIS. CONVERS&Atilde;O DO PEDIDO REINTEGRAT&Oacute;RIO EM INDENIZAT&Oacute;RIO. DESAPROPRIA&Ccedil;&Atilde;O INDIRETA. POSSIBILIDADE. PRECEDENTES DO STJ E DESTA CORTE. INDENIZA&Ccedil;&Atilde;O A SER AFERIDA POR LAUDO PERICIAL. NECESSIDADE DE RETORNO DOS AUTOS &Agrave; ORIGEM. APELA&Ccedil;&Atilde;O C&Iacute;VEL CONHECIDA E PROVIDA. SENTEN&Ccedil;A ANULADA.
+I-Trata-se de Recurso de Apela&ccedil;&atilde;o contra senten&ccedil;a proferida pelo Ju&iacute;zo da 1&ordf; Vara da Comarca de Quixad&aacute; que, nos autos de Interdito Proibit&oacute;rio aforado pelo pr&oacute;prio apelante contra o Munic&iacute;pio de Quixad&aacute;, julgou extinto o feito sem resolu&ccedil;&atilde;o do m&eacute;rito.
+
+II. Cinge-se o pleito em avaliar a convers&atilde;o do interdito proibit&oacute;rio em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por desapropria&ccedil;&atilde;o indireta, por considerar que, como o im&oacute;vel objeto do presente lit&iacute;gio tivera destina&ccedil;&atilde;o &agrave; utilidade p&uacute;blica, deveria o autor ser ressarcido. Subsidiariamente, pugnou pela convers&atilde;o em a&ccedil;&atilde;o de reintegra&ccedil;&atilde;o de posse cumulada com pedido de indeniza&ccedil;&atilde;o por perdas e danos.
+
+III. Conquanto tenha o Munic&iacute;pio de Quixad&aacute; afirmado, quanto aos fatos do processo, ter efetivado a desapropria&ccedil;&atilde;o do terreno objeto do presente lit&iacute;gio, n&atilde;o colaciona prova quanto &agrave; exist&ecirc;ncia de fato impeditivo, modificativo ou extintivo do direito do autor, &ocirc;nus que lhe incumbia por for&ccedil;a do art. 373, inciso II, do C&oacute;digo de Processo Civil. Portanto, caberia ao Munic&iacute;pio de Quixad&aacute; comprovar que, de fato, desapropriara o terreno nos moldes descritos no Decreto-Lei n&ordm; 3.365/1941. Por outro lado, o autor, comprovou, de fato, ter a posse e a propriedade do terreno, &ocirc;nus que lhe incumbia por for&ccedil;a do disposto no art. 373, inciso I.
+
+IV. Ao ingressar no terreno do autor, destruindo as suas cercas, o demandado promovera esbulho, fato este incontroverso e refor&ccedil;ado por laudo pericial. A prote&ccedil;&atilde;o do autor em face do esbulho se d&aacute; pela incid&ecirc;ncia do art. 506 do C&oacute;digo Civil de 1916. Entretanto, a prote&ccedil;&atilde;o possess&oacute;ria n&atilde;o mais &eacute; poss&iacute;vel, haja vista que a administra&ccedil;&atilde;o conferira destina&ccedil;&atilde;o p&uacute;blica ao im&oacute;vel objeto do presente lit&iacute;gio, integrando-o ao seu patrim&ocirc;nio. Desse modo, o autor pleiteou a convers&atilde;o do pedido em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por desapropria&ccedil;&atilde;o indireta. De fato, o pedido merece acolhimento.
+
+V. A transfer&ecirc;ncia compuls&oacute;ria do bem fora demonstrada, tendo em vista o esbulho praticado. No mais, em an&aacute;lise aos autos, &eacute; de se notar que fora dada destina&ccedil;&atilde;o de utilidade p&uacute;blica ao terreno, materializada na constru&ccedil;&atilde;o do Centro de Zoonoses do Munic&iacute;pio de Quixad&aacute; e no F&oacute;rum desta Comarca. Portanto, resta invi&aacute;vel a tutela da posse do autor no caso, em face do interesse p&uacute;blico secund&aacute;rio subjacente.
+
+VI. Nesse sentido, o Superior Tribunal de Justi&ccedil;a tem entendido pela possibilidade de convers&atilde;o do interdito proibit&oacute;rio em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por desapropria&ccedil;&atilde;o indireta, em casos semelhantes aos do autor, ainda que se extrapole a &oacute;rbita da fungibilidade das a&ccedil;&otilde;es possess&oacute;rias.
+
+VII. Esclarece-se que, de fato, pela previs&atilde;o constante no art. 5&ordm;, inciso XXIV, da Constitui&ccedil;&atilde;o Federal, em a&ccedil;&otilde;es que t&ecirc;m por objeto a desapropria&ccedil;&atilde;o, o ressarcimento ao propriet&aacute;rio do im&oacute;vel deve culminar em justa e pr&eacute;via indeniza&ccedil;&atilde;o. Desse modo, tal valor deve ser aferido por meio de laudo t&eacute;cnico, elaborado por especialista. Portanto, entendo pela necessidade de se anular o processo t&atilde;o somente a partir da senten&ccedil;a. Devem os autos retornar &agrave; origem para a fase de instru&ccedil;&atilde;o, sendo imprescind&iacute;vel a realiza&ccedil;&atilde;o de prova pericial para apura&ccedil;&atilde;o do valor devido.
+
+VIII. Apela&ccedil;&atilde;o conhecida e provida. Senten&ccedil;a desconstitu&iacute;da.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 3&ordf; C&acirc;mara Direito P&uacute;blico do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade de votos, em conhecer do presente recurso, para dar-lhe provimento, nos termos do voto da Relatora.
+
+Fortaleza, 23 de novembro de 2020
+
+
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+SILVIA SOARES DE S&Aacute; NOBREGA
+JU&Iacute;ZA CONVOCADA - PORT. 1196/2020
+Relatora  <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0000102-18.2000.8.06.0151, Rel. Desembargador(a)  SILVIA SOARES DE S&Aacute; NOBREGA - PORT. 1196/2020, 3&ordf; C&acirc;mara Direito P&uacute;blico, data do julgamento:&nbsp; 23/11/2020, data da publica&ccedil;&atilde;o:&nbsp; 24/11/2020)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Posse
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> SILVIA SOARES DE SÁ NOBREGA - PORT. 1196/2020
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Quixadá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Direito Público
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									23/11/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									24/11/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO ADMINISTRATIVO. INTERDITO PROIBITÓRIO. IMÓVEL DESTINADO À UTILIDADE PÚBLICA. CONSTRUÇÃO DE CENTRO DE ZOONOSES E FÓRUM DA COMARCA NO IMÓVEL DO AUTOR. PRELIMINARES. NULIDADE ABSOLUTA POR AUSÊNCIA DE INTIMAÇÃO DO MINISTÉRIO PÚBLICO. IMPROCEDENTE. INTERESSES MERAMENTE PATRIMONIAIS. CONVERSÃO DO PEDIDO REINTEGRATÓRIO EM INDENIZATÓRIO. DESAPROPRIAÇÃO INDIRETA. POSSIBILIDADE.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. DIREITO ADMINISTRATIVO. INTERDITO PROIBITÓRIO. IMÓVEL DESTINADO À UTILIDADE PÚBLICA. CONSTRUÇÃO DE CENTRO DE ZOONOSES E FÓRUM DA COMARCA NO IMÓVEL DO AUTOR. PRELIMINARES. NULIDADE ABSOLUTA POR AUSÊNCIA DE INTIMAÇÃO DO MINISTÉRIO PÚBLICO. IMPROCEDENTE. INTERESSES MERAMENTE PATRIMONIAIS. CONVERSÃO DO PEDIDO REINTEGRATÓRIO EM INDENIZATÓRIO. DESAPROPRIAÇÃO INDIRETA. POSSIBILIDADE. PRECEDENTES DO STJ E DESTA CORTE. INDENIZAÇÃO A SER AFERIDA POR LAUDO PERICIAL. NECESSIDADE DE RETORNO DOS AUTOS À ORIGEM. APELAÇÃO CÍVEL CONHECIDA E PROVIDA. SENTENÇA ANULADA.
+I-Trata-se de Recurso de Apelação contra sentença proferida pelo Juízo da 1ª Vara da Comarca de Quixadá que, nos autos de Interdito Proibitório aforado pelo próprio apelante contra o Município de Quixadá, julgou extinto o feito sem resolução do mérito.
+
+II. Cinge-se o pleito em avaliar a conversão do interdito proibitório em ação de indenização por desapropriação indireta, por considerar que, como o imóvel objeto do presente litígio tivera destinação à utilidade pública, deveria o autor ser ressarcido. Subsidiariamente, pugnou pela conversão em ação de reintegração de posse cumulada com pedido de indenização por perdas e danos.
+
+III. Conquanto tenha o Município de Quixadá afirmado, quanto aos fatos do processo, ter efetivado a desapropriação do terreno objeto do presente litígio, não colaciona prova quanto à existência de fato impeditivo, modificativo ou extintivo do direito do autor, ônus que lhe incumbia por força do art. 373, inciso II, do Código de Processo Civil. Portanto, caberia ao Município de Quixadá comprovar que, de fato, desapropriara o terreno nos moldes descritos no Decreto-Lei nº 3.365/1941. Por outro lado, o autor, comprovou, de fato, ter a posse e a propriedade do terreno, ônus que lhe incumbia por força do disposto no art. 373, inciso I.
+
+IV. Ao ingressar no terreno do autor, destruindo as suas cercas, o demandado promovera esbulho, fato este incontroverso e reforçado por laudo pericial. A proteção do autor em face do esbulho se dá pela incidência do art. 506 do Código Civil de 1916. Entretanto, a proteção possessória não mais é possível, haja vista que a administração conferira destinação pública ao imóvel objeto do presente litígio, integrando-o ao seu patrimônio. Desse modo, o autor pleiteou a conversão do pedido em ação de indenização por desapropriação indireta. De fato, o pedido merece acolhimento.
+
+V. A transferência compulsória do bem fora demonstrada, tendo em vista o esbulho praticado. No mais, em análise aos autos, é de se notar que fora dada destinação de utilidade pública ao terreno, materializada na construção do Centro de Zoonoses do Município de Quixadá e no Fórum desta Comarca. Portanto, resta inviável a tutela da posse do autor no caso, em face do interesse público secundário subjacente.
+
+VI. Nesse sentido, o Superior Tribunal de Justiça tem entendido pela possibilidade de conversão do interdito proibitório em ação de indenização por desapropriação indireta, em casos semelhantes aos do autor, ainda que se extrapole a órbita da fungibilidade das ações possessórias.
+
+VII. Esclarece-se que, de fato, pela previsão constante no art. 5º, inciso XXIV, da Constituição Federal, em ações que têm por objeto a desapropriação, o ressarcimento ao proprietário do imóvel deve culminar em justa e prévia indenização. Desse modo, tal valor deve ser aferido por meio de laudo técnico, elaborado por especialista. Portanto, entendo pela necessidade de se anular o processo tão somente a partir da sentença. Devem os autos retornar à origem para a fase de instrução, sendo imprescindível a realização de prova pericial para apuração do valor devido.
+
+VIII. Apelação conhecida e provida. Sentença desconstituída.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 3ª Câmara Direito Público do Tribunal de Justiça do Estado do Ceará, por unanimidade de votos, em conhecer do presente recurso, para dar-lhe provimento, nos termos do voto da Relatora.
+
+Fortaleza, 23 de novembro de 2020
+
+
+Presidente do Órgão Julgador
+
+
+
+SILVIA SOARES DE SÁ NOBREGA
+JUÍZA CONVOCADA - PORT. 1196/2020
+Relatora
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3342264" cdForo="0" >
+										0000175-76.2005.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3342264" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3342264);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3342264" style="display: none;" >
+	<div id="textAreaDados_3342264" class="mensagemSemFormatacao" >
+		CIVIL E PROCESSO CIVIL. A&Ccedil;&Atilde;O  REIVINDICAT&Oacute;RIA. PRELIMINAR DE NULIDADE DA SENTEN&Ccedil;A &#150; CERCEAMENTO DE DEFESA - DECIS&Atilde;O FUNDADA NO LIVRE CONVENCIMENTO MOTIVADO DO JUIZ. PRECEDENTES DO STJ. PEDIDO DE ANULA&Ccedil;&Atilde;O DO PROCESSO POR AUS&Ecirc;NCIA DE OUTORGA UX&Oacute;RIA &#150; N&Atilde;O ACOLHIDO. EXCE&Ccedil;&Atilde;O DE USUCAPI&Atilde;O. REQUISITOS PR&Oacute;PRIOS N&Atilde;O DEMONSTRADOS. APELO CONHECIDO E DESPROVIDO.
+1 &#150; Preambular do(a) apelante de nulidade da senten&ccedil;a por cerceamento de defesa. For&ccedil;oso reconhecer que a aprecia&ccedil;&atilde;o da prova, enquanto parte integrante da atividade jurisdicional, &eacute; poder conferido ao juiz e deve se adequar &agrave;s circunst&acirc;ncias f&aacute;ticas presentes em cada demanda. No caso em tela, a prova oral, com a oitiva de testemunhas, restou realizada. O Julgador de plan&iacute;cie, apenas, indeferiu nova argui&ccedil;&atilde;o das colaboradoras com a justi&ccedil;a. Senten&ccedil;a fundada nas provas produzidas por ambas as partes ao longo da marcha processual, de modo que, segundo seu crit&eacute;rio, o indeferimento de nova instru&ccedil;&atilde;o vislumbra-se cab&iacute;vel. A anula&ccedil;&atilde;o de senten&ccedil;a com base em cerceamento de defesa pelo exerc&iacute;cio da liberdade instrut&oacute;ria do julgador representaria grave viola&ccedil;&atilde;o &agrave; liberdade do &oacute;rg&atilde;o jurisdicional. Preliminar rejeitada. Precedente do STJ.
+2 &#150; A pretens&atilde;o de nulidade do feito, por se tratar de a&ccedil;&atilde;o real imobili&aacute;ria, processado sem a outorga ux&oacute;ria, est&aacute; prejudicada, porquanto a mulher do promovente, Sra. Albertina Melo de Andrade, &agrave;s fls. 177/178, compareceu espontaneamente &agrave; lide e passou a integrar o polo ativo do caderno processual.
+3 &#150; &Eacute; cedi&ccedil;o que a a&ccedil;&atilde;o reivindicat&oacute;ria, nos termos do artigo 1.228 do C&oacute;digo Civil, &eacute; um rem&eacute;dio processual para se reaver a coisa de quem injustamente a detenha ou possua. &Eacute; demanda de cunho petit&oacute;rio e, por isso, deve o autor provar a sua propriedade.
+4 &#150; Na esp&eacute;cie, a pretens&atilde;o reivindicat&oacute;ria tem lastro em documentos que comprovam, de forma escorreita, o dom&iacute;nio, tendo em vista a certid&atilde;o do Cart&oacute;rio de Registro de Im&oacute;veis de Fortaleza - 6&ordf; Zona.
+5 &#150; Por outro vezo, a exce&ccedil;&atilde;o de usucapi&atilde;o requer a prova da posse continuada, mansa e com animus domini, durante certo lapso de tempo. O prazo vindicado pelo(a) recurso(a), mesmo de 05 (cinco) anos, n&atilde;o est&aacute; demonstrado no feito.
+6 &#150; &Eacute; sabido que, o instituto da usucapi&atilde;o constitui meio de aquisi&ccedil;&atilde;o origin&aacute;ria da propriedade e exige, para sua configura&ccedil;&atilde;o, como n&atilde;o poderia deixar de ser, o requisito da exatid&atilde;o. Trata-se, neste caso concreto, de prova deficit&aacute;ria quanto &agrave; pretens&atilde;o, motivo pelo qual a senten&ccedil;a n&atilde;o pode ser convolada.
+7 &#150; Apela&ccedil;&atilde;o conhecida e n&atilde;o provida.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos os presentes autos de Apela&ccedil;&atilde;o C&iacute;vel ACORDAM os Desembargadores da 2&ordf; C&acirc;mara de Direito Privado, em, por unanimidade, conhecer do apelat&oacute;rio para desprov&ecirc;-lo, nos termos do voto do eminente Desembargador Relator.
+
+
+Fortaleza, 18 de novembro de 2020.
+
+
+
+FRANCISCO  DARIVAL BESERRA PRIMO
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR FRANCISCO  DARIVAL BESERRA PRIMO
+Relator
+ <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0000175-76.2005.8.06.0001, Rel. Desembargador(a)  FRANCISCO  DARIVAL BESERRA PRIMO, 2&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 18/11/2020, data da publica&ccedil;&atilde;o:&nbsp; 18/11/2020)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Posse
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> FRANCISCO  DARIVAL BESERRA PRIMO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									18/11/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									18/11/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>CIVIL E PROCESSO CIVIL. AÇÃO  REIVINDICATÓRIA. PRELIMINAR DE NULIDADE DA SENTENÇA  CERCEAMENTO DE DEFESA - DECISÃO FUNDADA NO LIVRE CONVENCIMENTO MOTIVADO DO JUIZ. PRECEDENTES DO STJ. PEDIDO DE ANULAÇÃO DO PROCESSO POR AUSÊNCIA DE OUTORGA UXÓRIA  NÃO ACOLHIDO. EXCEÇÃO DE <em>USUCAPIÃO</em>. REQUISITOS PRÓPRIOS NÃO DEMONSTRADOS. APELO CONHECIDO E DESPROVIDO.
+1  Preambular do(a) apelante de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>CIVIL E PROCESSO CIVIL. AÇÃO  REIVINDICATÓRIA. PRELIMINAR DE NULIDADE DA SENTENÇA  CERCEAMENTO DE DEFESA - DECISÃO FUNDADA NO LIVRE CONVENCIMENTO MOTIVADO DO JUIZ. PRECEDENTES DO STJ. PEDIDO DE ANULAÇÃO DO PROCESSO POR AUSÊNCIA DE OUTORGA UXÓRIA  NÃO ACOLHIDO. EXCEÇÃO DE <em>USUCAPIÃO</em>. REQUISITOS PRÓPRIOS NÃO DEMONSTRADOS. APELO CONHECIDO E DESPROVIDO.
+1  Preambular do(a) apelante de nulidade da sentença por cerceamento de defesa. Forçoso reconhecer que a apreciação da prova, enquanto parte integrante da atividade jurisdicional, é poder conferido ao juiz e deve se adequar às circunstâncias fáticas presentes em cada demanda. No caso em tela, a prova oral, com a oitiva de testemunhas, restou realizada. O Julgador de planície, apenas, indeferiu nova arguição das colaboradoras com a justiça. Sentença fundada nas provas produzidas por ambas as partes ao longo da marcha processual, de modo que, segundo seu critério, o indeferimento de nova instrução vislumbra-se cabível. A anulação de sentença com base em cerceamento de defesa pelo exercício da liberdade instrutória do julgador representaria grave violação à liberdade do órgão jurisdicional. Preliminar rejeitada. Precedente do STJ.
+2  A pretensão de nulidade do feito, por se tratar de ação real imobiliária, processado sem a outorga uxória, está prejudicada, porquanto a mulher do promovente, Sra. Albertina Melo de Andrade, às fls. 177/178, compareceu espontaneamente à lide e passou a integrar o polo ativo do caderno processual.
+3  É cediço que a ação reivindicatória, nos termos do artigo 1.228 do Código Civil, é um remédio processual para se reaver a coisa de quem injustamente a detenha ou possua. É demanda de cunho petitório e, por isso, deve o autor provar a sua propriedade.
+4  Na espécie, a pretensão reivindicatória tem lastro em documentos que comprovam, de forma escorreita, o domínio, tendo em vista a certidão do Cartório de Registro de Imóveis de Fortaleza - 6ª Zona.
+5  Por outro vezo, a exceção de <em>usucapião</em> requer a prova da posse continuada, mansa e com animus domini, durante certo lapso de tempo. O prazo vindicado pelo(a) recurso(a), mesmo de 05 (cinco) anos, não está demonstrado no feito.
+6  É sabido que, o instituto da <em>usucapião</em> constitui meio de aquisição originária da propriedade e exige, para sua configuração, como não poderia deixar de ser, o requisito da exatidão. Trata-se, neste caso concreto, de prova deficitária quanto à pretensão, motivo pelo qual a sentença não pode ser convolada.
+7  Apelação conhecida e não provida.
+
+ACÓRDÃO: Vistos, relatados e discutidos os presentes autos de Apelação Cível ACORDAM os Desembargadores da 2ª Câmara de Direito Privado, em, por unanimidade, conhecer do apelatório para desprovê-lo, nos termos do voto do eminente Desembargador Relator.
+
+
+Fortaleza, 18 de novembro de 2020.
+
+
+
+FRANCISCO  DARIVAL BESERRA PRIMO
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR FRANCISCO  DARIVAL BESERRA PRIMO
+Relator
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3296672" cdForo="0" >
+										0211337-06.2013.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3296672" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3296672);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3296672" style="display: none;" >
+	<div id="textAreaDados_3296672" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O REINVIDICAT&Oacute;RIA. ALEGA&Ccedil;&Atilde;O DE PREENCHIMENTO DOS REQUISITOS DO USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIO COMO MAT&Eacute;RIA DE DEFESA. AUS&Ecirc;NCIA POSSE MANSA E PAC&Iacute;FICA COM ANIMUS DOMINI. COMPROVA&Ccedil;&Atilde;O DA PROPRIEDADE DOS APELADOS E DA RESIST&Ecirc;NCIA DOS APELANTES EM DESOCUPAR O IM&Oacute;VEL. PERMAN&Ecirc;NCIA NO IM&Oacute;VEL DECORRENTE DE COMODATO VERBAL. REINVIDICAT&Oacute;RIA PROCEDENTE. RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, em vota&ccedil;&atilde;o un&acirc;nime, pelo conhecimento e improvimento do apelo, tudo em conformidade com os termos do voto do e. Desembargador Relator.
+
+Fortaleza, 26 de maio de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR DURVAL AIRES FILHO
+Relator
+
+
+
+Procurador de Justi&ccedil;a <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0211337-06.2013.8.06.0001, Rel. Desembargador(a)  DURVAL AIRES FILHO, 4&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 26/05/2020, data da publica&ccedil;&atilde;o:&nbsp; 26/05/2020)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(60 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Imissão
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> DURVAL AIRES FILHO
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/05/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									26/05/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO REINVIDICATÓRIA. ALEGAÇÃO DE PREENCHIMENTO DOS REQUISITOS DO <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIO</em> COMO MATÉRIA DE DEFESA. AUSÊNCIA POSSE MANSA E PACÍFICA COM ANIMUS DOMINI. COMPROVAÇÃO DA PROPRIEDADE DOS APELADOS E DA RESISTÊNCIA DOS APELANTES EM DESOCUPAR O IMÓVEL. PERMANÊNCIA NO IMÓVEL DECORRENTE DE COMODATO VERBAL. REINVIDICATÓRIA PROCEDENTE. RECURSO CONHECIDO E NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO REINVIDICATÓRIA. ALEGAÇÃO DE PREENCHIMENTO DOS REQUISITOS DO <em>USUCAPIÃO</em> <em>EXTRAORDINÁRIO</em> COMO MATÉRIA DE DEFESA. AUSÊNCIA POSSE MANSA E PACÍFICA COM ANIMUS DOMINI. COMPROVAÇÃO DA PROPRIEDADE DOS APELADOS E DA RESISTÊNCIA DOS APELANTES EM DESOCUPAR O IMÓVEL. PERMANÊNCIA NO IMÓVEL DECORRENTE DE COMODATO VERBAL. REINVIDICATÓRIA PROCEDENTE. RECURSO CONHECIDO E NÃO PROVIDO.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara Direito Privado do Tribunal de Justiça do Estado do Ceará, em votação unânime, pelo conhecimento e improvimento do apelo, tudo em conformidade com os termos do voto do e. Desembargador Relator.
+
+Fortaleza, 26 de maio de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR DURVAL AIRES FILHO
+Relator
+
+
+
+Procurador de Justiça
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3288131" cdForo="0" >
+										0140078-43.2016.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3288131" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3288131);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3288131" style="display: none;" >
+	<div id="textAreaDados_3288131" class="mensagemSemFormatacao" >
+
+CIVIL. PROCESSO CIVIL. APELA&Ccedil;&Atilde;O. NULIDADE. SENTEN&Ccedil;A FUNDAMENTADA. VIA ELEITA ADEQUADA. PRELIMINARES AFASTADAS. A&Ccedil;&Atilde;O DE REINTEGRA&Ccedil;&Atilde;O DE POSSE. POSSE COMPROVADA. ESBULHO PRATICADO. NOTIFICA&Ccedil;&Atilde;O PARA DESOCUPA&Ccedil;&Atilde;O N&Atilde;O ATENDIDA. ALUGUEL. PAGAMENTO. RECURSO CONHECIDO E N&Atilde;O PROVIDO. SENTEN&Ccedil;A MANTIDA.
+1. A senten&ccedil;a est&aacute; devidamente fundamentada, apresentando as raz&otilde;es que embasaram a conclus&atilde;o do magistrado. Com efeito, entendeu o julgador singular que n&atilde;o se restou comprovada a posse das promovidas, configurando-se mera deten&ccedil;&atilde;o. Assim, a posse sempre foi exercida pela autora, que permitiu a utiliza&ccedil;&atilde;o do im&oacute;vel pelas promovidas, estando configurada a posse da requerente. Quanto &agrave;s perdas e danos, entendeu-se que a partir da data em que deveria ter sido restitu&iacute;da a posse &agrave; requerente as promovidas devem arcar com o pagamento de aluguel, considerando a exist&ecirc;ncia de comodato. A a&ccedil;&atilde;o de reintegra&ccedil;&atilde;o de posse &eacute; o meio processual adequado para a autora que pretende reaver a posse plena do bem, tendo em vista que a quest&atilde;o gira em torno da exist&ecirc;ncia ou n&atilde;o de contrato de comodato verbal e gratuito, bem como se a posse das promovidas est&aacute; comprovada. Preliminares rejeitadas.
+2. As promovidas afirmam que residem no im&oacute;vel h&aacute; mais de 26 anos, estabelecendo nele sua moradia como leg&iacute;timos propriet&aacute;rios, arcando com os custos de cotas condominiais, despesas extras, energia e &aacute;gua. Ocorre que o bem est&aacute; registrado em nome da promovente, que afirma que adquiriu o bem com seu falecido esposo e que emprestou o im&oacute;vel para as promovidas estabelecerem resid&ecirc;ncia, considerando que o marido da promovente e o marido da promovida eram irm&atilde;os e muito pr&oacute;ximos. O parentesco entre os falecidos mencionados &eacute; incontroverso, sendo discutido nos autos a exist&ecirc;ncia de comodato gratuito e verbal entre as partes, bem como o exerc&iacute;cio das promoventes da posse mansa, pac&iacute;fica e ininterrupta, pelo lapso temporal da usucapi&atilde;o, do bem em lit&iacute;gio.
+3. A prova coligida esclarece a quest&atilde;o. As promovidas foram residir no im&oacute;vel com a anu&ecirc;ncia da promovente, propriet&aacute;ria do bem, considerando a rela&ccedil;&atilde;o de parentesco entre o marido da promovida e o marido e pai das promovidas. N&atilde;o se restou comprovado nos autos a exist&ecirc;ncia de doa&ccedil;&atilde;o, ao contr&aacute;rio, as provas atestam a exist&ecirc;ncia de comodato, verbal e gratuito. Os propriet&aacute;rios emprestaram o im&oacute;vel para as promovidas fixarem resid&ecirc;ncia, tendo em vista o estado de sa&uacute;de debilitado do marido e pai das promoventes, al&eacute;m da proximidade com seu irm&atilde;o, marido da promovida.
+4. As requeridas permaneceram no im&oacute;vel por mera liberalidade dos propriet&aacute;rios. Os atos de mera permiss&atilde;o ou toler&acirc;ncia n&atilde;o induzem posse, impossibilitando a aquisi&ccedil;&atilde;o da propriedade pela usucapi&atilde;o, nos termos do art. 1.208 do CC.
+5. N&atilde;o h&aacute; que se falar, portanto, em posse, afastando-se a usucapi&atilde;o, que exige o exerc&iacute;cio da posse para a aquisi&ccedil;&atilde;o da propriedade, bem como a manuten&ccedil;&atilde;o de posse. Como consequ&ecirc;ncia, o prazo de perman&ecirc;ncia no im&oacute;vel &eacute; irrelevante, tendo em vista que n&atilde;o caracterizou posse, mas sim mera toler&acirc;ncia.
+6. A prova do esbulho e da respectiva data est&atilde;o na notifica&ccedil;&atilde;o extrajudicial realizada, enquanto a perda da posse est&aacute; caracterizada pelo n&atilde;o atendimento &agrave; solicita&ccedil;&atilde;o, quer dizer, pela perman&ecirc;ncia das requeridas no im&oacute;vel. Assim, comprovados os requisitos legais do art. 561 do CPC, quais sejam, a posse, o esbulho praticado pela parte promovida, a data do esbulho e a perda da posse, a senten&ccedil;a que determinou a reintegra&ccedil;&atilde;o da autora na posse do im&oacute;vel deve ser mantida.
+7. A parte promovida foi notificada para desocupar o im&oacute;vel, mas n&atilde;o atendeu &agrave; solicita&ccedil;&atilde;o, configurando o esbulho. Uma vez decorrido o prazo para a devolu&ccedil;&atilde;o do bem concedido na notifica&ccedil;&atilde;o, o comodat&aacute;rio pratica esbulho e deve arcar com o pagamento do aluguel arbitrado pelo comodante (art. 582 do CC).
+8. Recurso conhecido e n&atilde;o provido. Senten&ccedil;a mantida.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara de Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER DO RECURSO, PARA NEGAR-LHE PROVIMENTO, nos termos do voto do Desembargador Relator.
+
+Fortaleza, 28 de abril de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR RAIMUNDO NONATO SILVA SANTOS
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0140078-43.2016.8.06.0001, Rel. Desembargador(a)  RAIMUNDO NONATO SILVA SANTOS, 4&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 28/04/2020, data da publica&ccedil;&atilde;o:&nbsp; 28/04/2020)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(27 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Posse
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> RAIMUNDO NONATO SILVA SANTOS
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									28/04/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									28/04/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>
+CIVIL. PROCESSO CIVIL. APELAÇÃO. NULIDADE. SENTENÇA FUNDAMENTADA. VIA ELEITA ADEQUADA. PRELIMINARES AFASTADAS. AÇÃO DE REINTEGRAÇÃO DE POSSE. POSSE COMPROVADA. ESBULHO PRATICADO. NOTIFICAÇÃO PARA DESOCUPAÇÃO NÃO ATENDIDA. ALUGUEL. PAGAMENTO. RECURSO CONHECIDO E NÃO PROVIDO. SENTENÇA MANTIDA.
+1. A sentença está devidamente fundamentada, apresentando as razões que embasaram a conclusão do
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>
+CIVIL. PROCESSO CIVIL. APELAÇÃO. NULIDADE. SENTENÇA FUNDAMENTADA. VIA ELEITA ADEQUADA. PRELIMINARES AFASTADAS. AÇÃO DE REINTEGRAÇÃO DE POSSE. POSSE COMPROVADA. ESBULHO PRATICADO. NOTIFICAÇÃO PARA DESOCUPAÇÃO NÃO ATENDIDA. ALUGUEL. PAGAMENTO. RECURSO CONHECIDO E NÃO PROVIDO. SENTENÇA MANTIDA.
+1. A sentença está devidamente fundamentada, apresentando as razões que embasaram a conclusão do magistrado. Com efeito, entendeu o julgador singular que não se restou comprovada a posse das promovidas, configurando-se mera detenção. Assim, a posse sempre foi exercida pela autora, que permitiu a utilização do imóvel pelas promovidas, estando configurada a posse da requerente. Quanto às perdas e danos, entendeu-se que a partir da data em que deveria ter sido restituída a posse à requerente as promovidas devem arcar com o pagamento de aluguel, considerando a existência de comodato. A ação de reintegração de posse é o meio processual adequado para a autora que pretende reaver a posse plena do bem, tendo em vista que a questão gira em torno da existência ou não de contrato de comodato verbal e gratuito, bem como se a posse das promovidas está comprovada. Preliminares rejeitadas.
+2. As promovidas afirmam que residem no imóvel há mais de 26 anos, estabelecendo nele sua moradia como legítimos proprietários, arcando com os custos de cotas condominiais, despesas extras, energia e água. Ocorre que o bem está registrado em nome da promovente, que afirma que adquiriu o bem com seu falecido esposo e que emprestou o imóvel para as promovidas estabelecerem residência, considerando que o marido da promovente e o marido da promovida eram irmãos e muito próximos. O parentesco entre os falecidos mencionados é incontroverso, sendo discutido nos autos a existência de comodato gratuito e verbal entre as partes, bem como o exercício das promoventes da posse mansa, pacífica e ininterrupta, pelo lapso temporal da <em>usucapião</em>, do bem em litígio.
+3. A prova coligida esclarece a questão. As promovidas foram residir no imóvel com a anuência da promovente, proprietária do bem, considerando a relação de parentesco entre o marido da promovida e o marido e pai das promovidas. Não se restou comprovado nos autos a existência de doação, ao contrário, as provas atestam a existência de comodato, verbal e gratuito. Os proprietários emprestaram o imóvel para as promovidas fixarem residência, tendo em vista o estado de saúde debilitado do marido e pai das promoventes, além da proximidade com seu irmão, marido da promovida.
+4. As requeridas permaneceram no imóvel por mera liberalidade dos proprietários. Os atos de mera permissão ou tolerância não induzem posse, impossibilitando a aquisição da propriedade pela <em>usucapião</em>, nos termos do art. 1.208 do CC.
+5. Não há que se falar, portanto, em posse, afastando-se a <em>usucapião</em>, que exige o exercício da posse para a aquisição da propriedade, bem como a manutenção de posse. Como consequência, o prazo de permanência no imóvel é irrelevante, tendo em vista que não caracterizou posse, mas sim mera tolerância.
+6. A prova do esbulho e da respectiva data estão na notificação extrajudicial realizada, enquanto a perda da posse está caracterizada pelo não atendimento à solicitação, quer dizer, pela permanência das requeridas no imóvel. Assim, comprovados os requisitos legais do art. 561 do CPC, quais sejam, a posse, o esbulho praticado pela parte promovida, a data do esbulho e a perda da posse, a sentença que determinou a reintegração da autora na posse do imóvel deve ser mantida.
+7. A parte promovida foi notificada para desocupar o imóvel, mas não atendeu à solicitação, configurando o esbulho. Uma vez decorrido o prazo para a devolução do bem concedido na notificação, o comodatário pratica esbulho e deve arcar com o pagamento do aluguel arbitrado pelo comodante (art. 582 do CC).
+8. Recurso conhecido e não provido. Sentença mantida.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara de Direito Privado do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER DO RECURSO, PARA NEGAR-LHE PROVIMENTO, nos termos do voto do Desembargador Relator.
+
+Fortaleza, 28 de abril de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR RAIMUNDO NONATO SILVA SANTOS
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3288130" cdForo="0" >
+										0146740-23.2016.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3288130" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3288130);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3288130" style="display: none;" >
+	<div id="textAreaDados_3288130" class="mensagemSemFormatacao" >
+
+CIVIL. PROCESSO CIVIL. APELA&Ccedil;&Atilde;O. A&Ccedil;&Atilde;O DE MANUTEN&Ccedil;&Atilde;O DE POSSE. POSSE N&Atilde;O COMPROVADA. MERA TOLER&Acirc;NCIA. RECURSO CONHECIDO E N&Atilde;O PROVIDO. SENTEN&Ccedil;A MANTIDA.
+1. As promoventes afirmam que residem no im&oacute;vel h&aacute; mais de 26 anos, estabelecendo nele sua moradia como leg&iacute;timos propriet&aacute;rios, arcando com os custos de cotas condominiais, despesas extras, energia e &aacute;gua. Ocorre que o bem est&aacute; registrado em nome da promovida, que afirma que adquiriu o bem com seu falecido esposo e que emprestou o im&oacute;vel para as promoventes estabelecerem resid&ecirc;ncia, considerando que o marido da promovida e o marido da promovente eram irm&atilde;os e muito pr&oacute;ximos. O parentesco entre os falecidos mencionados &eacute; incontroverso, sendo discutido nos autos a exist&ecirc;ncia de comodato gratuito e verbal entre as partes, bem como o exerc&iacute;cio das promoventes da posse mansa, pac&iacute;fica e ininterrupta, pelo lapso temporal da usucapi&atilde;o, do bem em lit&iacute;gio.
+2. A prova coligida esclarece a quest&atilde;o. As promoventes foram residir no im&oacute;vel com a anu&ecirc;ncia da promovida, propriet&aacute;ria do bem, considerando a rela&ccedil;&atilde;o de parentesco entre o marido da promovida e o marido e pai das promoventes. N&atilde;o se restou comprovado nos autos a exist&ecirc;ncia de doa&ccedil;&atilde;o, ao contr&aacute;rio, as provas atestam a exist&ecirc;ncia de comodato, verbal e gratuito. Os propriet&aacute;rios emprestaram o im&oacute;vel para as promoventes fixarem resid&ecirc;ncia, tendo em vista o estado de sa&uacute;de debilitado do marido e pai das promoventes, al&eacute;m da proximidade com seu irm&atilde;o, marido da promovida.
+3. As requerentes permaneceram no im&oacute;vel por mera liberalidade dos propriet&aacute;rios. Os atos de mera permiss&atilde;o ou toler&acirc;ncia n&atilde;o induzem posse, impossibilitando a aquisi&ccedil;&atilde;o da propriedade pela usucapi&atilde;o, nos termos do art. 1.208 do CC.
+4. N&atilde;o h&aacute; que se falar, portanto, em posse, afastando-se a usucapi&atilde;o, que exige o exerc&iacute;cio da posse para a aquisi&ccedil;&atilde;o da propriedade, bem como a manuten&ccedil;&atilde;o de posse. Como consequ&ecirc;ncia, o prazo de perman&ecirc;ncia no im&oacute;vel &eacute; irrelevante, tendo em vista que n&atilde;o caracterizou posse, mas sim mera toler&acirc;ncia.
+5. Recurso conhecido e n&atilde;o provido. Senten&ccedil;a mantida.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara de Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER DO RECURSO, PARA NEGAR-LHE PROVIMENTO, nos termos do voto do Desembargador Relator.
+
+Fortaleza, 28 de abril de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR RAIMUNDO NONATO SILVA SANTOS
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0146740-23.2016.8.06.0001, Rel. Desembargador(a)  RAIMUNDO NONATO SILVA SANTOS, 4&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 28/04/2020, data da publica&ccedil;&atilde;o:&nbsp; 28/04/2020)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Posse
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> RAIMUNDO NONATO SILVA SANTOS
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									28/04/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									28/04/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>
+CIVIL. PROCESSO CIVIL. APELAÇÃO. AÇÃO DE MANUTENÇÃO DE POSSE. POSSE NÃO COMPROVADA. MERA TOLERÂNCIA. RECURSO CONHECIDO E NÃO PROVIDO. SENTENÇA MANTIDA.
+1. As promoventes afirmam que residem no imóvel há mais de 26 anos, estabelecendo nele sua moradia como legítimos proprietários, arcando com os custos de cotas condominiais, despesas extras, energia e água. Ocorre que o bem está registrado em
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>
+CIVIL. PROCESSO CIVIL. APELAÇÃO. AÇÃO DE MANUTENÇÃO DE POSSE. POSSE NÃO COMPROVADA. MERA TOLERÂNCIA. RECURSO CONHECIDO E NÃO PROVIDO. SENTENÇA MANTIDA.
+1. As promoventes afirmam que residem no imóvel há mais de 26 anos, estabelecendo nele sua moradia como legítimos proprietários, arcando com os custos de cotas condominiais, despesas extras, energia e água. Ocorre que o bem está registrado em nome da promovida, que afirma que adquiriu o bem com seu falecido esposo e que emprestou o imóvel para as promoventes estabelecerem residência, considerando que o marido da promovida e o marido da promovente eram irmãos e muito próximos. O parentesco entre os falecidos mencionados é incontroverso, sendo discutido nos autos a existência de comodato gratuito e verbal entre as partes, bem como o exercício das promoventes da posse mansa, pacífica e ininterrupta, pelo lapso temporal da <em>usucapião</em>, do bem em litígio.
+2. A prova coligida esclarece a questão. As promoventes foram residir no imóvel com a anuência da promovida, proprietária do bem, considerando a relação de parentesco entre o marido da promovida e o marido e pai das promoventes. Não se restou comprovado nos autos a existência de doação, ao contrário, as provas atestam a existência de comodato, verbal e gratuito. Os proprietários emprestaram o imóvel para as promoventes fixarem residência, tendo em vista o estado de saúde debilitado do marido e pai das promoventes, além da proximidade com seu irmão, marido da promovida.
+3. As requerentes permaneceram no imóvel por mera liberalidade dos proprietários. Os atos de mera permissão ou tolerância não induzem posse, impossibilitando a aquisição da propriedade pela <em>usucapião</em>, nos termos do art. 1.208 do CC.
+4. Não há que se falar, portanto, em posse, afastando-se a <em>usucapião</em>, que exige o exercício da posse para a aquisição da propriedade, bem como a manutenção de posse. Como consequência, o prazo de permanência no imóvel é irrelevante, tendo em vista que não caracterizou posse, mas sim mera tolerância.
+5. Recurso conhecido e não provido. Sentença mantida.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara de Direito Privado do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER DO RECURSO, PARA NEGAR-LHE PROVIMENTO, nos termos do voto do Desembargador Relator.
+
+Fortaleza, 28 de abril de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR RAIMUNDO NONATO SILVA SANTOS
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3288127" cdForo="0" >
+										0913980-56.2014.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3288127" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3288127);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3288127" style="display: none;" >
+	<div id="textAreaDados_3288127" class="mensagemSemFormatacao" >
+
+CIVIL. PROCESSO CIVIL. APELA&Ccedil;&Atilde;O. NULIDADE. SENTEN&Ccedil;A FUNDAMENTADA. PRELIMINAR AFASTADA. A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O. POSSE N&Atilde;O COMPROVADA. MERA TOLER&Acirc;NCIA. RECURSO CONHECIDO E N&Atilde;O PROVIDO. SENTEN&Ccedil;A MANTIDA.
+1. A senten&ccedil;a est&aacute; devidamente fundamentada, apresentando as raz&otilde;es que embasaram a conclus&atilde;o do magistrado. Entendeu o julgador singular que n&atilde;o se restou comprovada a posse, configurando-se mera deten&ccedil;&atilde;o, o que afasta a usucapi&atilde;o. Assim, irrelevante tratar-se de usucapi&atilde;o extraordin&aacute;ria ou urbana, pois, independente do tempo de perman&ecirc;ncia no im&oacute;vel, n&atilde;o houve posse. Preliminar afastada.
+2. As promoventes afirmam que residem no im&oacute;vel h&aacute; mais de 26 anos, estabelecendo nele sua moradia como leg&iacute;timos propriet&aacute;rios, arcando com os custos de cotas condominiais, despesas extras, energia e &aacute;gua. Ocorre que o bem est&aacute; registrado em nome da promovida, que afirma que adquiriu o bem com seu falecido esposo e que emprestou o im&oacute;vel para as promoventes estabelecerem resid&ecirc;ncia, considerando que o marido da promovida e o marido da promovente eram irm&atilde;os e muito pr&oacute;ximos. O parentesco entre os falecidos mencionados &eacute; incontroverso, sendo discutido nos autos a exist&ecirc;ncia de comodato gratuito e verbal entre as partes, bem como o exerc&iacute;cio das promoventes da posse mansa, pac&iacute;fica e ininterrupta, pelo lapso temporal da usucapi&atilde;o, do bem em lit&iacute;gio.
+3. A prova coligida esclarece a quest&atilde;o. As promoventes foram residir no im&oacute;vel com a anu&ecirc;ncia da promovida, propriet&aacute;ria do bem, considerando a rela&ccedil;&atilde;o de parentesco entre o marido da promovida e o marido e pai das promoventes. N&atilde;o se restou comprovado nos autos a exist&ecirc;ncia de doa&ccedil;&atilde;o, ao contr&aacute;rio, as provas atestam a exist&ecirc;ncia de comodato, verbal e gratuito. Os propriet&aacute;rios emprestaram o im&oacute;vel para as promoventes fixarem resid&ecirc;ncia, tendo em vista o estado de sa&uacute;de debilitado do marido e pai das promoventes, al&eacute;m da proximidade com seu irm&atilde;o, marido da promovida.
+4. As requerentes permaneceram no im&oacute;vel por mera liberalidade dos propriet&aacute;rios. Os atos de mera permiss&atilde;o ou toler&acirc;ncia n&atilde;o induzem posse, impossibilitando a aquisi&ccedil;&atilde;o da propriedade pela usucapi&atilde;o, nos termos do art. 1.208 do CC.
+5. N&atilde;o h&aacute; que se falar, portanto, em posse, afastando-se a usucapi&atilde;o, que exige o exerc&iacute;cio da posse para a aquisi&ccedil;&atilde;o da propriedade. Como consequ&ecirc;ncia, o prazo de perman&ecirc;ncia no im&oacute;vel &eacute; irrelevante, tendo em vista que n&atilde;o caracterizou posse, mas sim mera toler&acirc;ncia.
+6. Recurso conhecido e n&atilde;o provido. Senten&ccedil;a mantida.
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara de Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER DO RECURSO, PARA NEGAR-LHE PROVIMENTO, nos termos do voto do Desembargador Relator.
+Fortaleza, 28 de abril de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADOR RAIMUNDO NONATO SILVA SANTOS
+Relator <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0913980-56.2014.8.06.0001, Rel. Desembargador(a)  RAIMUNDO NONATO SILVA SANTOS, 4&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 28/04/2020, data da publica&ccedil;&atilde;o:&nbsp; 28/04/2020)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(41 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Propriedade
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> RAIMUNDO NONATO SILVA SANTOS
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									28/04/2020
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									28/04/2020
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>
+CIVIL. PROCESSO CIVIL. APELAÇÃO. NULIDADE. SENTENÇA FUNDAMENTADA. PRELIMINAR AFASTADA. AÇÃO DE <em>USUCAPIÃO</em>. POSSE NÃO COMPROVADA. MERA TOLERÂNCIA. RECURSO CONHECIDO E NÃO PROVIDO. SENTENÇA MANTIDA.
+1. A sentença está devidamente fundamentada, apresentando as razões que embasaram a conclusão do magistrado. Entendeu o julgador singular que não se restou comprovada a posse, configurando-se
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>
+CIVIL. PROCESSO CIVIL. APELAÇÃO. NULIDADE. SENTENÇA FUNDAMENTADA. PRELIMINAR AFASTADA. AÇÃO DE <em>USUCAPIÃO</em>. POSSE NÃO COMPROVADA. MERA TOLERÂNCIA. RECURSO CONHECIDO E NÃO PROVIDO. SENTENÇA MANTIDA.
+1. A sentença está devidamente fundamentada, apresentando as razões que embasaram a conclusão do magistrado. Entendeu o julgador singular que não se restou comprovada a posse, configurando-se mera detenção, o que afasta a <em>usucapião</em>. Assim, irrelevante tratar-se de <em>usucapião</em> <em>extraordinária</em> ou urbana, pois, independente do tempo de permanência no imóvel, não houve posse. Preliminar afastada.
+2. As promoventes afirmam que residem no imóvel há mais de 26 anos, estabelecendo nele sua moradia como legítimos proprietários, arcando com os custos de cotas condominiais, despesas extras, energia e água. Ocorre que o bem está registrado em nome da promovida, que afirma que adquiriu o bem com seu falecido esposo e que emprestou o imóvel para as promoventes estabelecerem residência, considerando que o marido da promovida e o marido da promovente eram irmãos e muito próximos. O parentesco entre os falecidos mencionados é incontroverso, sendo discutido nos autos a existência de comodato gratuito e verbal entre as partes, bem como o exercício das promoventes da posse mansa, pacífica e ininterrupta, pelo lapso temporal da <em>usucapião</em>, do bem em litígio.
+3. A prova coligida esclarece a questão. As promoventes foram residir no imóvel com a anuência da promovida, proprietária do bem, considerando a relação de parentesco entre o marido da promovida e o marido e pai das promoventes. Não se restou comprovado nos autos a existência de doação, ao contrário, as provas atestam a existência de comodato, verbal e gratuito. Os proprietários emprestaram o imóvel para as promoventes fixarem residência, tendo em vista o estado de saúde debilitado do marido e pai das promoventes, além da proximidade com seu irmão, marido da promovida.
+4. As requerentes permaneceram no imóvel por mera liberalidade dos proprietários. Os atos de mera permissão ou tolerância não induzem posse, impossibilitando a aquisição da propriedade pela <em>usucapião</em>, nos termos do art. 1.208 do CC.
+5. Não há que se falar, portanto, em posse, afastando-se a <em>usucapião</em>, que exige o exercício da posse para a aquisição da propriedade. Como consequência, o prazo de permanência no imóvel é irrelevante, tendo em vista que não caracterizou posse, mas sim mera tolerância.
+6. Recurso conhecido e não provido. Sentença mantida.
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara de Direito Privado do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER DO RECURSO, PARA NEGAR-LHE PROVIMENTO, nos termos do voto do Desembargador Relator.
+Fortaleza, 28 de abril de 2020
+
+
+
+FRANCISCO BEZERRA CAVALCANTE
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADOR RAIMUNDO NONATO SILVA SANTOS
+Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="3134151" cdForo="0" >
+										0049615-41.2005.8.06.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="3134151" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(3134151);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_3134151" style="display: none;" >
+	<div id="textAreaDados_3134151" class="mensagemSemFormatacao" >
+		DIREITO CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. USUCAPI&Atilde;O ESPECIAL. SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. PRELIMINARES. DECIS&Atilde;O CONTR&Aacute;RIA A PROVA DOS AUTOS. CERCEAMENTO DE DEFESA EM RAZ&Atilde;O DO JULGAMENTO ANTECIPADO DA LIDE. REJEITADAS. INATENDIDOS  REQUISITOS DA A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O ESPECIAL. V&Iacute;NCULO EMPREGAT&Iacute;CIO COMPROVADO. COMODATO VERBAL.  PERMAN&Ecirc;NCIA NO IM&Oacute;VEL POR MERA PERMISS&Atilde;O DO EMPREGADOR. POSSE PREC&Aacute;RIA. AUS&Ecirc;NCIA DE ANIMUS DOMINI. PRESCRI&Ccedil;&Atilde;O AQUISITIVA N&Atilde;O CONFIGURADA. RECURSO CONHECIDO E IMPROVIDO. SENTEN&Ccedil;A MANTIDA IN TOTUM.
+1- Trata-se de Apela&ccedil;&atilde;o C&iacute;vel adversando senten&ccedil;a proferida pelo Ju&iacute;zo da 5&ordf; Vara C&iacute;vel desta Comarca, nos autos da A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O ESPECIAL ajuizada em desfavor da SOCIEDADE F&Ecirc;NIX CAIXEIREAL S/C, que julgou improcedente o pleito autoral.
+2- Ab initio, impende esclarecer que apesar da presente apela&ccedil;&atilde;o est&aacute; sendo apreciada sob a &eacute;gide do Novo Diploma de Ritos Civis, o seu cabimento e sua admissibilidade dever&atilde;o ser analisados de acordo com o disposto no C&oacute;digo anterior (CPC/73), posto que tanto a senten&ccedil;a guerreada quanto a pe&ccedil;a recursal possuem data de publica&ccedil;&atilde;o anterior a vig&ecirc;ncia do NCPC (18/03/2016)
+3- Antes de adentrar no m&eacute;rito, necess&aacute;rio se faz analisar as preliminares de decis&atilde;o contr&aacute;ria as prova dos autos e cerceamento de defesa, arguidas pela recorrente.
+4- Argumentou a apelante ter o Ju&iacute;zo de piso decidido contra a prova dos autos, decidindo exclusivamente esteado no parecer ministerial, desprezando o conjunto probat&oacute;rio atropelando o Rito Processual, suprimindo a realiza&ccedil;&atilde;o d audi&ecirc;ncia de instru&ccedil;&atilde;o, julgando antecipado a lide, cerceando o seu direito de defesa.
+5-A insurg&ecirc;ncia da apelante &eacute; que o Juiz de plan&iacute;cie decidiu exclusivamente esteado no parecer do Minist&eacute;rio P&uacute;blico, contrariando as provas dos autos, por&eacute;m n&atilde;o apontou quais as provas que iriam de encontro ao entendimento corporificado no dispositivo do decisum vergastado, limitando-se a justificar que por se tratar de quest&atilde;o f&aacute;tica, obrigat&oacute;ria seria a colheita de provas em audi&ecirc;ncia, fazendo uma confusa argumenta&ccedil;&atilde;o, onde correlaciona julgamento contr&aacute;rio a prova dos autos, necessidade de realiza&ccedil;&atilde;o de audi&ecirc;ncia, julgamento antecipado da lide e cerceamento de defesa.
+6.-Quanto a alega&ccedil;&atilde;o de cerceamento de defesa, &eacute; imperioso frisar que o magistrado &eacute; o destinat&aacute;rio das provas e a ele cabe aferir sobre a conveni&ecirc;ncia ou n&atilde;o da realiza&ccedil;&atilde;o da dila&ccedil;&atilde;o probat&oacute;ria, e se entender que as provas trazidas &agrave; cola&ccedil;&atilde;o s&atilde;o suficientes para o julgamento da lide, poder&aacute; dispens&aacute;-la, como ocorreu no caso vertente, cujo comportamento n&atilde;o caracteriza quebra dos princ&iacute;pios do contradit&oacute;rio e da ampla defesa.
+7-A senten&ccedil;a guerreada encontra-se em perfeita sintonia com as provas carreadas aos f&oacute;lios, corroborado pela manifesta&ccedil;&atilde;o do representante Parquet, ouvido como custos legis, sendo, portanto, incipiente e descabida a alegativa da apelante de ter sido a lide decidida contrariando &agrave; prova dos autos.
+8- Restou comprovada que a ocupa&ccedil;&atilde;o do im&oacute;vel usucapiendo se deu por for&ccedil;a de comodato verbal estabelecido entre a recorrente e a empresa recorrida, a qual permitiu em raz&atilde;o da rela&ccedil;&atilde;o empregat&iacute;cia que a parte autora morasse no terreno de sua propriedade com a sua fam&iacute;lia, restando afastada a possibilidade de caracteriza&ccedil;&atilde;o do animus domini.
+9- A jurisprud&ecirc;ncia p&aacute;tria j&aacute; firmou entendimento no sentido de que a posse decorrente de comodato verbal, por ser prec&aacute;ria, resulta de mera permiss&atilde;o ou toler&acirc;ncia do leg&iacute;timo propriet&aacute;rio, n&atilde;o ensejando o reconhecimento da a&ccedil;&atilde;o de usucapi&atilde;o, vez que ausente o animus domini.
+10- Recurso conhecido e improvido. Senten&ccedil;a Mantida in totum.
+
+
+AC&Oacute;RD&Atilde;O: Vistos, relatados e discutidos estes autos, acorda a 4&ordf; C&acirc;mara Direito Privado do Tribunal de Justi&ccedil;a do Estado do Cear&aacute;, por unanimidade, em CONHECER da APELA&Ccedil;&Atilde;O C&Iacute;VEL, para NEGAR-LHE PROVIMENTO, mantendo in totum a senten&ccedil;a combatida.
+
+Fortaleza, 25 de julho de 2017.
+
+
+
+DURVAL AIRES FILHO
+Presidente do &Oacute;rg&atilde;o Julgador
+
+
+
+DESEMBARGADORA HELENA L&Uacute;CIA SOARES
+Relatora
+
+
+
+
+Procurador(a) de Justi&ccedil;a <br><br>(Apela&ccedil;&atilde;o C&iacute;vel&nbsp;-  0049615-41.2005.8.06.0001, Rel. Desembargador(a)  HELENA LUCIA  SOARES, 4&ordf; C&acirc;mara Direito Privado, data do julgamento:&nbsp; 25/07/2017, data da publica&ccedil;&atilde;o:&nbsp; 25/07/2017)<br>
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(60 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Usucapião Extraordinária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> HELENA LUCIA  SOARES
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fortaleza
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Direito Privado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									25/07/2017
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									25/07/2017
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> ESPECIAL. SENTENÇA DE IMPROCEDÊNCIA. PRELIMINARES. DECISÃO CONTRÁRIA A PROVA DOS AUTOS. CERCEAMENTO DE DEFESA EM RAZÃO DO JULGAMENTO ANTECIPADO DA LIDE. REJEITADAS. INATENDIDOS  REQUISITOS DA AÇÃO DE <em>USUCAPIÃO</em> ESPECIAL. VÍNCULO EMPREGATÍCIO COMPROVADO. COMODATO VERBAL.  PERMANÊNCIA NO IMÓVEL POR MERA PERMISSÃO DO EMPREGADOR. POSSE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL. APELAÇÃO CÍVEL. <em>USUCAPIÃO</em> ESPECIAL. SENTENÇA DE IMPROCEDÊNCIA. PRELIMINARES. DECISÃO CONTRÁRIA A PROVA DOS AUTOS. CERCEAMENTO DE DEFESA EM RAZÃO DO JULGAMENTO ANTECIPADO DA LIDE. REJEITADAS. INATENDIDOS  REQUISITOS DA AÇÃO DE <em>USUCAPIÃO</em> ESPECIAL. VÍNCULO EMPREGATÍCIO COMPROVADO. COMODATO VERBAL.  PERMANÊNCIA NO IMÓVEL POR MERA PERMISSÃO DO EMPREGADOR. POSSE PRECÁRIA. AUSÊNCIA DE ANIMUS DOMINI. PRESCRIÇÃO AQUISITIVA NÃO CONFIGURADA. RECURSO CONHECIDO E IMPROVIDO. SENTENÇA MANTIDA IN TOTUM.
+1- Trata-se de Apelação Cível adversando sentença proferida pelo Juízo da 5ª Vara Cível desta Comarca, nos autos da AÇÃO DE <em>USUCAPIÃO</em> ESPECIAL ajuizada em desfavor da SOCIEDADE FÊNIX CAIXEIREAL S/C, que julgou improcedente o pleito autoral.
+2- Ab initio, impende esclarecer que apesar da presente apelação está sendo apreciada sob a égide do Novo Diploma de Ritos Civis, o seu cabimento e sua admissibilidade deverão ser analisados de acordo com o disposto no Código anterior (CPC/73), posto que tanto a sentença guerreada quanto a peça recursal possuem data de publicação anterior a vigência do NCPC (18/03/2016)
+3- Antes de adentrar no mérito, necessário se faz analisar as preliminares de decisão contrária as prova dos autos e cerceamento de defesa, arguidas pela recorrente.
+4- Argumentou a apelante ter o Juízo de piso decidido contra a prova dos autos, decidindo exclusivamente esteado no parecer ministerial, desprezando o conjunto probatório atropelando o Rito Processual, suprimindo a realização d audiência de instrução, julgando antecipado a lide, cerceando o seu direito de defesa.
+5-A insurgência da apelante é que o Juiz de planície decidiu exclusivamente esteado no parecer do Ministério Público, contrariando as provas dos autos, porém não apontou quais as provas que iriam de encontro ao entendimento corporificado no dispositivo do decisum vergastado, limitando-se a justificar que por se tratar de questão fática, obrigatória seria a colheita de provas em audiência, fazendo uma confusa argumentação, onde correlaciona julgamento contrário a prova dos autos, necessidade de realização de audiência, julgamento antecipado da lide e cerceamento de defesa.
+6.-Quanto a alegação de cerceamento de defesa, é imperioso frisar que o magistrado é o destinatário das provas e a ele cabe aferir sobre a conveniência ou não da realização da dilação probatória, e se entender que as provas trazidas à colação são suficientes para o julgamento da lide, poderá dispensá-la, como ocorreu no caso vertente, cujo comportamento não caracteriza quebra dos princípios do contraditório e da ampla defesa.
+7-A sentença guerreada encontra-se em perfeita sintonia com as provas carreadas aos fólios, corroborado pela manifestação do representante Parquet, ouvido como custos legis, sendo, portanto, incipiente e descabida a alegativa da apelante de ter sido a lide decidida contrariando à prova dos autos.
+8- Restou comprovada que a ocupação do imóvel usucapiendo se deu por força de comodato verbal estabelecido entre a recorrente e a empresa recorrida, a qual permitiu em razão da relação empregatícia que a parte autora morasse no terreno de sua propriedade com a sua <em>família</em>, restando afastada a possibilidade de caracterização do animus domini.
+9- A jurisprudência pátria já firmou entendimento no sentido de que a posse decorrente de comodato verbal, por ser precária, resulta de mera permissão ou tolerância do legítimo proprietário, não ensejando o reconhecimento da ação de <em>usucapião</em>, vez que ausente o animus domini.
+10- Recurso conhecido e improvido. Sentença Mantida in totum.
+
+
+ACÓRDÃO: Vistos, relatados e discutidos estes autos, acorda a 4ª Câmara Direito Privado do Tribunal de Justiça do Estado do Ceará, por unanimidade, em CONHECER da APELAÇÃO CÍVEL, para NEGAR-LHE PROVIMENTO, mantendo in totum a sentença combatida.
+
+Fortaleza, 25 de julho de 2017.
+
+
+
+DURVAL AIRES FILHO
+Presidente do Órgão Julgador
+
+
+
+DESEMBARGADORA HELENA LÚCIA SOARES
+Relatora
+
+
+
+
+Procurador(a) de Justiça
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="ACÓRDÃO">
+									<label for="ckTermo1">
+										ACÓRDÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="Câmara">
+									<label for="ckTermo2">
+										Câmara
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="Direito">
+									<label for="ckTermo3">
+										Direito
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="Estado">
+									<label for="ckTermo4">
+										Estado
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="Fortaleza">
+									<label for="ckTermo5">
+										Fortaleza
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="Justiça">
+									<label for="ckTermo6">
+										Justiça
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="Tribunal">
+									<label for="ckTermo7">
+										Tribunal
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="autos">
+									<label for="ckTermo8">
+										autos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="termos">
+									<label for="ckTermo9">
+										termos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="voto">
+									<label for="ckTermo10">
+										voto
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="Ceará">
+									<label for="ckTermo11">
+										Ceará
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="Privado">
+									<label for="ckTermo12">
+										Privado
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="Vistos">
+									<label for="ckTermo13">
+										Vistos
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="acorda">
+									<label for="ckTermo14">
+										acorda
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="discutidos">
+									<label for="ckTermo15">
+										discutidos
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 16
+			</strong>
+			de 16
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjce/test_cjsg_contract.py
+++ b/tests/tjce/test_cjsg_contract.py
@@ -1,0 +1,103 @@
+"""Offline contract tests for TJCE cjsg.
+
+Mocks ``resultadoCompleta.do`` + ``trocaDePagina.do`` with captured samples
+(see ``tests/fixtures/capture/tjce.py``) and asserts the public DataFrame
+contract. Covers typical multi-page, single-page, and zero-result scenarios.
+
+Also includes a unit-level regression test for the TLS ``SECLEVEL=1`` adapter
+required by the TJCE server.
+"""
+import ssl
+
+import pandas as pd
+import responses
+from requests.adapters import HTTPAdapter
+from responses.matchers import query_param_matcher, urlencoded_params_matcher
+
+import juscraper as jus
+from juscraper.courts.tjce.cjsg_download import _TJCETLSAdapter
+from tests._helpers import load_sample_bytes
+from tests.fixtures.capture._util import make_esaj_body
+
+BASE = "https://esaj.tjce.jus.br/cjsg"
+CJSG_MIN_COLUMNS = {"processo", "cd_acordao", "cd_foro", "ementa"}
+
+
+def _add_post(pesquisa: str) -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjce", "cjsg/post_initial.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(make_esaj_body(pesquisa), allow_blank=True)],
+    )
+
+
+def _add_get(pagina: int, sample_path: str) -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjce", sample_path),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": str(pagina)})],
+    )
+
+
+@responses.activate
+def test_cjsg_typical_com_paginacao(tmp_path, mocker):
+    """Typical multi-page query returns a DataFrame with the minimum schema."""
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+    _add_get(2, "cjsg/results_normal_page_02.html")
+
+    df = jus.scraper("tjce", download_path=str(tmp_path)).cjsg(
+        "dano moral", paginas=range(1, 3)
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_single_page(tmp_path, mocker):
+    """Query whose hits fit in one page skips the per-page loop."""
+    mocker.patch("time.sleep")
+    _add_post("usucapiao extraordinario predio rural familia")
+    _add_get(1, "cjsg/single_page.html")
+
+    df = jus.scraper("tjce", download_path=str(tmp_path)).cjsg(
+        "usucapiao extraordinario predio rural familia", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_no_results(tmp_path, mocker):
+    """Zero-result query returns an empty DataFrame instead of raising."""
+    mocker.patch("time.sleep")
+    _add_post("juscraper_probe_zero_hits_xyzqwe")
+    _add_get(1, "cjsg/no_results.html")
+
+    df = jus.scraper("tjce", download_path=str(tmp_path)).cjsg(
+        "juscraper_probe_zero_hits_xyzqwe", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_tls_adapter_configures_seclevel1():
+    """TJCE server requires ``SECLEVEL=1``; regression guard for the custom adapter."""
+    adapter = _TJCETLSAdapter()
+    assert isinstance(adapter, HTTPAdapter)
+
+    adapter.init_poolmanager(connections=1, maxsize=1)
+    ctx = adapter.poolmanager.connection_pool_kw["ssl_context"]
+    assert isinstance(ctx, ssl.SSLContext)

--- a/tests/tjms/samples/cjsg/no_results.html
+++ b/tests/tjms/samples/cjsg/no_results.html
@@ -1,0 +1,18 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(0)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="0" />
+
+
+
+			<div align="center" class="ementaClass" style="padding: 80px;">
+				<strong>
+					Não foi encontrado nenhum resultado correspondente à busca realizada.
+				</strong>
+			</div>

--- a/tests/tjms/samples/cjsg/post_initial.html
+++ b/tests/tjms/samples/cjsg/post_initial.html
@@ -1,0 +1,20836 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- Nodo 5 -->
+
+<html>
+	<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+
+
+
+
+
+
+
+
+
+
+
+
+    <script language="javascript" type="text/JavaScript"
+            src="https://esaj.tjms.jus.br/sajcas/verificarLogin.js?script=1776718199958"></script>
+
+    <script language="javascript">
+        if (window.sajcas && window.sajcas.usuarioLogadoNoCasServer) {
+            var GATEWAY_TRUE = 'gateway=true', GATEWAY_FALSE = 'gateway=false';
+            var urlRetornoSistema = 'https://esaj.tjms.jus.br/cjsg/consultaCompleta.do';
+            if (urlRetornoSistema === '') {
+                urlRetornoSistema = window.location.href;
+            }
+
+            if (urlRetornoSistema.indexOf(GATEWAY_FALSE) !== -1) {
+                urlRetornoSistema = urlRetornoSistema.replace(GATEWAY_FALSE, GATEWAY_TRUE);
+            } else {
+                urlRetornoSistema.lastIndexOf('?') !== -1 ? urlRetornoSistema += '&' : urlRetornoSistema += '?';
+                urlRetornoSistema += GATEWAY_TRUE;
+            }
+
+            window.location.href = urlRetornoSistema;
+        }
+    </script>
+
+
+
+
+
+
+
+
+
+
+	<title>Consulta de Jurisprudência do Segundo Grau</title>
+	<script>
+		window.saj = window.saj || {};
+		window.saj.env = window.saj.env || {};
+		window.saj.env.root = '/cjsg';
+		window.saj.env.css = '/cjsg/css';
+		window.saj.env.js = '/cjsg/js';
+		window.saj.env.imagens = '/cjsg/imagens';
+		window.saj.env.cliente = 'MS';
+	</script>
+ 	<script src="/cjsg/js/jquery/jquery.min.js?n=07104f1a-e0bc-4b8d-a509-99e0a853baed"></script>
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/saj/saj-web-2.2.41-4.js?n=cdcef227-fc18-4ed5-af16-77ab2b5de9a0"></script>
+
+
+ 	<script>var localeJS = "pt_BR"; </script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMsg.js"></script>
+<script language="javascript" type="text/JavaScript" src="/cjsg/js/spw/spwResourceMap_pt.js"></script>
+	<script src="/cjsg/js/jquery/jquery.browser.min.js?n=06c9893c-e0a8-46d4-a4b0-a832fbb2df18"></script>
+ 	<script src="/cjsg/js/spw/spwConcatenado.js?n=1794cb22-aa02-4f3a-9d1b-be03fa5a2e04"></script>
+ 	<link href="/cjsg/css/spw/spwConcatenado.css" rel="stylesheet" type="text/css" />
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+<meta http-equiv="pragma" content="no-cache"/>
+<meta http-equiv="cache-control" content="no-cache"/>
+<meta http-equiv="expires" content="0"/>
+
+<link href="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/css/esajComum.css" rel="stylesheet" type="text/css" />
+<link href="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/css/esajLayout.css" rel="stylesheet" type="text/css" />
+<link href="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/clientes/MS/css/esajLayoutMS.css" rel="stylesheet" type="text/css" />
+
+<style type="text/css">
+<!--
+/* botao default means o mais claro, que seria o "botï¿½o principal" */
+.spwBotaoDefault, .spwBotaoDefault-o {
+	background-image: url(https://esaj.tjms.jus.br/esaj-layout/tema/padrao/clientes/MS/imagens/layout/fundoBotaoDefault.gif);
+}
+/* o botao secundario, menos provavel de ser clicado, mais escuro */
+.spwBotao, .spwBotao-o {
+	background-image: url(https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/fundoBotao.gif);
+}
+-->
+</style>
+
+
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/js/menu.js?n=2553626853"></script>
+
+<link rel="shortcut icon" href="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/clientes/MS/imagens/favicon.ico" type="image/x-icon" />
+
+
+
+
+<script>
+    var dict = {
+        'certificado.tituloCertificadoDigital': 'Certificado digital',
+        'certificado.msgCarregandoCertificado': 'Carregando certificados...',
+        'certificado.msgNenhumCertificadoEncontrado': 'Nenhum certificado encontrado',
+        'certificado.msgErroCarregarCertificado': 'Erro ao carregar certificados',
+        'certificado.msgCertificadoExpirado': '[Expirado]',
+        'certificado.msgCertificadoNaoValido': '[Ainda não válido]',
+        'certificado.msgCertificadoNaoIcpBrasil': '[Não ICP-Brasil]',
+        'certificado.tituloProblemasAoAssinar': 'Falha de comunicação com o dispositivo de assinatura digital',
+
+        'label.contato': 'Contato',
+        'label.identificarSe': 'Identificar-se ',
+
+        'mensagem.aguarde': 'Por favor, aguarde.',
+        'mensagem.paginaNaoCarregada': 'Não foi possível carregar a página.',
+        'mensagem.marcarLido': 'Marcar como lido',
+        'mensagem.registrosSelecionados': 'Registros selecionados',
+        'mensagem.registroJaSelecionado': 'Este registro já está selecionado',
+
+        'mensagem.data.invalida': 'A data digitada é inválida.',
+        'mensagem.data.anoInvalido': 'O ano informado deve ser maior que',
+        'mensagem.data.mesInvalido': 'O mês não pode ser maior que 12.',
+        'mensagem.data.mes': 'O mês',
+        'mensagem.data.mesMaior29dias': 'não pode ter mais que 29 dias.',
+        'mensagem.data.mesMaior28dias': 'não pode ter mais que 28 dias.',
+        'mensagem.data.mesMaior31dias': 'não pode ter mais que 31 dias.',
+        'mensagem.data.mesMaior30dias': 'não pode ter mais que 30 dias.',
+
+        'mensagem.email.invalido': 'O formato do endereço de e-mail não é válido. Verifique se ele tem o formato "usuario@dominio".',
+        'mensagem.email.caracteresInvalidos': 'O endereço de e-mail possui caracteres inválidos',
+        'mensagem.email.usuarioInvalido': 'O formato do usuário informado no endereço de e-mail não é válido.',
+        'mensagem.email.ipInvalido': 'O endereço IP informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioInvalido': 'O formato do domínio informado no endereço de e-mail não é válido.',
+        'mensagem.email.dominioIncompleto': 'O domínio informado no endereço de e-mail deve possuir pelo menos duas partes. Por exemplo: "usuario@empresa.com.br".',
+
+        'mensagem.texto.tamanhoInvalido': 'O tamanho do texto digitado é maior do que o tamanho permitido. Tamanho permitido:',
+        'mensagem.texto.caracter': 'O caracter',
+        'mensagem.texto.caracterPosicaoInvalida': 'não está permitido na posição',
+
+        'mensagem.numero.numeroInvalido': 'O valor digitado não é um número válido.',
+        'mensagem.numero.numeroNaoPodeCasasDecimais': 'O número não pode conter casas decimais',
+        'mensagem.numero.numeroCasaDecimaisInvalidas': 'O número de casas decimais é inválido. O número pode conter apenas',
+        'mensagem.numero.casaDecimais': 'casas decimais',
+        'mensagem.numero.numeroInteiroInvalido': 'O número de dígitos inteiros é inválido. O número pode conter apenas',
+        'mensagem.numero.digitosInteiros': 'dígitos inteiros',
+        'mensagem.numero.numeroTamanhoInvalido': 'O número digitado não pode ser maior que',
+        'mensagem.numero.numeroZeroInvalido': 'O número digitado deve ser diferente de zero.'
+    }
+</script>
+
+
+
+
+
+
+
+
+
+ 	<script type="text/JavaScript" src="/cjsg/js/cjsg-2.2.5-0.js?n=260410155"></script>
+ 	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/MS/cjsg.css" />
+	<link rel="stylesheet" type="text/css" href="/cjsg/css/tema/MS/link.css" />
+
+
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/spw/spwTab.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-popup-modal.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/saj/saj-tree.css" />
+		<link rel="stylesheet" type="text/css" href="/cjsg/css/cjsg.css" />
+
+
+		<script type="text/JavaScript" src="/cjsg/js/jquery/jquery.blockUI.min.js?n=825fa94f-ae4e-4880-abd3-afb0f84d515f"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tooltip.js?n=69cd0ce2-3e62-45f8-aa9f-499fba88d345"></script>
+		<script type="text/JavaScript" src="/cjsg/js/spw/spwTab.js?n=2803951349"></script>
+		<script type="text/javascript" src="/cjsg/js/saj/saj-popup-modal-1.0.0-1.js?n=3af09c1d-d820-4ff5-9298-48c17486b2eb"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-popup.js?n=2538966893"></script>
+		<script type="text/JavaScript" src="/cjsg/js/saj/saj-tree-2.5.1-2.js?n=220661a1-922a-41aa-85f0-0bf021222fa5"></script>
+
+		<!-- remover valor da versao na proxima versao do sistema -->
+		<script type="text/JavaScript" src="/cjsg/js/filtrosLaterais.js?n=2874483102?c=123"></script>
+		<script type="text/JavaScript" src="/cjsg/jsp/completa/consultaCompleta.js?n=3513975997"></script>
+	</head>
+
+	<body style="margin: 0px;">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoCliente" summary=" " role="presentation">
+	<tr>
+		<td><a href="http://www.tjms.jus.br"><img src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/clientes/MS/imagens/layout/cabecalhoLogo.jpg" width="241" height="57" alt="Tribunal de Justi&ccedil;a de MS" /></a></td>
+	</tr>
+</table>
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/js/libras.js?n=369456521"></script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!-- cabecalho e-Saj -->
+<table width="100%" cellpadding="0" cellspacing="0" class="esajTabelaCabecalhoServico" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaCabecalhoServicoLogo">
+
+
+
+
+<a href="https://esaj.tjms.jus.br/esaj-layout/redirecionarNovoEsaj.do"><img src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServico.gif" title="Voltar para página inicial do e-SAJ" alt="Voltar para página inicial do e-SAJ" width="255" height="53" border="0" /></a><img src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/eSajServicoInf.gif" alt=" " width="255" height="28" border="0" />
+</td>
+		<td class="esajCelulaCabecalhoServicoMenu">
+		    <table width="100%" border="0" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+				<tr>
+					<td align="right">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        <div id="divopupContato" style="display: none;">
+                <br>
+<b>Suporte Técnico de Sistemas</b>
+<p>Central de serviços de TI<p/>
+<p><a href="http://www.tjms.jus.br/ti" target="blank">www.tjms.jus.br/ti</a></p>
+Horários de atendimento: </br>
+De Segunda à Sexta-feira das 12h às 19h </br>
+<i>*exceto feriados Federais e Estaduais</i>
+        </div>
+
+
+<!-- Devido ao alinhamento inline das imagens, elas nÃ£o podem ter nenhum tipo de espaÃ§amento entre elas, portanto Ã© necessÃ¡rio finalizar a linha iniciando um comentÃ¡rio e fechar o comentÃ¡rio imediatamente antes da abertura da nova tag-->
+<img height="24" width="47" alt=" " src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/inicioMenuSup.jpg"/><a href="https://esaj.tjms.jus.br/caixapostal"><!--
+
+    --><img height="24" width="83" border="0" alt="Caixa Postal" src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/caixaPostal.gif"/></a><!--
+    --><img height="24" width="4" alt=" " src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a href="https://esaj.tjms.jus.br/esaj/cadastro.do"><!--
+
+--><img src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/cadastro.gif" alt="Cadastro" width="81" height="24" border="0" /></a><!--
+
+    --><img height="24" width="4" alt=" " src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a id="linkContato" href="#"><!--
+    --><img height="24" width="68" border="0" alt="Contato" src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/contato.gif"/></a><!--
+
+
+    --><img height="24" width="4" alt=" " src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSeparador.jpg"/><a target="blank" href="https://esaj.tjms.jus.br/WebHelp/"><!--
+    --><img height="24" width="61" border="0" alt="Ajuda do e-Saj" src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/ajuda.gif"/></a><!--
+
+
+-->
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaIdentificacaoServico" >
+
+
+
+
+<style>
+
+    td.esajCelulaIdentificacao, td.esajCelulaIdentificacaoServico {
+        position: relative;
+    }
+
+    button.escolhaBeta {
+        border: 0;
+        background: #0078D7;
+        color: #fff;
+        margin-right: 5px;
+        font-family: verdana;
+        font-size: 12px;
+        height: 27px;
+        line-height: 14px;
+        border-radius: 0;
+        text-shadow: 1px 1px 1px #797979;
+        position: absolute;
+        top: 30px;
+        right: 3px;
+        padding: 7px 12px;
+        cursor: pointer;
+    }
+
+    button.escolhaBeta:hover {
+        background-color: #0b5c9c;
+    }
+</style>
+
+<span id="identificacao"></span>
+
+<button style="display: none" class="escolhaBeta"></button>
+
+
+
+
+
+
+        <script language="javascript" type="text/JavaScript" src="https://esaj.tjms.jus.br/sajcas/conteudoIdentificacao?script=1776674169120"></script>
+
+
+</td>
+				</tr>
+				<tr>
+					<td class="esajCelulaCabecalhoServicoCaminho" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<a href="" class="esajCaminhoLink"></a>
+
+ &gt;
+
+
+<a href="https://esaj.tjms.jus.br/esaj?servico=740000" class="esajCaminhoLink">Bem-vindo</a>
+
+ &gt;
+
+
+<a href="https://esaj.tjms.jus.br/esaj?servico=190090" class="esajCaminhoLink">Consultas</a>
+
+ &gt;
+
+
+<a href="https://esaj.tjms.jus.br/esaj?servico=789900" class="esajCaminhoLink">Jurisprudência</a>
+
+ &gt;
+
+
+
+Consulta Completa
+</td>
+				</tr>
+			</table>
+		</td>
+	</tr>
+</table>
+<!-- CONTEUDO -->
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaTitulo" role="presentation">
+	<tr>
+		<td class="esajCelulaMenuSuspenso">
+		<a href="#" onclick="return showMenuSuspenso()"><img src="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/imagens/layout/menuSuspenso.gif" alt="Menu de servi&ccedil;os" width="243" height="21" style="display:block" /></a>
+		<div id="layerMenu" style="display:none">
+
+
+<!-- MENU -->
+<ul id="esajMenuArea">
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Consultas</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cpopg5/open.do">Processos de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cposg5/open.do">Processos de 2º Grau</a></li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Pauta de Julgamento</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pauta-julgamento-virtual">Pauta de Julgamento Virtual do Segundo Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pauta-julgamento/consulta">Consulta das Pautas de Julgamento de Segundo Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Ordem de Processos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoPg.do">Julgamento de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoMagistradoSg.do">Julgamento de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cop/abrirConsultaDeOrdemDeJulgamentoMagistradoSgCr.do">Julgamento do Colégio Recursal e Turma de Uniformização</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cop/abrirConsultaDeOrdemDeAtoPg.do">Publicação e Cumprimento de Atos de 1º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuAberto"><a href="#" onclick="return esajMenu(this)">Jurisprudência</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cjsg/consultaCompleta.do">Completa</a></li>
+</ul>
+  </li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cdje">Diário da Justiça Eletrônico</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/cjpg/">Julgados de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://www5.tjms.jus.br/monitoramentoEsaj/">Disponibilidade do portal e-SAJ</a></li>
+  <li class="esajMenuItem"><a href="https://sti.tjms.jus.br/confluence/display/MANSAJ/Portal+e-SAJ">Orientações</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Solicitações e Pedidos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petpg-conciliacao/abrirSolicitacaoConciliacaoPreProcessual.do">Pedido de Conciliação - Vaga Escolar</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petpg-complemento/abrirPedidoMedicamentos.do">Providências de Saúde</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petpg-complemento/abrirConciliacaoSaudeSuplementar.do">Pedido de conciliação - Saúde suplementar</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petpg-conciliacao/abrirConciliacaoSuperendividamento.do">Conciliação no Superendividamento</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Recolhimento de Custas</a>
+<ul>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas de 1º Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=6&flTipoCusta=0&cdServicoCalculoCusta=690003">Emitir Custas</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=9&flTipoCusta=1&cdServicoCalculoCusta=690005">Diligências de Oficial de Justiça</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=11&flTipoCusta=5&cdServicoCalculoCusta=690004">Serviços</a></li>
+  <li class="esajMenuItem"><a href="https://www.tjms.jus.br/legislacao/visualizar.php?lei=32463">Consulta à tabela de valor das diligências</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/abrirConsultaCustas.do">Consulta de Custas</a></li>
+  <li class="esajMenuItem"><a href="https://servicos.efazenda.ms.gov.br/crd/CreditoTributario/IndicadoresSefaz/uferms">Link para consultar o valor da UFERMS</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas de 2º Grau</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=23&flTipoCusta=6&cdServicoCalculoCusta=690202">Emitir Preparo de Recursos</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=9&flTipoCusta=1&cdServicoCalculoCusta=690209">Diligências de Oficial de Justiça</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=6&flTipoCusta=0&cdServicoCalculoCusta=690015">Emitir Custas Iniciais</a></li>
+  <li class="esajMenuItem"><a href="https://www.tjms.jus.br/legislacao/visualizar.php?lei=32463">Consulta à tabela de valor das diligências</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/abrirConsultaCustasSg.do">Consulta de Custas</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=11&flTipoCusta=5&cdServicoCalculoCusta=690203">Serviços</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=25&flTipoCusta=0&cdServicoCalculoCusta=746000">Emitir Custas Finais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=28&flTipoCusta=1&cdServicoCalculoCusta=690213">Taxa Judiciária - Dívida Ativa - PGE</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Custas dos Juizados</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=17&flTipoCusta=1&cdServicoCalculoCusta=690011">Emitir guia de custas processuais 1</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=28&flTipoCusta=1&cdServicoCalculoCusta=690012">Emitir guia de custas processuais 2</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=26&flTipoCusta=0&cdServicoCalculoCusta=690201">Emitir Custas Iniciais - Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=24&flTipoCusta=6&cdServicoCalculoCusta=690205">Emitir Preparo de Recursos - Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://servicos.efazenda.ms.gov.br/crd/CreditoTributario/IndicadoresSefaz/uferms">Link para consultar o valor da UFERMS</a></li>
+</ul>
+  </li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Peticionamento Eletrônico</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petpg/abrirNovaPeticaoInicial.do?instancia=PG">Peticionamento Inicial de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petpg/abrirNovaPeticaoIntermediaria.do?instancia=PG">Peticionamento Intermediário de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petpg/abrirConsultaPeticoes.do">Consulta de Petições de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pettr/abrirNovaPeticaoInicial.do?instancia=CR">Peticionamento Inicial nas Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pettr/abrirNovaPeticaoIntermediaria.do?instancia=CR">Peticionamento Intermediário nas Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pettr/abrirConsultaPeticoes.do">Consulta de Petições nas Turmas Recursais</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petsg/abrirNovaPeticaoInicial.do?instancia=SG">Peticionamento Inicial de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petsg/abrirNovaPeticaoIntermediaria.do?instancia=SG">Peticionamento Intermediário de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/petsg/abrirConsultaPeticoes.do">Consulta de Petições de 2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Push - Acompanhar Processo Judicial</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/push">1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pushsg5tr">2º Grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Intimação e Citação Eletrônica</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/intimacoesweb/abrirConsultaAtosNaoRecebidos.do">Recebimento</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/intimacoesweb/abrirConsultaAtosRecebidos.do">Consulta das Recebidas</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Certidões</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/sco/abrirCadastro.do">Pedido de Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/scosg/abrirCadastro.do">Pedido de Certidão de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/sco/abrirConferencia.do">Conferência de Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/scosg/abrirConferencia.do">Conferência de Certidão de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/sco/abrirDownload.do">Baixar Certidão de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/scosg/abrirDownload.do">Baixar Certidão de 2º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustas.do?cdTipoCusta=11&flTipoCusta=5&cdServicoCalculoCusta=690004">Emissão de guia de custas p/ certidão 1º grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/ccpweb/iniciarCalculoDeCustasSg.do?cdTipoCusta=11&flTipoCusta=5&cdServicoCalculoCusta=690203">Emissão de guia de custas p/ certidão 2º grau</a></li>
+</ul>
+  </li>
+	<li class="esajMenuFechado"><a href="#" onclick="return esajMenu(this)">Conferência de Documentos</a>
+<ul>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pastadigital/pg/abrirConferenciaDocumento.do">Documento Digital de 1º Grau</a></li>
+  <li class="esajMenuItem"><a href="https://esaj.tjms.jus.br/pastadigital/sgcr/abrirConferenciaDocumento.do">Documento Digital de 2º Grau</a></li>
+</ul>
+  </li>
+  <li class="esajMenuFechado"><a href="https://esaj.tjms.jus.br/cpa">Pauta de Audiência</a></li>
+  <li class="esajMenuFechado"><a href="https://esaj.tjms.jus.br/administracao/abrirPortalAdministracao.do">ADM e-SAJ</a></li>
+</ul>
+
+		</div>
+		</td>
+		<td class="esajCelulaTituloServico"><h1 class="esajTituloPagina">Consulta Completa</h1></td>
+	</tr>
+</table>
+<table width="100%" cellpadding="0" cellspacing="0" summary=" " role="presentation">
+	<tr>
+		<td class="esajCelulaConteudoServico" >
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <span class="esajTituloOrientacoes">Orientações</span>
+
+
+
+
+            <ul class="esajUlOrientacoes" id="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<li>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Para detalhes sobre cada campo de busca, selecione o campo específico.
+
+
+
+	</li>
+
+
+
+
+            </ul>
+
+
+
+
+    <br>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<form name="consultaCompletaForm" method="post" action="/cjsg/resultadoCompleta.do;jsessionid=7E4838BB111F1014749E1AAC4D4C0D96.cjsg3" autocomplete="off" enctype="" onsubmit="return applySubmit(this, eval('function spwSubmit(t, e){decodificaInputMulSelOnSubmit();if (!IS_enableSubmit) return false; return BENV_isCamposValidos(t); } spwSubmit(this, event);'));" id="" target="">
+	<input type="hidden" name="conversationId" value="">
+
+
+
+
+
+<div style="display: none;">
+
+	<div id="inteiroTeor">
+		<b>"Pesquisa Livre"</b> <br />Busca acórdãos que contenham as <br /> palavras/expressões desejadas no seu inteiro teor.
+	</div>
+
+	<div id="ementa">
+		<b>"Ementa"</b><br>Busca acórdaos que contenham as palavras/express&otilde;es<br />desejadas na ementa do acórdão.
+	</div>
+
+	<div id="classesTooltip">
+		<b>"Classe"</b><br />Busca decisões que sejam de uma determinada classe processual.<br> Exemplo: Ação Penal.
+	</div>
+
+	<div id="assuntosTooltip">
+		<b>"Assuntos"</b><br />Busca acórdãos que sejam de um determinado assunto.
+	</div>
+
+	<div id="secoesTooltip">
+		<b>"Orgão julgadores"</b><br /> Busca acórdãos que sejam de uma determinado orgão julgador.
+	</div>
+
+	<div id="dtJulgamentoInicioTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtJulgamentoFimTooltip">
+		<b>"Data do Julgamento"</b><br>Busca acórdãos de julgamentos<br /> que tenham sido realizados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoInicioTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtPublicacaoFimTooltip">
+		<b>&quot;Data de Publicação&quot;</b><br> Busca acórdãos que tenham sido publicados em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroInicioTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="dtRegistroFimTooltip">
+		<b>&quot;Data de Registro&quot;</b><br> Busca acórdãos que tenham sido registradas em determinado per&iacute;odo.
+	</div>
+
+	<div id="orgaoJulgador">
+		<b>"Órgão Julgador"</b><br />Busca acórdãos que sejam de um determinado órgão julgador.<br />Exemplo: 10ª Câmara de Direito Público.
+	</div>
+
+	<div id="comarcaTooltip">
+		<b>"Comarca"</b><br>Busca acórdãos que sejam de uma determinada comarca de origem.<br> Exemplo: São Paulo.
+	</div>
+
+	<div id="agenteTooltip">
+		<b>"Relator"</b><br>Busca acórdãos que sejam de um determinado relator.
+	</div>
+
+	<div id="situacaoProvimentoTooltip">
+		<b>"Classificação do resultado"</b><br>Busca acórdãos que sejam de um determinado tipo de classificação do resultado.
+	</div>
+
+	<div id="juizProlatorTooltip">
+		<b>"Juiz prolator"</b><br>Busca acórdãos para o juiz prolator selecionado.<br />
+	</div>
+
+	<div id="nuRegistro">
+		<b>&quot;N&uacute;mero do Registro&quot;</b><br>Busca acórdãos que tenham sido registrados<br />com o número informado.
+	</div>
+
+	<div id="nuProcOrigem">
+		<b>"Número do recurso"</b><br/>Busca acórdãos que se referem ao<br/>número de recurso informado.
+	</div>
+
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Consulta Completa
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaInteiroTeor';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="top">
+
+
+
+
+				<label for="iddados.buscaInteiroTeor" class="" style="float:left;font-weight:bold;margin-top:3px;">Pesquisa livre</label><div style="text-align:right;font-weight:bold;margin-top:3px;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="top">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaInteiroTeor" maxlength="" size="100" value="dano moral" formatType="TEXT" formato="120" obrigatorio="" rotulo="Pesquisa livre" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaInteiroTeor" title="" alt="">
+
+
+
+
+
+
+
+						<div class="botoesOperadores" style="margin-top: 3px;">
+							<input type="button" value=" E " name="E" />
+							<input type="button" value=" OU " name="OU" />
+							<input type="button" value=" N&Atilde;O " name="NAO" />
+							<input type="button" value='"&nbsp;&nbsp;"' name="ASP" />
+							<a style="font-size: 11px; font-weight: bold; padding-left: 10px; padding-right: 2px;" href="https://esaj.tjms.jus.br/WebHelp//#id_operadores_logicos.htm" target="_blank">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="">
+
+
+
+	<span id="">Como utilizar os filtros</span>
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+							</a>
+							<input type="checkbox" name="dados.pesquisarComSinonimos" value="S" checked="checked" uncheckedValue="N"  onclick="CH_updateHiddenValue(this);" style="width: 10px" id="checkBoxSinonimos"><input type="hidden" value="S" name="dados.pesquisarComSinonimos" inputCheckBox="true">
+							<label for="checkBoxSinonimos" >
+								Pesquisar por sinônimos
+							</label>
+							&nbsp;&nbsp;&nbsp;
+						</div>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<div class="">
+
+			<br/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr valign="top">
+		<td height="21" valign="top" nowrap background="/cjsg/imagens/spw/fundo_subtitulo.gif">
+
+
+
+					<h2 class="subtitle">
+						Pesquisa por campos específicos
+
+					</h2>
+
+
+		</td>
+		<td background="/cjsg/imagens/spw/fundo_subtitulo2.gif" width="90%" aria-hidden="true">
+			<img src="/cjsg/imagens/spw/final_subtitulo.gif" width="16" height="20" tabindex="-1">
+		</td>
+	</tr>
+</table>
+
+
+
+			<br/>
+
+		<table id="" class="secaoFormBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.buscaEmenta';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="iddados.buscaEmenta" class="" style="float:left;font-weight:bold;">Ementa</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.buscaEmenta" maxlength="" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Ementa" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.buscaEmenta" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuProcOrigem';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="iddados.nuProcOrigem" class="" style="float:left;font-weight:bold;">Número do recurso</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuProcOrigem" maxlength="" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do recurso" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuProcOrigem" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.nuRegistro';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="iddados.nuRegistro" class="" style="float:left;font-weight:bold;">Número do registro</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<input type="text" name="dados.nuRegistro" maxlength="" size="100%" value="" formatType="TEXT" formato="120" obrigatorio="" rotulo="Número do registro" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.nuRegistro" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.relator" class="" style="float:left;font-weight:bold;">Relator(a)</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var agenteNomeCamposArray = new Array();
+ agenteNomeCamposArray[0] = 'codigoCr';
+ agenteNomeCamposArray[1] = 'codigoTr';
+ agenteNomeCamposArray[2] = 'nmAgente';
+ var codigoCrNomeCamposArray = agenteNomeCamposArray;
+ var codigoTrNomeCamposArray = agenteNomeCamposArray;
+ var nmAgenteNomeCamposArray = agenteNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="agente" idPai="null" filtroPai="null" url="jsp/search/searchAgente.jsp" input-select="agente" property="dados.agentes" name="codigoCr" title="Relatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="agenteSelectedEntitiesList"  value="" id="agenteSelectedEntitiesList" />
+<input type="hidden" name="contadoragente"  value="0" id="contadoragente" />
+<input type="hidden" name="contadorMaioragente"  value="0" id="contadorMaioragente" />
+    <tr>
+								<td >
+            <input type="text" name="codigoCr" id="codigoCr" bindingReference="codigoCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoTr" id="codigoTr" bindingReference="codigoTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoTr', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="agente" idIframe=""></td>
+								<td >
+            <input type="text" name="nmAgente" id="nmAgente" bindingReference="nmAgente" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('agente','/AjaxServlet.ajax', 'agente', 'nmAgente', this.value,'/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="agente" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('agente','/AjaxServlet.ajax', 'agente', 'codigoCr','','/cjsg','jsp/search/searchAgente.jsp', 'true', 'Relatores','300','500', '&bind_codigoCr=codigoCr&bind_codigoTr=codigoTr&bind_nmAgente=nmAgente', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('agente');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="agenteLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.juizProlator" class="" style="float:left;font-weight:bold;">Magistrado prolator</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="518">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+<table width="100%" cellspacing="0" cellpadding="0">
+	<tr>
+		<td class="inputSelectPersonalizado" width="*">
+
+
+
+
+
+							<script>
+
+var juizProlatorNomeCamposArray = new Array();
+ juizProlatorNomeCamposArray[0] = 'codigoJuizCr';
+ juizProlatorNomeCamposArray[1] = 'codigoJuizTr';
+ juizProlatorNomeCamposArray[2] = 'nmJuiz';
+ var codigoJuizCrNomeCamposArray = juizProlatorNomeCamposArray;
+ var codigoJuizTrNomeCamposArray = juizProlatorNomeCamposArray;
+ var nmJuizNomeCamposArray = juizProlatorNomeCamposArray;</script>
+
+<table class="spwInputSelect" width="100%" border="0" cellspacing="0" cellpadding="0" id="juizProlator" idPai="null" filtroPai="null" url="jsp/search/searchJuizProlator.jsp" input-select="juizProlator" property="dados.juizesProlatores" name="codigoJuizCr" title="Juizes prolatores" ctxPath="/cjsg" multiplaSelecao="true"  useAction="false" bindings="&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz"  entityPKClass="agentePK" idIframe="" altura="300" largura="500" useModulo="true" desabilitarSelecionados="false" carregaFilho="false"><tbody>
+<input type="hidden" name="juizProlatorSelectedEntitiesList"  value="" id="juizProlatorSelectedEntitiesList" />
+<input type="hidden" name="contadorjuizProlator"  value="0" id="contadorjuizProlator" />
+<input type="hidden" name="contadorMaiorjuizProlator"  value="0" id="contadorMaiorjuizProlator" />
+    <tr>
+								<td >
+            <input type="text" name="codigoJuizCr" id="codigoJuizCr" bindingReference="codigoJuizCr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="codigoJuizTr" id="codigoJuizTr" bindingReference="codigoJuizTr" value="" formatType="TEXT" obrigatorio="false" pk="true" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizTr', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width:100%" class="hidden" input-select="juizProlator" idIframe=""></td>
+								<td >
+            <input type="text" name="nmJuiz" id="nmJuiz" bindingReference="nmJuiz" value="" formatType="TEXT" obrigatorio="false" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'nmJuiz', this.value,'/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'false', event, 'InputSelectAutoComplete', '','false'); " style="width: 477px;" input-select="juizProlator" idIframe=""></td>
+
+        <td width="20" align="center"><img src="/cjsg/imagens/spw/botProcurar.gif" width="16" height="17" border="0" title="Abre a consulta" onmouseover="IH_mOver(this)" onmouseout="IH_mOut(this)" onclick="IS_request('juizProlator','/AjaxServlet.ajax', 'juizProlator', 'codigoJuizCr','','/cjsg','jsp/search/searchJuizProlator.jsp', 'true', 'Juizes prolatores','300','500', '&bind_codigoJuizCr=codigoJuizCr&bind_codigoJuizTr=codigoJuizTr&bind_nmJuiz=nmJuiz', 'true', event, 'InputSelectSearchGrid','','false')" ><img src="/cjsg/imagens/spw/botProcurar-d.gif" width="16" height="17" border="0" style="display:none" >
+        </td>
+    </tr>
+</tbody>
+</table>
+<script>
+
+</script>
+
+
+		</td>
+		<td width="16" valign="middle">
+			<img src="/cjsg/imagens/spw/botLimpar.gif" width="16" height="17" border="0" title="Limpar campo"
+				onclick="jQuery.saj.limparInputSelect('juizProlator');"
+				onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)"
+				style="cursor:pointer;" id="juizLimpar" />
+		</td>
+	</tr>
+</table>
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="classes_selectionText" class="" style="float:left;font-weight:bold;">Classe</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="classesId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="classesTreeSelection.values" value="" id="classes">
+						<span id="classes_action" value="/cjsg/classesTreeSelect.do" />
+
+						<input type="text" name="classesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'classes',
+								treeSelectId: 'classesId',
+								url: '/cjsg/classesTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="classes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_classes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_classes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'classes',
+				treeSelectId: 'classesId',
+				url: '/cjsg/classesTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true,
+				titulo: 'Classe'
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_classes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_classes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="assuntos_selectionText" class="" style="float:left;font-weight:bold;">Assunto</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="assuntosId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="assuntosTreeSelection.values" value="" id="assuntos">
+						<span id="assuntos_action" value="/cjsg/assuntosTreeSelect.do" />
+
+						<input type="text" name="assuntosTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'assuntos',
+								treeSelectId: 'assuntosId',
+								url: '/cjsg/assuntosTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="assuntos_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_assuntos"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_assuntos"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'assuntos',
+				treeSelectId: 'assuntosId',
+				url: '/cjsg/assuntosTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true,
+				titulo: 'Assunto'
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_assuntos').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_assuntos').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="secoes_selectionText" class="" style="float:left;font-weight:bold;">Órgão julgador</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<table id="secaoId" cellspacing="0" cellpadding="0" width="517" class="treeSelect">
+	<tr>
+		<td width="*">
+			<table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+					<td>
+						<input type="hidden" name="secoesTreeSelection.values" value="" id="secoes">
+						<span id="secoes_action" value="/cjsg/secaoTreeSelect.do" />
+
+						<input type="text" name="secoesTreeSelection.text" value="" formatType="TEXT" onkeypress="CT_KPS(this, event);" onblur="CT_BLR(this);" onkeydown="CT_KDN(this, event);" onmousemove="CT_MMOV(this, event);" onmouseout="CT_MOUT(this, event);" onmouseover="CT_MOV(this, event);" onfocus="C_OFC(this, event);" onchange="$.saj.tree.onTextPropertyChangeEvent({data:{ campoId: 'secoes',
+								treeSelectId: 'secaoId',
+								url: '/cjsg/secaoTreeSelect.do',
+								processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+								width: 600,
+								expectedHeight: 400,
+								reload: '' }}, event);" style="width:100%;" id="secoes_selectionText">
+
+					</td>
+					<td align="center" width="20">
+						<img id="botaoProcurar_secoes"
+						src="/cjsg/imagens/spw/botProcurar.gif" class="treeSelect_botaoHabilitado" height="17" border="0" width="16" title="Abre a consulta" style="cursor: pointer; margin-left: 4px;" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+						src="/cjsg/imagens/spw/botProcurar-d.gif" class="treeSelect_botaoDesabilitado" height="17" border="0" width="16" style="display:none; margin-left: 8px;" />
+					</td>
+				</tr>
+			</table>
+        </td>
+		<td width="16" valign="middle">
+			<img id="botaoLimpar_secoes"
+			src="/cjsg/imagens/spw/botLimpar.gif" class="treeSelect_botaoHabilitado" height="17" width="16" border="0" title="Limpa campo" onmouseout="IH_mOut(this)" onmouseover="IH_mOver(this)" /><img
+			src="/cjsg/imagens/spw/botLimpar-d.gif" class="treeSelect_botaoDesabilitado" height="17" width="16" border="0" style="display:none" />
+		</td>
+
+
+    </tr>
+</table>
+<script>
+	(function($) {
+
+		var bindTreeSelect = function() {
+			var options = {
+				campoId: 'secoes',
+				treeSelectId: 'secaoId',
+				url: '/cjsg/secaoTreeSelect.do',
+				processandoImgUrl: '/cjsg/imagens/spw/processandoNovo.gif',
+				width: 600,
+				expectedHeight: 400,
+				reload: '',
+				mostrarBotoesSelecaoRapida: true,
+				titulo: 'Órgão julgador'
+			};
+
+			$.saj.tree.updateSelectionText(options);
+
+			$('#botaoProcurar_secoes').bind('click', options, $.saj.tree.onPopupEvent);
+			$('#botaoLimpar_secoes').bind('click', options, $.saj.tree.onClearSelection);
+
+
+		};
+
+		bindTreeSelect();
+
+
+
+	})(jQuery);
+</script>
+
+
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtJulgamento" class="" style="float:left;font-weight:bold;">Data do julgamento</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoInicio">
+
+
+
+	<input type="text" name="dados.dtJulgamentoInicio" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtJulgamentoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtJulgamentoFim">
+
+
+
+	<input type="text" name="dados.dtJulgamentoFim" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtJulgamentoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+							<span id="dtJulgamentoFormato">
+								(dd/mm/aaaa)
+							</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.dtPublicacao" class="" style="float:left;font-weight:bold;">Data de publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoInicio';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoInicio">
+
+
+
+	<input type="text" name="dados.dtPublicacaoInicio" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoInicio" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						até
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<style>
+	/* remove borda vermelha de elementos required */
+	input:invalid {
+		box-shadow:none;
+	}
+</style>
+
+<script type="text/javascript">
+	(function($){
+		$(function() {
+			var saj = $.saj;
+			var id = 'iddados.dtPublicacaoFim';
+			var idObjetoReferencia = '#' + id;
+			if ('' !== '' && !false) {
+				$(idObjetoReferencia).registrarTooltip({
+					conteudoTooltip: '',
+					posicaoTooltip: 'direita',
+					objReferenciaPosicaoTooltip:$(idObjetoReferencia)
+				});
+			}
+			//remove comportamento de exibir mensagem de erro típica do html5
+			$('form:visible').attr('novalidate','');
+			if (''){
+				$(idObjetoReferencia).attr('aria-required','true').attr('required','');
+			}
+		});
+	})(jQuery);
+
+</script>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<span id="dtPublicacaoFim">
+
+
+
+	<input type="text" name="dados.dtPublicacaoFim" maxlength="" size="" value="" formatType="DATE" formato="" obrigatorio="" rotulo="(dd/mm/aaaa) " onkeypress="CD_KPS(this, event);" onblur="CD_BLR(this);" onkeydown="CD_KDN(this, event);" onmousemove="CD_MMOV(this, event);" onmouseout="CD_MOUT(this, event);" onmouseover="CD_MOV(this, event);" onfocus="CD_OFC(this, event);" style="" class="spwCampoTexto " id="iddados.dtPublicacaoFim" title="" alt="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		</span>
+
+
+
+
+
+
+						<span id="dtPublicacaoFormato">
+							(dd/mm/aaaa)
+						</span>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.origem" class="" style="float:left;font-weight:bold;">Origem</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<input type="checkbox" name="dados.origensSelecionadas" value="T" checked="checked" id="origem2grau">
+						<label for="origem2grau">
+							2° grau
+						</label>
+						<input type="checkbox" name="dados.origensSelecionadas" value="R" id="origemRecursal">
+						<label for="origemRecursal">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Turmas Recursais
+
+
+						</label>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.tpDecisao" class="" style="float:left;font-weight:bold;">Tipo de Publicação</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="100%">
+		<tr>
+			<td>
+
+
+
+						<div id="linhaTipoDecisao">
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="A" checked="checked" id="Acheckbox">
+								<label for="Acheckbox">
+									Acórdãos
+								</label>
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="H" id="Hcheckbox">
+								<label for="Hcheckbox">
+									Homologações de Acordo
+								</label>
+
+								<input type="checkbox" name="tipoDecisaoSelecionados" value="D" id="Dcheckbox">
+								<label for="Dcheckbox">
+									Decisões Monocráticas
+								</label>
+
+						</div>
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+				<tr class="">
+
+
+
+
+
+		  <td id="" width="160" valign="">
+
+
+
+
+				<label for="cjsg.consultaCompleta.label.ordenar" class="" style="float:left;font-weight:bold;">Ordenar por</label><div style="text-align:right;font-weight:bold;">: </div>
+
+
+
+		  </td>
+
+
+
+
+
+		    <td valign="">
+
+
+
+
+
+
+
+
+	<table cellpadding="0" cellspacing="0" border="0" width="600">
+		<tr>
+			<td>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenardtPublicacao">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenardtPublicacao" value="dtPublicacao" style="vertical-align:middle;" onclick="" class="" title=""  checked/>
+			Data de publicação
+		</label>
+
+	</span>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<span id="">
+		<label for="id_cjsg.consultaCompleta.label.ordenarRelevancia">
+			<input type="radio" name="dados.ordenarPor" id="id_cjsg.consultaCompleta.label.ordenarRelevancia" value="relevancia" style="vertical-align:middle;" onclick="" class="" title=""  />
+			Relevância
+		</label>
+
+	</span>
+
+
+
+
+			</td>
+		</tr>
+	  </table>
+
+
+
+
+
+
+
+		</td>
+
+			</tr>
+
+
+
+
+
+
+
+
+		</table>
+	</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<table id="" class="secaoBotoesBody" width="100%" style="" cellpadding="2" cellspacing="0" border="0">
+		<tr>
+
+ 				<td width="150">&nbsp;</td>
+
+			<td align="">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="submit" name="pbSubmit" value="Pesquisar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotaoDefault " id="pbSubmit">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	<input type="button" name="pbLimpar" value="Limpar" onclick="" onmouseover="B_mOver(this);" onmouseout="B_mOut(this);" class="spwBotao " id="pbLimpar">
+
+
+
+			</td>
+		</tr>
+	</table>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</form>
+
+
+
+
+			<!-- Resultado consulta -->
+
+				<!-- Tabs -->
+				<div id="tabs">
+					<ul>
+
+							<li tipo="A" >
+								<a href="A">
+									<span  id="nomeAba-A" >Acórdãos(149138)</span>
+									<input id="totalResultadoAba-A" type="hidden" value="149138" />
+								</a>
+							</li>
+
+					</ul>
+
+						<div id="tabs-A">
+
+
+
+
+
+
+
+
+
+
+<div id="paginacaoSuperior-A" style="padding-bottom: 15px;" >
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 100
+			</strong>
+			de 149138
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0">
+	<tr>
+		<td height="1" valign="top" id="tdResultados" width="*" >
+			<div id="divDadosResultado-A" >
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877970" cdForo="0" >
+										0800383-78.2024.8.12.0038
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877970" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877970);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877970" style="display: none;" >
+	<div id="textAreaDados_1877970" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C TUTELA DE URG&Ecirc;NCIA &ndash; REN&Uacute;NCIA DE MANDATO &ndash; INTIMA&Ccedil;&Atilde;O PARA REGULARIZA&Ccedil;&Atilde;O &ndash; IN&Eacute;RCIA &ndash; ARTIGO 76, &sect; 2&ordm;, I, DO CPC &ndash; AUS&Ecirc;NCIA DE PRESSUPOSTO DE CONSTITUI&Ccedil;&Atilde;O E DESENVOLVIMENTO V&Aacute;LIDO E REGULAR DO PROCESSO &ndash; RECURSO N&Atilde;O CONHECIDO.
+O n&atilde;o conhecimento do recurso &eacute; medida que se imp&otilde;e, uma vez que a parte apelante, intimada a regularizar a sua representa&ccedil;&atilde;o processual, quedou-se inerte. Aus&ecirc;ncia de pressuposto processual essencial ao processamento do recurso.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800383-78.2024.8.12.0038,&nbsp; Nioaque,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Fornecimento de medicamentos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Nioaque
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA – RENÚNCIA DE MANDATO – INTIMAÇÃO PARA REGULARIZAÇÃO – INÉRCIA – ARTIGO 76, § 2º, I, DO CPC – AUSÊNCIA DE PRESSUPOSTO DE CONSTITUIÇÃO E DESENVOLVIMENTO VÁLIDO E REGULAR DO PROCESSO – RECURSO NÃO CONHECIDO.
+O não conhecimento do recurso é medida que se impõe, uma vez que a parte apelante, intimada a regularizar a sua
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA – RENÚNCIA DE MANDATO – INTIMAÇÃO PARA REGULARIZAÇÃO – INÉRCIA – ARTIGO 76, § 2º, I, DO CPC – AUSÊNCIA DE PRESSUPOSTO DE CONSTITUIÇÃO E DESENVOLVIMENTO VÁLIDO E REGULAR DO PROCESSO – RECURSO NÃO CONHECIDO.
+O não conhecimento do recurso é medida que se impõe, uma vez que a parte apelante, intimada a regularizar a sua representação processual, quedou-se inerte. Ausência de pressuposto processual essencial ao processamento do recurso.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877978" cdForo="0" >
+										0801841-78.2023.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877978" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877978);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877978" style="display: none;" >
+	<div id="textAreaDados_1877978" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE COBRAN&Ccedil;A SECURIT&Aacute;RIA &ndash; SEGURO&nbsp;AGR&Iacute;COLA&nbsp;&ndash; SEGURADO CONSUMIDOR FINAL &ndash; HIPOSSUFICI&Ecirc;NCIA T&Eacute;CNICA DO SEGURADO PERANTE A SEGURADORA &ndash; INCID&Ecirc;NCIA DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; INVERS&Atilde;O DO &Ocirc;NUS DA PROVA MANTIDA &ndash; DIVERG&Ecirc;NCIA DE INFORMA&Ccedil;&Otilde;ES ENTRE AS PROPOSTAS ACEITAS PELO SEGURADO E AS CL&Aacute;USULAS PREVISTAS NA AP&Oacute;LICE DE SEGURO AGR&Iacute;COLA &ndash; CONTRATO DE ADES&Atilde;O &ndash; INTERPRETA&Ccedil;&Atilde;O MAIS BEN&Eacute;FICA AO CONSUMIDOR  &ndash; CONTRATA&Ccedil;&Atilde;O DE SEGURO NA MODALIDADE POR ITEM COM PREVIS&Atilde;O DE TR&Ecirc;S ITENS &ndash; INDENIZA&Ccedil;&Atilde;O SECURIT&Aacute;RIA DE FORMA INDIVIDUALIZADA POR ITEM &ndash; C&Aacute;LCULO DO PERITO JUDICIAL QUE OBSERVOU AS CL&Aacute;USULAS CONTRATUAIS E AS PROPOSTAS CONSTANTES DOS AUTOS &ndash;APURA&Ccedil;&Atilde;O DE SALDO REMANESCENTE &ndash; PAGAMENTO DA DIFEREN&Ccedil;A DEVIDO &ndash; FORMA DE PAGAMENTO A SER DISCUTIDA NA FASE CUMPRIMENTO DE SENTEN&Ccedil;A &ndash; ALTERA&Ccedil;&Atilde;O DO TERMO INICIAL DA CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA E JUROS DE MORA &ndash; OBSERV&Acirc;NCIA DA S&Uacute;MULA 632, DO STJ E DO ART. 405, DO C&Oacute;DIGO CIVIL -  RECURSO  CONHECIDO E PARCIALMENTE PROVIDO.
+A rela&ccedil;&atilde;o jur&iacute;dica mantida entre as partes do contrato de seguro agr&iacute;cola &eacute;, efetivamente, de consumo, que n&atilde;o se confunde com insumo, porquanto o consumidor &eacute; o destinat&aacute;rio final do produto, j&aacute; que o eventual cumprimento do contrato pela recorrente verter&aacute; em benef&iacute;cio pr&oacute;prio do segurado.
+Sendo o autor consumidor a parte vulner&aacute;vel na rela&ccedil;&atilde;o, conforme preceitua o artigo 4&ordm;, do CDC, e presentes os requisitos previstos no artigo 6&ordm;, VIII, do referido c&oacute;digo, pode o juiz inverter o &ocirc;nus da prova.
+No caso, o autor pleiteia saldo remanescente da indeniza&ccedil;&atilde;o securit&aacute;ria paga administrativamente pela seguradora, sob o argumento de erro de c&aacute;lculo pela seguradora e inobserv&acirc;ncia das propostas aceitas pelo autor-consumidor e que antecederam a contrata&ccedil;&atilde;o da ap&oacute;lice de seguro agr&iacute;cola na modalidade por item.
+&Agrave; luz dos princ&iacute;pios da fun&ccedil;&atilde;o social do contrato e da boa-f&eacute; objetiva (arts. 421 e 422, do CC), bem como aplica&ccedil;&atilde;o do C&oacute;digo de Defesa do Consumidor, acertada a senten&ccedil;a do ju&iacute;zo singular ao interpretar a contrata&ccedil;&atilde;o do seguro agr&iacute;cola de maneira mais ben&eacute;fica ao segurado-consumidor (arts. 6&ordm;, III; 46; 47; 54, &sect;&sect; 3&ordm; e 4&ordm;, do CDC), mormente diante da diverg&ecirc;ncia entre as propostas aderidas pelo segurado-consumidor que antecederam a contrata&ccedil;&atilde;o e aquelas inseridas unilateralmente pela seguradora na ap&oacute;lice firmada ao final.
+Restou evidenciado que a inten&ccedil;&atilde;o do produtor rural era contratar seguro agr&iacute;cola por item, com divis&atilde;o da unidade segurada em tr&ecirc;s itens, consoante propostas juntadas aos autos e que antecederam a contrata&ccedil;&atilde;o da ap&oacute;lice de seguro, visando eventual pagamento de indeniza&ccedil;&atilde;o de forma individualizada de acordo com a produtividade e eventuais sinistros de cada item.
+O laudo da vistoria t&eacute;cnica realizada por empresa contratada pela pr&oacute;pria seguradora, que concluiu pela ocorr&ecirc;ncia do sinistro coberta pela ap&oacute;lice, constatando pela exist&ecirc;ncia de 2% de ervas daninhas apenas no item 2 (subdividido em talh&otilde;es 2A e 2B), com &aacute;rea de 159,93 ha e colheita do item 3, com &aacute;rea de 67,71ha, de modo que as ervas daninhas (2%) devem ser descontadas apenas do item 2, com &aacute;rea de 159,93 ha, por configurar Parcela Deduzida a t&iacute;tulo de Risco N&atilde;o Coberto &ndash; PRNC, enquanto que o item 3, com &aacute;rea de 67,71ha, n&atilde;o deve ser computado para fins de compensa&ccedil;&atilde;o da indeniza&ccedil;&atilde;o securit&aacute;ria.
+O c&aacute;lculo elaborado pelo perito nomeado pelo ju&iacute;zo observou detidamente as cl&aacute;usulas contratuais, especialmente a f&oacute;rmula prevista na ap&oacute;lice de seguro firmada entre as partes, bem como as propostas que antecederam aludida contrata&ccedil;&atilde;o e os laudos de vistorias t&eacute;cnicos elaborados por empresa contratada pela seguradora e que  previram o seguro agr&iacute;cola por item, especificando 3 itens, ou seja, item 1 com &aacute;rea de 67,71 ha,  item 2 com &aacute;rea total de 159,93 ha, subdividido em dois talh&otilde;es (2.1 com &aacute;rea de 78,43 e 2.2 com &aacute;rea de 81,5 ha) e item 3 com &aacute;rea de 67,71 ha. O valor total da indeniza&ccedil;&atilde;o securit&aacute;ria apurado pelo aludido c&aacute;lculo n&atilde;o ultrapassa o LMI &ndash; Limite M&aacute;ximo de Indeniza&ccedil;&atilde;o, pelo que &eacute; devida a diferen&ccedil;a apurada.
+A forma de pagamento do saldo remanescente da indeniza&ccedil;&atilde;o securit&aacute;ria, se ao segurado ou ao benefici&aacute;rio, &eacute; quest&atilde;o a ser resolvida na fase de cumprimento de senten&ccedil;a.
+Altera&ccedil;&atilde;o do termo inicial dos juros de mora e corre&ccedil;&atilde;o monet&aacute;ria fixado na senten&ccedil;a, a fim de observarem o disposto no art. 405, do C&oacute;digo Civil, e a S&uacute;mula 632, do STJ, mantidos os &iacute;ndices previstos no contrato.
+Recurso conhecido e parcialmente provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801841-78.2023.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO CÍVEL – AÇÃO DE COBRANÇA SECURITÁRIA – SEGURO AGRÍCOLA – SEGURADO CONSUMIDOR FINAL – HIPOSSUFICIÊNCIA TÉCNICA DO SEGURADO PERANTE A SEGURADORA – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – INVERSÃO DO ÔNUS DA PROVA MANTIDA – DIVERGÊNCIA DE INFORMAÇÕES ENTRE AS PROPOSTAS ACEITAS PELO SEGURADO E AS CLÁUSULAS PREVISTAS NA APÓLICE DE SEGURO AGRÍCOLA – CONTRATO DE ADESÃO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO CÍVEL – AÇÃO DE COBRANÇA SECURITÁRIA – SEGURO AGRÍCOLA – SEGURADO CONSUMIDOR FINAL – HIPOSSUFICIÊNCIA TÉCNICA DO SEGURADO PERANTE A SEGURADORA – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – INVERSÃO DO ÔNUS DA PROVA MANTIDA – DIVERGÊNCIA DE INFORMAÇÕES ENTRE AS PROPOSTAS ACEITAS PELO SEGURADO E AS CLÁUSULAS PREVISTAS NA APÓLICE DE SEGURO AGRÍCOLA – CONTRATO DE ADESÃO – INTERPRETAÇÃO MAIS BENÉFICA AO CONSUMIDOR  – CONTRATAÇÃO DE SEGURO NA MODALIDADE POR ITEM COM PREVISÃO DE TRÊS ITENS – INDENIZAÇÃO SECURITÁRIA DE FORMA INDIVIDUALIZADA POR ITEM – CÁLCULO DO PERITO JUDICIAL QUE OBSERVOU AS CLÁUSULAS CONTRATUAIS E AS PROPOSTAS CONSTANTES DOS AUTOS –APURAÇÃO DE SALDO REMANESCENTE – PAGAMENTO DA DIFERENÇA DEVIDO – FORMA DE PAGAMENTO A SER DISCUTIDA NA FASE CUMPRIMENTO DE SENTENÇA – ALTERAÇÃO DO TERMO INICIAL DA CORREÇÃO MONETÁRIA E JUROS DE MORA – OBSERVÂNCIA DA SÚMULA 632, DO STJ E DO ART. 405, DO CÓDIGO CIVIL -  RECURSO  CONHECIDO E PARCIALMENTE PROVIDO.
+A relação jurídica mantida entre as partes do contrato de seguro agrícola é, efetivamente, de consumo, que não se confunde com insumo, porquanto o consumidor é o destinatário final do produto, já que o eventual cumprimento do contrato pela recorrente verterá em benefício próprio do segurado.
+Sendo o autor consumidor a parte vulnerável na relação, conforme preceitua o artigo 4º, do CDC, e presentes os requisitos previstos no artigo 6º, VIII, do referido código, pode o juiz inverter o ônus da prova.
+No caso, o autor pleiteia saldo remanescente da indenização securitária paga administrativamente pela seguradora, sob o argumento de erro de cálculo pela seguradora e inobservância das propostas aceitas pelo autor-consumidor e que antecederam a contratação da apólice de seguro agrícola na modalidade por item.
+À luz dos princípios da função social do contrato e da boa-fé objetiva (arts. 421 e 422, do CC), bem como aplicação do Código de Defesa do Consumidor, acertada a sentença do juízo singular ao interpretar a contratação do seguro agrícola de maneira mais benéfica ao segurado-consumidor (arts. 6º, III; 46; 47; 54, §§ 3º e 4º, do CDC), mormente diante da divergência entre as propostas aderidas pelo segurado-consumidor que antecederam a contratação e aquelas inseridas unilateralmente pela seguradora na apólice firmada ao final.
+Restou evidenciado que a intenção do produtor rural era contratar seguro agrícola por item, com divisão da unidade segurada em três itens, consoante propostas juntadas aos autos e que antecederam a contratação da apólice de seguro, visando eventual pagamento de indenização de forma individualizada de acordo com a produtividade e eventuais sinistros de cada item.
+O laudo da vistoria técnica realizada por empresa contratada pela própria seguradora, que concluiu pela ocorrência do sinistro coberta pela apólice, constatando pela existência de 2% de ervas daninhas apenas no item 2 (subdividido em talhões 2A e 2B), com área de 159,93 ha e colheita do item 3, com área de 67,71ha, de modo que as ervas daninhas (2%) devem ser descontadas apenas do item 2, com área de 159,93 ha, por configurar Parcela Deduzida a título de Risco Não Coberto – PRNC, enquanto que o item 3, com área de 67,71ha, não deve ser computado para fins de compensação da indenização securitária.
+O cálculo elaborado pelo perito nomeado pelo juízo observou detidamente as cláusulas contratuais, especialmente a fórmula prevista na apólice de seguro firmada entre as partes, bem como as propostas que antecederam aludida contratação e os laudos de vistorias técnicos elaborados por empresa contratada pela seguradora e que  previram o seguro agrícola por item, especificando 3 itens, ou seja, item 1 com área de 67,71 ha,  item 2 com área total de 159,93 ha, subdividido em dois talhões (2.1 com área de 78,43 e 2.2 com área de 81,5 ha) e item 3 com área de 67,71 ha. O valor total da indenização securitária apurado pelo aludido cálculo não ultrapassa o LMI – Limite Máximo de Indenização, pelo que é devida a diferença apurada.
+A forma de pagamento do saldo remanescente da indenização securitária, se ao segurado ou ao beneficiário, é questão a ser resolvida na fase de cumprimento de sentença.
+Alteração do termo inicial dos juros de mora e correção monetária fixado na sentença, a fim de observarem o disposto no art. 405, do Código Civil, e a Súmula 632, do STJ, mantidos os índices previstos no contrato.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877984" cdForo="0" >
+										0870227-32.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877984" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877984);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877984" style="display: none;" >
+	<div id="textAreaDados_1877984" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O &ndash; N&Atilde;O   PROVIMENTO DO RECURSO DE APELA&Ccedil;&Atilde;O DA EMBARGANTE &ndash; OMISS&Atilde;O E CONTRADI&Ccedil;&Atilde;O &ndash; ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE AN&Aacute;LISE QUANTO &Agrave; INEXIST&Ecirc;NCIA DE BIOMETRIA &ndash; ALEGA&Ccedil;&Atilde;O DE OCORR&Ecirc;NCIA DE FORTUITO INTERNO &ndash; AN&Aacute;LISE ACERCA DA EXCLUDENTE DE RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; V&Iacute;CIOS N&Atilde;O IDENTIFICADOS &ndash; MERA REDISCUSS&Atilde;O DAS MAT&Eacute;RIAS &ndash; RECURSO REJEITADO.
+Os embargos de declara&ccedil;&atilde;o t&ecirc;m por escopo a supress&atilde;o no ac&oacute;rd&atilde;o de eventual contradi&ccedil;&atilde;o, obscuridade ou omiss&atilde;o, e n&atilde;o servem de instrumento para ensejar a rediscuss&atilde;o da mat&eacute;ria ou o simples reexame de quest&otilde;es j&aacute; analisadas, com o intuito de dar efeito modificativo ao recurso.
+A parte recorrente alega que o Ac&oacute;rd&atilde;o vergastado foi omisso ao deixar de se pronunciar acerca da aus&ecirc;ncia de provas quanto &agrave; validade da assinatura da embargante, bem como que o caso dos autos se trata de fortuito interno e a n&atilde;o ocorr&ecirc;ncia de nenhuma excludente de responsabilidade, pisando-se pela exist&ecirc;ncia de omiss&atilde;o a alega&ccedil;&atilde;o de descumprimento dos requisitos dispostos na IN 138/2022.
+As mat&eacute;rias alegadas pela parte embargante versam acerca do m&eacute;rito da a&ccedil;&atilde;o de origem, n&atilde;o constituindo-se em omiss&otilde;es e contradi&ccedil;&otilde;es existentes no ac&oacute;rd&atilde;o de julgamento.
+Uma vez n&atilde;o verificada quaisquer v&iacute;cios pass&iacute;veis de serem sanados, os aclarat&oacute;rios devem ser rejeitados, nos termos do que estabelece o artigo 1.022, I e II, do C&oacute;digo de Processo Civil.   <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0870227-32.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Rescisão / Resolução
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									870227322024812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO   PROVIMENTO DO RECURSO DE APELAÇÃO DA EMBARGANTE – OMISSÃO E CONTRADIÇÃO – ALEGAÇÃO DE AUSÊNCIA DE ANÁLISE QUANTO À INEXISTÊNCIA DE BIOMETRIA – ALEGAÇÃO DE OCORRÊNCIA DE FORTUITO INTERNO – ANÁLISE ACERCA DA EXCLUDENTE DE RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – VÍCIOS NÃO IDENTIFICADOS – MERA REDISCUSSÃO DAS MATÉRIAS – RECURSO REJEITADO.
+Os embargos de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO   PROVIMENTO DO RECURSO DE APELAÇÃO DA EMBARGANTE – OMISSÃO E CONTRADIÇÃO – ALEGAÇÃO DE AUSÊNCIA DE ANÁLISE QUANTO À INEXISTÊNCIA DE BIOMETRIA – ALEGAÇÃO DE OCORRÊNCIA DE FORTUITO INTERNO – ANÁLISE ACERCA DA EXCLUDENTE DE RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – VÍCIOS NÃO IDENTIFICADOS – MERA REDISCUSSÃO DAS MATÉRIAS – RECURSO REJEITADO.
+Os embargos de declaração têm por escopo a supressão no acórdão de eventual contradição, obscuridade ou omissão, e não servem de instrumento para ensejar a rediscussão da matéria ou o simples reexame de questões já analisadas, com o intuito de dar efeito modificativo ao recurso.
+A parte recorrente alega que o Acórdão vergastado foi omisso ao deixar de se pronunciar acerca da ausência de provas quanto à validade da assinatura da embargante, bem como que o caso dos autos se trata de fortuito interno e a não ocorrência de nenhuma excludente de responsabilidade, pisando-se pela existência de omissão a alegação de descumprimento dos requisitos dispostos na IN 138/2022.
+As matérias alegadas pela parte embargante versam acerca do mérito da ação de origem, não constituindo-se em omissões e contradições existentes no acórdão de julgamento.
+Uma vez não verificada quaisquer vícios passíveis de serem sanados, os aclaratórios devem ser rejeitados, nos termos do que estabelece o artigo 1.022, I e II, do Código de Processo Civil.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878011" cdForo="0" >
+										0802926-02.2023.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878011" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878011);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878011" style="display: none;" >
+	<div id="textAreaDados_1878011" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O ANULAT&Oacute;RIA DE NEG&Oacute;CIO JUR&Iacute;DICO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CONTRATO DE EMPR&Eacute;STIMO DEVIDAMENTE FORMALIZADO PERANTE A INSTITUI&Ccedil;&Atilde;O FINANCEIRA APELANTE &ndash; AUTOR QUE RECEBEU O VALOR DO CONTRATO E UTILIZOU PARA PAGAMENTO DE BOLETO FALSO &ndash; AUS&Ecirc;NCIA DE ILICITUDE PRATICADA PELO BANCO &ndash; EXIST&Ecirc;NCIA DE PACTUA&Ccedil;&Atilde;O DISTINTA ENTRE O AUTOR E EMPRESA TERCEIRA &ndash; EXCLUDENTE DE RESPONSABILIDADE COMPROVADA &ndash; ART. 14, &sect;3&ordm;, II, DO CDC &ndash; FORTUITO EXTERNO &ndash; CULPA EXCLUSIVA DO CONSUMIDOR E/OU TERCEIRO &ndash; DECIS&Atilde;O MANTIDA &ndash; REDISCUSS&Atilde;O DA MAT&Eacute;RIA &ndash; PREQUESTIONAMENTO &ndash; DESNECESSIDADE DE MANIFESTA&Ccedil;&Atilde;O EXPRESSA &ndash; EMBARGOS REJEITADOS.
+A teor do disposto no art. 1022, do C&oacute;digo de Processo Civil, os embargos de declara&ccedil;&atilde;o t&ecirc;m por finalidade o aperfei&ccedil;oamento de pronunciamentos judiciais, afastando do decisum embargado eventuais v&iacute;cios, tais como obscuridade ou contradi&ccedil;&atilde;o ou, ainda, integrando-os por interm&eacute;dio da manifesta&ccedil;&atilde;o acerca de algum ponto ocasionalmente omisso, n&atilde;o se prestando, destarte, esta estreita via recursal, para alterar aquilo que restou decidido, salvo nos casos excepcionais em que, do saneamento de algum defeito, decorra l&oacute;gica e imediatamente uma mudan&ccedil;a substancial quanto &agrave; conclus&atilde;o anteriormente assentada acerca da controv&eacute;rsia posta &agrave; aprecia&ccedil;&atilde;o.
+Se o inconformismo do embargante prende-se a pontos isolados que foram elucidados no voto condutor e que serviram de lastro para fundamentar o ac&oacute;rd&atilde;o guerreado, tem-se claramente que o intuito &eacute; obter novo julgamento da quest&atilde;o versada, objetivo imposs&iacute;vel de se atingir atrav&eacute;s de embargos de declara&ccedil;&atilde;o, sob pena de se desvirtuar completamente a natureza do instrumento, dando azo &agrave; manipula&ccedil;&atilde;o de novo recurso de m&eacute;rito na mesma inst&acirc;ncia, o que a jurisprud&ecirc;ncia p&aacute;tria n&atilde;o admite.
+Em n&atilde;o sendo caso de nenhuma das hip&oacute;teses do art. 1.022, do C&oacute;digo de Processo Civil, rejeitam-se os embargos declarat&oacute;rios.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0802926-02.2023.8.12.0002,&nbsp; Dourados,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									802926022023812000250000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO ANULATÓRIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE EMPRÉSTIMO DEVIDAMENTE FORMALIZADO PERANTE A INSTITUIÇÃO FINANCEIRA APELANTE – AUTOR QUE RECEBEU O VALOR DO CONTRATO E UTILIZOU PARA PAGAMENTO DE BOLETO FALSO – AUSÊNCIA DE ILICITUDE PRATICADA PELO BANCO – EXISTÊNCIA DE PACTUAÇÃO DISTINTA ENTRE O AUTOR E EMPRESA TERCEIRA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO ANULATÓRIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE EMPRÉSTIMO DEVIDAMENTE FORMALIZADO PERANTE A INSTITUIÇÃO FINANCEIRA APELANTE – AUTOR QUE RECEBEU O VALOR DO CONTRATO E UTILIZOU PARA PAGAMENTO DE BOLETO FALSO – AUSÊNCIA DE ILICITUDE PRATICADA PELO BANCO – EXISTÊNCIA DE PACTUAÇÃO DISTINTA ENTRE O AUTOR E EMPRESA TERCEIRA – EXCLUDENTE DE RESPONSABILIDADE COMPROVADA – ART. 14, §3º, II, DO CDC – FORTUITO EXTERNO – CULPA EXCLUSIVA DO CONSUMIDOR E/OU TERCEIRO – DECISÃO MANTIDA – REDISCUSSÃO DA MATÉRIA – PREQUESTIONAMENTO – DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA – EMBARGOS REJEITADOS.
+A teor do disposto no art. 1022, do Código de Processo Civil, os embargos de declaração têm por finalidade o aperfeiçoamento de pronunciamentos judiciais, afastando do decisum embargado eventuais vícios, tais como obscuridade ou contradição ou, ainda, integrando-os por intermédio da manifestação acerca de algum ponto ocasionalmente omisso, não se prestando, destarte, esta estreita via recursal, para alterar aquilo que restou decidido, salvo nos casos excepcionais em que, do saneamento de algum defeito, decorra lógica e imediatamente uma mudança substancial quanto à conclusão anteriormente assentada acerca da controvérsia posta à apreciação.
+Se o inconformismo do embargante prende-se a pontos isolados que foram elucidados no voto condutor e que serviram de lastro para fundamentar o acórdão guerreado, tem-se claramente que o intuito é obter novo julgamento da questão versada, objetivo impossível de se atingir através de embargos de declaração, sob pena de se desvirtuar completamente a natureza do instrumento, dando azo à manipulação de novo recurso de mérito na mesma instância, o que a jurisprudência pátria não admite.
+Em não sendo caso de nenhuma das hipóteses do art. 1.022, do Código de Processo Civil, rejeitam-se os embargos declaratórios.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878013" cdForo="0" >
+										0814178-05.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878013" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878013);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878013" style="display: none;" >
+	<div id="textAreaDados_1878013" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O MONIT&Oacute;RIA &ndash; NOTA PROMISS&Oacute;RIA PRESCRITA &ndash; JUNTADA DE DOCUMENTOS EM SEDE RECURSAL &ndash; N&Atilde;O CONHECIMENTO &ndash; AUS&Ecirc;NCIA DE FATO NOVO OU FOR&Ccedil;A MAIOR &ndash; PRECLUS&Atilde;O (ARTS. 434 E 435 DO CPC) &ndash; M&Eacute;RITO &ndash; DISCUSS&Atilde;O DA CAUSA DEBENDI &ndash; POSSIBILIDADE &ndash; COMPROVA&Ccedil;&Atilde;O DE QUE O NEG&Oacute;CIO JUR&Iacute;DICO SUBJACENTE (COMPRA E VENDA DE SEMOVENTES) N&Atilde;O SE APERFEI&Ccedil;OOU &ndash; TRADI&Ccedil;&Atilde;O DO OBJETO A TERCEIRO COMPROVADA POR GUIAS DE TR&Acirc;NSITO ANIMAL (GTA) &ndash; INEXIGIBILIDADE DO T&Iacute;TULO &ndash; ALEGA&Ccedil;&Atilde;O DE ANALFABETISMO DO CREDOR E INAUTENTICIDADE DE DOCUMENTO &ndash; INOVA&Ccedil;&Atilde;O RECURSAL E PRECLUS&Atilde;O CONSUMATIVA &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO EM PARTE E, NA PARTE CONHECIDA, DESPROVIDO.
+I - A juntada de documentos em fase recursal &eacute; medida excepcional, admitida apenas para comprovar fatos novos ou se demonstrada a impossibilidade de apresenta&ccedil;&atilde;o oportuna por motivo de for&ccedil;a maior. Intelig&ecirc;ncia dos arts. 434 e 435 do CPC. Documenta&ccedil;&atilde;o que visa rediscutir fatos narrados desde o in&iacute;cio da lide n&atilde;o deve ser conhecida.
+II - As teses de que o credor original era analfabeto ou de que a declara&ccedil;&atilde;o por ele firmada seria inaut&ecirc;ntica n&atilde;o foram arguidas no momento oportuno (fase de instru&ccedil;&atilde;o), operando-se a preclus&atilde;o. A an&aacute;lise de tais mat&eacute;rias diretamente pelo Tribunal configuraria supress&atilde;o de inst&acirc;ncia e ofensa ao duplo grau de jurisdi&ccedil;&atilde;o.
+III - Em sede de A&ccedil;&atilde;o Monit&oacute;ria fundada em t&iacute;tulo prescrito, &eacute; admitida a discuss&atilde;o sobre a causa da d&iacute;vida. Demonstrado pelo devedor/embargante, por meio de prova documental dotada de f&eacute; p&uacute;blica (GTA e registros da SEFAZ), que os animais objeto da nota promiss&oacute;ria foram vendidos e entregues a terceiro na v&eacute;spera do vencimento do t&iacute;tulo, resta esvaziado o lastro do cr&eacute;dito.
+IV - A simples posse da c&aacute;rtula n&atilde;o autoriza a cobran&ccedil;a quando cabalmente comprovado o desfazimento ou a n&atilde;o concretiza&ccedil;&atilde;o do neg&oacute;cio jur&iacute;dico que lhe deu origem (causa debendi).
+V - Recurso conhecido em parte e, na parte conhecida, desprovido, com majora&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais em sede recursal (art. 85, &sect; 11, do CPC).  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0814178-05.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Duplicata
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO MONITÓRIA – NOTA PROMISSÓRIA PRESCRITA – JUNTADA DE DOCUMENTOS EM SEDE RECURSAL – NÃO CONHECIMENTO – AUSÊNCIA DE FATO NOVO OU FORÇA MAIOR – PRECLUSÃO (ARTS. 434 E 435 DO CPC) – MÉRITO – DISCUSSÃO DA CAUSA DEBENDI – POSSIBILIDADE – COMPROVAÇÃO DE QUE O NEGÓCIO JURÍDICO SUBJACENTE (COMPRA E VENDA DE SEMOVENTES) NÃO SE APERFEIÇOOU – TRADIÇÃO DO OBJETO A TERCEIRO COMPROVADA POR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO MONITÓRIA – NOTA PROMISSÓRIA PRESCRITA – JUNTADA DE DOCUMENTOS EM SEDE RECURSAL – NÃO CONHECIMENTO – AUSÊNCIA DE FATO NOVO OU FORÇA MAIOR – PRECLUSÃO (ARTS. 434 E 435 DO CPC) – MÉRITO – DISCUSSÃO DA CAUSA DEBENDI – POSSIBILIDADE – COMPROVAÇÃO DE QUE O NEGÓCIO JURÍDICO SUBJACENTE (COMPRA E VENDA DE SEMOVENTES) NÃO SE APERFEIÇOOU – TRADIÇÃO DO OBJETO A TERCEIRO COMPROVADA POR GUIAS DE TRÂNSITO ANIMAL (GTA) – INEXIGIBILIDADE DO TÍTULO – ALEGAÇÃO DE ANALFABETISMO DO CREDOR E INAUTENTICIDADE DE DOCUMENTO – INOVAÇÃO RECURSAL E PRECLUSÃO CONSUMATIVA – SENTENÇA MANTIDA – RECURSO CONHECIDO EM PARTE E, NA PARTE CONHECIDA, DESPROVIDO.
+I - A juntada de documentos em fase recursal é medida excepcional, admitida apenas para comprovar fatos novos ou se demonstrada a impossibilidade de apresentação oportuna por motivo de força maior. Inteligência dos arts. 434 e 435 do CPC. Documentação que visa rediscutir fatos narrados desde o início da lide não deve ser conhecida.
+II - As teses de que o credor original era analfabeto ou de que a declaração por ele firmada seria inautêntica não foram arguidas no momento oportuno (fase de instrução), operando-se a preclusão. A análise de tais matérias diretamente pelo Tribunal configuraria supressão de instância e ofensa ao duplo grau de jurisdição.
+III - Em sede de Ação Monitória fundada em título prescrito, é admitida a discussão sobre a causa da dívida. Demonstrado pelo devedor/embargante, por meio de prova documental dotada de fé pública (GTA e registros da SEFAZ), que os animais objeto da nota promissória foram vendidos e entregues a terceiro na véspera do vencimento do título, resta esvaziado o lastro do crédito.
+IV - A simples posse da cártula não autoriza a cobrança quando cabalmente comprovado o desfazimento ou a não concretização do negócio jurídico que lhe deu origem (causa debendi).
+V - Recurso conhecido em parte e, na parte conhecida, desprovido, com majoração dos honorários sucumbenciais em sede recursal (art. 85, § 11, do CPC).
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878039" cdForo="0" >
+										0831188-33.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878039" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878039);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878039" style="display: none;" >
+	<div id="textAreaDados_1878039" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O ORDIN&Aacute;RIA, DESCONTOS EM FOLHA DE PAGAMENTO, ABUSIVIDADE C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; EMPR&Eacute;STIMO CONSIGNADO &ndash; ASSINATURA FALSIFICADA &ndash; PROVA PERICIAL CONCLUSIVA &ndash; NULIDADE DOS CONTRATOS &ndash; RESTITUI&Ccedil;&Atilde;O EM DOBRO DEVIDA A PARTIR DE 29/03/2021 &ndash; AUS&Ecirc;NCIA DE PROVA DO ENGANO JUSTIFIC&Aacute;VEL &ndash; DANO MORAL &ndash; OCORR&Ecirc;NCIA &ndash; DESCONTOS ELEVADOS EM REMUNERA&Ccedil;&Atilde;O &ndash; APLICA&Ccedil;&Atilde;O DAS ALTERA&Ccedil;&Otilde;ES DA LEI N.&ordm; 14.905/2024  - SENTEN&Ccedil;A REFORMADA QUANTO AO &Iacute;NDICE APLICADO &Agrave;S RESTITUI&Ccedil;&Otilde;ES ANTERIORES &Agrave; LEI 14.905/2024 &ndash; RECURSO CONHECIDO E PROVIDO EM PARTE.
+A falsifica&ccedil;&atilde;o da assinatura no contrato de empr&eacute;stimo consignado, devidamente constatada por prova pericial grafot&eacute;cnica, inviabiliza a manifesta&ccedil;&atilde;o v&aacute;lida da vontade do consumidor e acarreta a nulidade absoluta do neg&oacute;cio jur&iacute;dico.
+Considerando que est&atilde;o presentes os requisitos do art. 42, par&aacute;grafo &uacute;nico, do CDC; que a parte fornecedora n&atilde;o logrou comprovar que seu engano foi justific&aacute;vel nos moldes aqui estabelecidos, ou seja, que tomou todas as cautelas devidas para que o fato n&atilde;o acontecesse; devida a restitui&ccedil;&atilde;o dos valores indevidamente descontados na forma dobrada.
+As especificidades do caso concreto, a saber, valor da remunera&ccedil;&atilde;o e dos descontos indevidos, implicam na conclus&atilde;o de ocorr&ecirc;ncia de les&atilde;o extrapatrimonial indeniz&aacute;vel.
+&nbsp;Em face do conjunto probat&oacute;rio do caso concreto, entendo que a quantia de R$ 5.000,00 (oito mil reais) se mostra suficiente, justa, razo&aacute;vel e adequada, atendendo &agrave; fun&ccedil;&atilde;o pedag&oacute;gica da condena&ccedil;&atilde;o.
+Impositiva a compensa&ccedil;&atilde;o entre o valor depositado em conta de titularidade da parte autora, devidamente atualizado, com o montante da condena&ccedil;&atilde;o, de modo a se evitar o enriquecimento il&iacute;cito da parte.
+Tratando-se o presente caso de responsabilidade extracontratual &ndash; quando n&atilde;o existe contrato &ndash;, o termo inicial dos juros de mora da condena&ccedil;&atilde;o por danos materiais e morais deve observar o evento danoso. Isto &eacute;, em rela&ccedil;&atilde;o &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, a contar de cada desconto indevido, e dos danos morais, da data do primeiro desconto indevido (quando o dano foi provocado).
+A t&iacute;tulo de corre&ccedil;&atilde;o monet&aacute;ria, o IPCA-E deve incidir desde a data de cada desconto, no que concerne &agrave; repara&ccedil;&atilde;o material e, a partir do arbitramento, quanto &agrave; repara&ccedil;&atilde;o moral.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0831188-33.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(72 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO ORDINÁRIA, DESCONTOS EM FOLHA DE PAGAMENTO, ABUSIVIDADE C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – ASSINATURA FALSIFICADA – PROVA PERICIAL CONCLUSIVA – NULIDADE DOS CONTRATOS – RESTITUIÇÃO EM DOBRO DEVIDA A PARTIR DE 29/03/2021 – AUSÊNCIA DE PROVA DO ENGANO JUSTIFICÁVEL – <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA – DESCONTOS ELEVADOS EM REMUNERAÇÃO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO ORDINÁRIA, DESCONTOS EM FOLHA DE PAGAMENTO, ABUSIVIDADE C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – ASSINATURA FALSIFICADA – PROVA PERICIAL CONCLUSIVA – NULIDADE DOS CONTRATOS – RESTITUIÇÃO EM DOBRO DEVIDA A PARTIR DE 29/03/2021 – AUSÊNCIA DE PROVA DO ENGANO JUSTIFICÁVEL – <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA – DESCONTOS ELEVADOS EM REMUNERAÇÃO – APLICAÇÃO DAS ALTERAÇÕES DA LEI N.º 14.905/2024  - SENTENÇA REFORMADA QUANTO AO ÍNDICE APLICADO ÀS RESTITUIÇÕES ANTERIORES À LEI 14.905/2024 – RECURSO CONHECIDO E PROVIDO EM PARTE.
+A falsificação da assinatura no contrato de empréstimo consignado, devidamente constatada por prova pericial grafotécnica, inviabiliza a manifestação válida da vontade do consumidor e acarreta a nulidade absoluta do negócio jurídico.
+Considerando que estão presentes os requisitos do art. 42, parágrafo único, do CDC; que a parte fornecedora não logrou comprovar que seu engano foi justificável nos moldes aqui estabelecidos, ou seja, que tomou todas as cautelas devidas para que o fato não acontecesse; devida a restituição dos valores indevidamente descontados na forma dobrada.
+As especificidades do caso concreto, a saber, valor da remuneração e dos descontos indevidos, implicam na conclusão de ocorrência de lesão extrapatrimonial indenizável.
+ Em face do conjunto probatório do caso concreto, entendo que a quantia de R$ 5.000,00 (oito mil reais) se mostra suficiente, justa, razoável e adequada, atendendo à função pedagógica da condenação.
+Impositiva a compensação entre o valor depositado em conta de titularidade da parte autora, devidamente atualizado, com o montante da condenação, de modo a se evitar o enriquecimento ilícito da parte.
+Tratando-se o presente caso de responsabilidade extracontratual – quando não existe contrato –, o termo inicial dos juros de mora da condenação por danos materiais e morais deve observar o evento danoso. Isto é, em relação à repetição do indébito, a contar de cada desconto indevido, e dos danos morais, da data do primeiro desconto indevido (quando o <em>dano</em> foi provocado).
+A título de correção monetária, o IPCA-E deve incidir desde a data de cada desconto, no que concerne à reparação material e, a partir do arbitramento, quanto à reparação <em>moral</em>.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878052" cdForo="0" >
+										0800560-55.2023.8.12.0045
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878052" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878052);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878052" style="display: none;" >
+	<div id="textAreaDados_1878052" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; ERRO NA IDENTIFICA&Ccedil;&Atilde;O DE PACIENTE EM UNIDADE HOSPITALAR &ndash; DECLARA&Ccedil;&Atilde;O INDEVIDA DE &Oacute;BITO &ndash; CESSA&Ccedil;&Atilde;O DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. RESPONSABILIDADE CIVIL DO ESTADO &ndash; CONFIGURADA. TEORIA DO RISCO ADMINISTRATIVO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; NEXO CAUSAL CONFIGURADO. DANO MORAL CARACTERIZADO &ndash; QUANTUM INDENIZAT&Oacute;RIO (R$20.000,00) &ndash; REVESTIDO DE RAZOABILIDADE E PROPORCIONALIDADE. PRETENS&Otilde;ES DE MAJORA&Ccedil;&Atilde;O (AUTOR) E MINORA&Ccedil;&Atilde;O (REQUERIDOS &ndash; REJEITADAS. SENTEN&Ccedil;A MANTIDA, RECURSOS DESPROVIDOS.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800560-55.2023.8.12.0045,&nbsp; Sidrol&acirc;ndia,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sidrolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ERRO NA IDENTIFICAÇÃO DE PACIENTE EM UNIDADE HOSPITALAR – DECLARAÇÃO INDEVIDA DE ÓBITO – CESSAÇÃO DE BENEFÍCIO PREVIDENCIÁRIO. RESPONSABILIDADE CIVIL DO ESTADO – CONFIGURADA. TEORIA DO RISCO ADMINISTRATIVO – FALHA NA PRESTAÇÃO DO SERVIÇO – NEXO CAUSAL CONFIGURADO. <em>DANO</em> <em>MORAL</em> CARACTERIZADO – QUANTUM INDENIZATÓRIO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ERRO NA IDENTIFICAÇÃO DE PACIENTE EM UNIDADE HOSPITALAR – DECLARAÇÃO INDEVIDA DE ÓBITO – CESSAÇÃO DE BENEFÍCIO PREVIDENCIÁRIO. RESPONSABILIDADE CIVIL DO ESTADO – CONFIGURADA. TEORIA DO RISCO ADMINISTRATIVO – FALHA NA PRESTAÇÃO DO SERVIÇO – NEXO CAUSAL CONFIGURADO. <em>DANO</em> <em>MORAL</em> CARACTERIZADO – QUANTUM INDENIZATÓRIO (R$20.000,00) – REVESTIDO DE RAZOABILIDADE E PROPORCIONALIDADE. PRETENSÕES DE MAJORAÇÃO (AUTOR) E MINORAÇÃO (REQUERIDOS – REJEITADAS. SENTENÇA MANTIDA, RECURSOS DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878059" cdForo="0" >
+										0800121-60.2020.8.12.0009
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878059" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878059);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878059" style="display: none;" >
+	<div id="textAreaDados_1878059" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE RESCIS&Atilde;O CONTRATUAL C/C INDENIZA&Ccedil;&Atilde;O. PRELIMINAR DE N&Atilde;O CONHECIMENTO PARCIAL DO RECURSO &ndash; AFASTADA. M&Eacute;RITO &ndash; SISTEMA FOTOVOLTAICO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; N&Atilde;O COMPROVA&Ccedil;&Atilde;O DE PERFORMANCE PROMETIDA &ndash; RESCIS&Atilde;O CONTRATUAL &ndash; RESTITUI&Ccedil;&Atilde;O DE VALORES &ndash; LUCROS CESSANTES &ndash; MANUTEN&Ccedil;&Atilde;O &ndash; PROVA PERICIAL N&Atilde;O REALIZADA POR IN&Eacute;RCIA DA R&Eacute; &ndash; INVERS&Atilde;O DO &Ocirc;NUS DA PROVA. DANOS MORAIS &ndash; PESSOA JUR&Iacute;DICA &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DE ABALO &Agrave; HONRA OBJETIVA &ndash; MERO INADIMPLEMENTO CONTRATUAL &ndash; INDENIZA&Ccedil;&Atilde;O INDEVIDA. RECURSO PARCIALMENTE PROVIDO.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800121-60.2020.8.12.0009,&nbsp; Costa Rica,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Costa Rica
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESCISÃO CONTRATUAL C/C INDENIZAÇÃO. PRELIMINAR DE NÃO CONHECIMENTO PARCIAL DO RECURSO – AFASTADA. MÉRITO – SISTEMA FOTOVOLTAICO – FALHA NA PRESTAÇÃO DO SERVIÇO – NÃO COMPROVAÇÃO DE PERFORMANCE PROMETIDA – RESCISÃO CONTRATUAL – RESTITUIÇÃO DE VALORES – LUCROS CESSANTES – MANUTENÇÃO – PROVA PERICIAL NÃO REALIZADA POR INÉRCIA DA RÉ – INVERSÃO DO ÔNUS DA PROVA. DANOS MORAIS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESCISÃO CONTRATUAL C/C INDENIZAÇÃO. PRELIMINAR DE NÃO CONHECIMENTO PARCIAL DO RECURSO – AFASTADA. MÉRITO – SISTEMA FOTOVOLTAICO – FALHA NA PRESTAÇÃO DO SERVIÇO – NÃO COMPROVAÇÃO DE PERFORMANCE PROMETIDA – RESCISÃO CONTRATUAL – RESTITUIÇÃO DE VALORES – LUCROS CESSANTES – MANUTENÇÃO – PROVA PERICIAL NÃO REALIZADA POR INÉRCIA DA RÉ – INVERSÃO DO ÔNUS DA PROVA. DANOS MORAIS – PESSOA JURÍDICA – AUSÊNCIA DE COMPROVAÇÃO DE ABALO À HONRA OBJETIVA – MERO INADIMPLEMENTO CONTRATUAL – INDENIZAÇÃO INDEVIDA. RECURSO PARCIALMENTE PROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878061" cdForo="0" >
+										1400892-06.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878061" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878061);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878061" style="display: none;" >
+	<div id="textAreaDados_1878061" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. AGRAVO DE INSTRUMENTO DA OPERADORA DE PLANO DE SA&Uacute;DE CONTRA DECIS&Atilde;O QUE REJEITOU A EXCE&Ccedil;&Atilde;O DE PR&Eacute;-EXECUTIVIDADE E DETERMINOU O PROSSEGUIMENTO DO CUMPRIMENTO DE SENTEN&Ccedil;A MOVIDO PELA AGRAVADA. DESCABIDA A REDU&Ccedil;&Atilde;O DOS ASTREINTES EM RAZ&Atilde;O DA DEMORA DESARAZOADA PARA O CUMPRIMENTO DA OBRIGA&Ccedil;&Atilde;O. RECURSO IMPROVIDO.
+I. Caso em exame
+1. Agravo de Instrumento contra decis&atilde;o que rejeitou a Exce&ccedil;&atilde;o de Pr&eacute;-Executividade e determinou o prosseguimento do Cumprimento de Senten&ccedil;a movido pela Agravada.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em an&aacute;lise diz respeito &agrave; possibilidade de redu&ccedil;&atilde;o da multa cominat&oacute;ria, com fundamento no artigo 537, &sect; 1&ordm; do C&oacute;digo de Processo Civil, bem como &agrave; contagem de prazo em dias &uacute;teis.
+III. Raz&otilde;es de decidir
+3. A possibilidade de alterar o valor da multa caso o juiz verifique que ela se tornou excessiva, conforme disposto no inciso I, &sect;1&ordm;, do art. 537 do CPC, trata-se de uma faculdade n&atilde;o exercida pelo magistrado de origem em raz&atilde;o da reiterada in&eacute;rcia da empresa Agravante em cumprir a obriga&ccedil;&atilde;o imposta, pois da concess&atilde;o liminar &agrave; autoriza&ccedil;&atilde;o para o procedimento transcorreu mais de um ano e meio, ou seja, n&atilde;o houve razoabilidade por parte da operadora para o atraso injustificado do cumprimento da obriga&ccedil;&atilde;o
+IV. Dispositivo e tese
+4. Agravo de Instrumento conhecido e improvido.
+
+Tese de julgamento:
+
+Dispositivo relevante citado: CPC, art. 537, &sect; 1&ordm;.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1400892-06.2026.8.12.0000,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Suplementar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. AÇÃO DE OBRIGAÇÃO DE FAZER. AGRAVO DE INSTRUMENTO DA OPERADORA DE PLANO DE SAÚDE CONTRA DECISÃO QUE REJEITOU A EXCEÇÃO DE PRÉ-EXECUTIVIDADE E DETERMINOU O PROSSEGUIMENTO DO CUMPRIMENTO DE SENTENÇA MOVIDO PELA AGRAVADA. DESCABIDA A REDUÇÃO DOS ASTREINTES EM RAZÃO DA DEMORA DESARAZOADA PARA O CUMPRIMENTO DA OBRIGAÇÃO. RECURSO IMPROVIDO.
+I. Caso em exame
+1. Agravo
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. AÇÃO DE OBRIGAÇÃO DE FAZER. AGRAVO DE INSTRUMENTO DA OPERADORA DE PLANO DE SAÚDE CONTRA DECISÃO QUE REJEITOU A EXCEÇÃO DE PRÉ-EXECUTIVIDADE E DETERMINOU O PROSSEGUIMENTO DO CUMPRIMENTO DE SENTENÇA MOVIDO PELA AGRAVADA. DESCABIDA A REDUÇÃO DOS ASTREINTES EM RAZÃO DA DEMORA DESARAZOADA PARA O CUMPRIMENTO DA OBRIGAÇÃO. RECURSO IMPROVIDO.
+I. Caso em exame
+1. Agravo de Instrumento contra decisão que rejeitou a Exceção de Pré-Executividade e determinou o prosseguimento do Cumprimento de Sentença movido pela Agravada.
+II. Questão em discussão
+2. A questão em análise diz respeito à possibilidade de redução da multa cominatória, com fundamento no artigo 537, § 1º do Código de Processo Civil, bem como à contagem de prazo em dias úteis.
+III. Razões de decidir
+3. A possibilidade de alterar o valor da multa caso o juiz verifique que ela se tornou excessiva, conforme disposto no inciso I, §1º, do art. 537 do CPC, trata-se de uma faculdade não exercida pelo magistrado de origem em razão da reiterada inércia da empresa Agravante em cumprir a obrigação imposta, pois da concessão liminar à autorização para o procedimento transcorreu mais de um ano e meio, ou seja, não houve razoabilidade por parte da operadora para o atraso injustificado do cumprimento da obrigação
+IV. Dispositivo e tese
+4. Agravo de Instrumento conhecido e improvido.
+
+Tese de julgamento:
+
+Dispositivo relevante citado: CPC, art. 537, § 1º.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878083" cdForo="0" >
+										0872565-76.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878083" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878083);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878083" style="display: none;" >
+	<div id="textAreaDados_1878083" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; TRANSPORTE A&Eacute;REO INTERNACIONAL &ndash; PRELIMINAR DE SOBRESTAMENTO (TEMA 1.417 STF) &ndash; HIP&Oacute;TESE N&Atilde;O CONFIGURADA - PRELIMINAR REJEITADA &ndash; EXTRAVIO TEMPOR&Aacute;RIO DE BAGAGEM &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; RESPONSABILIDADE OBJETIVA &ndash; DANO MORAL CONFIGURADO (IN RE IPSA) &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; DANOS MATERIAIS DEVIDOS &ndash; RESSARCIMENTO DE DESPESAS COM ITENS B&Aacute;SICOS E MALA DANIFICADA &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA &ndash; INCID&Ecirc;NCIA DA TAXA SELIC E DA LEI 14.905/2024 &ndash; RECURSO CONHECIDO E DESPROVIDO.
+I - A suspens&atilde;o nacional determinada pelo STF no Tema 1.417 restringe-se a processos que discutem fortuito externo ou for&ccedil;a maior (art. 256, &sect; 3&ordm;, do CBA). Hip&oacute;tese de extravio de bagagem em voo internacional que n&atilde;o se enquadra nas exce&ccedil;&otilde;es taxativas, permitindo o regular julgamento do feito.
+II - O transportador a&eacute;reo possui obriga&ccedil;&atilde;o de resultado, respondendo objetivamente pela cust&oacute;dia da bagagem. O extravio, ainda que tempor&aacute;rio, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o e gera dano moral pass&iacute;vel de repara&ccedil;&atilde;o, diante do tempo perdido e da ang&uacute;stia causada ao passageiro fora de seu domic&iacute;lio.
+III - &Eacute; devido o ressarcimento das despesas efetuadas com a compra de itens de higiene e vestu&aacute;rio essencial, bem como o valor da mala danificada, nos termos do art. 33 da Resolu&ccedil;&atilde;o n&ordm; 400 da ANAC, n&atilde;o subsistindo a tese de que a devolu&ccedil;&atilde;o posterior da bagagem afasta o preju&iacute;zo patrimonial imediato.
+IV - A indeniza&ccedil;&atilde;o deve ser fixada com observ&acirc;ncia aos princ&iacute;pios da razoabilidade e proporcionalidade. No caso concreto, o valor de R$ 10.000,00 revela-se razo&aacute;vel e proporcional para a situa&ccedil;&atilde;o suportada pelo consumidor.
+V - Consect&aacute;rios Legais: (Danos Morais) Corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA a partir do arbitramento (S&uacute;mula 362/STJ). Juros de mora pela Taxa Selic (deduzido o IPCA) a partir da cita&ccedil;&atilde;o. (Danos Materiais) Aplica&ccedil;&atilde;o exclusiva da Taxa Selic (juros e corre&ccedil;&atilde;o englobados) desde o desembolso at&eacute; 29/08/2024. A partir de 30/08/2024 (vig&ecirc;ncia da Lei 14.905/2024), incidir&aacute; corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA e juros de mora pela Taxa Selic (deduzido o IPCA).
+VI - Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0872565-76.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(49 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Irregularidade no atendimento
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – TRANSPORTE AÉREO INTERNACIONAL – PRELIMINAR DE SOBRESTAMENTO (TEMA 1.417 STF) – HIPÓTESE NÃO CONFIGURADA - PRELIMINAR REJEITADA – EXTRAVIO TEMPORÁRIO DE BAGAGEM – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> CONFIGURADO (IN RE IPSA) – QUANTUM INDENIZATÓRIO MANTIDO – DANOS MATERIAIS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – TRANSPORTE AÉREO INTERNACIONAL – PRELIMINAR DE SOBRESTAMENTO (TEMA 1.417 STF) – HIPÓTESE NÃO CONFIGURADA - PRELIMINAR REJEITADA – EXTRAVIO TEMPORÁRIO DE BAGAGEM – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> CONFIGURADO (IN RE IPSA) – QUANTUM INDENIZATÓRIO MANTIDO – DANOS MATERIAIS DEVIDOS – RESSARCIMENTO DE DESPESAS COM ITENS BÁSICOS E MALA DANIFICADA – ATUALIZAÇÃO MONETÁRIA – INCIDÊNCIA DA TAXA SELIC E DA LEI 14.905/2024 – RECURSO CONHECIDO E DESPROVIDO.
+I - A suspensão nacional determinada pelo STF no Tema 1.417 restringe-se a processos que discutem fortuito externo ou força maior (art. 256, § 3º, do CBA). Hipótese de extravio de bagagem em voo internacional que não se enquadra nas exceções taxativas, permitindo o regular julgamento do feito.
+II - O transportador aéreo possui obrigação de resultado, respondendo objetivamente pela custódia da bagagem. O extravio, ainda que temporário, configura falha na prestação do serviço e gera <em>dano</em> <em>moral</em> passível de reparação, diante do tempo perdido e da angústia causada ao passageiro fora de seu domicílio.
+III - É devido o ressarcimento das despesas efetuadas com a compra de itens de higiene e vestuário essencial, bem como o valor da mala danificada, nos termos do art. 33 da Resolução nº 400 da ANAC, não subsistindo a tese de que a devolução posterior da bagagem afasta o prejuízo patrimonial imediato.
+IV - A indenização deve ser fixada com observância aos princípios da razoabilidade e proporcionalidade. No caso concreto, o valor de R$ 10.000,00 revela-se razoável e proporcional para a situação suportada pelo consumidor.
+V - Consectários Legais: (Danos Morais) Correção monetária pelo IPCA a partir do arbitramento (Súmula 362/STJ). Juros de mora pela Taxa Selic (deduzido o IPCA) a partir da citação. (Danos Materiais) Aplicação exclusiva da Taxa Selic (juros e correção englobados) desde o desembolso até 29/08/2024. A partir de 30/08/2024 (vigência da Lei 14.905/2024), incidirá correção monetária pelo IPCA e juros de mora pela Taxa Selic (deduzido o IPCA).
+VI - Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878088" cdForo="0" >
+										0800814-77.2025.8.12.0006
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878088" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878088);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878088" style="display: none;" >
+	<div id="textAreaDados_1878088" class="mensagemSemFormatacao" >
+		PROCESSO CIVIL - EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; OMISS&Atilde;O  &ndash; CORRE&Ccedil;&Atilde;O DO V&Iacute;CIO SEM EFEITOS INFRINGENTES &ndash; EMBARGOS DE DECLARA&Ccedil;&Atilde;O ACOLHIDOS, SEM ATRIBUI&Ccedil;&Atilde;O DE EFEITO MODIFICATIVO.
+I. CASO EM EXAME
+1. Embargos de Declara&ccedil;&atilde;o opostos contra Ac&oacute;rd&atilde;o que negou provimento ao recurso de Apela&ccedil;&atilde;o interposto pelo embargante.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso a ocorr&ecirc;ncia de omiss&atilde;o no Ac&oacute;rd&atilde;o embargado.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Nos  termos do art. 1.022, do C&oacute;digo de Processo Civil/2015,  os  Embargos de Declara&ccedil;&atilde;o  &ndash;  recurso  de  natureza estrita  e   de  fundamenta&ccedil;&atilde;o  vinculada   &ndash;   s&atilde;o   cab&iacute;veis apenas para:  a) esclarecer  obscuridade;   b) eliminar   contradi&ccedil;&atilde;o;    c) suprir  omiss&atilde;o de ponto ou de quest&atilde;o sobre a qual devia se pronunciar o juiz de of&iacute;cio ou a requerimento,   e/ou    d) para  corrigir  eventual  erro  material.
+4. Omiss&atilde;o sanada, sem, contudo, atribui&ccedil;&atilde;o de efeitos infringentes aos aclarat&oacute;rios.
+IV. DISPOSITIVO
+5. Embargos  de Declara&ccedil;&atilde;o acolhidos, sem efeitos infringentes.           <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0800814-77.2025.8.12.0006,&nbsp; Camapu&atilde;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Camapuã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800814772025812000650000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>PROCESSO CIVIL - EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – OMISSÃO  – CORREÇÃO DO VÍCIO SEM EFEITOS INFRINGENTES – EMBARGOS DE DECLARAÇÃO ACOLHIDOS, SEM ATRIBUIÇÃO DE EFEITO MODIFICATIVO.
+I. CASO EM EXAME
+1. Embargos de Declaração opostos contra Acórdão que negou provimento ao recurso de Apelação interposto pelo embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>PROCESSO CIVIL - EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – OMISSÃO  – CORREÇÃO DO VÍCIO SEM EFEITOS INFRINGENTES – EMBARGOS DE DECLARAÇÃO ACOLHIDOS, SEM ATRIBUIÇÃO DE EFEITO MODIFICATIVO.
+I. CASO EM EXAME
+1. Embargos de Declaração opostos contra Acórdão que negou provimento ao recurso de Apelação interposto pelo embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso a ocorrência de omissão no Acórdão embargado.
+III. RAZÕES DE DECIDIR
+3. Nos  termos do art. 1.022, do Código de Processo Civil/2015,  os  Embargos de Declaração  –  recurso  de  natureza estrita  e   de  fundamentação  vinculada   –   são   cabíveis apenas para:  a) esclarecer  obscuridade;   b) eliminar   contradição;    c) suprir  omissão de ponto ou de questão sobre a qual devia se pronunciar o juiz de ofício ou a requerimento,   e/ou    d) para  corrigir  eventual  erro  material.
+4. Omissão sanada, sem, contudo, atribuição de efeitos infringentes aos aclaratórios.
+IV. DISPOSITIVO
+5. Embargos  de Declaração acolhidos, sem efeitos infringentes.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878093" cdForo="0" >
+										0801068-88.2024.8.12.0037
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878093" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878093);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878093" style="display: none;" >
+	<div id="textAreaDados_1878093" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; SUPOSTA INSCRI&Ccedil;&Atilde;O INDEVIDA EM CADASTROS DE INADIMPLENTES &ndash; DOCUMENTO EXTRA&Iacute;DO DA PLATAFORMA &quot;ACERTA ESSENCIAL&quot; &ndash; AMBIENTE RESTRITO DE RENEGOCIA&Ccedil;&Atilde;O DE D&Iacute;VIDAS &ndash; AUS&Ecirc;NCIA DE PUBLICIDADE E DE RESTRI&Ccedil;&Atilde;O AO CR&Eacute;DITO NO MERCADO &ndash; DANO MORAL IN RE IPSA N&Atilde;O CONFIGURADO &ndash; RELA&Ccedil;&Atilde;O CONTRATUAL COMPROVADA PELA INSTITUI&Ccedil;&Atilde;O CREDORA &ndash; ALEGA&Ccedil;&Atilde;O DE FALTA DE NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA AFASTADA &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA &ndash; MAJORA&Ccedil;&Atilde;O DOS HONOR&Aacute;RIOS RECURSAIS &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A inser&ccedil;&atilde;o de dados do consumidor em plataformas de pontua&ccedil;&atilde;o de cr&eacute;dito ou de renegocia&ccedil;&atilde;o de d&iacute;vidas de acesso restrito (como o &quot;Acerta Essencial&quot; ou &quot;Serasa Limpa Nome&quot;) n&atilde;o se confunde com a negativa&ccedil;&atilde;o p&uacute;blica em cadastros de inadimplentes (SPC/SERASA).
+Inexistindo a publicidade do apontamento para o mercado financeiro e comercial, n&atilde;o h&aacute; restri&ccedil;&atilde;o de cr&eacute;dito apta a ensejar a presun&ccedil;&atilde;o de abalo extrapatrimonial (dano moral in re ipsa).
+Comprovada, por parte da institui&ccedil;&atilde;o requerida, a regularidade da contrata&ccedil;&atilde;o e a origem do d&eacute;bito, bem como a aus&ecirc;ncia de negativa&ccedil;&atilde;o p&uacute;blica, n&atilde;o prospera a tese de indeniza&ccedil;&atilde;o fulcrada na falta de notifica&ccedil;&atilde;o pr&eacute;via (art. 43, &sect; 2&ordm;, do CDC), porquanto incab&iacute;vel &agrave; esp&eacute;cie.
+Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801068-88.2024.8.12.0037,&nbsp; Itapor&atilde;,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Itaporã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – SUPOSTA INSCRIÇÃO INDEVIDA EM CADASTROS DE INADIMPLENTES – DOCUMENTO EXTRAÍDO DA PLATAFORMA "ACERTA ESSENCIAL" – AMBIENTE RESTRITO DE RENEGOCIAÇÃO DE DÍVIDAS – AUSÊNCIA DE PUBLICIDADE E DE RESTRIÇÃO AO CRÉDITO NO MERCADO – <em>DANO</em> <em>MORAL</em> IN RE IPSA NÃO CONFIGURADO – RELAÇÃO CONTRATUAL COMPROVADA PELA INSTITUIÇÃO CREDORA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – SUPOSTA INSCRIÇÃO INDEVIDA EM CADASTROS DE INADIMPLENTES – DOCUMENTO EXTRAÍDO DA PLATAFORMA "ACERTA ESSENCIAL" – AMBIENTE RESTRITO DE RENEGOCIAÇÃO DE DÍVIDAS – AUSÊNCIA DE PUBLICIDADE E DE RESTRIÇÃO AO CRÉDITO NO MERCADO – <em>DANO</em> <em>MORAL</em> IN RE IPSA NÃO CONFIGURADO – RELAÇÃO CONTRATUAL COMPROVADA PELA INSTITUIÇÃO CREDORA – ALEGAÇÃO DE FALTA DE NOTIFICAÇÃO PRÉVIA AFASTADA – SENTENÇA DE IMPROCEDÊNCIA MANTIDA – MAJORAÇÃO DOS HONORÁRIOS RECURSAIS – RECURSO CONHECIDO E DESPROVIDO.
+A inserção de dados do consumidor em plataformas de pontuação de crédito ou de renegociação de dívidas de acesso restrito (como o "Acerta Essencial" ou "Serasa Limpa Nome") não se confunde com a negativação pública em cadastros de inadimplentes (SPC/SERASA).
+Inexistindo a publicidade do apontamento para o mercado financeiro e comercial, não há restrição de crédito apta a ensejar a presunção de abalo extrapatrimonial (<em>dano</em> <em>moral</em> in re ipsa).
+Comprovada, por parte da instituição requerida, a regularidade da contratação e a origem do débito, bem como a ausência de negativação pública, não prospera a tese de indenização fulcrada na falta de notificação prévia (art. 43, § 2º, do CDC), porquanto incabível à espécie.
+Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878094" cdForo="0" >
+										0802271-27.2024.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878094" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878094);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878094" style="display: none;" >
+	<div id="textAreaDados_1878094" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; DESCONTOS INDEVIDOS EM CONTA CORRENTE &ndash; SERVI&Ccedil;O N&Atilde;O CONTRATADO &ndash; DANO MORAL CONFIGURADO &ndash; QUANTUM FIXADO EM R$ 3.000,00 &ndash; RAZOABILIDADE E PROPORCIONALIDADE &ndash; RECURSO CONHECIDO E PROVIDO  EM TERMOS.
+A responsabilidade das institui&ccedil;&otilde;es financeiras e empresas de servi&ccedil;os &eacute; objetiva, respondendo pelos danos causados por falhas na presta&ccedil;&atilde;o do servi&ccedil;o, salvo prova de culpa exclusiva do consumidor ou de terceiro, o que n&atilde;o ocorreu no caso.
+O desconto indevido de valores em conta corrente, decorrente de servi&ccedil;o n&atilde;o contratado, gera dano moral in re ipsa, especialmente quando envolve pessoa idosa e vulner&aacute;vel.
+Considerando a curta dura&ccedil;&atilde;o das cobran&ccedil;as indevidas e a extens&atilde;o do dano, fixa-se a indeniza&ccedil;&atilde;o em R$ 3.000,00 (tr&ecirc;s mil reais), valor que atende &agrave;s finalidades punitiva e pedag&oacute;gica, sem causar enriquecimento il&iacute;cito.
+Recurso conhecido e provido em termos. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802271-27.2024.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE – SERVIÇO NÃO CONTRATADO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM FIXADO EM R$ 3.000,00 – RAZOABILIDADE E PROPORCIONALIDADE – RECURSO CONHECIDO E PROVIDO  EM TERMOS.
+A responsabilidade das instituições financeiras e empresas de serviços é
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE – SERVIÇO NÃO CONTRATADO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM FIXADO EM R$ 3.000,00 – RAZOABILIDADE E PROPORCIONALIDADE – RECURSO CONHECIDO E PROVIDO  EM TERMOS.
+A responsabilidade das instituições financeiras e empresas de serviços é objetiva, respondendo pelos danos causados por falhas na prestação do serviço, salvo prova de culpa exclusiva do consumidor ou de terceiro, o que não ocorreu no caso.
+O desconto indevido de valores em conta corrente, decorrente de serviço não contratado, gera <em>dano</em> <em>moral</em> in re ipsa, especialmente quando envolve pessoa idosa e vulnerável.
+Considerando a curta duração das cobranças indevidas e a extensão do <em>dano</em>, fixa-se a indenização em R$ 3.000,00 (três mil reais), valor que atende às finalidades punitiva e pedagógica, sem causar enriquecimento ilícito.
+Recurso conhecido e provido em termos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878097" cdForo="0" >
+										0818119-31.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878097" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878097);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878097" style="display: none;" >
+	<div id="textAreaDados_1878097" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIGIBILIDADE DE D&Eacute;BITO C.C. RESTITUI&Ccedil;&Atilde;O DE IND&Eacute;BITO C.C. DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. DANOS MORAIS CONFIGURADOS.  REDISCUSS&Atilde;O DO M&Eacute;RITO. IMPOSSIBILIDADE. PREQUESTIONAMENTO. DESNECESSIDADE DE MANIFESTA&Ccedil;&Atilde;O EXPRESSA. EMBARGOS REJEITADOS.
+Os embargos de declara&ccedil;&atilde;o t&ecirc;m como escopo esclarecer senten&ccedil;as ou ac&oacute;rd&atilde;os que pade&ccedil;am de v&iacute;cios, como a obscuridade, omiss&atilde;o, contradi&ccedil;&atilde;o ou erro material.
+Assim, ainda que os aclarat&oacute;rios possuam natureza recursal, n&atilde;o t&ecirc;m cond&atilde;o de ser opostos com a inten&ccedil;&atilde;o de rediscutir o julgado, da mesma forma n&atilde;o se prestam &agrave; manifesta&ccedil;&atilde;o expressa sobre aplica&ccedil;&atilde;o ou viola&ccedil;&atilde;o de dispositivos legais ou constitucionais com a finalidade &uacute;nica de prequestionamento.
+Embargos rejeitados.
+  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0818119-31.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									818119312021812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C.C. RESTITUIÇÃO DE INDÉBITO C.C. DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. DANOS MORAIS CONFIGURADOS.  REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. PREQUESTIONAMENTO. DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA. EMBARGOS REJEITADOS.
+Os embargos de declaração têm como escopo esclarecer sentenças
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C.C. RESTITUIÇÃO DE INDÉBITO C.C. DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. DANOS MORAIS CONFIGURADOS.  REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. PREQUESTIONAMENTO. DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA. EMBARGOS REJEITADOS.
+Os embargos de declaração têm como escopo esclarecer sentenças ou acórdãos que padeçam de vícios, como a obscuridade, omissão, contradição ou erro material.
+Assim, ainda que os aclaratórios possuam natureza recursal, não têm condão de ser opostos com a intenção de rediscutir o julgado, da mesma forma não se prestam à manifestação expressa sobre aplicação ou violação de dispositivos legais ou constitucionais com a finalidade única de prequestionamento.
+Embargos rejeitados.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878102" cdForo="0" >
+										0857686-98.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878102" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878102);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878102" style="display: none;" >
+	<div id="textAreaDados_1878102" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO &ndash; SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. APELO DOS BANCOS &ndash; CORRE&Ccedil;&Atilde;O DO VALOR DA CAUSA &ndash; POSSIBILIDADE - ALEGA&Ccedil;&Atilde;O DE POSSIBILIDADE DE DESCONTOS DOS EMPR&Eacute;STIMOS CONSIGNADOS CONFORME CONTRATADOS &ndash; DESCONTOS QUE ULTRAPASSAM A MARGEM CONSIGN&Aacute;VEL S&Atilde;O INDEVIDOS DE ACORDO COM A LEI MUNICIPAL 13.870/2019. LIMITA&Ccedil;&Atilde;O EM 30% DOS RENDIMENTOS BRUTOS DO SERVIDOR &ndash; SENTEN&Ccedil;A ALTERADA APENAS NO VALOR DA CAUSA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO .  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0857686-98.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO – SENTENÇA DE PROCEDÊNCIA. APELO DOS BANCOS – CORREÇÃO DO VALOR DA CAUSA – POSSIBILIDADE - ALEGAÇÃO DE POSSIBILIDADE DE DESCONTOS DOS EMPRÉSTIMOS CONSIGNADOS CONFORME CONTRATADOS – DESCONTOS QUE ULTRAPASSAM A MARGEM CONSIGNÁVEL SÃO INDEVIDOS DE ACORDO COM A LEI MUNICIPAL 13.870/2019. LIMITAÇÃO EM 30% DOS RENDIMENTOS BRUTOS DO SERVIDOR – SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO – SENTENÇA DE PROCEDÊNCIA. APELO DOS BANCOS – CORREÇÃO DO VALOR DA CAUSA – POSSIBILIDADE - ALEGAÇÃO DE POSSIBILIDADE DE DESCONTOS DOS EMPRÉSTIMOS CONSIGNADOS CONFORME CONTRATADOS – DESCONTOS QUE ULTRAPASSAM A MARGEM CONSIGNÁVEL SÃO INDEVIDOS DE ACORDO COM A LEI MUNICIPAL 13.870/2019. LIMITAÇÃO EM 30% DOS RENDIMENTOS BRUTOS DO SERVIDOR – SENTENÇA ALTERADA APENAS NO VALOR DA CAUSA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO .
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878105" cdForo="0" >
+										0821021-98.2014.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878105" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878105);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878105" style="display: none;" >
+	<div id="textAreaDados_1878105" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. PROMESSA DE COMPRA E VENDA DE IM&Oacute;VEL. ATRASO NA ENTREGA DA OBRA. INOVA&Ccedil;&Atilde;O RECURSAL. N&Atilde;O CONHECIMENTO. RETIFICA&Ccedil;&Atilde;O DO TERMO FINAL DO PRAZO DE ENTREGA. DANOS MORAIS. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por adquirente de im&oacute;vel, menor representado por sua genitora, contra senten&ccedil;a que julgou parcialmente procedente a&ccedil;&atilde;o de revis&atilde;o contratual proposta em face de incorporadoras imobili&aacute;rias, em raz&atilde;o de atraso na entrega de unidade residencial adquirida mediante promessa de compra e venda.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es submetidas a julgamento consistem em: i) verificar se houve inova&ccedil;&atilde;o recursal quanto aos pedidos de rescis&atilde;o contratual e restitui&ccedil;&atilde;o integral dos valores pagos; ii) definir o termo final do prazo contratual de entrega do im&oacute;vel, considerado o per&iacute;odo de toler&acirc;ncia; iii) analisar a possibilidade de majora&ccedil;&atilde;o da indeniza&ccedil;&atilde;o por danos morais fixada na senten&ccedil;a.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A pretens&atilde;o de rescis&atilde;o contratual com restitui&ccedil;&atilde;o integral dos valores pagos configura inova&ccedil;&atilde;o recursal, pois n&atilde;o foi deduzida na peti&ccedil;&atilde;o inicial nem objeto de aditamento ao longo da instru&ccedil;&atilde;o processual, sendo vedada sua aprecia&ccedil;&atilde;o em sede de apela&ccedil;&atilde;o, sob pena de viola&ccedil;&atilde;o aos princ&iacute;pios da adstri&ccedil;&atilde;o e da congru&ecirc;ncia (arts. 141 e 492 do CPC).
+4. Nos termos dos arts. 322 e 324 do CPC, a peti&ccedil;&atilde;o inicial delimita os pedidos que podem ser apreciados pelo Poder Judici&aacute;rio, sendo inadmiss&iacute;vel a formula&ccedil;&atilde;o de pretens&atilde;o in&eacute;dita em grau recursal, salvo hip&oacute;teses de mat&eacute;ria de ordem p&uacute;blica ou fatos supervenientes, o que n&atilde;o se verifica no caso.
+5. Quanto ao prazo de entrega do im&oacute;vel, o contrato estabeleceu como data de conclus&atilde;o o dia 30/06/2013, com toler&acirc;ncia contratual de 180 dias. Assim, o termo final correto corresponde a 27/12/2013, e n&atilde;o 27/01/2014, como constou na decis&atilde;o recorrida.
+6. Em rela&ccedil;&atilde;o aos danos morais, o valor de R$ 10.000,00 arbitrado na senten&ccedil;a mostra-se adequado e proporcional &agrave;s circunst&acirc;ncias do caso concreto, considerando que o im&oacute;vel foi adquirido em nome de menor para fins de investimento, inexistindo expectativa imediata de moradia pr&oacute;pria.
+7. Ademais, a aus&ecirc;ncia de demonstra&ccedil;&atilde;o de abalo psicol&oacute;gico relevante e a posterior disponibiliza&ccedil;&atilde;o do im&oacute;vel refor&ccedil;am a sufici&ecirc;ncia do valor fixado, que atende aos crit&eacute;rios de razoabilidade, proporcionalidade e car&aacute;ter pedag&oacute;gico da indeniza&ccedil;&atilde;o, sem ensejar enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+Preliminar acolhida para n&atilde;o conhecer das teses e pedidos relativos &agrave; rescis&atilde;o contratual e &agrave; restitui&ccedil;&atilde;o integral dos valores pagos, por inova&ccedil;&atilde;o recursal.
+Recurso parcialmente provido, apenas para retificar o termo final do prazo contratual de entrega do im&oacute;vel para 27/12/2013, mantida a senten&ccedil;a nos demais termos.
+Tese de julgamento:
+1. Configura inova&ccedil;&atilde;o recursal a formula&ccedil;&atilde;o, em sede de apela&ccedil;&atilde;o, de pedido de rescis&atilde;o contratual e restitui&ccedil;&atilde;o de valores n&atilde;o deduzido na peti&ccedil;&atilde;o inicial, sendo vedado ao tribunal apreciar pretens&otilde;es in&eacute;ditas n&atilde;o submetidas ao ju&iacute;zo de primeiro grau.
+2. Em contrato de promessa de compra e venda de im&oacute;vel com previs&atilde;o de toler&acirc;ncia de 180 dias para entrega da obra, o termo final do prazo contratual corresponde &agrave; soma do prazo originalmente pactuado com o per&iacute;odo de toler&acirc;ncia previsto no instrumento contratual.
+3. A indeniza&ccedil;&atilde;o por danos morais decorrente de atraso na entrega de im&oacute;vel deve observar os crit&eacute;rios de razoabilidade e proporcionalidade, podendo ser mantida quando o valor fixado n&atilde;o se revela manifestamente irris&oacute;rio nem desproporcional &agrave;s circunst&acirc;ncias do caso concreto.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0821021-98.2014.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. ATRASO NA ENTREGA DA OBRA. INOVAÇÃO RECURSAL. NÃO CONHECIMENTO. RETIFICAÇÃO DO TERMO FINAL DO PRAZO DE ENTREGA. DANOS MORAIS. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por adquirente de imóvel, menor representado por sua genitora, contra sentença que julgou parcialmente
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. ATRASO NA ENTREGA DA OBRA. INOVAÇÃO RECURSAL. NÃO CONHECIMENTO. RETIFICAÇÃO DO TERMO FINAL DO PRAZO DE ENTREGA. DANOS MORAIS. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por adquirente de imóvel, menor representado por sua genitora, contra sentença que julgou parcialmente procedente ação de revisão contratual proposta em face de incorporadoras imobiliárias, em razão de atraso na entrega de unidade residencial adquirida mediante promessa de compra e venda.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões submetidas a julgamento consistem em: i) verificar se houve inovação recursal quanto aos pedidos de rescisão contratual e restituição integral dos valores pagos; ii) definir o termo final do prazo contratual de entrega do imóvel, considerado o período de tolerância; iii) analisar a possibilidade de majoração da indenização por danos morais fixada na sentença.
+III. RAZÕES DE DECIDIR
+3. A pretensão de rescisão contratual com restituição integral dos valores pagos configura inovação recursal, pois não foi deduzida na petição inicial nem objeto de aditamento ao longo da instrução processual, sendo vedada sua apreciação em sede de apelação, sob pena de violação aos princípios da adstrição e da congruência (arts. 141 e 492 do CPC).
+4. Nos termos dos arts. 322 e 324 do CPC, a petição inicial delimita os pedidos que podem ser apreciados pelo Poder Judiciário, sendo inadmissível a formulação de pretensão inédita em grau recursal, salvo hipóteses de matéria de ordem pública ou fatos supervenientes, o que não se verifica no caso.
+5. Quanto ao prazo de entrega do imóvel, o contrato estabeleceu como data de conclusão o dia 30/06/2013, com tolerância contratual de 180 dias. Assim, o termo final correto corresponde a 27/12/2013, e não 27/01/2014, como constou na decisão recorrida.
+6. Em relação aos danos morais, o valor de R$ 10.000,00 arbitrado na sentença mostra-se adequado e proporcional às circunstâncias do caso concreto, considerando que o imóvel foi adquirido em nome de menor para fins de investimento, inexistindo expectativa imediata de moradia própria.
+7. Ademais, a ausência de demonstração de abalo psicológico relevante e a posterior disponibilização do imóvel reforçam a suficiência do valor fixado, que atende aos critérios de razoabilidade, proporcionalidade e caráter pedagógico da indenização, sem ensejar enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+Preliminar acolhida para não conhecer das teses e pedidos relativos à rescisão contratual e à restituição integral dos valores pagos, por inovação recursal.
+Recurso parcialmente provido, apenas para retificar o termo final do prazo contratual de entrega do imóvel para 27/12/2013, mantida a sentença nos demais termos.
+Tese de julgamento:
+1. Configura inovação recursal a formulação, em sede de apelação, de pedido de rescisão contratual e restituição de valores não deduzido na petição inicial, sendo vedado ao tribunal apreciar pretensões inéditas não submetidas ao juízo de primeiro grau.
+2. Em contrato de promessa de compra e venda de imóvel com previsão de tolerância de 180 dias para entrega da obra, o termo final do prazo contratual corresponde à soma do prazo originalmente pactuado com o período de tolerância previsto no instrumento contratual.
+3. A indenização por danos morais decorrente de atraso na entrega de imóvel deve observar os critérios de razoabilidade e proporcionalidade, podendo ser mantida quando o valor fixado não se revela manifestamente irrisório nem desproporcional às circunstâncias do caso concreto.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878114" cdForo="0" >
+										0816774-25.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878114" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878114);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878114" style="display: none;" >
+	<div id="textAreaDados_1878114" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL E RECURSO ADESIVO EM  A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER/N&Atilde;O FAZER C C DANOS MORAIS &ndash; SENTEN&Ccedil;A DE PARCIAL PROCED&Ecirc;NCIA. PRELIMINAR DE OFENSA AO PRINC&Iacute;PIO DA DIALETICIDADE RECURSAL - REJEITADA. APELA&Ccedil;&Atilde;O DA CONSUMIDORA &ndash; PEDIDO PARA MAJORA&Ccedil;&Atilde;O DO VALOR FIXADO A T&Iacute;TULO DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS - INDEFERIDO - PRINC&Iacute;PIO DA RAZOABILIDADE E DA PROPORCIONALIDADE UTILIZADOS CORRETAMENTE PELO MAGISTRADO  &ndash; ENRIQUECIMENTO SEM CAUSA. RECURSO ADESIVO DE GAZIN - A&Ccedil;&Atilde;O EM QUE SE DISCUTE A OCORR&Ecirc;NCIA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O PELO FORNECEDOR - PRAZO DE ENTREGA N&Atilde;O CUMPRIDO &ndash; INTELIG&Ecirc;NCIA DO ART. 14 CDC &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO DE APELA&Ccedil;&Atilde;O E ADESIVO CONHECIDOS E DESPROVIDOS.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816774-25.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO EM  AÇÃO DE OBRIGAÇÃO DE FAZER/NÃO FAZER C C DANOS MORAIS – SENTENÇA DE PARCIAL PROCEDÊNCIA. PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE RECURSAL - REJEITADA. APELAÇÃO DA CONSUMIDORA – PEDIDO PARA MAJORAÇÃO DO VALOR FIXADO A TÍTULO DE INDENIZAÇÃO POR DANOS MORAIS - INDEFERIDO - PRINCÍPIO DA RAZOABILIDADE E DA PROPORCIONALIDADE UTILIZADOS CORRETAMENTE PELO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO EM  AÇÃO DE OBRIGAÇÃO DE FAZER/NÃO FAZER C C DANOS MORAIS – SENTENÇA DE PARCIAL PROCEDÊNCIA. PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE RECURSAL - REJEITADA. APELAÇÃO DA CONSUMIDORA – PEDIDO PARA MAJORAÇÃO DO VALOR FIXADO A TÍTULO DE INDENIZAÇÃO POR DANOS MORAIS - INDEFERIDO - PRINCÍPIO DA RAZOABILIDADE E DA PROPORCIONALIDADE UTILIZADOS CORRETAMENTE PELO MAGISTRADO  – ENRIQUECIMENTO SEM CAUSA. RECURSO ADESIVO DE GAZIN - AÇÃO EM QUE SE DISCUTE A OCORRÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO PELO FORNECEDOR - PRAZO DE ENTREGA NÃO CUMPRIDO – INTELIGÊNCIA DO ART. 14 CDC – SENTENÇA MANTIDA – RECURSO DE APELAÇÃO E ADESIVO CONHECIDOS E DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878127" cdForo="0" >
+										0801392-76.2023.8.12.0049
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878127" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878127);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878127" style="display: none;" >
+	<div id="textAreaDados_1878127" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA C/C A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O DE DANOS MATERIAL E MORAL &ndash; APELA&Ccedil;&Atilde;O DA CONSUMIDORA E DA EMPRESA PRESTADORA DE SERVI&Ccedil;O &ndash; M&Eacute;RITO &ndash; CONTRATO DE INSTALA&Ccedil;&Atilde;O DE GERADOR E C&Eacute;LULA FOTOVOLTAICA PARA GERA&Ccedil;&Atilde;O DE ENERGIA SOLAR &ndash; LEGITIMIDADE DA INSTITUI&Ccedil;&Atilde;O BANC&Aacute;RIA QUE FINANCIOU A COMPRA E INSTALA&Ccedil;&Atilde;O DO PRODUTO, POR SE TRATAR HIP&Oacute;TESE DE CONTRATOS COLIGADOS, NA FORMA DO ARTIGO 54-F, DO CDC &ndash; RESPONSABILIDADE SOLID&Aacute;RIA, CONFORME ARTIGO 7&ordm;, PAR&Aacute;GRAFO &Uacute;NICO, DO CDC &ndash; COROL&Aacute;RIO DA RESCIS&Atilde;O DO CONTRATO DE FORNECIMENTO DO PRODUTO &Eacute; A RESCIS&Atilde;O DO CONTRATO DE FINANCIAMENTO, POSTO QUE S&Atilde;O CORRELATOS E CODEPENDENTES &ndash; RESTITUI&Ccedil;&Atilde;O DOS VALORES PAGOS DEVE SE DAR NA FORMA DOBRADA, EIS QUE A PR&Oacute;PRIA EMPRESA CONFESSA QUE N&Atilde;O FORNECEU O PRODUTO NO PRAZO AVEN&Ccedil;ADO, N&Atilde;O TENDO SUSPENDIDO A COBRAN&Ccedil;A DOS VALORES &ndash; AUS&Ecirc;NCIA DE ENTREGA DO PRODUTO E DA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O CONTRATADO, QUE SEQUER ENTREGOU O GERADOR E OU AS C&Eacute;LULAS FOTOVOLTAICAS NA RESID&Ecirc;NCIA DA CONSUMIDORA, O QUE INDICA SITUA&Ccedil;&Atilde;O QUE EXTRAPOLOU OS LIMITES DO MERO INADIMPLEMENTO CONTRATUAL, E TAMB&Eacute;M DO MERO DISSABOR, CONFIGURANDO A EXIST&Ecirc;NCIA DE DANO DE ORDEM MORAL &ndash; APLICA&Ccedil;&Atilde;O DO DISPOSTO NO CDC, RELATIVAMENTE &Agrave; M&Aacute; PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; COMPROVADO O LIAME CAUSAL ENTRE A CONDUTA DO FORNECEDOR E O DANO MORAL AO CONSUMIDOR &ndash; INDENIZA&Ccedil;&Atilde;O ARBITRADA LEVANDO-SE EM CONTA OS PAR&Acirc;METROS DE RAZOABILIDADE E PROPORCIONALIDADE &ndash; ALEGADA MULTA CONTRATUAL E SERVI&Ccedil;OS COM TERCEIRO (ELETRICISTA) N&Atilde;O COMPROVADAS, PELO QUE O PEDIDO &Eacute; IMPROCEDENTE, NESTA PARTE &ndash; INDEFERIMENTO DA IMPUGNA&Ccedil;&Atilde;O &Agrave; GRATUIDADE DA JUSTI&Ccedil;A &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO DA EMPRESA PRESTADORA DE SERVI&Ccedil;O (APENAS COM RELA&Ccedil;&Atilde;O &Agrave; LEGITIMIDADE DO BANCO PARA RESPONDER AOS TERMOS DA A&Ccedil;&Atilde;O) PROVIDO &ndash; RECURSO DA CONSUMIDORA CONHECIDO E PARCIALMENTE PROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801392-76.2023.8.12.0049,&nbsp; Agua Clara,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(49 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Agua Clara
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA C/C AÇÃO DE REPARAÇÃO DE DANOS MATERIAL E <em>MORAL</em> – APELAÇÃO DA CONSUMIDORA E DA EMPRESA PRESTADORA DE SERVIÇO – MÉRITO – CONTRATO DE INSTALAÇÃO DE GERADOR E CÉLULA FOTOVOLTAICA PARA GERAÇÃO DE ENERGIA SOLAR – LEGITIMIDADE DA INSTITUIÇÃO BANCÁRIA QUE FINANCIOU A COMPRA E INSTALAÇÃO DO PRODUTO, POR SE TRATAR HIPÓTESE DE CONTRATOS COLIGADOS, NA FORMA DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA C/C AÇÃO DE REPARAÇÃO DE DANOS MATERIAL E <em>MORAL</em> – APELAÇÃO DA CONSUMIDORA E DA EMPRESA PRESTADORA DE SERVIÇO – MÉRITO – CONTRATO DE INSTALAÇÃO DE GERADOR E CÉLULA FOTOVOLTAICA PARA GERAÇÃO DE ENERGIA SOLAR – LEGITIMIDADE DA INSTITUIÇÃO BANCÁRIA QUE FINANCIOU A COMPRA E INSTALAÇÃO DO PRODUTO, POR SE TRATAR HIPÓTESE DE CONTRATOS COLIGADOS, NA FORMA DO ARTIGO 54-F, DO CDC – RESPONSABILIDADE SOLIDÁRIA, CONFORME ARTIGO 7º, PARÁGRAFO ÚNICO, DO CDC – COROLÁRIO DA RESCISÃO DO CONTRATO DE FORNECIMENTO DO PRODUTO É A RESCISÃO DO CONTRATO DE FINANCIAMENTO, POSTO QUE SÃO CORRELATOS E CODEPENDENTES – RESTITUIÇÃO DOS VALORES PAGOS DEVE SE DAR NA FORMA DOBRADA, EIS QUE A PRÓPRIA EMPRESA CONFESSA QUE NÃO FORNECEU O PRODUTO NO PRAZO AVENÇADO, NÃO TENDO SUSPENDIDO A COBRANÇA DOS VALORES – AUSÊNCIA DE ENTREGA DO PRODUTO E DA PRESTAÇÃO DO SERVIÇO CONTRATADO, QUE SEQUER ENTREGOU O GERADOR E OU AS CÉLULAS FOTOVOLTAICAS NA RESIDÊNCIA DA CONSUMIDORA, O QUE INDICA SITUAÇÃO QUE EXTRAPOLOU OS LIMITES DO MERO INADIMPLEMENTO CONTRATUAL, E TAMBÉM DO MERO DISSABOR, CONFIGURANDO A EXISTÊNCIA DE <em>DANO</em> DE ORDEM <em>MORAL</em> – APLICAÇÃO DO DISPOSTO NO CDC, RELATIVAMENTE À MÁ PRESTAÇÃO DO SERVIÇO – COMPROVADO O LIAME CAUSAL ENTRE A CONDUTA DO FORNECEDOR E O <em>DANO</em> <em>MORAL</em> AO CONSUMIDOR – INDENIZAÇÃO ARBITRADA LEVANDO-SE EM CONTA OS PARÂMETROS DE RAZOABILIDADE E PROPORCIONALIDADE – ALEGADA MULTA CONTRATUAL E SERVIÇOS COM TERCEIRO (ELETRICISTA) NÃO COMPROVADAS, PELO QUE O PEDIDO É IMPROCEDENTE, NESTA PARTE – INDEFERIMENTO DA IMPUGNAÇÃO À GRATUIDADE DA JUSTIÇA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO DA EMPRESA PRESTADORA DE SERVIÇO (APENAS COM RELAÇÃO À LEGITIMIDADE DO BANCO PARA RESPONDER AOS TERMOS DA AÇÃO) PROVIDO – RECURSO DA CONSUMIDORA CONHECIDO E PARCIALMENTE PROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878141" cdForo="0" >
+										0803485-38.2024.8.12.0029
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878141" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878141);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878141" style="display: none;" >
+	<div id="textAreaDados_1878141" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C DANOS MORAIS E MATERIAIS  &ndash;  PEDIDO DE JUSTI&Ccedil;A GRATUITA INDEFERIDO &ndash; DETERMINA&Ccedil;&Atilde;O DE RECOLHIMENTO DE PREPARO N&Atilde;O ATENDIDA &ndash;  DESER&Ccedil;&Atilde;O VERIFICADA  &ndash;  RECURSO N&Atilde;O CONHECIDO.
+Deixa-se de conhecer do recurso quando a parte apelante, diante do indeferimento do pedido de justi&ccedil;a gratuita e intima&ccedil;&atilde;o para recolher o preparo, deixa transcorrer o prazo in albis.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803485-38.2024.8.12.0029,&nbsp; Navira&iacute;,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Naviraí
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C DANOS MORAIS E MATERIAIS  –  PEDIDO DE JUSTIÇA GRATUITA INDEFERIDO – DETERMINAÇÃO DE RECOLHIMENTO DE PREPARO NÃO ATENDIDA –  DESERÇÃO VERIFICADA  –  RECURSO NÃO CONHECIDO.
+Deixa-se de conhecer do recurso quando a parte apelante, diante do indeferimento do pedido de justiça gratuita e intimação para recolher o preparo, deixa
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C DANOS MORAIS E MATERIAIS  –  PEDIDO DE JUSTIÇA GRATUITA INDEFERIDO – DETERMINAÇÃO DE RECOLHIMENTO DE PREPARO NÃO ATENDIDA –  DESERÇÃO VERIFICADA  –  RECURSO NÃO CONHECIDO.
+Deixa-se de conhecer do recurso quando a parte apelante, diante do indeferimento do pedido de justiça gratuita e intimação para recolher o preparo, deixa transcorrer o prazo in albis.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878143" cdForo="0" >
+										0800217-78.2025.8.12.0016
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878143" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878143);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878143" style="display: none;" >
+	<div id="textAreaDados_1878143" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIGIBILIDADE DE D&Eacute;BITO C/C ANULA&Ccedil;&Atilde;O DE CONTRATO, REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. INEXIST&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O. DESIST&Ecirc;NCIA DE PER&Iacute;CIA GRAFOT&Eacute;CNICA PELO BANCO. &Ocirc;NUS DA PROVA. RESTITUI&Ccedil;&Atilde;O SIMPLES. DANO MORAL CONFIGURADO. RECURSO DO BANCO DESPROVIDO. RECURSO DO AUTOR PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es interpostas por Banco BMG S/A. e por Jose dos Santos Gomes contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito c/c anula&ccedil;&atilde;o de contrato, repeti&ccedil;&atilde;o de ind&eacute;bito e danos morais, julgou parcialmente procedentes os pedidos para: a) declarar inexistente a rela&ccedil;&atilde;o jur&iacute;dica relativa a contrato de cart&atilde;o de cr&eacute;dito consignado; b) determinar a restitui&ccedil;&atilde;o simples dos valores descontados do benef&iacute;cio previdenci&aacute;rio do autor, observada a prescri&ccedil;&atilde;o quinquenal; c) afastar o pedido de indeniza&ccedil;&atilde;o por danos morais.
+2. O banco sustenta a regularidade da contrata&ccedil;&atilde;o e a validade dos descontos, alegando assinatura do contrato e utiliza&ccedil;&atilde;o do cart&atilde;o pelo autor, bem como pugna pelo afastamento das condena&ccedil;&otilde;es ou compensa&ccedil;&atilde;o de valores.
+3. O autor requer a restitui&ccedil;&atilde;o em dobro dos valores descontados, indeniza&ccedil;&atilde;o por danos morais no valor de R$ 10.000,00 e majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. As controv&eacute;rsias consistem em definir: a) se houve comprova&ccedil;&atilde;o v&aacute;lida da contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado; b) se &eacute; devida a restitui&ccedil;&atilde;o em dobro dos valores descontados;  c) se os descontos indevidos em benef&iacute;cio previdenci&aacute;rio ensejam dano moral; d) se h&aacute; fundamento para majora&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais.
+III. RAZ&Otilde;ES DE DECIDIR
+5. Incide ao caso o C&oacute;digo de Defesa do Consumidor, nos termos dos arts. 2&ordm; e 3&ordm; do CDC, sendo aplic&aacute;vel a invers&atilde;o do &ocirc;nus da prova (art. 6&ordm;, VIII, do CDC).
+6. Impugnada a autenticidade da assinatura aposta no contrato, foi determinada a realiza&ccedil;&atilde;o de per&iacute;cia grafot&eacute;cnica, cujo &ocirc;nus financeiro foi atribu&iacute;do ao banco, nos termos do art. 373, II, do CPC e do art. 429, II, do CPC.
+7. A institui&ccedil;&atilde;o financeira, contudo, desistiu expressamente da prova pericial ap&oacute;s fixa&ccedil;&atilde;o dos honor&aacute;rios, operando-se a preclus&atilde;o quanto &agrave; demonstra&ccedil;&atilde;o da autenticidade da assinatura.
+8. A desist&ecirc;ncia da prova t&eacute;cnica impede a comprova&ccedil;&atilde;o da regularidade da contrata&ccedil;&atilde;o, impondo-se a presun&ccedil;&atilde;o de veracidade da alega&ccedil;&atilde;o de inexist&ecirc;ncia de v&iacute;nculo contratual.
+9. Demonstrada a aus&ecirc;ncia de contrata&ccedil;&atilde;o v&aacute;lida, os descontos realizados sobre benef&iacute;cio previdenci&aacute;rio revelam-se indevidos, legitimando a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito.
+10. Quanto &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, o Superior Tribunal de Justi&ccedil;a, ao julgar o EAREsp 600.663/RS (Tema 929), fixou entendimento de que a restitui&ccedil;&atilde;o em dobro prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC exige conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva.
+11. No caso concreto, embora reconhecida a inexist&ecirc;ncia da contrata&ccedil;&atilde;o, n&atilde;o h&aacute; elementos suficientes a demonstrar m&aacute;-f&eacute; ou conduta dolosa da institui&ccedil;&atilde;o financeira, sendo devida a restitui&ccedil;&atilde;o na forma simples.
+12. No tocante ao dano moral, os descontos indevidos incidentes sobre benef&iacute;cio previdenci&aacute;rio &ndash; verba de natureza alimentar &ndash; ultrapassam o mero aborrecimento, especialmente diante da vulnerabilidade do consumidor e da inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica v&aacute;lida.
+13. O preju&iacute;zo reiterado, com descontos mensais entre junho/2020 e fevereiro/2025, configura viola&ccedil;&atilde;o &agrave; dignidade da pessoa humana e enseja repara&ccedil;&atilde;o extrapatrimonial, nos termos do art. 186 do C&oacute;digo Civil.
+14. &Agrave; luz dos princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano, a capacidade econ&ocirc;mica das partes e o car&aacute;ter pedag&oacute;gico da medida, fixa-se a indeniza&ccedil;&atilde;o por danos morais em R$ 5.000,00.
+15. A corre&ccedil;&atilde;o monet&aacute;ria incide a partir do arbitramento (S&uacute;mula 362/STJ), pelo IPCA, nos termos do art. 389, par&aacute;grafo &uacute;nico, do C&oacute;digo Civil (Lei n&ordm; 14.905/2024), e os juros de mora fluem desde o evento danoso (S&uacute;mula 54/STJ), observada a taxa legal vigente.
+16. Quanto aos honor&aacute;rios advocat&iacute;cios, a verba fixada na origem (10% sobre o valor da causa) atende aos crit&eacute;rios do art. 85, &sect; 2&ordm;, do CPC, inexistindo fundamento para majora&ccedil;&atilde;o.
+IV. DISPOSITIVO E TESE
+17. Recurso do Banco BMG S/A. desprovido.
+18. Recurso de Jose dos Santos Gomes parcialmente provido, para condenar o r&eacute;u ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 5.000,00, mantidos os demais termos da senten&ccedil;a, com redimensionamento dos &ocirc;nus sucumbenciais (90% para o r&eacute;u e 10% para o autor, suspensa a exigibilidade quanto a este, nos termos do art. 98, &sect; 3&ordm;, do CPC).
+Tese de julgamento:
+19. Impugnada a autenticidade da assinatura em contrato banc&aacute;rio e determinada per&iacute;cia grafot&eacute;cnica, a desist&ecirc;ncia da prova pela institui&ccedil;&atilde;o financeira, a quem incumbia o &ocirc;nus probat&oacute;rio, implica presun&ccedil;&atilde;o de inexist&ecirc;ncia da contrata&ccedil;&atilde;o.
+20. A restitui&ccedil;&atilde;o em dobro prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC exige demonstra&ccedil;&atilde;o de conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva, n&atilde;o sendo cab&iacute;vel quando ausente comprova&ccedil;&atilde;o de m&aacute;-f&eacute; do fornecedor.
+21. Descontos indevidos incidentes sobre benef&iacute;cio previdenci&aacute;rio, verba de natureza alimentar, configuram dano moral indeniz&aacute;vel, por viola&ccedil;&atilde;o &agrave; dignidade do consumidor. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800217-78.2025.8.12.0016,&nbsp; Mundo Novo,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(55 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mundo Novo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C/C ANULAÇÃO DE CONTRATO, REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO. INEXISTÊNCIA DE CONTRATAÇÃO. DESISTÊNCIA DE PERÍCIA GRAFOTÉCNICA PELO BANCO. ÔNUS DA PROVA. RESTITUIÇÃO SIMPLES. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO DO BANCO DESPROVIDO. RECURSO DO AUTOR PARCIALMENTE PROVIDO.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C/C ANULAÇÃO DE CONTRATO, REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO. INEXISTÊNCIA DE CONTRATAÇÃO. DESISTÊNCIA DE PERÍCIA GRAFOTÉCNICA PELO BANCO. ÔNUS DA PROVA. RESTITUIÇÃO SIMPLES. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO DO BANCO DESPROVIDO. RECURSO DO AUTOR PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelações interpostas por Banco BMG S/A. e por Jose dos Santos Gomes contra sentença que, em ação declaratória de inexistência de débito c/c anulação de contrato, repetição de indébito e danos morais, julgou parcialmente procedentes os pedidos para: a) declarar inexistente a relação jurídica relativa a contrato de cartão de crédito consignado; b) determinar a restituição simples dos valores descontados do benefício previdenciário do autor, observada a prescrição quinquenal; c) afastar o pedido de indenização por danos morais.
+2. O banco sustenta a regularidade da contratação e a validade dos descontos, alegando assinatura do contrato e utilização do cartão pelo autor, bem como pugna pelo afastamento das condenações ou compensação de valores.
+3. O autor requer a restituição em dobro dos valores descontados, indenização por danos morais no valor de R$ 10.000,00 e majoração dos honorários advocatícios.
+II. QUESTÃO EM DISCUSSÃO
+4. As controvérsias consistem em definir: a) se houve comprovação válida da contratação do cartão de crédito consignado; b) se é devida a restituição em dobro dos valores descontados;  c) se os descontos indevidos em benefício previdenciário ensejam <em>dano</em> <em>moral</em>; d) se há fundamento para majoração dos honorários sucumbenciais.
+III. RAZÕES DE DECIDIR
+5. Incide ao caso o Código de Defesa do Consumidor, nos termos dos arts. 2º e 3º do CDC, sendo aplicável a inversão do ônus da prova (art. 6º, VIII, do CDC).
+6. Impugnada a autenticidade da assinatura aposta no contrato, foi determinada a realização de perícia grafotécnica, cujo ônus financeiro foi atribuído ao banco, nos termos do art. 373, II, do CPC e do art. 429, II, do CPC.
+7. A instituição financeira, contudo, desistiu expressamente da prova pericial após fixação dos honorários, operando-se a preclusão quanto à demonstração da autenticidade da assinatura.
+8. A desistência da prova técnica impede a comprovação da regularidade da contratação, impondo-se a presunção de veracidade da alegação de inexistência de vínculo contratual.
+9. Demonstrada a ausência de contratação válida, os descontos realizados sobre benefício previdenciário revelam-se indevidos, legitimando a declaração de inexistência do débito.
+10. Quanto à repetição do indébito, o Superior Tribunal de Justiça, ao julgar o EAREsp 600.663/RS (Tema 929), fixou entendimento de que a restituição em dobro prevista no art. 42, parágrafo único, do CDC exige conduta contrária à boa-fé objetiva.
+11. No caso concreto, embora reconhecida a inexistência da contratação, não há elementos suficientes a demonstrar má-fé ou conduta dolosa da instituição financeira, sendo devida a restituição na forma simples.
+12. No tocante ao <em>dano</em> <em>moral</em>, os descontos indevidos incidentes sobre benefício previdenciário – verba de natureza alimentar – ultrapassam o mero aborrecimento, especialmente diante da vulnerabilidade do consumidor e da inexistência de relação jurídica válida.
+13. O prejuízo reiterado, com descontos mensais entre junho/2020 e fevereiro/2025, configura violação à dignidade da pessoa humana e enseja reparação extrapatrimonial, nos termos do art. 186 do Código Civil.
+14. À luz dos princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em>, a capacidade econômica das partes e o caráter pedagógico da medida, fixa-se a indenização por danos morais em R$ 5.000,00.
+15. A correção monetária incide a partir do arbitramento (Súmula 362/STJ), pelo IPCA, nos termos do art. 389, parágrafo único, do Código Civil (Lei nº 14.905/2024), e os juros de mora fluem desde o evento danoso (Súmula 54/STJ), observada a taxa legal vigente.
+16. Quanto aos honorários advocatícios, a verba fixada na origem (10% sobre o valor da causa) atende aos critérios do art. 85, § 2º, do CPC, inexistindo fundamento para majoração.
+IV. DISPOSITIVO E TESE
+17. Recurso do Banco BMG S/A. desprovido.
+18. Recurso de Jose dos Santos Gomes parcialmente provido, para condenar o réu ao pagamento de indenização por danos morais no valor de R$ 5.000,00, mantidos os demais termos da sentença, com redimensionamento dos ônus sucumbenciais (90% para o réu e 10% para o autor, suspensa a exigibilidade quanto a este, nos termos do art. 98, § 3º, do CPC).
+Tese de julgamento:
+19. Impugnada a autenticidade da assinatura em contrato bancário e determinada perícia grafotécnica, a desistência da prova pela instituição financeira, a quem incumbia o ônus probatório, implica presunção de inexistência da contratação.
+20. A restituição em dobro prevista no art. 42, parágrafo único, do CDC exige demonstração de conduta contrária à boa-fé objetiva, não sendo cabível quando ausente comprovação de má-fé do fornecedor.
+21. Descontos indevidos incidentes sobre benefício previdenciário, verba de natureza alimentar, configuram <em>dano</em> <em>moral</em> indenizável, por violação à dignidade do consumidor.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>21&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878146" cdForo="0" >
+										0034993-27.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878146" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878146);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878146" style="display: none;" >
+	<div id="textAreaDados_1878146" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C REPARA&Ccedil;&Atilde;O DE DANOS &ndash; ALEGADOS V&Iacute;CIOS DE OBRA EM EDIFICA&Ccedil;&Atilde;O &ndash; RECURSO DO CONSTRUTOR &ndash; PROVAS PERICIAL E TESTEMUNHAL PRODUZIDAS NOS AUTOS COMPROVAM A OCORR&Ecirc;NCIA DE V&Iacute;CIO DE CONSTRU&Ccedil;&Atilde;O, CONSUBSTANCIADO EM DEFEITO DE OBRA QUE OCASIONA O ALAGAMENTO DO IM&Oacute;VEL EM &Eacute;POCA DE CHUVA, O QUE FAZ EXSURGIR A RESPONSABILIDADE CIVIL DO CONSTRUTOR &ndash; EVIDENTE NEXO DE CAUSALIDADE ENTRE OS DANOS CONSTATADOS E A NEGLIG&Ecirc;NCIA NO MOMENTO DA CONSTRU&Ccedil;&Atilde;O DA EDIFICA&Ccedil;&Atilde;O &ndash; AUS&Ecirc;NCIA DE DEMONSTRA&Ccedil;&Atilde;O DE CULPA CONCORRENTE DO AUTOR, POR AMPLIA&Ccedil;&Atilde;O DO IM&Oacute;VEL, EIS QUE TAL OBRA RESPEITOU OS LIMITES DE ZONEAMENTO URBANO DA LEGISLA&Ccedil;&Atilde;O MUNICIPAL VIGENTE &Agrave; &Eacute;POCA DA AMPLIA&Ccedil;&Atilde;O &ndash; N&Atilde;O CONFIGURA&Ccedil;&Atilde;O DE ENRIQUECIMENTO IL&Iacute;CITO PELO ARBITRAMENTO DE INDENIZA&Ccedil;&Atilde;O A T&Iacute;TULO DE PERDAS E DANOS, EIS QUE CORRESPONDENTE AO VALOR DA RECONSTRU&Ccedil;&Atilde;O DE PARTE DO BEM, COM VISTAS A TORN&Aacute;-LO HABIT&Aacute;VEL, COM CORRE&Ccedil;&Atilde;O DO V&Iacute;CIO DE OBRA CONSTATADO &ndash; IMPUGNA&Ccedil;&Atilde;O AO VALOR DA INDENIZA&Ccedil;&Atilde;O QUE DEVE SER INDEFERIDO, EIS QUE TAL VALOR FOI ARBITRADO COM BASE EM DADOS T&Eacute;CNICOS CONSTANTES NO LAUDO PERICIAL DE ENGENHARIA CONFECCIONADO NOS AUTOS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0034993-27.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Vícios de Construção
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE DANOS – ALEGADOS VÍCIOS DE OBRA EM EDIFICAÇÃO – RECURSO DO CONSTRUTOR – PROVAS PERICIAL E TESTEMUNHAL PRODUZIDAS NOS AUTOS COMPROVAM A OCORRÊNCIA DE VÍCIO DE CONSTRUÇÃO, CONSUBSTANCIADO EM DEFEITO DE OBRA QUE OCASIONA O ALAGAMENTO DO IMÓVEL EM ÉPOCA DE CHUVA, O QUE FAZ EXSURGIR A RESPONSABILIDADE CIVIL DO CONSTRUTOR – EVIDENTE NEXO DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE DANOS – ALEGADOS VÍCIOS DE OBRA EM EDIFICAÇÃO – RECURSO DO CONSTRUTOR – PROVAS PERICIAL E TESTEMUNHAL PRODUZIDAS NOS AUTOS COMPROVAM A OCORRÊNCIA DE VÍCIO DE CONSTRUÇÃO, CONSUBSTANCIADO EM DEFEITO DE OBRA QUE OCASIONA O ALAGAMENTO DO IMÓVEL EM ÉPOCA DE CHUVA, O QUE FAZ EXSURGIR A RESPONSABILIDADE CIVIL DO CONSTRUTOR – EVIDENTE NEXO DE CAUSALIDADE ENTRE OS DANOS CONSTATADOS E A NEGLIGÊNCIA NO MOMENTO DA CONSTRUÇÃO DA EDIFICAÇÃO – AUSÊNCIA DE DEMONSTRAÇÃO DE CULPA CONCORRENTE DO AUTOR, POR AMPLIAÇÃO DO IMÓVEL, EIS QUE TAL OBRA RESPEITOU OS LIMITES DE ZONEAMENTO URBANO DA LEGISLAÇÃO MUNICIPAL VIGENTE À ÉPOCA DA AMPLIAÇÃO – NÃO CONFIGURAÇÃO DE ENRIQUECIMENTO ILÍCITO PELO ARBITRAMENTO DE INDENIZAÇÃO A TÍTULO DE PERDAS E DANOS, EIS QUE CORRESPONDENTE AO VALOR DA RECONSTRUÇÃO DE PARTE DO BEM, COM VISTAS A TORNÁ-LO HABITÁVEL, COM CORREÇÃO DO VÍCIO DE OBRA CONSTATADO – IMPUGNAÇÃO AO VALOR DA INDENIZAÇÃO QUE DEVE SER INDEFERIDO, EIS QUE TAL VALOR FOI ARBITRADO COM BASE EM DADOS TÉCNICOS CONSTANTES NO LAUDO PERICIAL DE ENGENHARIA CONFECCIONADO NOS AUTOS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>22&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878154" cdForo="0" >
+										0801158-47.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878154" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878154);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878154" style="display: none;" >
+	<div id="textAreaDados_1878154" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C.C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. RECURSO DO BANCO. LEGALIDADE DA ADES&Atilde;O AO SEGURO &ndash; N&Atilde;O COMPROVADA &ndash; BANCO N&Atilde;O SE DESINCUMBIU DO &Ocirc;NUS PROBAT&Oacute;RIO QUE LHE FOI ATRIBU&Iacute;DO DE COMPROVAR A AUTENTICIDADE DO CONTRATO DIGITAL. DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; MANTIDA &ndash; VIOLA&Ccedil;&Atilde;O &Agrave; BOA-F&Eacute; OBJETIVA. DANO MORAL &ndash; CONFIGURADO &ndash; MINORA&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO FIXADO &ndash; REJEITADA. RECURSO DO AUTOR. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; MAJORA&Ccedil;&Atilde;O PRETENDIDA PELO DEMANDANTE &ndash; REJEITADA. VALOR FIXADO ATENDE AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. RECURSO DO REQUERIDO E RECURSO DO AUTOR DESPROVIDOS. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801158-47.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. RECURSO DO BANCO. LEGALIDADE DA ADESÃO AO SEGURO – NÃO COMPROVADA – BANCO NÃO SE DESINCUMBIU DO ÔNUS PROBATÓRIO QUE LHE FOI ATRIBUÍDO DE COMPROVAR A AUTENTICIDADE DO CONTRATO DIGITAL. DEVOLUÇÃO EM DOBRO – MANTIDA – VIOLAÇÃO À BOA-FÉ OBJETIVA. <em>DANO</em> <em>MORAL</em> –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. RECURSO DO BANCO. LEGALIDADE DA ADESÃO AO SEGURO – NÃO COMPROVADA – BANCO NÃO SE DESINCUMBIU DO ÔNUS PROBATÓRIO QUE LHE FOI ATRIBUÍDO DE COMPROVAR A AUTENTICIDADE DO CONTRATO DIGITAL. DEVOLUÇÃO EM DOBRO – MANTIDA – VIOLAÇÃO À BOA-FÉ OBJETIVA. <em>DANO</em> <em>MORAL</em> – CONFIGURADO – MINORAÇÃO DO QUANTUM INDENIZATÓRIO FIXADO – REJEITADA. RECURSO DO AUTOR. INDENIZAÇÃO POR DANOS MORAIS – MAJORAÇÃO PRETENDIDA PELO DEMANDANTE – REJEITADA. VALOR FIXADO ATENDE AOS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. RECURSO DO REQUERIDO E RECURSO DO AUTOR DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>23&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878160" cdForo="0" >
+										0802960-22.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878160" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878160);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878160" style="display: none;" >
+	<div id="textAreaDados_1878160" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE BUSCA E APREENS&Atilde;O &ndash; PRELIMINAR DE CERCEAMENTO DE DEFESA &ndash; PARTE QUE NEGA TER FIRMADO O CONTRATO &ndash; &Ocirc;NUS DA PROVA DA  REGULARIDADE DA CONTRATA&Ccedil;&Atilde;O QUE INCUMBE &Agrave; INSTITUI&Ccedil;&Atilde;O FINANCEIRA  - ART. 429, II DO CPC &ndash; AUS&Ecirc;NCIA DE OUTROS ELEMENTOS A PERMITIR A CONCLUS&Atilde;O PELA AUTENTICIDADE DA ASSINATURA &ndash; NECESSIDADE DE PRODU&Ccedil;&Atilde;O DE PROVA PERICIAL &ndash; TEMA N.&ordm; 1.061 DO STJ &ndash; RECURSO CONHECIDO E PROVIDO &ndash; SENTEN&Ccedil;A INSUBSISTENTE.
+Fato incontroverso que a rela&ccedil;&atilde;o jur&iacute;dica existente entre as partes tem natureza consumerista, impondo-se, pois, a aplica&ccedil;&atilde;o do C&oacute;digo de Defesa do Consumidor, em conson&acirc;ncia com a S&uacute;mula n&ordm; 297 do Egr&eacute;gio Superior Tribunal de Justi&ccedil;a (&quot;O C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras&quot;).
+A prova da regularidade da opera&ccedil;&atilde;o deve ser produzida pelo banco, fornecedor dos servi&ccedil;os, conforme disp&otilde;e o artigo 6&deg;, inciso VIII, do C&oacute;digo de Defesa do Consumidor, designadamente porque se afigura impratic&aacute;vel a produ&ccedil;&atilde;o de prova negativa por parte do r&eacute;u/consumidor.
+A parte recorrente argumenta ter sido v&iacute;tima de fraude contratual, refutando a contrata&ccedil;&atilde;o e negando a assinatura do contrato e a posse do bem. O ve&iacute;culo n&atilde;o foi apreendido em sua posse e, da an&aacute;lise das assinaturas apostas no contrato e, ainda, em documento pessoal da parte, n&atilde;o &eacute; poss&iacute;vel concluir, sem conhecimento t&eacute;cnico espec&iacute;fico, pela respectiva veracidade ou falsidade, dadas algumas incompatibilidades.
+Contestada a assinatura de documento particular, cessa sua f&eacute;, cabendo ao impugnado, isto &eacute;, &agrave; parte que produziu o documento e que sustenta a idoneidade da assinatura, o &ocirc;nus da prova de sua autenticidade, nos termos do artigo 429, inciso II do C&oacute;digo de Processo Civil. &Eacute; nesse sentido o Tema n.&ordm; 1.061 do STJ 'Na hip&oacute;tese em que o consumidor/autor impugnar a autenticidade da assinatura constante em contrato banc&aacute;rio juntado ao processo pela institui&ccedil;&atilde;o financeira, caber&aacute; a esta o &ocirc;nus de provar a sua autenticidade (CPC, arts. 6&ordm;, 368 e 429, II).'
+Diante da impugna&ccedil;&atilde;o quanto ao documento juntado, a aus&ecirc;ncia de outros elementos a permitir a conclus&atilde;o de regularidade da contrata&ccedil;&atilde;o (apreens&atilde;o do ve&iacute;culo na posse do contratante, benef&iacute;cio financeiro) e, ainda, a impossibilidade de aferi&ccedil;&atilde;o da veracidade da assinatura sem exame de grafot&eacute;cnico por especialista, &eacute; de se concluir que, no caso espec&iacute;fico, o indeferimento da prova pericial ensejou cerceamento de defesa. Senten&ccedil;a insubsistente, para retorno dos autos &agrave; origem e produ&ccedil;&atilde;o de prova pericial.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802960-22.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Alienação Fiduciária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE BUSCA E APREENSÃO – PRELIMINAR DE CERCEAMENTO DE DEFESA – PARTE QUE NEGA TER FIRMADO O CONTRATO – ÔNUS DA PROVA DA  REGULARIDADE DA CONTRATAÇÃO QUE INCUMBE À INSTITUIÇÃO FINANCEIRA  - ART. 429, II DO CPC – AUSÊNCIA DE OUTROS ELEMENTOS A PERMITIR A CONCLUSÃO PELA AUTENTICIDADE DA ASSINATURA – NECESSIDADE DE PRODUÇÃO DE PROVA PERICIAL – TEMA N.º 1.061 DO STJ – RECURSO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE BUSCA E APREENSÃO – PRELIMINAR DE CERCEAMENTO DE DEFESA – PARTE QUE NEGA TER FIRMADO O CONTRATO – ÔNUS DA PROVA DA  REGULARIDADE DA CONTRATAÇÃO QUE INCUMBE À INSTITUIÇÃO FINANCEIRA  - ART. 429, II DO CPC – AUSÊNCIA DE OUTROS ELEMENTOS A PERMITIR A CONCLUSÃO PELA AUTENTICIDADE DA ASSINATURA – NECESSIDADE DE PRODUÇÃO DE PROVA PERICIAL – TEMA N.º 1.061 DO STJ – RECURSO CONHECIDO E PROVIDO – SENTENÇA INSUBSISTENTE.
+Fato incontroverso que a relação jurídica existente entre as partes tem natureza consumerista, impondo-se, pois, a aplicação do Código de Defesa do Consumidor, em consonância com a Súmula nº 297 do Egrégio Superior Tribunal de Justiça ("O Código de Defesa do Consumidor é aplicável às instituições financeiras").
+A prova da regularidade da operação deve ser produzida pelo banco, fornecedor dos serviços, conforme dispõe o artigo 6°, inciso VIII, do Código de Defesa do Consumidor, designadamente porque se afigura impraticável a produção de prova negativa por parte do réu/consumidor.
+A parte recorrente argumenta ter sido vítima de fraude contratual, refutando a contratação e negando a assinatura do contrato e a posse do bem. O veículo não foi apreendido em sua posse e, da análise das assinaturas apostas no contrato e, ainda, em documento pessoal da parte, não é possível concluir, sem conhecimento técnico específico, pela respectiva veracidade ou falsidade, dadas algumas incompatibilidades.
+Contestada a assinatura de documento particular, cessa sua fé, cabendo ao impugnado, isto é, à parte que produziu o documento e que sustenta a idoneidade da assinatura, o ônus da prova de sua autenticidade, nos termos do artigo 429, inciso II do Código de Processo Civil. É nesse sentido o Tema n.º 1.061 do STJ 'Na hipótese em que o consumidor/autor impugnar a autenticidade da assinatura constante em contrato bancário juntado ao processo pela instituição financeira, caberá a esta o ônus de provar a sua autenticidade (CPC, arts. 6º, 368 e 429, II).'
+Diante da impugnação quanto ao documento juntado, a ausência de outros elementos a permitir a conclusão de regularidade da contratação (apreensão do veículo na posse do contratante, benefício financeiro) e, ainda, a impossibilidade de aferição da veracidade da assinatura sem exame de grafotécnico por especialista, é de se concluir que, no caso específico, o indeferimento da prova pericial ensejou cerceamento de defesa. Sentença insubsistente, para retorno dos autos à origem e produção de prova pericial.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>24&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878161" cdForo="0" >
+										0800409-11.2025.8.12.0016
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878161" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878161);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878161" style="display: none;" >
+	<div id="textAreaDados_1878161" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; REVISIONAL &ndash; FATURA DE ENERGIA &ndash; CONSUMO MUITO SUPERIOR &Agrave; M&Eacute;DIA DA UNIDADE CONSUMIDORA &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DA REGULARIDADE DA MEDI&Ccedil;&Atilde;O &ndash; COBRAN&Ccedil;A INDEVIDA -  PROTESTO INDEVIDO &ndash; DANO MORAL IN RE IPSA &ndash; MANUTEN&Ccedil;&Atilde;O DO VALOR DA COMPENSA&Ccedil;&Atilde;O.
+1. Aferido valor muito superior &agrave; m&eacute;dia de consumo mensal do consumidor e n&atilde;o tendo a concession&aacute;ria de energia el&eacute;trica comprovado a regularidade da medi&ccedil;&atilde;o, &eacute; indevida a cobran&ccedil;a do valor impugnado.
+2. O dano moral proveniente de&nbsp;protesto&nbsp;indevido&nbsp;&eacute; in re ipsa, ou seja, prescinde da prova do efetivo preju&iacute;zo.
+3. O valor fixado a t&iacute;tulo de compensa&ccedil;&atilde;o pelos danos morais &eacute; mantido quando observados, na senten&ccedil;a, os aspectos objetivos e subjetivos da demanda, em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recurso n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800409-11.2025.8.12.0016,&nbsp; Mundo Novo,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inexequibilidade do Título / Inexigibilidade da Obrigação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mundo Novo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – REVISIONAL – FATURA DE ENERGIA – CONSUMO MUITO SUPERIOR À MÉDIA DA UNIDADE CONSUMIDORA – AUSÊNCIA DE COMPROVAÇÃO DA REGULARIDADE DA MEDIÇÃO – COBRANÇA INDEVIDA -  PROTESTO INDEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR DA COMPENSAÇÃO.
+1. Aferido valor muito superior à média de consumo mensal do consumidor e não tendo a concessionária de energia
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – REVISIONAL – FATURA DE ENERGIA – CONSUMO MUITO SUPERIOR À MÉDIA DA UNIDADE CONSUMIDORA – AUSÊNCIA DE COMPROVAÇÃO DA REGULARIDADE DA MEDIÇÃO – COBRANÇA INDEVIDA -  PROTESTO INDEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR DA COMPENSAÇÃO.
+1. Aferido valor muito superior à média de consumo mensal do consumidor e não tendo a concessionária de energia elétrica comprovado a regularidade da medição, é indevida a cobrança do valor impugnado.
+2. O <em>dano</em> <em>moral</em> proveniente de protesto indevido é in re ipsa, ou seja, prescinde da prova do efetivo prejuízo.
+3. O valor fixado a título de compensação pelos danos morais é mantido quando observados, na sentença, os aspectos objetivos e subjetivos da demanda, em consonância com os princípios da razoabilidade e da proporcionalidade.
+Recurso não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>25&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878171" cdForo="0" >
+										0848287-11.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878171" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878171);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878171" style="display: none;" >
+	<div id="textAreaDados_1878171" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO BANC&Aacute;RIO &ndash; PRELIMINAR DE NULIDADE DA SENTEN&Ccedil;A POR DECIS&Atilde;O SURPRESA (ART. 10, CPC) E CERCEAMENTO DE DEFESA &ndash; AFASTADA &ndash; JULGAMENTO ANTECIPADO DA LIDE &ndash; POSSIBILIDADE &ndash; MAGISTRADO COMO DESTINAT&Aacute;RIO DA PROVA &ndash; M&Eacute;RITO &ndash; REVELIA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; PRESUN&Ccedil;&Atilde;O RELATIVA DE VERACIDADE &ndash; AN&Aacute;LISE DO CONTRATO E DAS TAXAS M&Eacute;DIAS DE MERCADO (BACEN) &ndash; ABUSIVIDADES N&Atilde;O CONFIGURADAS &ndash; JUROS REMUNERAT&Oacute;RIOS E CAPITALIZA&Ccedil;&Atilde;O EM CONFORMIDADE COM A JURISPRUD&Ecirc;NCIA DO STJ &ndash; DEVER DE INFORMA&Ccedil;&Atilde;O PRESERVADO &ndash; DANO MORAL E REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO INDEVIDOS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+I - O julgamento antecipado da lide n&atilde;o configura viola&ccedil;&atilde;o ao art. 10 do CPC ou cerceamento de defesa quando o acervo documental for suficiente para a forma&ccedil;&atilde;o do convencimento do magistrado. Sendo o juiz o destinat&aacute;rio da prova (art. 370, CPC), cabe a ele indeferir dilig&ecirc;ncias in&uacute;teis ou protelat&oacute;rias, especialmente quando a controv&eacute;rsia envolve mat&eacute;ria exclusivamente de direito ou pass&iacute;vel de prova documental (exame de encargos contratuais).
+II - A revelia n&atilde;o implica a proced&ecirc;ncia autom&aacute;tica dos pedidos, gerando apenas presun&ccedil;&atilde;o relativa de veracidade dos fatos narrados. Tal presun&ccedil;&atilde;o pode ser mitigada pelo livre convencimento do juiz diante das provas dos autos e da aplica&ccedil;&atilde;o do direito &agrave; esp&eacute;cie, especialmente em a&ccedil;&otilde;es revisionais onde o contrato permite o cotejo direto das cl&aacute;usulas com a legisla&ccedil;&atilde;o e a jurisprud&ecirc;ncia.
+III - Conforme entendimento do STJ, a estipula&ccedil;&atilde;o de juros acima de 12% ao ano n&atilde;o &eacute;, por si s&oacute;, abusiva, e a capitaliza&ccedil;&atilde;o mensal &eacute; permitida se expressamente pactuada (previs&atilde;o de taxa anual superior ao duod&eacute;cuplo da mensal). N&atilde;o demonstrada discrep&acirc;ncia substancial em rela&ccedil;&atilde;o &agrave; taxa m&eacute;dia de mercado divulgada pelo BACEN, mant&eacute;m-se a higidez das taxas contratadas.
+IV - Inexiste v&iacute;cio no dever de informa&ccedil;&atilde;o (art. 6&ordm;, III, CDC) quando as cl&aacute;usulas contratuais s&atilde;o claras e o instrumento foi disponibilizado &agrave; consumidora. Ausente a comprova&ccedil;&atilde;o de ato il&iacute;cito ou cobran&ccedil;a abusiva, n&atilde;o h&aacute; que se falar em repeti&ccedil;&atilde;o de ind&eacute;bito (dobro) ou indeniza&ccedil;&atilde;o por danos morais, configurando-se os descontos como regular exerc&iacute;cio de direito decorrente do pacto.
+V - Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0848287-11.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – PRELIMINAR DE NULIDADE DA SENTENÇA POR DECISÃO SURPRESA (ART. 10, CPC) E CERCEAMENTO DE DEFESA – AFASTADA – JULGAMENTO ANTECIPADO DA LIDE – POSSIBILIDADE – MAGISTRADO COMO DESTINATÁRIO DA PROVA – MÉRITO – REVELIA DA INSTITUIÇÃO FINANCEIRA – PRESUNÇÃO RELATIVA DE VERACIDADE – ANÁLISE DO CONTRATO E DAS TAXAS MÉDIAS DE MERCADO (BACEN) –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – PRELIMINAR DE NULIDADE DA SENTENÇA POR DECISÃO SURPRESA (ART. 10, CPC) E CERCEAMENTO DE DEFESA – AFASTADA – JULGAMENTO ANTECIPADO DA LIDE – POSSIBILIDADE – MAGISTRADO COMO DESTINATÁRIO DA PROVA – MÉRITO – REVELIA DA INSTITUIÇÃO FINANCEIRA – PRESUNÇÃO RELATIVA DE VERACIDADE – ANÁLISE DO CONTRATO E DAS TAXAS MÉDIAS DE MERCADO (BACEN) – ABUSIVIDADES NÃO CONFIGURADAS – JUROS REMUNERATÓRIOS E CAPITALIZAÇÃO EM CONFORMIDADE COM A JURISPRUDÊNCIA DO STJ – DEVER DE INFORMAÇÃO PRESERVADO – <em>DANO</em> <em>MORAL</em> E REPETIÇÃO DE INDÉBITO INDEVIDOS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+I - O julgamento antecipado da lide não configura violação ao art. 10 do CPC ou cerceamento de defesa quando o acervo documental for suficiente para a formação do convencimento do magistrado. Sendo o juiz o destinatário da prova (art. 370, CPC), cabe a ele indeferir diligências inúteis ou protelatórias, especialmente quando a controvérsia envolve matéria exclusivamente de direito ou passível de prova documental (exame de encargos contratuais).
+II - A revelia não implica a procedência automática dos pedidos, gerando apenas presunção relativa de veracidade dos fatos narrados. Tal presunção pode ser mitigada pelo livre convencimento do juiz diante das provas dos autos e da aplicação do direito à espécie, especialmente em ações revisionais onde o contrato permite o cotejo direto das cláusulas com a legislação e a jurisprudência.
+III - Conforme entendimento do STJ, a estipulação de juros acima de 12% ao ano não é, por si só, abusiva, e a capitalização mensal é permitida se expressamente pactuada (previsão de taxa anual superior ao duodécuplo da mensal). Não demonstrada discrepância substancial em relação à taxa média de mercado divulgada pelo BACEN, mantém-se a higidez das taxas contratadas.
+IV - Inexiste vício no dever de informação (art. 6º, III, CDC) quando as cláusulas contratuais são claras e o instrumento foi disponibilizado à consumidora. Ausente a comprovação de ato ilícito ou cobrança abusiva, não há que se falar em repetição de indébito (dobro) ou indenização por danos morais, configurando-se os descontos como regular exercício de direito decorrente do pacto.
+V - Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>26&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878172" cdForo="0" >
+										0818958-51.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878172" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878172);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878172" style="display: none;" >
+	<div id="textAreaDados_1878172" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. COBRAN&Ccedil;A DE FATURA DE ENERGIA EL&Eacute;TRICA. ALEGA&Ccedil;&Atilde;O DE CONSUMO EXCESSIVO. MEDIDOR SUBMETIDO &Agrave; VERIFICA&Ccedil;&Atilde;O T&Eacute;CNICA PELO INMETRO. LAUDO QUE ATESTA REGULARIDADE DO EQUIPAMENTO. AUS&Ecirc;NCIA DE PROVA DE IRREGULARIDADE NA MEDI&Ccedil;&Atilde;O OU NO FATURAMENTO. VARIA&Ccedil;&Atilde;O DE CONSUMO QUE, POR SI S&Oacute;, N&Atilde;O DEMONSTRA FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME: Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedentes os pedidos formulados em a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer cumulada com indeniza&ccedil;&atilde;o por danos morais proposta por consumidora em face de concession&aacute;ria de energia el&eacute;trica.
+A autora sustenta a ocorr&ecirc;ncia de cobran&ccedil;a abusiva em fatura de energia el&eacute;trica referente ao m&ecirc;s de abril de 2023, no valor de R$ 2.594,20, montante significativamente superior &agrave; m&eacute;dia hist&oacute;rica de consumo da unidade consumidora.
+A concession&aacute;ria defendeu a regularidade da cobran&ccedil;a e apresentou laudo t&eacute;cnico de verifica&ccedil;&atilde;o do medidor, realizado por &oacute;rg&atilde;o delegado do INMETRO, que concluiu pela inexist&ecirc;ncia de irregularidade no equipamento de medi&ccedil;&atilde;o.
+A senten&ccedil;a julgou improcedentes os pedidos de declara&ccedil;&atilde;o de inexigibilidade do d&eacute;bito, repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais, condenando a autora ao pagamento das custas e honor&aacute;rios advocat&iacute;cios, com exigibilidade suspensa em raz&atilde;o da gratuidade da justi&ccedil;a.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O: A quest&atilde;o em discuss&atilde;o consiste em verificar:
+a) se a cobran&ccedil;a da fatura de energia el&eacute;trica referente ao m&ecirc;s de abril de 2023 foi indevida em raz&atilde;o de suposta irregularidade no medidor ou no faturamento;
+b) se a discrep&acirc;ncia entre a fatura impugnada e a m&eacute;dia hist&oacute;rica de consumo &eacute; suficiente para caracterizar falha na presta&ccedil;&atilde;o do servi&ccedil;o;
+c) se est&atilde;o presentes os requisitos para repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR: A rela&ccedil;&atilde;o jur&iacute;dica estabelecida entre as partes &eacute; de consumo, aplicando-se as normas do C&oacute;digo de Defesa do Consumidor, que consagram a responsabilidade objetiva do fornecedor de servi&ccedil;os pelos danos decorrentes de defeitos na presta&ccedil;&atilde;o do servi&ccedil;o.
+Entretanto, a invers&atilde;o do &ocirc;nus da prova prevista na legisla&ccedil;&atilde;o consumerista n&atilde;o dispensa o consumidor da apresenta&ccedil;&atilde;o de elementos m&iacute;nimos capazes de evidenciar a plausibilidade de suas alega&ccedil;&otilde;es.
+No caso, embora a fatura impugnada apresente valor superior &agrave; m&eacute;dia hist&oacute;rica de consumo da unidade consumidora, tal circunst&acirc;ncia, isoladamente, n&atilde;o comprova irregularidade na medi&ccedil;&atilde;o ou na cobran&ccedil;a.
+A concession&aacute;ria demonstrou que o medidor foi submetido &agrave; verifica&ccedil;&atilde;o t&eacute;cnica por &oacute;rg&atilde;o delegado do INMETRO, cujo laudo concluiu pela regularidade do equipamento, documento que goza de presun&ccedil;&atilde;o de legitimidade e veracidade, nos termos da regulamenta&ccedil;&atilde;o da ANEEL.
+A parte autora n&atilde;o produziu prova apta a infirmar o resultado do exame realizado nem requereu a produ&ccedil;&atilde;o de per&iacute;cia judicial para questionar a conclus&atilde;o do &oacute;rg&atilde;o oficial.
+Ademais, varia&ccedil;&otilde;es de consumo podem decorrer de diversos fatores, como aumento no uso de equipamentos el&eacute;tricos, varia&ccedil;&atilde;o sazonal ou condi&ccedil;&otilde;es da instala&ccedil;&atilde;o interna da unidade consumidora, cuja manuten&ccedil;&atilde;o &eacute; de responsabilidade do usu&aacute;rio.
+Assim, n&atilde;o demonstrada irregularidade no funcionamento do medidor ou no faturamento realizado pela concession&aacute;ria, n&atilde;o se configura falha na presta&ccedil;&atilde;o do servi&ccedil;o nem ato il&iacute;cito capaz de ensejar repeti&ccedil;&atilde;o de ind&eacute;bito ou indeniza&ccedil;&atilde;o por danos morais.
+IV. DISPOSITIVO E TESE: Recurso conhecido e desprovido.
+Mantida integralmente a senten&ccedil;a que julgou improcedentes os pedidos iniciais.
+Honor&aacute;rios advocat&iacute;cios majorados de 10% para 15% sobre o valor da causa, nos termos do art. 85, &sect;11, do CPC, observada a suspens&atilde;o de exigibilidade em raz&atilde;o da gratuidade da justi&ccedil;a.
+Tese de julgamento: A discrep&acirc;ncia entre o valor de fatura de energia el&eacute;trica e a m&eacute;dia hist&oacute;rica de consumo da unidade consumidora, por si s&oacute;, n&atilde;o &eacute; suficiente para demonstrar irregularidade na medi&ccedil;&atilde;o ou cobran&ccedil;a.
+O laudo t&eacute;cnico de verifica&ccedil;&atilde;o do medidor realizado por &oacute;rg&atilde;o oficial delegado do INMETRO goza de presun&ccedil;&atilde;o de legitimidade e veracidade, sendo apto a comprovar a regularidade do equipamento quando n&atilde;o impugnado por prova t&eacute;cnica id&ocirc;nea.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0818958-51.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA DE FATURA DE ENERGIA ELÉTRICA. ALEGAÇÃO DE CONSUMO EXCESSIVO. MEDIDOR SUBMETIDO À VERIFICAÇÃO TÉCNICA PELO INMETRO. LAUDO QUE ATESTA REGULARIDADE DO EQUIPAMENTO. AUSÊNCIA DE PROVA DE IRREGULARIDADE NA MEDIÇÃO OU NO FATURAMENTO. VARIAÇÃO DE CONSUMO QUE, POR SI SÓ, NÃO DEMONSTRA FALHA NA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA DE FATURA DE ENERGIA ELÉTRICA. ALEGAÇÃO DE CONSUMO EXCESSIVO. MEDIDOR SUBMETIDO À VERIFICAÇÃO TÉCNICA PELO INMETRO. LAUDO QUE ATESTA REGULARIDADE DO EQUIPAMENTO. AUSÊNCIA DE PROVA DE IRREGULARIDADE NA MEDIÇÃO OU NO FATURAMENTO. VARIAÇÃO DE CONSUMO QUE, POR SI SÓ, NÃO DEMONSTRA FALHA NA PRESTAÇÃO DO SERVIÇO. SENTENÇA DE IMPROCEDÊNCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME: Apelação cível interposta contra sentença que julgou improcedentes os pedidos formulados em ação de obrigação de fazer cumulada com indenização por danos morais proposta por consumidora em face de concessionária de energia elétrica.
+A autora sustenta a ocorrência de cobrança abusiva em fatura de energia elétrica referente ao mês de abril de 2023, no valor de R$ 2.594,20, montante significativamente superior à média histórica de consumo da unidade consumidora.
+A concessionária defendeu a regularidade da cobrança e apresentou laudo técnico de verificação do medidor, realizado por órgão delegado do INMETRO, que concluiu pela inexistência de irregularidade no equipamento de medição.
+A sentença julgou improcedentes os pedidos de declaração de inexigibilidade do débito, repetição de indébito e indenização por danos morais, condenando a autora ao pagamento das custas e honorários advocatícios, com exigibilidade suspensa em razão da gratuidade da justiça.
+II. QUESTÃO EM DISCUSSÃO: A questão em discussão consiste em verificar:
+a) se a cobrança da fatura de energia elétrica referente ao mês de abril de 2023 foi indevida em razão de suposta irregularidade no medidor ou no faturamento;
+b) se a discrepância entre a fatura impugnada e a média histórica de consumo é suficiente para caracterizar falha na prestação do serviço;
+c) se estão presentes os requisitos para repetição de indébito e indenização por danos morais.
+III. RAZÕES DE DECIDIR: A relação jurídica estabelecida entre as partes é de consumo, aplicando-se as normas do Código de Defesa do Consumidor, que consagram a responsabilidade objetiva do fornecedor de serviços pelos danos decorrentes de defeitos na prestação do serviço.
+Entretanto, a inversão do ônus da prova prevista na legislação consumerista não dispensa o consumidor da apresentação de elementos mínimos capazes de evidenciar a plausibilidade de suas alegações.
+No caso, embora a fatura impugnada apresente valor superior à média histórica de consumo da unidade consumidora, tal circunstância, isoladamente, não comprova irregularidade na medição ou na cobrança.
+A concessionária demonstrou que o medidor foi submetido à verificação técnica por órgão delegado do INMETRO, cujo laudo concluiu pela regularidade do equipamento, documento que goza de presunção de legitimidade e veracidade, nos termos da regulamentação da ANEEL.
+A parte autora não produziu prova apta a infirmar o resultado do exame realizado nem requereu a produção de perícia judicial para questionar a conclusão do órgão oficial.
+Ademais, variações de consumo podem decorrer de diversos fatores, como aumento no uso de equipamentos elétricos, variação sazonal ou condições da instalação interna da unidade consumidora, cuja manutenção é de responsabilidade do usuário.
+Assim, não demonstrada irregularidade no funcionamento do medidor ou no faturamento realizado pela concessionária, não se configura falha na prestação do serviço nem ato ilícito capaz de ensejar repetição de indébito ou indenização por danos morais.
+IV. DISPOSITIVO E TESE: Recurso conhecido e desprovido.
+Mantida integralmente a sentença que julgou improcedentes os pedidos iniciais.
+Honorários advocatícios majorados de 10% para 15% sobre o valor da causa, nos termos do art. 85, §11, do CPC, observada a suspensão de exigibilidade em razão da gratuidade da justiça.
+Tese de julgamento: A discrepância entre o valor de fatura de energia elétrica e a média histórica de consumo da unidade consumidora, por si só, não é suficiente para demonstrar irregularidade na medição ou cobrança.
+O laudo técnico de verificação do medidor realizado por órgão oficial delegado do INMETRO goza de presunção de legitimidade e veracidade, sendo apto a comprovar a regularidade do equipamento quando não impugnado por prova técnica idônea.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>27&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878174" cdForo="0" >
+										0864377-94.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878174" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878174);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878174" style="display: none;" >
+	<div id="textAreaDados_1878174" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO - ILEGITIMIDADE PASSIVA - REJEI&Ccedil;&Atilde;O CONFIRMADA - DANO MORAL &ndash; OCORR&Ecirc;NCIA - DESCONTOS REALIZADOS EM CONTA-CORRENTE ONDE A PESSOA IDOSA RECEBE SEU BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO - QUANTIA RAZO&Aacute;VEL E PROPORCIONAL - RESTITUI&Ccedil;&Atilde;O EM DOBRO DO IND&Eacute;BITO - MANTIDA &ndash; RECURSO DA AUTORA, CONHECIDO E PROVIDO &ndash; APELO DO R&Eacute;U, CONHECIDO EM PARTE E DESPROVIDO.
+Na quantifica&ccedil;&atilde;o da indeniza&ccedil;&atilde;o por dano moral, deve o julgador, atendo-se &agrave;s espec&iacute;ficas condi&ccedil;&otilde;es do caso concreto, fixar o valor mais justo para o ressarcimento, lastreado nos princ&iacute;pios da razoabilidade e proporcionalidade. Nesse prop&oacute;sito, imp&otilde;e-se que sejam observadas as condi&ccedil;&otilde;es do ofensor, assim como a intensidade do sofrimento, o grau de reprova&ccedil;&atilde;o da atua&ccedil;&atilde;o do agente ativo da ilicitude, bem como a finalidade de impor ao executor o car&aacute;ter punitivo da condena&ccedil;&atilde;o para que n&atilde;o seja reincidente nessa conduta.
+Considerando que est&atilde;o presentes os requisitos do art. 42, par&aacute;grafo &uacute;nico, do CDC; que as partes fornecedoras n&atilde;o lograram comprovar engano justific&aacute;vel nos moldes aqui estabelecidos ou que tomaram todas as cautelas devidas para que o fato n&atilde;o acontecesse; e que n&atilde;o est&aacute; presente a hip&oacute;tese moduladora do  EAREsp n. 676.608/RS, nesse ponto, a senten&ccedil;a deve ser mantida.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0864377-94.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(83 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO - ILEGITIMIDADE PASSIVA - REJEIÇÃO CONFIRMADA - <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA - DESCONTOS REALIZADOS EM CONTA-CORRENTE ONDE A PESSOA IDOSA RECEBE SEU BENEFÍCIO PREVIDENCIÁRIO - QUANTIA RAZOÁVEL E PROPORCIONAL - RESTITUIÇÃO EM DOBRO DO INDÉBITO - MANTIDA – RECURSO DA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO - ILEGITIMIDADE PASSIVA - REJEIÇÃO CONFIRMADA - <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA - DESCONTOS REALIZADOS EM CONTA-CORRENTE ONDE A PESSOA IDOSA RECEBE SEU BENEFÍCIO PREVIDENCIÁRIO - QUANTIA RAZOÁVEL E PROPORCIONAL - RESTITUIÇÃO EM DOBRO DO INDÉBITO - MANTIDA – RECURSO DA AUTORA, CONHECIDO E PROVIDO – APELO DO RÉU, CONHECIDO EM PARTE E DESPROVIDO.
+Na quantificação da indenização por <em>dano</em> <em>moral</em>, deve o julgador, atendo-se às específicas condições do caso concreto, fixar o valor mais justo para o ressarcimento, lastreado nos princípios da razoabilidade e proporcionalidade. Nesse propósito, impõe-se que sejam observadas as condições do ofensor, assim como a intensidade do sofrimento, o grau de reprovação da atuação do agente ativo da ilicitude, bem como a finalidade de impor ao executor o caráter punitivo da condenação para que não seja reincidente nessa conduta.
+Considerando que estão presentes os requisitos do art. 42, parágrafo único, do CDC; que as partes fornecedoras não lograram comprovar engano justificável nos moldes aqui estabelecidos ou que tomaram todas as cautelas devidas para que o fato não acontecesse; e que não está presente a hipótese moduladora do  EAREsp n. 676.608/RS, nesse ponto, a sentença deve ser mantida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>28&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878175" cdForo="0" >
+										0801365-43.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878175" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878175);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878175" style="display: none;" >
+	<div id="textAreaDados_1878175" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E CONDENA&Ccedil;&Atilde;O EM DANOS MORAIS &ndash; CERCEAMENTO DE DEFESA N&Atilde;O EVIDENCIADO &ndash; INCID&Ecirc;NCIA DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; DESCONTOS REALIZADOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; VALIDADE DA CONTRATA&Ccedil;&Atilde;O N&Atilde;O DEMONSTRADA &ndash; AJUSTE COM DIVERG&Ecirc;NCIA QUANTO &Agrave; GEOLOCALIZA&Ccedil;&Atilde;O E N&Uacute;MERO DE TELEFONE UTILIZADO PARA ADES&Atilde;O - INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA ENTRE AS PARTES &ndash; DESCONTOS INDEVIDOS &ndash; DANO MORAL EXISTENTE E RESTITUI&Ccedil;&Atilde;O DAS QUANTIAS INDEVIDAMENTE DESCONTADAS &ndash; JUROS E CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA - RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO &ndash; RECURSO DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA CONHECIDO E N&Atilde;O PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produ&ccedil;&atilde;o de provas. E, portanto, n&atilde;o h&aacute; que se falar em cerceamento de defesa quando o julgador de primeira inst&acirc;ncia entendeu n&atilde;o ser necess&aacute;ria complementa&ccedil;&atilde;o probat&oacute;ria para o deslinde da causa, eis que as provas constantes nos autos s&atilde;o suficientes para o julgamento da demanda.
+O  C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave; rela&ccedil;&atilde;o jur&iacute;dica entabulada entre as partes, nos termos da S&uacute;mula 297, do STJ: &quot;O C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras.&quot;
+O recorrente n&atilde;o comprovou nos autos a exist&ecirc;ncia de&nbsp;contrato digital v&aacute;lido e regular a justificar os descontos reclamados pela parte autora, nos moldes do art. 373 do CPC. No caso dos autos, o ajuste colacionado foi firmado pela via digital, mas por meio de telefone de origem diversa do domic&iacute;lio da parte autora e sem apresenta&ccedil;&atilde;o de documentos pessoais. A diverg&ecirc;ncia &eacute; mais evidente quando se consulta a geolocaliza&ccedil;&atilde;o constante do contrato, donde se extrai que foi firmado na Avenida Senador Virg&iacute;lio T&aacute;vora, Fortaleza &ndash; Cear&aacute;, enquanto o endere&ccedil;o da parte autora, idosa, &eacute; em Campo Grande &ndash; MS.
+Os valores indevidamente descontados da parte autora devem ser restitu&iacute;dos em dobro, nos termos do art. 42 do CDC.
+No caso, os valores foram indevidamente debitados do benef&iacute;cio previdenci&aacute;rio da parte autora, pessoa idosa e pensionista do INSS &ndash;  situa&ccedil;&atilde;o que evidentemente foi de molde a caracterizar atentado &agrave; seguran&ccedil;a e tranquilidade financeiras da v&iacute;tima, privando-lhe de parcela de verba alimentar destinada a custear sua subsist&ecirc;ncia, de maneira que o dano moral indeniz&aacute;vel encontra-se suficientemente caracterizado.
+Tratando-se o caso de responsabilidade extracontratual &ndash; quando n&atilde;o existe contrato, o termo inicial dos juros de mora da condena&ccedil;&atilde;o por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido, enquanto a corre&ccedil;&atilde;o monet&aacute;ria, a data do arbitramento.
+Outrossim, deve ser aplicada a Taxa SELIC como crit&eacute;rio de transi&ccedil;&atilde;o e unifica&ccedil;&atilde;o, tanto na repara&ccedil;&atilde;o moral quanto material, a t&iacute;tulo de juros e corre&ccedil;&atilde;o monet&aacute;ria, at&eacute; o advento da Lei n&ordm; 14.905/24, a partir de quando a taxa Selic dever&aacute; incidir como &iacute;ndice de juros morat&oacute;rios com a dedu&ccedil;&atilde;o do &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria IPCA-IBGE, ou &iacute;ndice que vier a substitu&iacute;-lo, enquanto a corre&ccedil;&atilde;o monet&aacute;ria unicamente pelo IPCA, observados os termos iniciais j&aacute; fixados.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801365-43.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(88 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E CONDENAÇÃO EM DANOS MORAIS – CERCEAMENTO DE DEFESA NÃO EVIDENCIADO – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – DESCONTOS REALIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – VALIDADE DA CONTRATAÇÃO NÃO DEMONSTRADA – AJUSTE COM DIVERGÊNCIA QUANTO À GEOLOCALIZAÇÃO E NÚMERO DE TELEFONE UTILIZADO PARA ADESÃO -
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E CONDENAÇÃO EM DANOS MORAIS – CERCEAMENTO DE DEFESA NÃO EVIDENCIADO – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – DESCONTOS REALIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – VALIDADE DA CONTRATAÇÃO NÃO DEMONSTRADA – AJUSTE COM DIVERGÊNCIA QUANTO À GEOLOCALIZAÇÃO E NÚMERO DE TELEFONE UTILIZADO PARA ADESÃO - INEXISTÊNCIA DE RELAÇÃO JURÍDICA ENTRE AS PARTES – DESCONTOS INDEVIDOS – <em>DANO</em> <em>MORAL</em> EXISTENTE E RESTITUIÇÃO DAS QUANTIAS INDEVIDAMENTE DESCONTADAS – JUROS E CORREÇÃO MONETÁRIA - RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO – RECURSO DA INSTITUIÇÃO FINANCEIRA CONHECIDO E NÃO PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produção de provas. E, portanto, não há que se falar em cerceamento de defesa quando o julgador de primeira instância entendeu não ser necessária complementação probatória para o deslinde da causa, eis que as provas constantes nos autos são suficientes para o julgamento da demanda.
+O  Código de Defesa do Consumidor é aplicável à relação jurídica entabulada entre as partes, nos termos da Súmula 297, do STJ: "O Código de Defesa do Consumidor é aplicável às instituições financeiras."
+O recorrente não comprovou nos autos a existência de contrato digital válido e regular a justificar os descontos reclamados pela parte autora, nos moldes do art. 373 do CPC. No caso dos autos, o ajuste colacionado foi firmado pela via digital, mas por meio de telefone de origem diversa do domicílio da parte autora e sem apresentação de documentos pessoais. A divergência é mais evidente quando se consulta a geolocalização constante do contrato, donde se extrai que foi firmado na Avenida Senador Virgílio Távora, Fortaleza – Ceará, enquanto o endereço da parte autora, idosa, é em Campo Grande – MS.
+Os valores indevidamente descontados da parte autora devem ser restituídos em dobro, nos termos do art. 42 do CDC.
+No caso, os valores foram indevidamente debitados do benefício previdenciário da parte autora, pessoa idosa e pensionista do INSS –  situação que evidentemente foi de molde a caracterizar atentado à segurança e tranquilidade financeiras da vítima, privando-lhe de parcela de verba alimentar destinada a custear sua subsistência, de maneira que o <em>dano</em> <em>moral</em> indenizável encontra-se suficientemente caracterizado.
+Tratando-se o caso de responsabilidade extracontratual – quando não existe contrato, o termo inicial dos juros de mora da condenação por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido, enquanto a correção monetária, a data do arbitramento.
+Outrossim, deve ser aplicada a Taxa SELIC como critério de transição e unificação, tanto na reparação <em>moral</em> quanto material, a título de juros e correção monetária, até o advento da Lei nº 14.905/24, a partir de quando a taxa Selic deverá incidir como índice de juros moratórios com a dedução do índice de correção monetária IPCA-IBGE, ou índice que vier a substituí-lo, enquanto a correção monetária unicamente pelo IPCA, observados os termos iniciais já fixados.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>29&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878176" cdForo="0" >
+										0807056-09.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878176" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878176);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878176" style="display: none;" >
+	<div id="textAreaDados_1878176" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O &ndash; INDENIZAT&Oacute;RIA E COMPENSAT&Oacute;RIA &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; VIOLA&Ccedil;&Atilde;O DA INTEGRIDADE F&Iacute;SICA &ndash; DANO MORAL IN RE IPSA &ndash; MANUTEN&Ccedil;&Atilde;O DO VALOR.
+1. O dano moral &eacute; in re ipsa nas hip&oacute;teses em que ocorre viola&ccedil;&atilde;o da integridade f&iacute;sica decorrente de acidente de tr&acirc;nsito.
+2. O valor fixado a t&iacute;tulo de compensa&ccedil;&atilde;o por danos morais &eacute; mantido quando observados, na senten&ccedil;a, os aspectos objetivos e subjetivos da demanda, em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recursos n&atilde;o providos.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0807056-09.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INDENIZATÓRIA E COMPENSATÓRIA – ACIDENTE DE TRÂNSITO – VIOLAÇÃO DA INTEGRIDADE FÍSICA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR.
+1. O <em>dano</em> <em>moral</em> é in re ipsa nas hipóteses em que ocorre violação da integridade física decorrente de acidente de trânsito.
+2. O valor fixado a título de compensação por danos morais é mantido quando
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INDENIZATÓRIA E COMPENSATÓRIA – ACIDENTE DE TRÂNSITO – VIOLAÇÃO DA INTEGRIDADE FÍSICA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR.
+1. O <em>dano</em> <em>moral</em> é in re ipsa nas hipóteses em que ocorre violação da integridade física decorrente de acidente de trânsito.
+2. O valor fixado a título de compensação por danos morais é mantido quando observados, na sentença, os aspectos objetivos e subjetivos da demanda, em observância aos princípios da razoabilidade e da proporcionalidade.
+Recursos não providos.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>30&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878177" cdForo="0" >
+										0813568-66.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878177" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878177);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878177" style="display: none;" >
+	<div id="textAreaDados_1878177" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA - DANOS MORAIS DEVIDOS.
+O desconto indevido em benef&iacute;cio previdenci&aacute;rio do consumidor proveniente de contribui&ccedil;&atilde;o n&atilde;o contratada gera o dever de indenizar, independentemente da comprova&ccedil;&atilde;o do dano, por ser in re ipsa.
+Valor fixado em observ&acirc;ncia aos aspectos objetivos e subjetivos da demanda, em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recurso provido.
+
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0813568-66.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – CONTRATAÇÃO NÃO COMPROVADA - DANOS MORAIS DEVIDOS.
+O desconto indevido em benefício previdenciário do consumidor proveniente de contribuição não contratada gera o dever de indenizar, independentemente da comprovação do <em>dano</em>, por ser in re ipsa.
+Valor fixado em observância aos aspectos objetivos e subjetivos da demanda,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – CONTRATAÇÃO NÃO COMPROVADA - DANOS MORAIS DEVIDOS.
+O desconto indevido em benefício previdenciário do consumidor proveniente de contribuição não contratada gera o dever de indenizar, independentemente da comprovação do <em>dano</em>, por ser in re ipsa.
+Valor fixado em observância aos aspectos objetivos e subjetivos da demanda, em consonância com os princípios da razoabilidade e da proporcionalidade.
+Recurso provido.
+
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>31&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878182" cdForo="0" >
+										0828147-19.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878182" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878182);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878182" style="display: none;" >
+	<div id="textAreaDados_1878182" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR &ndash; RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; APONTAMENTO DE D&Iacute;VIDA NO SISTEMA DE INFORMA&Ccedil;&Otilde;ES DE CR&Eacute;DITO (SCR) OPERACIONALIZADO PELO BANCO CENTRAL DO BRASIL &ndash; ANOTA&Ccedil;&Atilde;O COM NATUREZA RESTRITIVA DE CR&Eacute;DITO &ndash; EXIG&Ecirc;NCIA DE PR&Eacute;VIA COMUNICA&Ccedil;&Atilde;O AO CONSUMIDOR DA REMESSA DE DADOS AO SCR &ndash; AUS&Ecirc;NCIA DE PROVA DA PR&Eacute;VIA COMUNICA&Ccedil;&Atilde;O ACERCA DO APONTAMENTO &ndash; ATO IL&Iacute;CITO CONFIGURADO  &ndash;  AUS&Ecirc;NCIA DE DANO MORAL &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Recurso de Apela&ccedil;&atilde;o interposto em face de senten&ccedil;a que julgou improcedentes os pedidos formulados em A&ccedil;&atilde;o de Obriga&ccedil;&atilde;o de Fazer c/c Danos Morais que tem por objeto o questionamento de apontamento de d&iacute;vida constante do Sistema de Informa&ccedil;&otilde;es do Cr&eacute;dito (SCR).
+II. HIP&Oacute;TESE EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a (in)validade do apontamento de d&iacute;vida no Sistema de Informa&ccedil;&otilde;es de Cr&eacute;dito (SCR); b) a ocorr&ecirc;ncia, ou n&atilde;o, de danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A Primeira Turma do STJ, no julgamento do REsp 1.626.547-RS, j&aacute; assentou o entendimento no sentido de que o BACEN &eacute; parte ileg&iacute;tima para figurar no polo passivo de demanda em que o consumidor questiona a falta de pr&eacute;via notifica&ccedil;&atilde;o em cadastro operacionalizado por tal autarquia federal, como &eacute; o caso do SCR. Preliminar de incompet&ecirc;ncia da Justi&ccedil;a Estadual rejeitada.
+4. O SCR &ndash; Sistema de Informa&ccedil;&otilde;es de Cr&eacute;ditos (SCR) &eacute; constitu&iacute;do por informa&ccedil;&otilde;es periodicamente remetidas ao Banco Central do Brasil acerca de opera&ccedil;&otilde;es de cr&eacute;dito firmadas por institui&ccedil;&otilde;es financeiras atuantes no pa&iacute;s, e tem por finalidade: (i) a consolida&ccedil;&atilde;o de informa&ccedil;&otilde;es ao BACEN para fins de monitoramento do cr&eacute;dito e exerc&iacute;cio de fiscaliza&ccedil;&atilde;o; e, (ii) propiciar o interc&acirc;mbio de informa&ccedil;&otilde;es entre institui&ccedil;&otilde;es financeiras e entre demais entidades, sobre o montante de responsabilidades de clientes em opera&ccedil;&otilde;es de cr&eacute;dito.
+5. Apesar da finalidade prec&iacute;pua de consolida&ccedil;&atilde;o de informa&ccedil;&otilde;es para fins de monitoramento e fiscaliza&ccedil;&atilde;o, o Superior Tribunal de Justi&ccedil;a j&aacute; ressaltou, no &acirc;mbito do REsp n&ordm; 1.626.547/RS, que, eventualmente, a t&iacute;tulo de efeito secund&aacute;rio, a inscri&ccedil;&atilde;o nos cadastros tamb&eacute;m tem o cond&atilde;o de controlar a inadimpl&ecirc;ncia em rela&ccedil;&atilde;o aos clientes de institui&ccedil;&otilde;es financeiras, o que tem o potencial de causar restri&ccedil;&atilde;o ao cr&eacute;dito, sendo que, at&eacute; mesmo por conta dessa potencialidade de restri&ccedil;&atilde;o ao cr&eacute;dito, o art. 13 da Resolu&ccedil;&atilde;o-CMN n&ordm; 5.037/2022 prev&ecirc; que &quot;As institui&ccedil;&otilde;es originadoras das opera&ccedil;&otilde;es de cr&eacute;dito ou que tenham adquirido tais opera&ccedil;&otilde;es de entidades n&atilde;o integrantes do Sistema Financeiro Nacional devem comunicar previamente ao cliente que os dados de suas respectivas opera&ccedil;&otilde;es ser&atilde;o registrados no SCR&quot;.
+6. A interpreta&ccedil;&atilde;o teleol&oacute;gica do art. 13, &sect;&sect; 2&ordm; e 3&ordm;, da Resolu&ccedil;&atilde;o-CMN n&ordm; 5.037/2022 indica que a comunica&ccedil;&atilde;o pr&eacute;via deve ser espec&iacute;fica, pessoal e realizada antes da remessa da informa&ccedil;&atilde;o ao SCR-BACEN; caso assim n&atilde;o fosse, n&atilde;o haveria raz&atilde;o para que se exigisse que a institui&ccedil;&atilde;o financeira mantenha a &quot;guarda da comunica&ccedil;&atilde;o de que trata este artigo, em meio f&iacute;sico ou eletr&ocirc;nico que permita comprovar a sua autenticidade&quot; (&sect; 3&ordm;).
+7. No caso, resta configurada a  pr&aacute;tica de ato il&iacute;cito pela r&eacute;, pois sua omiss&atilde;o na pr&eacute;via comunica&ccedil;&atilde;o da remessa de dados ao SCR atenta contra a transpar&ecirc;ncia, o equil&iacute;brio nas rela&ccedil;&otilde;es de consumo e o direito ao contradit&oacute;rio e ampla defesa.
+8. A simples aus&ecirc;ncia de notifica&ccedil;&atilde;o pr&eacute;via quanto &agrave; inclus&atilde;o no SCR, especialmente quando a d&iacute;vida &eacute; reconhecida pelo pr&oacute;prio devedor, n&atilde;o configura, por si s&oacute;, ato apto a ensejar indeniza&ccedil;&atilde;o por danos morais.
+9. A inser&ccedil;&atilde;o indevida  somada a exist&ecirc;ncia da d&iacute;vida importa em mero dissabor.
+
+IV. DISPOSITIVO
+11. Apela&ccedil;&atilde;o C&iacute;vel conhecida e parcialmente provida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0828147-19.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(66 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS – APONTAMENTO DE DÍVIDA NO SISTEMA DE INFORMAÇÕES DE CRÉDITO (SCR) OPERACIONALIZADO PELO BANCO CENTRAL DO BRASIL – ANOTAÇÃO COM NATUREZA RESTRITIVA DE CRÉDITO – EXIGÊNCIA DE PRÉVIA COMUNICAÇÃO AO CONSUMIDOR DA REMESSA DE DADOS AO SCR – AUSÊNCIA DE PROVA DA PRÉVIA COMUNICAÇÃO ACERCA DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS – APONTAMENTO DE DÍVIDA NO SISTEMA DE INFORMAÇÕES DE CRÉDITO (SCR) OPERACIONALIZADO PELO BANCO CENTRAL DO BRASIL – ANOTAÇÃO COM NATUREZA RESTRITIVA DE CRÉDITO – EXIGÊNCIA DE PRÉVIA COMUNICAÇÃO AO CONSUMIDOR DA REMESSA DE DADOS AO SCR – AUSÊNCIA DE PROVA DA PRÉVIA COMUNICAÇÃO ACERCA DO APONTAMENTO – ATO ILÍCITO CONFIGURADO  –  AUSÊNCIA DE <em>DANO</em> <em>MORAL</em> – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Recurso de Apelação interposto em face de sentença que julgou improcedentes os pedidos formulados em Ação de Obrigação de Fazer c/c Danos Morais que tem por objeto o questionamento de apontamento de dívida constante do Sistema de Informações do Crédito (SCR).
+II. HIPÓTESE EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a (in)validade do apontamento de dívida no Sistema de Informações de Crédito (SCR); b) a ocorrência, ou não, de danos morais.
+III. RAZÕES DE DECIDIR
+3. A Primeira Turma do STJ, no julgamento do REsp 1.626.547-RS, já assentou o entendimento no sentido de que o BACEN é parte ilegítima para figurar no polo passivo de demanda em que o consumidor questiona a falta de prévia notificação em cadastro operacionalizado por tal autarquia federal, como é o caso do SCR. Preliminar de incompetência da Justiça Estadual rejeitada.
+4. O SCR – Sistema de Informações de Créditos (SCR) é constituído por informações periodicamente remetidas ao Banco Central do Brasil acerca de operações de crédito firmadas por instituições financeiras atuantes no país, e tem por finalidade: (i) a consolidação de informações ao BACEN para fins de monitoramento do crédito e exercício de fiscalização; e, (ii) propiciar o intercâmbio de informações entre instituições financeiras e entre demais entidades, sobre o montante de responsabilidades de clientes em operações de crédito.
+5. Apesar da finalidade precípua de consolidação de informações para fins de monitoramento e fiscalização, o Superior Tribunal de Justiça já ressaltou, no âmbito do REsp nº 1.626.547/RS, que, eventualmente, a título de efeito secundário, a inscrição nos cadastros também tem o condão de controlar a inadimplência em relação aos clientes de instituições financeiras, o que tem o potencial de causar restrição ao crédito, sendo que, até mesmo por conta dessa potencialidade de restrição ao crédito, o art. 13 da Resolução-CMN nº 5.037/2022 prevê que "As instituições originadoras das operações de crédito ou que tenham adquirido tais operações de entidades não integrantes do Sistema Financeiro Nacional devem comunicar previamente ao cliente que os dados de suas respectivas operações serão registrados no SCR".
+6. A interpretação teleológica do art. 13, §§ 2º e 3º, da Resolução-CMN nº 5.037/2022 indica que a comunicação prévia deve ser específica, pessoal e realizada antes da remessa da informação ao SCR-BACEN; caso assim não fosse, não haveria razão para que se exigisse que a instituição financeira mantenha a "guarda da comunicação de que trata este artigo, em meio físico ou eletrônico que permita comprovar a sua autenticidade" (§ 3º).
+7. No caso, resta configurada a  prática de ato ilícito pela ré, pois sua omissão na prévia comunicação da remessa de dados ao SCR atenta contra a transparência, o equilíbrio nas relações de consumo e o direito ao contraditório e ampla defesa.
+8. A simples ausência de notificação prévia quanto à inclusão no SCR, especialmente quando a dívida é reconhecida pelo próprio devedor, não configura, por si só, ato apto a ensejar indenização por danos morais.
+9. A inserção indevida  somada a existência da dívida importa em mero dissabor.
+
+IV. DISPOSITIVO
+11. Apelação Cível conhecida e parcialmente provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>32&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878186" cdForo="0" >
+										0800629-90.2021.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878186" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878186);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878186" style="display: none;" >
+	<div id="textAreaDados_1878186" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL E RECURSO ADESIVO &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; EMPR&Eacute;STIMO CONSIGNADO N&Atilde;O CONTRATADO &ndash; DESCONTOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; S&Uacute;MULA 479 DO STJ &ndash; DANO MORAL CONFIGURADO IN RE IPSA &ndash; DESNECESSIDADE DE PROVA DO SOFRIMENTO &ndash; VIOLA&Ccedil;&Atilde;O DA ESFERA PATRIMONIAL E MORAL DE PESSOA IDOSA &ndash; VALOR DA INDENIZA&Ccedil;&Atilde;O &ndash; REDU&Ccedil;&Atilde;O PARA R$ 5.000,00 &ndash; OBSERV&Acirc;NCIA AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; JUROS DE MORA DESDE O EVENTO DANOSO (S&Uacute;MULA 54 STJ) &ndash; CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA A PARTIR DO ARBITRAMENTO (S&Uacute;MULA 362 STJ) &ndash; RECURSO ADESIVO DESPROVIDO &ndash; RECURSO DO BANCO PROVIDO EM PARTE.
+A fraude banc&aacute;ria que resulta em descontos indevidos em aposentadoria gera dano moral presumido (in re ipsa), dispensando a comprova&ccedil;&atilde;o de abalo psicol&oacute;gico severo, diante da natureza alimentar da verba e da vulnerabilidade do consumidor. A fixa&ccedil;&atilde;o do montante indenizat&oacute;rio deve pautar-se pelo crit&eacute;rio da modera&ccedil;&atilde;o, considerando a capacidade econ&ocirc;mica das partes e a extens&atilde;o do dano, sendo o valor de R$ 5.000,00 adequado para cumprir a fun&ccedil;&atilde;o punitiva e compensat&oacute;ria sem gerar enriquecimento il&iacute;cito. Em se tratando de responsabilidade extracontratual por ato il&iacute;cito, os juros morat&oacute;rios fluem a partir do evento danoso e a corre&ccedil;&atilde;o monet&aacute;ria desde a data do arbitramento. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800629-90.2021.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO NÃO CONTRATADO – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – SÚMULA 479 DO STJ – <em>DANO</em> <em>MORAL</em> CONFIGURADO IN RE IPSA – DESNECESSIDADE DE PROVA DO SOFRIMENTO – VIOLAÇÃO DA ESFERA PATRIMONIAL E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO NÃO CONTRATADO – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – SÚMULA 479 DO STJ – <em>DANO</em> <em>MORAL</em> CONFIGURADO IN RE IPSA – DESNECESSIDADE DE PROVA DO SOFRIMENTO – VIOLAÇÃO DA ESFERA PATRIMONIAL E <em>MORAL</em> DE PESSOA IDOSA – VALOR DA INDENIZAÇÃO – REDUÇÃO PARA R$ 5.000,00 – OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – JUROS DE MORA DESDE O EVENTO DANOSO (SÚMULA 54 STJ) – CORREÇÃO MONETÁRIA A PARTIR DO ARBITRAMENTO (SÚMULA 362 STJ) – RECURSO ADESIVO DESPROVIDO – RECURSO DO BANCO PROVIDO EM PARTE.
+A fraude bancária que resulta em descontos indevidos em aposentadoria gera <em>dano</em> <em>moral</em> presumido (in re ipsa), dispensando a comprovação de abalo psicológico severo, diante da natureza alimentar da verba e da vulnerabilidade do consumidor. A fixação do montante indenizatório deve pautar-se pelo critério da moderação, considerando a capacidade econômica das partes e a extensão do <em>dano</em>, sendo o valor de R$ 5.000,00 adequado para cumprir a função punitiva e compensatória sem gerar enriquecimento ilícito. Em se tratando de responsabilidade extracontratual por ato ilícito, os juros moratórios fluem a partir do evento danoso e a correção monetária desde a data do arbitramento.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>33&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878191" cdForo="0" >
+										0800137-44.2025.8.12.0007
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878191" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878191);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878191" style="display: none;" >
+	<div id="textAreaDados_1878191" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC) &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA &ndash; RECURSO DA PARTE AUTORA &ndash; PRETENS&Atilde;O DE CONVERS&Atilde;O DO NEG&Oacute;CIO JUR&Iacute;DICO EM CONTRATO DE M&Uacute;TUO COMUM &ndash; MAT&Eacute;RIA N&Atilde;O ARGUIDA NA PETI&Ccedil;&Atilde;O INICIAL &ndash; INOVA&Ccedil;&Atilde;O RECURSAL CONFIGURADA &ndash; SUPRESS&Atilde;O DE INST&Acirc;NCIA &ndash; VEDA&Ccedil;&Atilde;O PELO ORDENAMENTO JUR&Iacute;DICO &ndash; PRELIMINAR SUSCITADA DE OF&Iacute;CIO &ndash; RECURSO N&Atilde;O CONHECIDO.
+I - O efeito devolutivo da apela&ccedil;&atilde;o limita a aprecia&ccedil;&atilde;o do Tribunal &agrave;s quest&otilde;es que foram objeto de debate e decis&atilde;o no ju&iacute;zo de primeiro grau. &Eacute; vedado &agrave; parte inovar em sede recursal, formulando pedido ou causa de pedir n&atilde;o elencados na exordial, sob pena de viola&ccedil;&atilde;o ao princ&iacute;pio do duplo grau de jurisdi&ccedil;&atilde;o e de indevida supress&atilde;o de inst&acirc;ncia.
+II - Na peti&ccedil;&atilde;o inicial, a autora limitou-se a pleitear a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito e, subsidiariamente, a rescis&atilde;o contratual. Ao requerer, apenas em grau de recurso, a convers&atilde;o da modalidade contratual (de cart&atilde;o de cr&eacute;dito consignado para empr&eacute;stimo consignado t&iacute;pico) com base em erro substancial, a apelante extrapola os limites da lide fixados na inst&acirc;ncia origin&aacute;ria.
+III - Constatada a inova&ccedil;&atilde;o quanto ao objeto principal do recurso, imp&otilde;e-se o acolhimento da preliminar, suscitada de of&iacute;cio, para o n&atilde;o conhecimento do apelo.
+IV - Recurso n&atilde;o conhecido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800137-44.2025.8.12.0007,&nbsp; Cassil&acirc;ndia,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cassilândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – SENTENÇA DE IMPROCEDÊNCIA – RECURSO DA PARTE AUTORA – PRETENSÃO DE CONVERSÃO DO NEGÓCIO JURÍDICO EM CONTRATO DE MÚTUO COMUM – MATÉRIA NÃO ARGUIDA NA PETIÇÃO INICIAL – INOVAÇÃO RECURSAL CONFIGURADA – SUPRESSÃO DE INSTÂNCIA – VEDAÇÃO PELO ORDENAMENTO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – SENTENÇA DE IMPROCEDÊNCIA – RECURSO DA PARTE AUTORA – PRETENSÃO DE CONVERSÃO DO NEGÓCIO JURÍDICO EM CONTRATO DE MÚTUO COMUM – MATÉRIA NÃO ARGUIDA NA PETIÇÃO INICIAL – INOVAÇÃO RECURSAL CONFIGURADA – SUPRESSÃO DE INSTÂNCIA – VEDAÇÃO PELO ORDENAMENTO JURÍDICO – PRELIMINAR SUSCITADA DE OFÍCIO – RECURSO NÃO CONHECIDO.
+I - O efeito devolutivo da apelação limita a apreciação do Tribunal às questões que foram objeto de debate e decisão no juízo de primeiro grau. É vedado à parte inovar em sede recursal, formulando pedido ou causa de pedir não elencados na exordial, sob pena de violação ao princípio do duplo grau de jurisdição e de indevida supressão de instância.
+II - Na petição inicial, a autora limitou-se a pleitear a declaração de inexistência do débito e, subsidiariamente, a rescisão contratual. Ao requerer, apenas em grau de recurso, a conversão da modalidade contratual (de cartão de crédito consignado para empréstimo consignado típico) com base em erro substancial, a apelante extrapola os limites da lide fixados na instância originária.
+III - Constatada a inovação quanto ao objeto principal do recurso, impõe-se o acolhimento da preliminar, suscitada de ofício, para o não conhecimento do apelo.
+IV - Recurso não conhecido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>34&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878192" cdForo="0" >
+										0801944-27.2024.8.12.0010
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878192" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878192);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878192" style="display: none;" >
+	<div id="textAreaDados_1878192" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE ID&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO C/C DANOS MORAIS &ndash; INCID&Ecirc;NCIA DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; CONTRATO DE ADES&Atilde;O ASSOCIA&Ccedil;&Atilde;O  &ndash; AUS&Ecirc;NCIA DE ASSINATURA V&Aacute;LIDA &ndash; ASSINATURA SEM BIOMETRIA E SELF &ndash; GEOLOCALIZA&Ccedil;&Atilde;O INDICATIVA SOMENTE DA CIDADE EM QUE OCORREU O NEG&Oacute;CIO JUR&Iacute;DICO &ndash; CONTRATO NULO -  DANO MORAL EXISTENTE - RESTITUI&Ccedil;&Atilde;O DAS QUANTIAS INDEVIDAMENTE DESCONTADAS EM DOBRO &ndash; APLICA&Ccedil;&Atilde;O DO TEMA 1368 DO STJ - JUROS DE MORA E CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA PELA TAXA SELIC AT&Eacute; ENTRADA EM VIGOR DA LEI 14.905/2024 - RECURSO CONHECIDO E PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produ&ccedil;&atilde;o de provas. E, portanto, n&atilde;o h&aacute; que se falar em cerceamento de defesa quando magistrado entendeu pela desnecessidade de realiza&ccedil;&atilde;o de per&iacute;cia.
+Documento apresentado pelo banco n&atilde;o cont&eacute;m assinatura f&iacute;sica ou eletr&ocirc;nica v&aacute;lida da consumidora, indicando a geolocaliza&ccedil;&atilde;o somente a cidade de F&aacute;tima do Sul sem especificar endere&ccedil;o do consumidor ou da associa&ccedil;&atilde;o, bem como ausentes outros elementos comprobat&oacute;rios da regularidade da contrata&ccedil;&atilde;o tais como self, biometria e documentos pessoais da parte, sendo, portanto, nula a ades&atilde;o da consumidora &agrave; entidade associativa por aus&ecirc;ncia de assinatura v&aacute;lida.
+Em decorr&ecirc;ncia da nulidade da ades&atilde;o e autoriza&ccedil;&atilde;o de descontos, todas as parcelas debitadas do benef&iacute;cio da parte autora devem ser restitu&iacute;das com dobro, face a n&atilde;o demonstra&ccedil;&atilde;o de ocorr&ecirc;ncia de engano justific&aacute;vel do credor.
+No caso, os valores foram indevidamente debitados da aposentadoria do apelante, pessoa idosa e aposentada que percebe mensalmente 01 sal&aacute;rio m&iacute;nimo, situa&ccedil;&atilde;o que foi de molde a caracterizar atentado &agrave; tranquilidade financeira da consumidora, privando-lhe de parte de seus proventos que j&aacute; apresentam car&aacute;ter m&oacute;dico, de maneira que o dano moral indeniz&aacute;vel encontra-se suficientemente caracterizado, sendo fixado o valor de R$ 5.000,00 (cinco mil reais), observados os princ&iacute;pios da proporcionalidade e razoabilidade.
+Tratando-se o caso de responsabilidade extracontratual &ndash; quando n&atilde;o existe contrato -, os encargos ficam assim fixados conforme Tema 1368 do STJ: i) a indeniza&ccedil;&atilde;o por dano moral o termo inicial dos juros de mora da condena&ccedil;&atilde;o por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido (quando o dano foi provocado),  o qual dever&aacute; ser corrigido pela SELIC. Ap&oacute;s a data do in&iacute;cio da vig&ecirc;ncia da Lei n. 14.905/2024, a corre&ccedil;&atilde;o dever&aacute; ser feita pelo IPCA e os juros de mora indexados pela SELIC, deduzido o IPCA, consoante previs&atilde;o do artigo 406, do C&oacute;digo de Processo Civil,  ii) a repeti&ccedil;&atilde;o do ind&eacute;bito em dobro dever&aacute; ser corrigida e sofrer incid&ecirc;ncia de juros de mora desde o desconto indevido (S&uacute;mula 43 do STJ) unicamente pela taxa SELIC, at&eacute; entrada em vigor da Lei 14.905/2024 e, ap&oacute;s, ser corrigida monetariamente pelo IPCA e ter incid&ecirc;ncia de juros de mora da SELIC, deduzido o IPCA. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801944-27.2024.8.12.0010,&nbsp; F&aacute;tima do Sul,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(61 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fátima do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE IDÉBITO C/C REPETIÇÃO DE INDÉBITO C/C DANOS MORAIS – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – CONTRATO DE ADESÃO ASSOCIAÇÃO  – AUSÊNCIA DE ASSINATURA VÁLIDA – ASSINATURA SEM BIOMETRIA E SELF – GEOLOCALIZAÇÃO INDICATIVA SOMENTE DA CIDADE EM QUE OCORREU O NEGÓCIO JURÍDICO – CONTRATO NULO -  <em>DANO</em> <em>MORAL</em> EXISTENTE - RESTITUIÇÃO DAS QUANTIAS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE IDÉBITO C/C REPETIÇÃO DE INDÉBITO C/C DANOS MORAIS – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – CONTRATO DE ADESÃO ASSOCIAÇÃO  – AUSÊNCIA DE ASSINATURA VÁLIDA – ASSINATURA SEM BIOMETRIA E SELF – GEOLOCALIZAÇÃO INDICATIVA SOMENTE DA CIDADE EM QUE OCORREU O NEGÓCIO JURÍDICO – CONTRATO NULO -  <em>DANO</em> <em>MORAL</em> EXISTENTE - RESTITUIÇÃO DAS QUANTIAS INDEVIDAMENTE DESCONTADAS EM DOBRO – APLICAÇÃO DO TEMA 1368 DO STJ - JUROS DE MORA E CORREÇÃO MONETÁRIA PELA TAXA SELIC ATÉ ENTRADA EM VIGOR DA LEI 14.905/2024 - RECURSO CONHECIDO E PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produção de provas. E, portanto, não há que se falar em cerceamento de defesa quando magistrado entendeu pela desnecessidade de realização de perícia.
+Documento apresentado pelo banco não contém assinatura física ou eletrônica válida da consumidora, indicando a geolocalização somente a cidade de Fátima do Sul sem especificar endereço do consumidor ou da associação, bem como ausentes outros elementos comprobatórios da regularidade da contratação tais como self, biometria e documentos pessoais da parte, sendo, portanto, nula a adesão da consumidora à entidade associativa por ausência de assinatura válida.
+Em decorrência da nulidade da adesão e autorização de descontos, todas as parcelas debitadas do benefício da parte autora devem ser restituídas com dobro, face a não demonstração de ocorrência de engano justificável do credor.
+No caso, os valores foram indevidamente debitados da aposentadoria do apelante, pessoa idosa e aposentada que percebe mensalmente 01 salário mínimo, situação que foi de molde a caracterizar atentado à tranquilidade financeira da consumidora, privando-lhe de parte de seus proventos que já apresentam caráter módico, de maneira que o <em>dano</em> <em>moral</em> indenizável encontra-se suficientemente caracterizado, sendo fixado o valor de R$ 5.000,00 (cinco mil reais), observados os princípios da proporcionalidade e razoabilidade.
+Tratando-se o caso de responsabilidade extracontratual – quando não existe contrato -, os encargos ficam assim fixados conforme Tema 1368 do STJ: i) a indenização por <em>dano</em> <em>moral</em> o termo inicial dos juros de mora da condenação por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido (quando o <em>dano</em> foi provocado),  o qual deverá ser corrigido pela SELIC. Após a data do início da vigência da Lei n. 14.905/2024, a correção deverá ser feita pelo IPCA e os juros de mora indexados pela SELIC, deduzido o IPCA, consoante previsão do artigo 406, do Código de Processo Civil,  ii) a repetição do indébito em dobro deverá ser corrigida e sofrer incidência de juros de mora desde o desconto indevido (Súmula 43 do STJ) unicamente pela taxa SELIC, até entrada em vigor da Lei 14.905/2024 e, após, ser corrigida monetariamente pelo IPCA e ter incidência de juros de mora da SELIC, deduzido o IPCA.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>35&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878198" cdForo="0" >
+										0800494-67.2025.8.12.0025
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878198" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878198);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878198" style="display: none;" >
+	<div id="textAreaDados_1878198" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; DEMANDA DE COBRAN&Ccedil;A DE SEGURO AGR&Iacute;COLA &ndash; CL&Aacute;USULA RESTRITIVA DE COBERTURA (PLANTIO EM &Aacute;REA DE PASTAGEM) &ndash; AUS&Ecirc;NCIA DE PROVA DE CI&Ecirc;NCIA INEQU&Iacute;VOCA DO SEGURADO &ndash; VIOLA&Ccedil;&Atilde;O AO DEVER DE INFORMA&Ccedil;&Atilde;O - REPARA&Ccedil;&Atilde;O POR DANOS MORAIS INDEVIDA.
+1.&Eacute; inopon&iacute;vel a cl&aacute;usula restritiva de direitos sem a demonstra&ccedil;&atilde;o de informa&ccedil;&atilde;o pr&eacute;via, clara e inequ&iacute;voca ao segurado no momento da contrata&ccedil;&atilde;o.
+2.Inexiste dano moral em decorr&ecirc;ncia de negativa de cobertura fundada em diverg&ecirc;ncia de interpreta&ccedil;&atilde;o contratual.
+Recurso parcialmente provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800494-67.2025.8.12.0025,&nbsp; Bandeirantes,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Bandeirantes
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DEMANDA DE COBRANÇA DE SEGURO AGRÍCOLA – CLÁUSULA RESTRITIVA DE COBERTURA (PLANTIO EM ÁREA DE PASTAGEM) – AUSÊNCIA DE PROVA DE CIÊNCIA INEQUÍVOCA DO SEGURADO – VIOLAÇÃO AO DEVER DE INFORMAÇÃO - REPARAÇÃO POR DANOS MORAIS INDEVIDA.
+1.É inoponível a cláusula restritiva de direitos sem a demonstração de informação prévia, clara e inequívoca ao segurado no momento da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DEMANDA DE COBRANÇA DE SEGURO AGRÍCOLA – CLÁUSULA RESTRITIVA DE COBERTURA (PLANTIO EM ÁREA DE PASTAGEM) – AUSÊNCIA DE PROVA DE CIÊNCIA INEQUÍVOCA DO SEGURADO – VIOLAÇÃO AO DEVER DE INFORMAÇÃO - REPARAÇÃO POR DANOS MORAIS INDEVIDA.
+1.É inoponível a cláusula restritiva de direitos sem a demonstração de informação prévia, clara e inequívoca ao segurado no momento da contratação.
+2.Inexiste <em>dano</em> <em>moral</em> em decorrência de negativa de cobertura fundada em divergência de interpretação contratual.
+Recurso parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>36&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878202" cdForo="0" >
+										0847743-57.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878202" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878202);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878202" style="display: none;" >
+	<div id="textAreaDados_1878202" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O &ndash; TRANSPORTE A&Eacute;REO INTERNACIONAL &ndash; AQUISI&Ccedil;&Atilde;O DE PASSAGENS EM CLASSE EXECUTIVA (PREMIUM BUSINESS) &ndash; PRE&Ccedil;O MANIFESTAMENTE IRRIS&Oacute;RIO &ndash; ERRO GROSSEIRO NA OFERTA &ndash; INAPLICABILIDADE DO ARTIGO 30 DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR - AUS&Ecirc;NCIA  DE FALHA NA PRESTA&Ccedil;&Atilde;O DE SERVI&Ccedil;O &ndash; RESTITUI&Ccedil;&Atilde;O DO VALOR PAGO DEVIDA.
+1. O artigo 30 do C&oacute;digo de Defesa do Consumidor prev&ecirc; a vincula&ccedil;&atilde;o da oferta ao fornecedor, integrando o contrato. Contudo, essa regra n&atilde;o &eacute; absoluta, sendo afastada quando h&aacute; erro grosseiro e evidente, capaz de excluir a leg&iacute;tima expectativa do consumidor quanto ao cumprimento da oferta.
+2. Ausente falha na presta&ccedil;&atilde;o do servi&ccedil;o, inexiste o dever de indenizar.
+3. Diante da altera&ccedil;&atilde;o da categoria sem concord&acirc;ncia da parte autora, devido a retorno das partes ao status quo ante, com a restitui&ccedil;&atilde;o do valor pago.
+Recurso das r&eacute;s provido e dos autores n&atilde;o provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0847743-57.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – TRANSPORTE AÉREO INTERNACIONAL – AQUISIÇÃO DE PASSAGENS EM CLASSE EXECUTIVA (PREMIUM BUSINESS) – PREÇO MANIFESTAMENTE IRRISÓRIO – ERRO GROSSEIRO NA OFERTA – INAPLICABILIDADE DO ARTIGO 30 DO CÓDIGO DE DEFESA DO CONSUMIDOR - AUSÊNCIA  DE FALHA NA PRESTAÇÃO DE SERVIÇO – RESTITUIÇÃO DO VALOR PAGO DEVIDA.
+1. O artigo 30 do Código de Defesa do Consumidor prevê a vinculação da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – TRANSPORTE AÉREO INTERNACIONAL – AQUISIÇÃO DE PASSAGENS EM CLASSE EXECUTIVA (PREMIUM BUSINESS) – PREÇO MANIFESTAMENTE IRRISÓRIO – ERRO GROSSEIRO NA OFERTA – INAPLICABILIDADE DO ARTIGO 30 DO CÓDIGO DE DEFESA DO CONSUMIDOR - AUSÊNCIA  DE FALHA NA PRESTAÇÃO DE SERVIÇO – RESTITUIÇÃO DO VALOR PAGO DEVIDA.
+1. O artigo 30 do Código de Defesa do Consumidor prevê a vinculação da oferta ao fornecedor, integrando o contrato. Contudo, essa regra não é absoluta, sendo afastada quando há erro grosseiro e evidente, capaz de excluir a legítima expectativa do consumidor quanto ao cumprimento da oferta.
+2. Ausente falha na prestação do serviço, inexiste o dever de indenizar.
+3. Diante da alteração da categoria sem concordância da parte autora, devido a retorno das partes ao status quo ante, com a restituição do valor pago.
+Recurso das rés provido e dos autores não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>37&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878212" cdForo="0" >
+										0810442-05.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878212" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878212);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878212" style="display: none;" >
+	<div id="textAreaDados_1878212" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O &ndash; INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA, REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E COMPENSA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; DESCONTOS INDEVIDOS EM CONTA CORRENTE&ndash; RESPONSABILIDADE DA INSTITUI&Ccedil;&Atilde;O BANC&Aacute;RIA &ndash; RESTITUI&Ccedil;&Atilde;O &ndash; DANO MORAL &ndash; VALOR MANTIDO.
+1. A responsabilidade do banco &eacute; caracterizada quando ocorrem   descontos em conta corrente do autor sem autoriza&ccedil;&atilde;o expressa.
+2. Considerando que a parte r&eacute; n&atilde;o comprovou a exist&ecirc;ncia de contrato de seguro, &eacute; necess&aacute;rio o retorno das partes ao status quo ante, com a restitui&ccedil;&atilde;o do valor descontado.
+3. O valor fixado a t&iacute;tulo de compensa&ccedil;&atilde;o pelos danos morais &eacute; mantido quando observados, na senten&ccedil;a, os aspectos objetivos e subjetivos da demanda, em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recursos n&atilde;o providos. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0810442-05.2025.8.12.0002,&nbsp; Dourados,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Descontos dos benefícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INEXISTÊNCIA DE RELAÇÃO JURÍDICA, REPETIÇÃO DE INDÉBITO E COMPENSAÇÃO POR DANOS MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE– RESPONSABILIDADE DA INSTITUIÇÃO BANCÁRIA – RESTITUIÇÃO – <em>DANO</em> <em>MORAL</em> – VALOR MANTIDO.
+1. A responsabilidade do banco é caracterizada quando ocorrem   descontos em conta corrente do autor sem autorização expressa.
+2. Considerando
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INEXISTÊNCIA DE RELAÇÃO JURÍDICA, REPETIÇÃO DE INDÉBITO E COMPENSAÇÃO POR DANOS MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE– RESPONSABILIDADE DA INSTITUIÇÃO BANCÁRIA – RESTITUIÇÃO – <em>DANO</em> <em>MORAL</em> – VALOR MANTIDO.
+1. A responsabilidade do banco é caracterizada quando ocorrem   descontos em conta corrente do autor sem autorização expressa.
+2. Considerando que a parte ré não comprovou a existência de contrato de seguro, é necessário o retorno das partes ao status quo ante, com a restituição do valor descontado.
+3. O valor fixado a título de compensação pelos danos morais é mantido quando observados, na sentença, os aspectos objetivos e subjetivos da demanda, em consonância com os princípios da razoabilidade e da proporcionalidade.
+Recursos não providos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>38&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878216" cdForo="0" >
+										0806882-44.2024.8.12.0017
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878216" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878216);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878216" style="display: none;" >
+	<div id="textAreaDados_1878216" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. MAJORA&Ccedil;&Atilde;O DO DANO MORAL. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Trata-se de apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica cumulada com repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais, julgou parcialmente procedentes os pedidos.
+2. O ju&iacute;zo de origem declarou a inexist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, determinou a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados e fixou indeniza&ccedil;&atilde;o por danos morais em R$ 3.000,00, al&eacute;m de honor&aacute;rios advocat&iacute;cios.
+3. O apelante insurge-se exclusivamente quanto ao valor da indeniza&ccedil;&atilde;o moral, pleiteando sua majora&ccedil;&atilde;o, bem como a eleva&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. A controv&eacute;rsia recursal cinge-se a:
+a) verificar a adequa&ccedil;&atilde;o do quantum indenizat&oacute;rio fixado a t&iacute;tulo de danos morais decorrentes de descontos indevidos em benef&iacute;cio previdenci&aacute;rio;
+b) definir o crit&eacute;rio de fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios sucumbenciais.
+III. RAZ&Otilde;ES DE DECIDIR
+5. Restou incontroversa a inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica entre as partes e a ilicitude dos descontos realizados, configurando ato il&iacute;cito nos termos dos arts. 186 e 927 do C&oacute;digo Civil.
+6. Os descontos indevidos em benef&iacute;cio previdenci&aacute;rio, de natureza alimentar, configuram dano moral in re ipsa, dispensando prova do preju&iacute;zo extrapatrimonial.
+7. O valor da indeniza&ccedil;&atilde;o deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, atendendo &agrave;s fun&ccedil;&otilde;es compensat&oacute;ria e pedag&oacute;gica, considerando:
+a) a vulnerabilidade econ&ocirc;mica do autor, aposentado por incapacidade;
+b) a natureza alimentar do benef&iacute;cio atingido;
+c) a reitera&ccedil;&atilde;o dos descontos por per&iacute;odo prolongado (quase um ano);
+d) a gravidade da conduta il&iacute;cita.
+8. O montante fixado na origem (R$ 3.000,00) revela-se insuficiente, sendo adequada sua majora&ccedil;&atilde;o para R$ 5.000,00.
+9. Quanto aos honor&aacute;rios advocat&iacute;cios, inaplic&aacute;vel a fixa&ccedil;&atilde;o por equidade (art. 85, &sect;8&ordm;, do CPC) quando h&aacute; condena&ccedil;&atilde;o mensur&aacute;vel, devendo prevalecer o crit&eacute;rio percentual previsto no &sect;2&ordm; do mesmo dispositivo.
+10. Assim, mostra-se adequada a fixa&ccedil;&atilde;o dos honor&aacute;rios em 20% sobre o valor da condena&ccedil;&atilde;o, em aten&ccedil;&atilde;o aos crit&eacute;rios legais.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e parcialmente provido.
+Tese de julgamento:
+12. Os descontos indevidos em benef&iacute;cio previdenci&aacute;rio, sobretudo de natureza alimentar, configuram dano moral in re ipsa, sendo devida a indeniza&ccedil;&atilde;o independentemente de prova do preju&iacute;zo.
+13. O quantum indenizat&oacute;rio por danos morais deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano, a condi&ccedil;&atilde;o da v&iacute;tima e o car&aacute;ter pedag&oacute;gico da medida, admitindo-se majora&ccedil;&atilde;o quando o valor fixado se mostrar insuficiente.
+14. Havendo condena&ccedil;&atilde;o com valor mensur&aacute;vel, os honor&aacute;rios advocat&iacute;cios devem ser fixados com base no percentual previsto no art. 85, &sect;2&ordm;, do CPC, sendo excepcional a fixa&ccedil;&atilde;o por equidade. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806882-44.2024.8.12.0017,&nbsp; Nova Andradina,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Nova Andradina
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. MAJORAÇÃO DO <em>DANO</em> <em>MORAL</em>. HONORÁRIOS ADVOCATÍCIOS. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Trata-se de apelação cível interposta contra sentença que, em ação declaratória de inexistência
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. MAJORAÇÃO DO <em>DANO</em> <em>MORAL</em>. HONORÁRIOS ADVOCATÍCIOS. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Trata-se de apelação cível interposta contra sentença que, em ação declaratória de inexistência de relação jurídica cumulada com repetição de indébito e indenização por danos morais, julgou parcialmente procedentes os pedidos.
+2. O juízo de origem declarou a inexistência da relação jurídica, determinou a restituição em dobro dos valores indevidamente descontados e fixou indenização por danos morais em R$ 3.000,00, além de honorários advocatícios.
+3. O apelante insurge-se exclusivamente quanto ao valor da indenização <em>moral</em>, pleiteando sua majoração, bem como a elevação dos honorários sucumbenciais.
+II. QUESTÃO EM DISCUSSÃO
+4. A controvérsia recursal cinge-se a:
+a) verificar a adequação do quantum indenizatório fixado a título de danos morais decorrentes de descontos indevidos em benefício previdenciário;
+b) definir o critério de fixação dos honorários advocatícios sucumbenciais.
+III. RAZÕES DE DECIDIR
+5. Restou incontroversa a inexistência de relação jurídica entre as partes e a ilicitude dos descontos realizados, configurando ato ilícito nos termos dos arts. 186 e 927 do Código Civil.
+6. Os descontos indevidos em benefício previdenciário, de natureza alimentar, configuram <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo extrapatrimonial.
+7. O valor da indenização deve observar os princípios da razoabilidade e proporcionalidade, atendendo às funções compensatória e pedagógica, considerando:
+a) a vulnerabilidade econômica do autor, aposentado por incapacidade;
+b) a natureza alimentar do benefício atingido;
+c) a reiteração dos descontos por período prolongado (quase um ano);
+d) a gravidade da conduta ilícita.
+8. O montante fixado na origem (R$ 3.000,00) revela-se insuficiente, sendo adequada sua majoração para R$ 5.000,00.
+9. Quanto aos honorários advocatícios, inaplicável a fixação por equidade (art. 85, §8º, do CPC) quando há condenação mensurável, devendo prevalecer o critério percentual previsto no §2º do mesmo dispositivo.
+10. Assim, mostra-se adequada a fixação dos honorários em 20% sobre o valor da condenação, em atenção aos critérios legais.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e parcialmente provido.
+Tese de julgamento:
+12. Os descontos indevidos em benefício previdenciário, sobretudo de natureza alimentar, configuram <em>dano</em> <em>moral</em> in re ipsa, sendo devida a indenização independentemente de prova do prejuízo.
+13. O quantum indenizatório por danos morais deve observar os princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em>, a condição da vítima e o caráter pedagógico da medida, admitindo-se majoração quando o valor fixado se mostrar insuficiente.
+14. Havendo condenação com valor mensurável, os honorários advocatícios devem ser fixados com base no percentual previsto no art. 85, §2º, do CPC, sendo excepcional a fixação por equidade.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>39&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878219" cdForo="0" >
+										0803592-35.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878219" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878219);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878219" style="display: none;" >
+	<div id="textAreaDados_1878219" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE NEG&Oacute;CIO JUR&Iacute;DICO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC). ALEGA&Ccedil;&Atilde;O DE V&Iacute;CIO DE CONSENTIMENTO. AUS&Ecirc;NCIA DE PROVA. CONTRATA&Ccedil;&Atilde;O V&Aacute;LIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por Roberto Ramai da Costa contra senten&ccedil;a que julgou improcedentes os pedidos em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de neg&oacute;cio jur&iacute;dico cumulada com repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais, ajuizada em face de Banco Bmg S/A.
+2. O autor sustenta que pretendia contratar empr&eacute;stimo consignado simples, mas aderiu a cart&atilde;o de cr&eacute;dito consignado (RMC), alegando v&iacute;cio de consentimento, falha no dever de informa&ccedil;&atilde;o e cobran&ccedil;a abusiva decorrente de d&iacute;vida de natureza rotativa.
+3. Requer a nulidade do contrato ou sua convers&atilde;o em m&uacute;tuo consignado, restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. A controv&eacute;rsia consiste em verificar:
+a) se houve v&iacute;cio de consentimento na contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado (RMC);
+b) se houve falha no dever de informa&ccedil;&atilde;o capaz de invalidar o neg&oacute;cio jur&iacute;dico;
+c) se s&atilde;o devidos restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+5. Preliminares rejeitadas. N&atilde;o configurada ofensa ao princ&iacute;pio da dialeticidade, uma vez que as raz&otilde;es recursais enfrentam os fundamentos da senten&ccedil;a. Inocorr&ecirc;ncia de prescri&ccedil;&atilde;o e decad&ecirc;ncia, por se tratar de rela&ccedil;&atilde;o de trato sucessivo, cujo prazo conta-se do &uacute;ltimo desconto.
+6. A rela&ccedil;&atilde;o jur&iacute;dica &eacute; de consumo, sendo aplic&aacute;vel o C&oacute;digo de Defesa do Consumidor, conforme S&uacute;mula 297 do STJ.
+7. A institui&ccedil;&atilde;o financeira comprovou a regular contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado, mediante termo de ades&atilde;o assinado e demonstra&ccedil;&atilde;o de disponibiliza&ccedil;&atilde;o do cr&eacute;dito ao consumidor.
+8. Inexistente prova de v&iacute;cio de consentimento (erro, dolo ou coa&ccedil;&atilde;o), incumbindo ao autor o &ocirc;nus probat&oacute;rio, nos termos do art. 373, I, do CPC.
+9. O mero alegado desconhecimento das caracter&iacute;sticas do contrato n&atilde;o &eacute; suficiente para invalidar o neg&oacute;cio jur&iacute;dico, especialmente quando as condi&ccedil;&otilde;es contratuais constam expressamente no instrumento firmado.
+10. A utiliza&ccedil;&atilde;o do cr&eacute;dito e a aus&ecirc;ncia de prova de irregularidade afastam a alega&ccedil;&atilde;o de falha no dever de informa&ccedil;&atilde;o.
+11. A modalidade de cart&atilde;o de cr&eacute;dito consignado (RMC) &eacute; l&iacute;cita e regulamentada, sendo v&aacute;lida a cobran&ccedil;a do pagamento m&iacute;nimo da fatura mediante desconto em folha.
+12. Ausente ilegalidade na contrata&ccedil;&atilde;o, inexiste fundamento para repeti&ccedil;&atilde;o de ind&eacute;bito ou indeniza&ccedil;&atilde;o por danos morais.
+IV. DISPOSITIVO E TESE
+13. Recurso desprovido.
+Tese de julgamento:
+14. A contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado (RMC) &eacute; v&aacute;lida quando comprovada por termo de ades&atilde;o assinado e disponibiliza&ccedil;&atilde;o do cr&eacute;dito, inexistindo nulidade sem prova de v&iacute;cio de consentimento.
+15. O &ocirc;nus de demonstrar erro substancial ou falha no dever de informa&ccedil;&atilde;o incumbe ao consumidor, n&atilde;o sendo suficiente a alega&ccedil;&atilde;o gen&eacute;rica de desconhecimento da modalidade contratada.
+16. A natureza rotativa do cr&eacute;dito consignado, com desconto do valor m&iacute;nimo da fatura, n&atilde;o configura abusividade quando expressamente prevista no contrato.
+17. Inexistindo irregularidade na contrata&ccedil;&atilde;o, s&atilde;o indevidos a repeti&ccedil;&atilde;o de ind&eacute;bito e o dano moral. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803592-35.2025.8.12.0001,&nbsp; Terenos,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Terenos
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO (RMC). ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO. AUSÊNCIA DE PROVA. CONTRATAÇÃO VÁLIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por Roberto Ramai da Costa contra sentença que julgou improcedentes os
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO (RMC). ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO. AUSÊNCIA DE PROVA. CONTRATAÇÃO VÁLIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por Roberto Ramai da Costa contra sentença que julgou improcedentes os pedidos em ação declaratória de inexistência de negócio jurídico cumulada com repetição de indébito e indenização por danos morais, ajuizada em face de Banco Bmg S/A.
+2. O autor sustenta que pretendia contratar empréstimo consignado simples, mas aderiu a cartão de crédito consignado (RMC), alegando vício de consentimento, falha no dever de informação e cobrança abusiva decorrente de dívida de natureza rotativa.
+3. Requer a nulidade do contrato ou sua conversão em mútuo consignado, restituição de valores e indenização por danos morais.
+II. QUESTÃO EM DISCUSSÃO
+4. A controvérsia consiste em verificar:
+a) se houve vício de consentimento na contratação do cartão de crédito consignado (RMC);
+b) se houve falha no dever de informação capaz de invalidar o negócio jurídico;
+c) se são devidos restituição de valores e indenização por danos morais.
+III. RAZÕES DE DECIDIR
+5. Preliminares rejeitadas. Não configurada ofensa ao princípio da dialeticidade, uma vez que as razões recursais enfrentam os fundamentos da sentença. Inocorrência de prescrição e decadência, por se tratar de relação de trato sucessivo, cujo prazo conta-se do último desconto.
+6. A relação jurídica é de consumo, sendo aplicável o Código de Defesa do Consumidor, conforme Súmula 297 do STJ.
+7. A instituição financeira comprovou a regular contratação do cartão de crédito consignado, mediante termo de adesão assinado e demonstração de disponibilização do crédito ao consumidor.
+8. Inexistente prova de vício de consentimento (erro, dolo ou coação), incumbindo ao autor o ônus probatório, nos termos do art. 373, I, do CPC.
+9. O mero alegado desconhecimento das características do contrato não é suficiente para invalidar o negócio jurídico, especialmente quando as condições contratuais constam expressamente no instrumento firmado.
+10. A utilização do crédito e a ausência de prova de irregularidade afastam a alegação de falha no dever de informação.
+11. A modalidade de cartão de crédito consignado (RMC) é lícita e regulamentada, sendo válida a cobrança do pagamento mínimo da fatura mediante desconto em folha.
+12. Ausente ilegalidade na contratação, inexiste fundamento para repetição de indébito ou indenização por danos morais.
+IV. DISPOSITIVO E TESE
+13. Recurso desprovido.
+Tese de julgamento:
+14. A contratação de cartão de crédito consignado (RMC) é válida quando comprovada por termo de adesão assinado e disponibilização do crédito, inexistindo nulidade sem prova de vício de consentimento.
+15. O ônus de demonstrar erro substancial ou falha no dever de informação incumbe ao consumidor, não sendo suficiente a alegação genérica de desconhecimento da modalidade contratada.
+16. A natureza rotativa do crédito consignado, com desconto do valor mínimo da fatura, não configura abusividade quando expressamente prevista no contrato.
+17. Inexistindo irregularidade na contratação, são indevidos a repetição de indébito e o <em>dano</em> <em>moral</em>.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>40&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878224" cdForo="0" >
+										0861350-40.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878224" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878224);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878224" style="display: none;" >
+	<div id="textAreaDados_1878224" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; DIREITO CIVIL &ndash; A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO BANC&Aacute;RIO &ndash; LITIG&Acirc;NCIA PREDAT&Oacute;RIA N&Atilde;O CONFIGURADA &ndash; CERCEAMENTO DE DEFESA AFASTADO &ndash; JUROS REMUNERAT&Oacute;RIOS &ndash; TAXA M&Eacute;DIA DE MERCADO &ndash; ABUSIVIDADE CONSTATADA &ndash; RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Trata-se de apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou procedentes os pedidos formulados pela parte autora em a&ccedil;&atilde;o revisional, para limitar os juros remunerat&oacute;rios &agrave; taxa m&eacute;dia de mercado e descaracterizar eventual mora.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) Verifica-se a discuss&atilde;o sobre: i) ocorr&ecirc;ncia de cerceamento de defesa por indeferimento de provas; ii) alega&ccedil;&atilde;o de litig&acirc;ncia predat&oacute;ria por ajuizamento reiterado de a&ccedil;&otilde;es semelhantes; iii) possibilidade de revis&atilde;o das cl&aacute;usulas contratuais, notadamente quanto &agrave; abusividade das taxas de juros remunerat&oacute;rios pactuadas acima da taxa m&eacute;dia de mercado.
+III. RAZ&Otilde;ES DE DECIDIR
+3) Quanto &agrave; preliminar de litig&acirc;ncia predat&oacute;ria, inexistem provas concretas de ajuizamento massivo e padronizado de a&ccedil;&otilde;es pela mesma patrona em preju&iacute;zo da parte recorrente, raz&atilde;o pela qual foi afastada.
+4) Rejeita-se tamb&eacute;m a alega&ccedil;&atilde;o de cerceamento de defesa, haja vista que a mat&eacute;ria em an&aacute;lise &eacute; predominantemente de direito e os documentos j&aacute; constantes nos autos s&atilde;o suficientes &agrave; forma&ccedil;&atilde;o do convencimento do ju&iacute;zo, dispensando a produ&ccedil;&atilde;o de outras provas, inclusive pericial.
+5) No m&eacute;rito, resta evidenciada a abusividade das taxas de juros remunerat&oacute;rios pactuadas, por serem significativamente superiores &agrave; taxa m&eacute;dia de mercado divulgada pelo Banco Central para contratos similares &agrave; &eacute;poca da contrata&ccedil;&atilde;o.
+6) A revis&atilde;o das taxas contratadas se ampara em jurisprud&ecirc;ncia consolidada do STJ, especialmente no julgamento do REsp 1.061.530/RS, que admite a revis&atilde;o excepcional de juros quando comprovada a abusividade no caso concreto, sobretudo em rela&ccedil;&otilde;es de consumo.
+7)Diante da constata&ccedil;&atilde;o de abusividade, correta a limita&ccedil;&atilde;o dos juros &agrave; taxa m&eacute;dia de mercado e consequente descaracteriza&ccedil;&atilde;o da mora, conforme entendimento do STJ no Tema 28.
+IV. DISPOSITIVO E TESE
+8) Recurso desprovido.
+Tese de julgamento:
+9) A simples alega&ccedil;&atilde;o de ajuizamento reiterado de demandas contra a mesma institui&ccedil;&atilde;o financeira, sem provas concretas, n&atilde;o configura litig&acirc;ncia predat&oacute;ria.
+10) N&atilde;o h&aacute; cerceamento de defesa quando a prova requerida se mostra desnecess&aacute;ria e a mat&eacute;ria em julgamento &eacute; eminentemente de direito, sendo leg&iacute;tima a forma&ccedil;&atilde;o do convencimento judicial com base nas provas documentais constantes dos autos.
+11) &Eacute; abusiva a cobran&ccedil;a de juros remunerat&oacute;rios em patamar significativamente superior &agrave; taxa m&eacute;dia de mercado divulgada pelo Banco Central, sendo leg&iacute;tima sua limita&ccedil;&atilde;o, com fundamento nos princ&iacute;pios da boa-f&eacute; objetiva e da fun&ccedil;&atilde;o social do contrato.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0861350-40.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DIREITO CIVIL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – LITIGÂNCIA PREDATÓRIA NÃO CONFIGURADA – CERCEAMENTO DE DEFESA AFASTADO – JUROS REMUNERATÓRIOS – TAXA MÉDIA DE MERCADO – ABUSIVIDADE CONSTATADA – RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Trata-se de apelação cível interposta contra sentença que julgou procedentes os pedidos formulados pela parte autora em ação revisional,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DIREITO CIVIL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – LITIGÂNCIA PREDATÓRIA NÃO CONFIGURADA – CERCEAMENTO DE DEFESA AFASTADO – JUROS REMUNERATÓRIOS – TAXA MÉDIA DE MERCADO – ABUSIVIDADE CONSTATADA – RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Trata-se de apelação cível interposta contra sentença que julgou procedentes os pedidos formulados pela parte autora em ação revisional, para limitar os juros remuneratórios à taxa média de mercado e descaracterizar eventual mora.
+II. QUESTÃO EM DISCUSSÃO
+2) Verifica-se a discussão sobre: i) ocorrência de cerceamento de defesa por indeferimento de provas; ii) alegação de litigância predatória por ajuizamento reiterado de ações semelhantes; iii) possibilidade de revisão das cláusulas contratuais, notadamente quanto à abusividade das taxas de juros remuneratórios pactuadas acima da taxa média de mercado.
+III. RAZÕES DE DECIDIR
+3) Quanto à preliminar de litigância predatória, inexistem provas concretas de ajuizamento massivo e padronizado de ações pela mesma patrona em prejuízo da parte recorrente, razão pela qual foi afastada.
+4) Rejeita-se também a alegação de cerceamento de defesa, haja vista que a matéria em análise é predominantemente de direito e os documentos já constantes nos autos são suficientes à formação do convencimento do juízo, dispensando a produção de outras provas, inclusive pericial.
+5) No mérito, resta evidenciada a abusividade das taxas de juros remuneratórios pactuadas, por serem significativamente superiores à taxa média de mercado divulgada pelo Banco Central para contratos similares à época da contratação.
+6) A revisão das taxas contratadas se ampara em jurisprudência consolidada do STJ, especialmente no julgamento do REsp 1.061.530/RS, que admite a revisão excepcional de juros quando comprovada a abusividade no caso concreto, sobretudo em relações de consumo.
+7)Diante da constatação de abusividade, correta a limitação dos juros à taxa média de mercado e consequente descaracterização da mora, conforme entendimento do STJ no Tema 28.
+IV. DISPOSITIVO E TESE
+8) Recurso desprovido.
+Tese de julgamento:
+9) A simples alegação de ajuizamento reiterado de demandas contra a mesma instituição financeira, sem provas concretas, não configura litigância predatória.
+10) Não há cerceamento de defesa quando a prova requerida se mostra desnecessária e a matéria em julgamento é eminentemente de direito, sendo legítima a formação do convencimento judicial com base nas provas documentais constantes dos autos.
+11) É abusiva a cobrança de juros remuneratórios em patamar significativamente superior à taxa média de mercado divulgada pelo Banco Central, sendo legítima sua limitação, com fundamento nos princípios da boa-fé objetiva e da função social do contrato.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>41&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878227" cdForo="0" >
+										0801548-20.2024.8.12.0020
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878227" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878227);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878227" style="display: none;" >
+	<div id="textAreaDados_1878227" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS. PRELIMINAR DE ILEGITIMIDADE PASSIVA ACOLHIDA NA ORIGEM. BANCO RESPONS&Aacute;VEL PELA GEST&Atilde;O E SEGURAN&Ccedil;A DA CONTA CORRENTE. DESCONTOS INDEVIDOS REALIZADOS SEM AUTORIZA&Ccedil;&Atilde;O DA CORRENTISTA. RESPONSABILIDADE OBJETIVA. CDC. AUS&Ecirc;NCIA DE APRECIA&Ccedil;&Atilde;O DAS DEMAIS PRELIMINARES SUSCITADAS NA CONTESTA&Ccedil;&Atilde;O. CAUSA N&Atilde;O MADURA PARA JULGAMENTO DIRETO. ANULA&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por Julia Gen&eacute;sia Garcia contra senten&ccedil;a que acolheu a preliminar de ilegitimidade passiva do Banco Bradesco S/A e extinguiu o feito sem resolu&ccedil;&atilde;o de m&eacute;rito, nos termos do art. 485, VI, do C&oacute;digo de Processo Civil, condenando a autora ao pagamento das custas processuais e honor&aacute;rios advocat&iacute;cios, com exigibilidade suspensa em raz&atilde;o da gratuidade da justi&ccedil;a.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o central consiste em definir se o Banco Bradesco S/A det&eacute;m legitimidade passiva para figurar no polo passivo de a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito cumulada com indeniza&ccedil;&atilde;o por danos materiais e morais, em raz&atilde;o de descontos realizados em conta corrente de sua titularidade sem autoriza&ccedil;&atilde;o expressa da correntista.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O banco que administra conta corrente e efetua descontos em favor de terceiro sem verificar a regularidade da autoriza&ccedil;&atilde;o do correntista responde objetivamente pelos danos causados, nos termos do art. 14 do C&oacute;digo de Defesa do Consumidor e da S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a, que estabelece a responsabilidade objetiva das institui&ccedil;&otilde;es financeiras pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no &acirc;mbito de opera&ccedil;&otilde;es banc&aacute;rias.
+4. A mera intermedia&ccedil;&atilde;o operacional n&atilde;o afasta a legitimidade passiva da institui&ccedil;&atilde;o financeira quando inexiste nos autos prova de autoriza&ccedil;&atilde;o expressa do correntista para a realiza&ccedil;&atilde;o dos descontos, &ocirc;nus que incumbia ao banco, especialmente diante da invers&atilde;o do &ocirc;nus da prova reconhecida na pr&oacute;pria senten&ccedil;a recorrida.
+5. A extin&ccedil;&atilde;o prematura do feito em rela&ccedil;&atilde;o ao Banco Bradesco S/A, sem aprecia&ccedil;&atilde;o das demais preliminares suscitadas na contesta&ccedil;&atilde;o &ndash;  falta de interesse de agir, in&eacute;pcia da inicial, impugna&ccedil;&atilde;o &agrave; justi&ccedil;a gratuita, prescri&ccedil;&atilde;o e decad&ecirc;ncia &ndash; , impede o julgamento imediato do m&eacute;rito pelo Tribunal, pois a causa n&atilde;o se encontra madura para tanto, impondo-se a anula&ccedil;&atilde;o da senten&ccedil;a para que o ju&iacute;zo de origem aprecie todas as quest&otilde;es preliminares e, se for o caso, prossiga no exame do m&eacute;rito.
+IV. DISPOSITIVO
+Recurso provido para anular a senten&ccedil;a.
+Tese de julgamento:
+1. A institui&ccedil;&atilde;o financeira que administra conta corrente e efetua descontos em favor de terceiro, sem verificar a regular autoriza&ccedil;&atilde;o do titular, possui legitimidade passiva em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito, respondendo objetivamente pelos danos causados, nos termos do art. 14 do CDC e da S&uacute;mula 479 do STJ.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801548-20.2024.8.12.0020,&nbsp; Rio Brilhante,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Brilhante
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS. PRELIMINAR DE ILEGITIMIDADE PASSIVA ACOLHIDA NA ORIGEM. BANCO RESPONSÁVEL PELA GESTÃO E SEGURANÇA DA CONTA CORRENTE. DESCONTOS INDEVIDOS REALIZADOS SEM AUTORIZAÇÃO DA CORRENTISTA. RESPONSABILIDADE OBJETIVA. CDC. AUSÊNCIA DE APRECIAÇÃO DAS DEMAIS PRELIMINARES SUSCITADAS NA CONTESTAÇÃO. CAUSA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS. PRELIMINAR DE ILEGITIMIDADE PASSIVA ACOLHIDA NA ORIGEM. BANCO RESPONSÁVEL PELA GESTÃO E SEGURANÇA DA CONTA CORRENTE. DESCONTOS INDEVIDOS REALIZADOS SEM AUTORIZAÇÃO DA CORRENTISTA. RESPONSABILIDADE OBJETIVA. CDC. AUSÊNCIA DE APRECIAÇÃO DAS DEMAIS PRELIMINARES SUSCITADAS NA CONTESTAÇÃO. CAUSA NÃO MADURA PARA JULGAMENTO DIRETO. ANULAÇÃO DA SENTENÇA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por Julia Genésia Garcia contra sentença que acolheu a preliminar de ilegitimidade passiva do Banco Bradesco S/A e extinguiu o feito sem resolução de mérito, nos termos do art. 485, VI, do Código de Processo Civil, condenando a autora ao pagamento das custas processuais e honorários advocatícios, com exigibilidade suspensa em razão da gratuidade da justiça.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão central consiste em definir se o Banco Bradesco S/A detém legitimidade passiva para figurar no polo passivo de ação declaratória de inexistência de débito cumulada com indenização por danos materiais e morais, em razão de descontos realizados em conta corrente de sua titularidade sem autorização expressa da correntista.
+III. RAZÕES DE DECIDIR
+3. O banco que administra conta corrente e efetua descontos em favor de terceiro sem verificar a regularidade da autorização do correntista responde objetivamente pelos danos causados, nos termos do art. 14 do Código de Defesa do Consumidor e da Súmula 479 do Superior Tribunal de Justiça, que estabelece a responsabilidade objetiva das instituições financeiras pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no âmbito de operações bancárias.
+4. A mera intermediação operacional não afasta a legitimidade passiva da instituição financeira quando inexiste nos autos prova de autorização expressa do correntista para a realização dos descontos, ônus que incumbia ao banco, especialmente diante da inversão do ônus da prova reconhecida na própria sentença recorrida.
+5. A extinção prematura do feito em relação ao Banco Bradesco S/A, sem apreciação das demais preliminares suscitadas na contestação –  falta de interesse de agir, inépcia da inicial, impugnação à justiça gratuita, prescrição e decadência – , impede o julgamento imediato do mérito pelo Tribunal, pois a causa não se encontra madura para tanto, impondo-se a anulação da sentença para que o juízo de origem aprecie todas as questões preliminares e, se for o caso, prossiga no exame do mérito.
+IV. DISPOSITIVO
+Recurso provido para anular a sentença.
+Tese de julgamento:
+1. A instituição financeira que administra conta corrente e efetua descontos em favor de terceiro, sem verificar a regular autorização do titular, possui legitimidade passiva em ação declaratória de inexistência de débito, respondendo objetivamente pelos danos causados, nos termos do art. 14 do CDC e da Súmula 479 do STJ.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>42&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878307" cdForo="0" >
+										0806969-79.2023.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878307" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878307);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878307" style="display: none;" >
+	<div id="textAreaDados_1878307" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O DE DANOS MORAIS E EST&Eacute;TICOS &ndash; RECURSOS INTERPOSTOS PELAS EMPRESAS REQUERIDAS &ndash; CONCESSION&Aacute;RIA E PRESTADORA DE SERVI&Ccedil;OS P&Uacute;BLICOS &ndash;&nbsp;ACIDENTE&nbsp;DE TR&Acirc;NSITO COM MOTOCICLISTA &ndash;&nbsp; FIO SOLTO NA VIA P&Uacute;BLICA &ndash;  HIP&Oacute;TESE DE RESPONSABILIDADE OBJETIVA, PELA TEORIA DO RISCO ADMINISTRATIVO &ndash; NEXO CAUSAL DEMONSTRADO &ndash; CULPA DE TERCEIRO N&Atilde;O DEMONSTRADA &ndash; ALEGADA PROPRIEDADE E RESPONSABILIDADE DE OUTRA EMPRESA PELO FIO N&Atilde;O COMPROVADA &ndash; DANO MORAL CONFIGURADO &ndash; DANO EST&Eacute;TICO COMPROVADO. PEDIDO DE REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO &ndash; N&Atilde;O ACOLHIDO &ndash; ATENDIMENTO AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; SENTEN&Ccedil;A MANTIDA. RECURSOS DESPROVIDOS. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806969-79.2023.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE REPARAÇÃO DE DANOS MORAIS E ESTÉTICOS – RECURSOS INTERPOSTOS PELAS EMPRESAS REQUERIDAS – CONCESSIONÁRIA E PRESTADORA DE SERVIÇOS PÚBLICOS – ACIDENTE DE TRÂNSITO COM MOTOCICLISTA –  FIO SOLTO NA VIA PÚBLICA –  HIPÓTESE DE RESPONSABILIDADE OBJETIVA, PELA TEORIA DO RISCO ADMINISTRATIVO – NEXO CAUSAL DEMONSTRADO – CULPA DE TERCEIRO NÃO DEMONSTRADA – ALEGADA PROPRIEDADE E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE REPARAÇÃO DE DANOS MORAIS E ESTÉTICOS – RECURSOS INTERPOSTOS PELAS EMPRESAS REQUERIDAS – CONCESSIONÁRIA E PRESTADORA DE SERVIÇOS PÚBLICOS – ACIDENTE DE TRÂNSITO COM MOTOCICLISTA –  FIO SOLTO NA VIA PÚBLICA –  HIPÓTESE DE RESPONSABILIDADE OBJETIVA, PELA TEORIA DO RISCO ADMINISTRATIVO – NEXO CAUSAL DEMONSTRADO – CULPA DE TERCEIRO NÃO DEMONSTRADA – ALEGADA PROPRIEDADE E RESPONSABILIDADE DE OUTRA EMPRESA PELO FIO NÃO COMPROVADA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – <em>DANO</em> ESTÉTICO COMPROVADO. PEDIDO DE REDUÇÃO DO QUANTUM INDENIZATÓRIO – NÃO ACOLHIDO – ATENDIMENTO AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA MANTIDA. RECURSOS DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>43&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878356" cdForo="0" >
+										0806491-86.2024.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878356" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878356);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878356" style="display: none;" >
+	<div id="textAreaDados_1878356" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; ACORDO CELEBRADO COM UM DOS R&Eacute;US (INSTITUI&Ccedil;&Atilde;O FINANCEIRA) &ndash; SOLIDARIEDADE PASSIVA CONFIGURADA &ndash; ART. 7&ordm;, PAR&Aacute;GRAFO &Uacute;NICO, E ART. 25, &sect; 1&ordm;, AMBOS DO CDC &ndash; EXTENS&Atilde;O DOS EFEITOS DA TRANSA&Ccedil;&Atilde;O AO CODEVEDOR &ndash; ART. 844, &sect; 3&ordm;, DO C&Oacute;DIGO CIVIL &ndash; QUITA&Ccedil;&Atilde;O INTEGRAL DO OBJETO DA LIDE &ndash; EXTIN&Ccedil;&Atilde;O DA OBRIGA&Ccedil;&Atilde;O QUANTO A TODOS OS DEVEDORES &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A responsabilidade entre os integrantes da cadeia de fornecimento de servi&ccedil;os (banco e entidade conveniada) &eacute; solid&aacute;ria, nos termos do C&oacute;digo de Defesa do Consumidor.
+A transa&ccedil;&atilde;o celebrada entre o credor e um dos devedores solid&aacute;rios extingue a d&iacute;vida em rela&ccedil;&atilde;o aos demais co-devedores, salvo se houver ressalva expressa, o que n&atilde;o ocorreu no caso em tela.
+Uma vez quitado o valor acordado para dar fim &agrave; lide que discutia a inexist&ecirc;ncia do d&eacute;bito e o dano moral, a obriga&ccedil;&atilde;o est&aacute; satisfeita, n&atilde;o subsistindo interesse processual no prosseguimento do feito contra o corr&eacute;u.
+Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806491-86.2024.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – ACORDO CELEBRADO COM UM DOS RÉUS (INSTITUIÇÃO FINANCEIRA) – SOLIDARIEDADE PASSIVA CONFIGURADA – ART. 7º, PARÁGRAFO ÚNICO, E ART. 25, § 1º, AMBOS DO CDC – EXTENSÃO DOS EFEITOS DA TRANSAÇÃO AO CODEVEDOR – ART. 844, § 3º, DO CÓDIGO CIVIL – QUITAÇÃO INTEGRAL DO OBJETO DA LIDE – EXTINÇÃO DA OBRIGAÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – ACORDO CELEBRADO COM UM DOS RÉUS (INSTITUIÇÃO FINANCEIRA) – SOLIDARIEDADE PASSIVA CONFIGURADA – ART. 7º, PARÁGRAFO ÚNICO, E ART. 25, § 1º, AMBOS DO CDC – EXTENSÃO DOS EFEITOS DA TRANSAÇÃO AO CODEVEDOR – ART. 844, § 3º, DO CÓDIGO CIVIL – QUITAÇÃO INTEGRAL DO OBJETO DA LIDE – EXTINÇÃO DA OBRIGAÇÃO QUANTO A TODOS OS DEVEDORES – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+A responsabilidade entre os integrantes da cadeia de fornecimento de serviços (banco e entidade conveniada) é solidária, nos termos do Código de Defesa do Consumidor.
+A transação celebrada entre o credor e um dos devedores solidários extingue a dívida em relação aos demais co-devedores, salvo se houver ressalva expressa, o que não ocorreu no caso em tela.
+Uma vez quitado o valor acordado para dar fim à lide que discutia a inexistência do débito e o <em>dano</em> <em>moral</em>, a obrigação está satisfeita, não subsistindo interesse processual no prosseguimento do feito contra o corréu.
+Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>44&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878364" cdForo="0" >
+										0828473-76.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878364" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878364);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878364" style="display: none;" >
+	<div id="textAreaDados_1878364" class="mensagemSemFormatacao" >
+		EMENTA - APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZAT&Oacute;RIA &ndash; MOTORISTA DE APLICATIVO E PLATAFORMA DE TECNOLOGIA &ndash; DESCREDENCIAMENTO DE CONTA &ndash; LOCALIZA&Ccedil;&Atilde;O DE APONTAMENTO CRIMINAL ANTIGO COM TRANSA&Ccedil;&Atilde;O PENAL &ndash; IRRELEV&Acirc;NCIA PARA A SEARA CIVIL &ndash; LIBERDADE CONTRATUAL E AUTONOMIA DA VONTADE &ndash; EXERC&Iacute;CIO REGULAR DE DIREITO DA EMPRESA &ndash; VIOLA&Ccedil;&Atilde;O AOS TERMOS DE USO E &Agrave; POL&Iacute;TICA DE SEGURAN&Ccedil;A &ndash; IL&Iacute;CITO CIVIL N&Atilde;O CONFIGURADO &ndash; DANOS MORAIS E LUCROS CESSANTES INDEVIDOS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A rela&ccedil;&atilde;o havida entre os motoristas parceiros e as plataformas de aplicativos de transporte possui natureza civil, regendo-se pelos princ&iacute;pios da liberdade contratual e da autonomia da vontade (art. 421 do CC).
+Conquanto o cumprimento de transa&ccedil;&atilde;o penal obste a gera&ccedil;&atilde;o de maus antecedentes na esfera criminal, tal fato n&atilde;o retira da empresa privada o direito de rescindir a parceria, especialmente quando as diretrizes internas de seguran&ccedil;a &ndash;  previamente aceitas pelo usu&aacute;rio por meio dos Termos de Uso &ndash;  estabelecem a aus&ecirc;ncia de apontamentos criminais como requisito para a manuten&ccedil;&atilde;o do cadastro.
+O descredenciamento de motorista que deixa de preencher os requisitos de seguran&ccedil;a da plataforma configura exerc&iacute;cio regular de direito (art. 188, I, do CC), recha&ccedil;ando a configura&ccedil;&atilde;o de ato il&iacute;cito e, por consequ&ecirc;ncia, o dever de indenizar a t&iacute;tulo de lucros cessantes ou danos morais.
+Recurso conhecido e desprovido. Senten&ccedil;a mantida. Honor&aacute;rios recursais majorados, com exigibilidade suspensa.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0828473-76.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMENTA - APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZATÓRIA – MOTORISTA DE APLICATIVO E PLATAFORMA DE TECNOLOGIA – DESCREDENCIAMENTO DE CONTA – LOCALIZAÇÃO DE APONTAMENTO CRIMINAL ANTIGO COM TRANSAÇÃO PENAL – IRRELEVÂNCIA PARA A SEARA CIVIL – LIBERDADE CONTRATUAL E AUTONOMIA DA VONTADE – EXERCÍCIO REGULAR DE DIREITO DA EMPRESA – VIOLAÇÃO AOS TERMOS DE USO E À POLÍTICA DE SEGURANÇA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMENTA - APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZATÓRIA – MOTORISTA DE APLICATIVO E PLATAFORMA DE TECNOLOGIA – DESCREDENCIAMENTO DE CONTA – LOCALIZAÇÃO DE APONTAMENTO CRIMINAL ANTIGO COM TRANSAÇÃO PENAL – IRRELEVÂNCIA PARA A SEARA CIVIL – LIBERDADE CONTRATUAL E AUTONOMIA DA VONTADE – EXERCÍCIO REGULAR DE DIREITO DA EMPRESA – VIOLAÇÃO AOS TERMOS DE USO E À POLÍTICA DE SEGURANÇA – ILÍCITO CIVIL NÃO CONFIGURADO – DANOS MORAIS E LUCROS CESSANTES INDEVIDOS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+A relação havida entre os motoristas parceiros e as plataformas de aplicativos de transporte possui natureza civil, regendo-se pelos princípios da liberdade contratual e da autonomia da vontade (art. 421 do CC).
+Conquanto o cumprimento de transação penal obste a geração de maus antecedentes na esfera criminal, tal fato não retira da empresa privada o direito de rescindir a parceria, especialmente quando as diretrizes internas de segurança –  previamente aceitas pelo usuário por meio dos Termos de Uso –  estabelecem a ausência de apontamentos criminais como requisito para a manutenção do cadastro.
+O descredenciamento de motorista que deixa de preencher os requisitos de segurança da plataforma configura exercício regular de direito (art. 188, I, do CC), rechaçando a configuração de ato ilícito e, por consequência, o dever de indenizar a título de lucros cessantes ou danos morais.
+Recurso conhecido e desprovido. Sentença mantida. Honorários recursais majorados, com exigibilidade suspensa.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>45&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878371" cdForo="0" >
+										0806053-74.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878371" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878371);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878371" style="display: none;" >
+	<div id="textAreaDados_1878371" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; DESCONTOS N&Atilde;O AUTORIZADOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; INEXIST&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O RECONHECIDA NA ORIGEM &ndash; DANO MORAL CONFIGURADO &ndash; PRIVA&Ccedil;&Atilde;O DE VERBA DE NATUREZA ALIMENTAR &ndash; DANO IN RE IPSA &ndash; QUANTUM INDENIZAT&Oacute;RIO FIXADO EM R$ 5.000,00 &ndash; OBSERV&Acirc;NCIA AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; JUROS DE MORA &ndash; RESPONSABILIDADE EXTRACONTRATUAL &ndash; TERMO INICIAL A PARTIR DO EVENTO DANOSO &ndash; INTELIG&Ecirc;NCIA DA S&Uacute;MULA 54 DO SUPERIOR TRIBUNAL DE JUSTI&Ccedil;A &ndash; REDISTRIBUI&Ccedil;&Atilde;O DO &Ocirc;NUS DE SUCUMB&Ecirc;NCIA &ndash; RECURSO CONHECIDO E PROVIDO EM TERMOS.
+A realiza&ccedil;&atilde;o de descontos n&atilde;o autorizados em benef&iacute;cio previdenci&aacute;rio, verba de ineg&aacute;vel car&aacute;ter alimentar essencial &agrave; subsist&ecirc;ncia, extrapola o mero aborrecimento cotidiano e configura dano moral presumido (in re ipsa), ensejando o dever de indenizar.
+Na fixa&ccedil;&atilde;o do quantum indenizat&oacute;rio, deve o magistrado observar os princ&iacute;pios da razoabilidade e da proporcionalidade, atendendo &agrave; dupla finalidade da condena&ccedil;&atilde;o (compensat&oacute;ria e pedag&oacute;gica), sem propiciar o enriquecimento sem causa da v&iacute;tima. O valor de R$ 5.000,00 (cinco mil reais) revela-se adequado &agrave;s circunst&acirc;ncias do caso e aos precedentes da C&acirc;mara.
+Tratando-se de responsabilidade extracontratual decorrente de fraude ou inexist&ecirc;ncia de contrata&ccedil;&atilde;o, os juros de mora incidentes sobre a indeniza&ccedil;&atilde;o por danos morais fluem a partir do evento danoso (data do primeiro desconto indevido), nos moldes da S&uacute;mula 54 do Superior Tribunal de Justi&ccedil;a.
+Recurso conhecido e provido em termos. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806053-74.2025.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – DESCONTOS NÃO AUTORIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – INEXISTÊNCIA DE CONTRATAÇÃO RECONHECIDA NA ORIGEM – <em>DANO</em> <em>MORAL</em> CONFIGURADO – PRIVAÇÃO DE VERBA DE NATUREZA ALIMENTAR – <em>DANO</em> IN RE IPSA – QUANTUM INDENIZATÓRIO FIXADO EM R$ 5.000,00 –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – DESCONTOS NÃO AUTORIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – INEXISTÊNCIA DE CONTRATAÇÃO RECONHECIDA NA ORIGEM – <em>DANO</em> <em>MORAL</em> CONFIGURADO – PRIVAÇÃO DE VERBA DE NATUREZA ALIMENTAR – <em>DANO</em> IN RE IPSA – QUANTUM INDENIZATÓRIO FIXADO EM R$ 5.000,00 – OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – JUROS DE MORA – RESPONSABILIDADE EXTRACONTRATUAL – TERMO INICIAL A PARTIR DO EVENTO DANOSO – INTELIGÊNCIA DA SÚMULA 54 DO SUPERIOR TRIBUNAL DE JUSTIÇA – REDISTRIBUIÇÃO DO ÔNUS DE SUCUMBÊNCIA – RECURSO CONHECIDO E PROVIDO EM TERMOS.
+A realização de descontos não autorizados em benefício previdenciário, verba de inegável caráter alimentar essencial à subsistência, extrapola o mero aborrecimento cotidiano e configura <em>dano</em> <em>moral</em> presumido (in re ipsa), ensejando o dever de indenizar.
+Na fixação do quantum indenizatório, deve o magistrado observar os princípios da razoabilidade e da proporcionalidade, atendendo à dupla finalidade da condenação (compensatória e pedagógica), sem propiciar o enriquecimento sem causa da vítima. O valor de R$ 5.000,00 (cinco mil reais) revela-se adequado às circunstâncias do caso e aos precedentes da Câmara.
+Tratando-se de responsabilidade extracontratual decorrente de fraude ou inexistência de contratação, os juros de mora incidentes sobre a indenização por danos morais fluem a partir do evento danoso (data do primeiro desconto indevido), nos moldes da Súmula 54 do Superior Tribunal de Justiça.
+Recurso conhecido e provido em termos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>46&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878382" cdForo="0" >
+										0801982-24.2024.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878382" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878382);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878382" style="display: none;" >
+	<div id="textAreaDados_1878382" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE NEG&Oacute;CIO JUR&Iacute;DICO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; PEDIDO DE MAJORA&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO &ndash; IMPOSSIBILIDADE &ndash; VALOR ARBITRADO EM CONSON&Acirc;NCIA COM OS PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE &ndash; MAJORA&Ccedil;&Atilde;O DOS HONOR&Aacute;RIOS SUCUMBENCIAIS OU FIXA&Ccedil;&Atilde;O POR EQUIDADE &ndash; DESCABIMENTO &ndash; APLICA&Ccedil;&Atilde;O DO TEMA 1.076 DO STJ E DO ART. 85, &sect; 2&ordm;, DO CPC &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+O valor da indeniza&ccedil;&atilde;o por danos morais deve ser fixado com modera&ccedil;&atilde;o, em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e da proporcionalidade, servindo para compensar a v&iacute;tima pelo abalo sofrido e punir o ofensor, sem importar em enriquecimento sem causa. A quantia de R$ 4.000,00 revela-se adequada e suficiente para as peculiaridades do caso.
+Havendo condena&ccedil;&atilde;o mensur&aacute;vel em dinheiro, os honor&aacute;rios advocat&iacute;cios devem ser fixados entre 10% e 20% sobre esse valor, conforme o art. 85, &sect; 2&ordm;, do CPC, sendo vedada a fixa&ccedil;&atilde;o por aprecia&ccedil;&atilde;o equitativa, em estrita observ&acirc;ncia ao Tema Repetitivo n&ordm; 1.076 do Superior Tribunal de Justi&ccedil;a. O percentual de 15% fixado na origem remunera adequadamente o trabalho desenvolvido.
+Tratando-se de recurso integralmente desprovido, imp&otilde;e-se a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios, por for&ccedil;a do disposto no &sect; 11 do art. 85 do CPC.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801982-24.2024.8.12.0015,&nbsp; Miranda,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – PEDIDO DE MAJORAÇÃO DO QUANTUM INDENIZATÓRIO – IMPOSSIBILIDADE – VALOR ARBITRADO EM CONSONÂNCIA COM OS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE – MAJORAÇÃO DOS HONORÁRIOS SUCUMBENCIAIS OU FIXAÇÃO POR EQUIDADE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – PEDIDO DE MAJORAÇÃO DO QUANTUM INDENIZATÓRIO – IMPOSSIBILIDADE – VALOR ARBITRADO EM CONSONÂNCIA COM OS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE – MAJORAÇÃO DOS HONORÁRIOS SUCUMBENCIAIS OU FIXAÇÃO POR EQUIDADE – DESCABIMENTO – APLICAÇÃO DO TEMA 1.076 DO STJ E DO ART. 85, § 2º, DO CPC – RECURSO CONHECIDO E NÃO PROVIDO.
+O valor da indenização por danos morais deve ser fixado com moderação, em observância aos princípios da razoabilidade e da proporcionalidade, servindo para compensar a vítima pelo abalo sofrido e punir o ofensor, sem importar em enriquecimento sem causa. A quantia de R$ 4.000,00 revela-se adequada e suficiente para as peculiaridades do caso.
+Havendo condenação mensurável em dinheiro, os honorários advocatícios devem ser fixados entre 10% e 20% sobre esse valor, conforme o art. 85, § 2º, do CPC, sendo vedada a fixação por apreciação equitativa, em estrita observância ao Tema Repetitivo nº 1.076 do Superior Tribunal de Justiça. O percentual de 15% fixado na origem remunera adequadamente o trabalho desenvolvido.
+Tratando-se de recurso integralmente desprovido, impõe-se a majoração dos honorários advocatícios, por força do disposto no § 11 do art. 85 do CPC.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>47&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878383" cdForo="0" >
+										0850718-18.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878383" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878383);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878383" style="display: none;" >
+	<div id="textAreaDados_1878383" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL (RMC) C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E RESTITUI&Ccedil;&Atilde;O DE VALORES &ndash; CONTRATA&Ccedil;&Atilde;O V&Aacute;LIDA &ndash; AUS&Ecirc;NCIA DE V&Iacute;CIO DE CONSENTIMENTO &ndash; INFORMA&Ccedil;&Otilde;ES CLARAS NO INSTRUMENTO CONTRATUAL &ndash; SAQUE DO LIMITE DE CR&Eacute;DITO &ndash; OPERA&Ccedil;&Atilde;O REGULAR E INERENTE &Agrave; MODALIDADE &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA &ndash; HONOR&Aacute;RIOS RECURSAIS FIXADOS &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+&Eacute; l&iacute;cita e v&aacute;lida a contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito com reserva de margem consign&aacute;vel (RMC) quando o instrumento assinado pelo consumidor disp&otilde;e de forma expressa sobre a modalidade do cr&eacute;dito, a autoriza&ccedil;&atilde;o para desconto do m&iacute;nimo da fatura e a incid&ecirc;ncia de juros rotativos.
+A realiza&ccedil;&atilde;o de saque do limite de cr&eacute;dito disponibilizado no cart&atilde;o, com a correspondente transfer&ecirc;ncia do numer&aacute;rio para a conta banc&aacute;ria do consumidor, constitui opera&ccedil;&atilde;o regular e prevista para esta esp&eacute;cie de pacto, n&atilde;o configurando, de forma isolada, abusividade ou induzimento a erro. Inexistindo prova de v&iacute;cio de consentimento e n&atilde;o demonstrada qualquer falha na presta&ccedil;&atilde;o do servi&ccedil;o pela institui&ccedil;&atilde;o financeira, a manuten&ccedil;&atilde;o da senten&ccedil;a que julgou improcedentes os pedidos iniciais &eacute; medida que se imp&otilde;e.
+Desprovido integralmente o recurso, &eacute; devida a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios de sucumb&ecirc;ncia, conforme a regra do artigo 85, &sect; 11, do C&oacute;digo de Processo Civil.
+Recurso conhecido e n&atilde;o provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0850718-18.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC) C/C INDENIZAÇÃO POR DANOS MORAIS E RESTITUIÇÃO DE VALORES – CONTRATAÇÃO VÁLIDA – AUSÊNCIA DE VÍCIO DE CONSENTIMENTO – INFORMAÇÕES CLARAS NO INSTRUMENTO CONTRATUAL – SAQUE DO LIMITE DE CRÉDITO – OPERAÇÃO REGULAR E INERENTE À MODALIDADE – SENTENÇA DE IMPROCEDÊNCIA MANTIDA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC) C/C INDENIZAÇÃO POR DANOS MORAIS E RESTITUIÇÃO DE VALORES – CONTRATAÇÃO VÁLIDA – AUSÊNCIA DE VÍCIO DE CONSENTIMENTO – INFORMAÇÕES CLARAS NO INSTRUMENTO CONTRATUAL – SAQUE DO LIMITE DE CRÉDITO – OPERAÇÃO REGULAR E INERENTE À MODALIDADE – SENTENÇA DE IMPROCEDÊNCIA MANTIDA – HONORÁRIOS RECURSAIS FIXADOS – RECURSO CONHECIDO E NÃO PROVIDO.
+É lícita e válida a contratação de cartão de crédito com reserva de margem consignável (RMC) quando o instrumento assinado pelo consumidor dispõe de forma expressa sobre a modalidade do crédito, a autorização para desconto do mínimo da fatura e a incidência de juros rotativos.
+A realização de saque do limite de crédito disponibilizado no cartão, com a correspondente transferência do numerário para a conta bancária do consumidor, constitui operação regular e prevista para esta espécie de pacto, não configurando, de forma isolada, abusividade ou induzimento a erro. Inexistindo prova de vício de consentimento e não demonstrada qualquer falha na prestação do serviço pela instituição financeira, a manutenção da sentença que julgou improcedentes os pedidos iniciais é medida que se impõe.
+Desprovido integralmente o recurso, é devida a majoração dos honorários advocatícios de sucumbência, conforme a regra do artigo 85, § 11, do Código de Processo Civil.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>48&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878387" cdForo="0" >
+										1402247-51.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878387" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878387);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878387" style="display: none;" >
+	<div id="textAreaDados_1878387" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; TUTELA DE URG&Ecirc;NCIA &ndash; CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC) &ndash; PEDIDO DE CANCELAMENTO DO CART&Atilde;O E SUSPENS&Atilde;O DOS DESCONTOS EM FOLHA DE PAGAMENTO &ndash; DIREITO POTESTATIVO DO CONSUMIDOR DE RESCINDIR O SERVI&Ccedil;O DE CR&Eacute;DITO &ndash; CANCELAMENTO DO PL&Aacute;STICO DEVIDO &ndash; SUSPENS&Atilde;O DOS DESCONTOS MENSAIS &ndash; IMPOSSIBILIDADE &ndash; MANUTEN&Ccedil;&Atilde;O AT&Eacute; A QUITA&Ccedil;&Atilde;O DE EVENTUAL SALDO DEVEDOR PREEXISTENTE &ndash; DECIS&Atilde;O PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O consumidor possui o direito potestativo de postular o cancelamento de cart&atilde;o de cr&eacute;dito a qualquer tempo, a fim de evitar a cobran&ccedil;a de novos encargos e anuidades atrelados &agrave; mera disponibiliza&ccedil;&atilde;o do servi&ccedil;o, restando preenchidos os requisitos do art. 300 do CPC neste aspecto. O cancelamento do cart&atilde;o de cr&eacute;dito n&atilde;o extingue a d&iacute;vida contra&iacute;da em momento anterior &agrave; rescis&atilde;o. Inexistindo prova inequ&iacute;voca da quita&ccedil;&atilde;o integral do d&eacute;bito, revela-se invi&aacute;vel a suspens&atilde;o imediata dos descontos efetuados na folha de pagamento da parte agravante, devendo as consigna&ccedil;&otilde;es serem mantidas para a amortiza&ccedil;&atilde;o do saldo devedor at&eacute; o seu integral adimplemento.
+Recurso conhecido e parcialmente provido.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1402247-51.2026.8.12.0000,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C OBRIGAÇÃO DE FAZER – TUTELA DE URGÊNCIA – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – PEDIDO DE CANCELAMENTO DO CARTÃO E SUSPENSÃO DOS DESCONTOS EM FOLHA DE PAGAMENTO – DIREITO POTESTATIVO DO CONSUMIDOR DE RESCINDIR O SERVIÇO DE CRÉDITO – CANCELAMENTO DO PLÁSTICO DEVIDO – SUSPENSÃO DOS DESCONTOS MENSAIS – IMPOSSIBILIDADE –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C OBRIGAÇÃO DE FAZER – TUTELA DE URGÊNCIA – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – PEDIDO DE CANCELAMENTO DO CARTÃO E SUSPENSÃO DOS DESCONTOS EM FOLHA DE PAGAMENTO – DIREITO POTESTATIVO DO CONSUMIDOR DE RESCINDIR O SERVIÇO DE CRÉDITO – CANCELAMENTO DO PLÁSTICO DEVIDO – SUSPENSÃO DOS DESCONTOS MENSAIS – IMPOSSIBILIDADE – MANUTENÇÃO ATÉ A QUITAÇÃO DE EVENTUAL SALDO DEVEDOR PREEXISTENTE – DECISÃO PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O consumidor possui o direito potestativo de postular o cancelamento de cartão de crédito a qualquer tempo, a fim de evitar a cobrança de novos encargos e anuidades atrelados à mera disponibilização do serviço, restando preenchidos os requisitos do art. 300 do CPC neste aspecto. O cancelamento do cartão de crédito não extingue a dívida contraída em momento anterior à rescisão. Inexistindo prova inequívoca da quitação integral do débito, revela-se inviável a suspensão imediata dos descontos efetuados na folha de pagamento da parte agravante, devendo as consignações serem mantidas para a amortização do saldo devedor até o seu integral adimplemento.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>49&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878407" cdForo="0" >
+										0823803-97.2022.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878407" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878407);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878407" style="display: none;" >
+	<div id="textAreaDados_1878407" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSOS DE APELA&Ccedil;&Atilde;O E RECURSO ADESIVO. COBRAN&Ccedil;A VEXAT&Oacute;RIA POR LIGA&Ccedil;&Otilde;ES EXCESSIVAS AP&Oacute;S DECLARA&Ccedil;&Atilde;O DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO. RECURSOS DESPROVIDOS.
+CASO EM EXAME
+Recursos de apela&ccedil;&atilde;o interpostos por Banco Votorantim S/A e, adesivamente, por Geovano de O. contra senten&ccedil;a que julgou procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, em raz&atilde;o de cobran&ccedil;as indevidas e reiteradas, inclusive no local de trabalho do autor, fixando indeniza&ccedil;&atilde;o em R$ 10.000,00, com crit&eacute;rios de corre&ccedil;&atilde;o monet&aacute;ria e juros, e definindo honor&aacute;rios.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) saber se a conduta de cobran&ccedil;a, com liga&ccedil;&otilde;es excessivas e reiteradas, inclusive ao local de trabalho do consumidor, ap&oacute;s reconhecimento judicial da inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica, configura dano moral indeniz&aacute;vel, &agrave; luz do CDC e da responsabilidade objetiva do fornecedor; e (ii) saber se o quantum indenizat&oacute;rio de R$ 10.000,00 e os crit&eacute;rios de atualiza&ccedil;&atilde;o (inclusive com aplica&ccedil;&atilde;o da SELIC nos termos definidos na senten&ccedil;a em raz&atilde;o de legisla&ccedil;&atilde;o superveniente) devem ser alterados, bem como se &eacute; cab&iacute;vel a majora&ccedil;&atilde;o do dano moral e dos honor&aacute;rios no recurso adesivo.
+RAZ&Otilde;ES DE DECIDIR
+Manteve-se a senten&ccedil;a quanto &agrave; responsabilidade do banco e ao dever de indenizar, porque a controv&eacute;rsia &eacute; regida pelo CDC (CDC, art. 3&ordm;, &sect; 2&ordm;; S&uacute;mula n&ordm; 297 do STJ) e a responsabilidade do fornecedor &eacute; objetiva (CDC, art. 14). Reconheceram-se hipossufici&ecirc;ncia e verossimilhan&ccedil;a, autorizando a invers&atilde;o do &ocirc;nus da prova (CDC, art. 6&ordm;, VIII), sem que o r&eacute;u demonstrasse excludente. A prova testemunhal descreveu liga&ccedil;&otilde;es reiteradas e cobran&ccedil;a indevida de d&iacute;vida j&aacute; declarada inexistente, inclusive no local de trabalho, com exposi&ccedil;&atilde;o do autor e impacto no v&iacute;nculo empregat&iacute;cio. A situa&ccedil;&atilde;o excede mero aborrecimento e configura dano moral, com amparo em CF/1988, art. 5&ordm;, incs. V e X, CC, art. 186, e CDC, art. 6&ordm;, VI, conforme precedentes citados no voto (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 29/04/2025, p. 05/05/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0805745-24.2024.8.12.0018, Rel. Des&ordf; Jaceguara Dantas da Silva, 5&ordf; C&acirc;mara C&iacute;vel, j. 26/03/2025, p. 28/03/2025).
+Rejeitou-se a pretens&atilde;o de redu&ccedil;&atilde;o do quantum, porque o valor de R$ 10.000,00 foi considerado proporcional &agrave; gravidade da cobran&ccedil;a indevida e reiterada, especialmente no ambiente de trabalho, e adequado &agrave;s fun&ccedil;&otilde;es compensat&oacute;ria, preventiva e punitiva da repara&ccedil;&atilde;o, sem ensejar enriquecimento sem causa e com preserva&ccedil;&atilde;o do car&aacute;ter pedag&oacute;gico.
+Manteve-se a disciplina de corre&ccedil;&atilde;o monet&aacute;ria e juros, porque a senten&ccedil;a j&aacute; aplicou a legisla&ccedil;&atilde;o superveniente (Lei n&ordm; 000), estabelecendo, a partir de 28/08/2024, corre&ccedil;&atilde;o pelo IPCA/IBGE e juros pela SELIC, deduzido o &iacute;ndice de atualiza&ccedil;&atilde;o, al&eacute;m de fixar, at&eacute; 27/08/2024, corre&ccedil;&atilde;o pelo IPCA e juros de 1% ao m&ecirc;s, com refer&ecirc;ncia a CC, art. 406, CTN, art. 161, &sect; 1&ordm;, e CC, art. 389, p.u.
+Negou-se provimento ao recurso adesivo do autor, porque o colegiado considerou adequado o montante de R$ 10.000,00 fixado a t&iacute;tulo de danos morais e n&atilde;o acolheu a majora&ccedil;&atilde;o pretendida, inclusive quanto aos honor&aacute;rios, conforme conclus&atilde;o expressa do voto.
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o do Banco Votorantim S/A conhecido e desprovido. Recurso adesivo de Geovano de Oliveira. conhecido e desprovido.
+Dispositivos relevantes citados: CDC, art. 3&ordm;, &sect; 2&ordm;; CDC, art. 6&ordm;, incs. VI e VIII; CDC, art. 14; CF/1988, art. 5&ordm;, incs. V e X; CC, art. 186; CC, art. 389, p.u.; CC, art. 406; CTN, art. 161, &sect; 1&ordm;; e CPC, art. 373, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula n&ordm; 297; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 29/04/2025, p. 05/05/2025; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0805745-24.2024.8.12.0018, Rel. Des&ordf; Jaceguara Dantas da Silva, 5&ordf; C&acirc;mara C&iacute;vel, j. 26/03/2025, p. 28/03/2025. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0823803-97.2022.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(17 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSOS DE APELAÇÃO E RECURSO ADESIVO. COBRANÇA VEXATÓRIA POR LIGAÇÕES EXCESSIVAS APÓS DECLARAÇÃO DE INEXISTÊNCIA DE DÉBITO. RECURSOS DESPROVIDOS.
+CASO EM EXAME
+Recursos de apelação interpostos por Banco Votorantim S/A e, adesivamente, por Geovano de O. contra sentença que julgou procedente ação de indenização por danos morais, em razão de cobranças
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSOS DE APELAÇÃO E RECURSO ADESIVO. COBRANÇA VEXATÓRIA POR LIGAÇÕES EXCESSIVAS APÓS DECLARAÇÃO DE INEXISTÊNCIA DE DÉBITO. RECURSOS DESPROVIDOS.
+CASO EM EXAME
+Recursos de apelação interpostos por Banco Votorantim S/A e, adesivamente, por Geovano de O. contra sentença que julgou procedente ação de indenização por danos morais, em razão de cobranças indevidas e reiteradas, inclusive no local de trabalho do autor, fixando indenização em R$ 10.000,00, com critérios de correção monetária e juros, e definindo honorários.
+QUESTÃO EM DISCUSSÃO
+Há duas questões em discussão: (i) saber se a conduta de cobrança, com ligações excessivas e reiteradas, inclusive ao local de trabalho do consumidor, após reconhecimento judicial da inexistência de relação jurídica, configura <em>dano</em> <em>moral</em> indenizável, à luz do CDC e da responsabilidade objetiva do fornecedor; e (ii) saber se o quantum indenizatório de R$ 10.000,00 e os critérios de atualização (inclusive com aplicação da SELIC nos termos definidos na sentença em razão de legislação superveniente) devem ser alterados, bem como se é cabível a majoração do <em>dano</em> <em>moral</em> e dos honorários no recurso adesivo.
+RAZÕES DE DECIDIR
+Manteve-se a sentença quanto à responsabilidade do banco e ao dever de indenizar, porque a controvérsia é regida pelo CDC (CDC, art. 3º, § 2º; Súmula nº 297 do STJ) e a responsabilidade do fornecedor é objetiva (CDC, art. 14). Reconheceram-se hipossuficiência e verossimilhança, autorizando a inversão do ônus da prova (CDC, art. 6º, VIII), sem que o réu demonstrasse excludente. A prova testemunhal descreveu ligações reiteradas e cobrança indevida de dívida já declarada inexistente, inclusive no local de trabalho, com exposição do autor e impacto no vínculo empregatício. A situação excede mero aborrecimento e configura <em>dano</em> <em>moral</em>, com amparo em CF/1988, art. 5º, incs. V e X, CC, art. 186, e CDC, art. 6º, VI, conforme precedentes citados no voto (TJMS, Apelação Cível n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 29/04/2025, p. 05/05/2025; TJMS, Apelação Cível n. 0805745-24.2024.8.12.0018, Rel. Desª Jaceguara Dantas da Silva, 5ª Câmara Cível, j. 26/03/2025, p. 28/03/2025).
+Rejeitou-se a pretensão de redução do quantum, porque o valor de R$ 10.000,00 foi considerado proporcional à gravidade da cobrança indevida e reiterada, especialmente no ambiente de trabalho, e adequado às funções compensatória, preventiva e punitiva da reparação, sem ensejar enriquecimento sem causa e com preservação do caráter pedagógico.
+Manteve-se a disciplina de correção monetária e juros, porque a sentença já aplicou a legislação superveniente (Lei nº 000), estabelecendo, a partir de 28/08/2024, correção pelo IPCA/IBGE e juros pela SELIC, deduzido o índice de atualização, além de fixar, até 27/08/2024, correção pelo IPCA e juros de 1% ao mês, com referência a CC, art. 406, CTN, art. 161, § 1º, e CC, art. 389, p.u.
+Negou-se provimento ao recurso adesivo do autor, porque o colegiado considerou adequado o montante de R$ 10.000,00 fixado a título de danos morais e não acolheu a majoração pretendida, inclusive quanto aos honorários, conforme conclusão expressa do voto.
+DISPOSITIVO
+Recurso de apelação do Banco Votorantim S/A conhecido e desprovido. Recurso adesivo de Geovano de Oliveira. conhecido e desprovido.
+Dispositivos relevantes citados: CDC, art. 3º, § 2º; CDC, art. 6º, incs. VI e VIII; CDC, art. 14; CF/1988, art. 5º, incs. V e X; CC, art. 186; CC, art. 389, p.u.; CC, art. 406; CTN, art. 161, § 1º; e CPC, art. 373, I.
+Jurisprudência relevante citada: STJ, Súmula nº 297; TJMS, Apelação Cível n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 29/04/2025, p. 05/05/2025; e TJMS, Apelação Cível n. 0805745-24.2024.8.12.0018, Rel. Desª Jaceguara Dantas da Silva, 5ª Câmara Cível, j. 26/03/2025, p. 28/03/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>50&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878409" cdForo="0" >
+										0832601-76.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878409" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878409);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878409" style="display: none;" >
+	<div id="textAreaDados_1878409" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSO DE APELA&Ccedil;&Atilde;O. A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. PAGAMENTO DE BOLETO/PIX FRAUDULENTO EM SUPOSTO SITE DE CONCESSION&Aacute;RIA DE ENERGIA EL&Eacute;TRICA. RESPONSABILIDADE OBJETIVA E EXCLUDENTE POR CULPA EXCLUSIVA DE TERCEIRO. SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.
+CASO EM EXAME
+Recurso de apela&ccedil;&atilde;o interposto por Z.A.S. e J.A. contra senten&ccedil;a que julgou improcedentes pedidos de restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais, em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos materiais e morais fundada em pagamento fraudulento de faturas de energia el&eacute;trica.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em saber se o pagamento de faturas por meio de PIX/boletos gerados em ambiente digital, com benefici&aacute;rio diverso da concession&aacute;ria, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o apta a caracterizar fortuito interno e a gerar dever de restitui&ccedil;&atilde;o e indeniza&ccedil;&atilde;o, ou se h&aacute; excludente de responsabilidade por fato de terceiro e aus&ecirc;ncia de nexo causal, nos termos do art. 14, &sect; 3&ordm;, II, do CDC.
+RAZ&Otilde;ES DE DECIDIR
+Reconheceu-se a rela&ccedil;&atilde;o de consumo (CDC, arts. 2&ordm; e 3&ordm;) e a responsabilidade objetiva do fornecedor (CDC, art. 14). Assentou-se, contudo, que essa responsabilidade pode ser afastada quando configurada excludente legal (CDC, art. 14, &sect; 3&ordm;).
+Afastou-se a responsabilidade da concession&aacute;ria e manteve-se a improced&ecirc;ncia, porque os comprovantes indicaram benefici&aacute;rios distintos da r&eacute; (X55 e Autentica Pag Ltda.), sem prova segura de acesso ao site oficial para emiss&atilde;o de boleto. Concluiu-se pela aus&ecirc;ncia de nexo causal e pela configura&ccedil;&atilde;o de excludente de responsabilidade (CDC, art. 14, &sect; 3&ordm;, II), pois a fraude foi praticada por terceiro e os autores n&atilde;o demonstraram cautela m&iacute;nima. Aplicaram-se, como refor&ccedil;o, precedentes do pr&oacute;prio Tribunal em casos de pagamento de boleto fraudulento (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801316-17.2024.8.12.0017, Rel. Des&ordf; E.R.B., 4&ordf; C&acirc;mara C&iacute;vel, j. 26.11.2025, p. 27.11.2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 09.05.2025, p. 12.05.2025).
+Fixaram-se honor&aacute;rios recursais em 2% sobre o valor da causa, a serem somados aos honor&aacute;rios fixados na origem. Suspendeu-se a exigibilidade na forma do CPC, art. 98, &sect; 3&ordm;.
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o conhecido e desprovido.
+Dispositivos relevantes citados: CDC, arts. 2&ordm;, 3&ordm; e 14, &sect; 3&ordm;, II; e CPC, art. 98, &sect; 3&ordm;.
+Jurisprud&ecirc;ncia relevante citada: TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801316-17.2024.8.12.0017, Rel. Des&ordf; E.R.B., 4&ordf; C&acirc;mara C&iacute;vel, j. 26.11.2025, p. 27.11.2025; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 09.05.2025, p. 12.05.2025  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0832601-76.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSO DE APELAÇÃO. AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – SENTENÇA DE IMPROCEDÊNCIA. PAGAMENTO DE BOLETO/PIX FRAUDULENTO EM SUPOSTO SITE DE CONCESSIONÁRIA DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E EXCLUDENTE POR CULPA EXCLUSIVA DE TERCEIRO. SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Z.A.S. e
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSO DE APELAÇÃO. AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – SENTENÇA DE IMPROCEDÊNCIA. PAGAMENTO DE BOLETO/PIX FRAUDULENTO EM SUPOSTO SITE DE CONCESSIONÁRIA DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E EXCLUDENTE POR CULPA EXCLUSIVA DE TERCEIRO. SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Z.A.S. e J.A. contra sentença que julgou improcedentes pedidos de restituição de valores e indenização por danos morais, em ação de indenização por danos materiais e morais fundada em pagamento fraudulento de faturas de energia elétrica.
+QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em saber se o pagamento de faturas por meio de PIX/boletos gerados em ambiente digital, com beneficiário diverso da concessionária, configura falha na prestação do serviço apta a caracterizar fortuito interno e a gerar dever de restituição e indenização, ou se há excludente de responsabilidade por fato de terceiro e ausência de nexo causal, nos termos do art. 14, § 3º, II, do CDC.
+RAZÕES DE DECIDIR
+Reconheceu-se a relação de consumo (CDC, arts. 2º e 3º) e a responsabilidade objetiva do fornecedor (CDC, art. 14). Assentou-se, contudo, que essa responsabilidade pode ser afastada quando configurada excludente legal (CDC, art. 14, § 3º).
+Afastou-se a responsabilidade da concessionária e manteve-se a improcedência, porque os comprovantes indicaram beneficiários distintos da ré (X55 e Autentica Pag Ltda.), sem prova segura de acesso ao site oficial para emissão de boleto. Concluiu-se pela ausência de nexo causal e pela configuração de excludente de responsabilidade (CDC, art. 14, § 3º, II), pois a fraude foi praticada por terceiro e os autores não demonstraram cautela mínima. Aplicaram-se, como reforço, precedentes do próprio Tribunal em casos de pagamento de boleto fraudulento (TJMS, Apelação Cível n. 0801316-17.2024.8.12.0017, Rel. Desª E.R.B., 4ª Câmara Cível, j. 26.11.2025, p. 27.11.2025; TJMS, Apelação Cível n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 09.05.2025, p. 12.05.2025).
+Fixaram-se honorários recursais em 2% sobre o valor da causa, a serem somados aos honorários fixados na origem. Suspendeu-se a exigibilidade na forma do CPC, art. 98, § 3º.
+DISPOSITIVO
+Recurso de apelação conhecido e desprovido.
+Dispositivos relevantes citados: CDC, arts. 2º, 3º e 14, § 3º, II; e CPC, art. 98, § 3º.
+Jurisprudência relevante citada: TJMS, Apelação Cível n. 0801316-17.2024.8.12.0017, Rel. Desª E.R.B., 4ª Câmara Cível, j. 26.11.2025, p. 27.11.2025; e TJMS, Apelação Cível n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 09.05.2025, p. 12.05.2025
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>51&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878413" cdForo="0" >
+										0824187-89.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878413" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878413);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878413" style="display: none;" >
+	<div id="textAreaDados_1878413" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O &ndash; TRANSPORTE A&Eacute;REO &ndash; 	SENTEN&Ccedil;A DE PARCIAL PROCED&Ecirc;NCIA. TRANSPORTE A&Eacute;REO -  OVERBOOKING &ndash; RESPONSABILIDADE OBJETIVA &ndash; DANO MORAL CONFIGURADO &ndash; VALOR FIXADO PREENCHE OS REQUISITOS DA RAZOABILIDADE E PROPORCIONALIDADE.  SENTEN&Ccedil;A DEVIDAMENTE FUNDAMENTADA, RAZ&Atilde;O PORQUE DEVE SER MANTIDA. RECURSO CONHECIDO E DESPROVIDO. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0824187-89.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1878413" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO – TRANSPORTE AÉREO – 	SENTENÇA DE PARCIAL PROCEDÊNCIA. TRANSPORTE AÉREO -  OVERBOOKING – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – VALOR FIXADO PREENCHE OS REQUISITOS DA RAZOABILIDADE E PROPORCIONALIDADE.  SENTENÇA DEVIDAMENTE FUNDAMENTADA, RAZÃO PORQUE DEVE SER MANTIDA. RECURSO CONHECIDO E DESPROVIDO.
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>52&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878420" cdForo="0" >
+										0837422-89.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878420" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878420);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878420" style="display: none;" >
+	<div id="textAreaDados_1878420" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. PLANO DE SA&Uacute;DE. LEGITIMIDADE UNIMED CAMPO GRANDE CONFIRMADA. NEGATIVA DE COBERTURA DE PROCEDIMENTO CIR&Uacute;RGICO INDEVIDA. INDENIZA&Ccedil;&Atilde;O CAB&Iacute;VEL. QUANTUM RAZO&Aacute;VEL. SENTEN&Ccedil;A MANTIDA. RECURSO CONHECIDO E DESPROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0837422-89.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1878420" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												APELAÇÃO CÍVEL. AÇÃO DE OBRIGAÇÃO DE FAZER. PLANO DE SAÚDE. LEGITIMIDADE UNIMED CAMPO GRANDE CONFIRMADA. NEGATIVA DE COBERTURA DE PROCEDIMENTO CIRÚRGICO INDEVIDA. INDENIZAÇÃO CABÍVEL. QUANTUM RAZOÁVEL. SENTENÇA MANTIDA. RECURSO CONHECIDO E DESPROVIDO.
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>53&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878422" cdForo="0" >
+										0829907-03.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878422" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878422);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878422" style="display: none;" >
+	<div id="textAreaDados_1878422" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E DIREITO CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. COBRAN&Ccedil;A E RESTRI&Ccedil;&Atilde;O CREDIT&Iacute;CIA POR D&Eacute;BITO INEXIG&Iacute;VEL. RECURSO DESPROVIDO.
+CASO EM EXAME
+Apela&ccedil;&atilde;o interposta por Cristiane Bentos da Silva contra senten&ccedil;a que julgou parcialmente procedentes os pedidos em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais ajuizada em face de Energisa Mato Grosso do Sul-Distribuidora de Energia S.A., para declarar a inexigibilidade de d&eacute;bitos vinculados ao CPF da autora, determinar a exclus&atilde;o de protesto e restri&ccedil;&otilde;es credit&iacute;cias, impor a viabiliza&ccedil;&atilde;o de cadastro e presta&ccedil;&atilde;o do servi&ccedil;o de energia el&eacute;trica em novo endere&ccedil;o sem condicionamento ao pagamento dos valores tidos por inexig&iacute;veis, condenar ao pagamento de indeniza&ccedil;&atilde;o por dano moral em R$ 5.000,00, e julgar improcedente a repeti&ccedil;&atilde;o de ind&eacute;bito por aus&ecirc;ncia de prova de pagamento.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em saber se o valor fixado a t&iacute;tulo de indeniza&ccedil;&atilde;o por dano moral (R$ 5.000,00) deve ser majorado para R$ 10.000,00, &agrave; luz das fun&ccedil;&otilde;es compensat&oacute;ria e punitivo-pedag&oacute;gica da responsabilidade civil e dos crit&eacute;rios de razoabilidade e proporcionalidade.
+RAZ&Otilde;ES DE DECIDIR
+Negou-se provimento ao recurso, mantendo-se a indeniza&ccedil;&atilde;o por dano moral em R$ 5.000,00, porque a fun&ccedil;&atilde;o compensat&oacute;ria deve orientar primordialmente o arbitramento, e o montante fixado foi considerado razo&aacute;vel e proporcional &agrave;s circunst&acirc;ncias do caso e compat&iacute;vel com os par&acirc;metros adotados pela C&acirc;mara. Considerou-se, ainda, a dupla fun&ccedil;&atilde;o da repara&ccedil;&atilde;o extrapatrimonial (compensat&oacute;ria e inibit&oacute;ria), sem identifica&ccedil;&atilde;o de fundamento concreto para majora&ccedil;&atilde;o, em conformidade com precedentes apontados no voto (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4&ordf; C&acirc;mara C&iacute;vel, j. 23/02/2026, p. 24/02/2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1&ordf; C&acirc;mara C&iacute;vel, j. 23/09/2025, p. 24/09/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3&ordf; C&acirc;mara C&iacute;vel, j. 31/07/2025, p. 04/08/2025).
+DISPOSITIVO
+Apela&ccedil;&atilde;o conhecida e desprovida.
+Dispositivos relevantes citados: CPC, art. 487, inc. I; CC, art. 406, &sect; 1&ordm;; CPC, art. 373, inc. II; CF/1988, art. 5&ordm;, V e X; CC, art. 944; e CPC, arts. 489, &sect; 1&ordm;, e 1.022.
+Jurisprud&ecirc;ncia relevante citada: TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4&ordf; C&acirc;mara C&iacute;vel, j. 23/02/2026, p. 24/02/2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1&ordf; C&acirc;mara C&iacute;vel, j. 23/09/2025, p. 24/09/2025; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3&ordf; C&acirc;mara C&iacute;vel, j. 31/07/2025, p. 04/08/2025. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0829907-03.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. APELAÇÃO CÍVEL. INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA E RESTRIÇÃO CREDITÍCIA POR DÉBITO INEXIGÍVEL. RECURSO DESPROVIDO.
+CASO EM EXAME
+Apelação interposta por Cristiane Bentos da Silva contra sentença que julgou parcialmente procedentes os pedidos em ação de indenização por danos morais ajuizada em face de Energisa Mato Grosso do Sul-Distribuidora de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. APELAÇÃO CÍVEL. INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA E RESTRIÇÃO CREDITÍCIA POR DÉBITO INEXIGÍVEL. RECURSO DESPROVIDO.
+CASO EM EXAME
+Apelação interposta por Cristiane Bentos da Silva contra sentença que julgou parcialmente procedentes os pedidos em ação de indenização por danos morais ajuizada em face de Energisa Mato Grosso do Sul-Distribuidora de Energia S.A., para declarar a inexigibilidade de débitos vinculados ao CPF da autora, determinar a exclusão de protesto e restrições creditícias, impor a viabilização de cadastro e prestação do serviço de energia elétrica em novo endereço sem condicionamento ao pagamento dos valores tidos por inexigíveis, condenar ao pagamento de indenização por <em>dano</em> <em>moral</em> em R$ 5.000,00, e julgar improcedente a repetição de indébito por ausência de prova de pagamento.
+QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em saber se o valor fixado a título de indenização por <em>dano</em> <em>moral</em> (R$ 5.000,00) deve ser majorado para R$ 10.000,00, à luz das funções compensatória e punitivo-pedagógica da responsabilidade civil e dos critérios de razoabilidade e proporcionalidade.
+RAZÕES DE DECIDIR
+Negou-se provimento ao recurso, mantendo-se a indenização por <em>dano</em> <em>moral</em> em R$ 5.000,00, porque a função compensatória deve orientar primordialmente o arbitramento, e o montante fixado foi considerado razoável e proporcional às circunstâncias do caso e compatível com os parâmetros adotados pela Câmara. Considerou-se, ainda, a dupla função da reparação extrapatrimonial (compensatória e inibitória), sem identificação de fundamento concreto para majoração, em conformidade com precedentes apontados no voto (TJMS, Apelação Cível n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4ª Câmara Cível, j. 23/02/2026, p. 24/02/2026; TJMS, Apelação Cível n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1ª Câmara Cível, j. 23/09/2025, p. 24/09/2025; TJMS, Apelação Cível n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3ª Câmara Cível, j. 31/07/2025, p. 04/08/2025).
+DISPOSITIVO
+Apelação conhecida e desprovida.
+Dispositivos relevantes citados: CPC, art. 487, inc. I; CC, art. 406, § 1º; CPC, art. 373, inc. II; CF/1988, art. 5º, V e X; CC, art. 944; e CPC, arts. 489, § 1º, e 1.022.
+Jurisprudência relevante citada: TJMS, Apelação Cível n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4ª Câmara Cível, j. 23/02/2026, p. 24/02/2026; TJMS, Apelação Cível n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1ª Câmara Cível, j. 23/09/2025, p. 24/09/2025; e TJMS, Apelação Cível n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3ª Câmara Cível, j. 31/07/2025, p. 04/08/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>54&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878432" cdForo="0" >
+										0802234-97.2024.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878432" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878432);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878432" style="display: none;" >
+	<div id="textAreaDados_1878432" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANO MORAL JULGADA IMPROCEDENTE &ndash; RECURSO DA CONSUMIDORA &ndash; M&Eacute;RITO &ndash; ELEMENTOS TRAZIDOS PELA INSTITUI&Ccedil;&Atilde;O FINANCEIRA, TAIS COMO C&Oacute;PIA DE CONTRATO COM IDENTIFICA&Ccedil;&Atilde;O BIOM&Eacute;TRICA (FACIAL), QUE CUMPRE OS REQUISITOS LEGAIS, COMPROVAM A CONTRATA&Ccedil;&Atilde;O DO CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL (RMC), BEM COMO DO EMPR&Eacute;STIMO CONSIGNADO ORIUNDO DE TAL CONTRATO &ndash; IMPROCED&Ecirc;NCIA DOS PEDIDOS DE NULIDADE DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA, RESTITUI&Ccedil;&Atilde;O DE VALORES EM DOBRO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802234-97.2024.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em> JULGADA IMPROCEDENTE – RECURSO DA CONSUMIDORA – MÉRITO – ELEMENTOS TRAZIDOS PELA INSTITUIÇÃO FINANCEIRA, TAIS COMO CÓPIA DE CONTRATO COM IDENTIFICAÇÃO BIOMÉTRICA (FACIAL), QUE CUMPRE OS REQUISITOS LEGAIS, COMPROVAM A CONTRATAÇÃO DO CARTÃO DE CRÉDITO COM RESERVA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em> JULGADA IMPROCEDENTE – RECURSO DA CONSUMIDORA – MÉRITO – ELEMENTOS TRAZIDOS PELA INSTITUIÇÃO FINANCEIRA, TAIS COMO CÓPIA DE CONTRATO COM IDENTIFICAÇÃO BIOMÉTRICA (FACIAL), QUE CUMPRE OS REQUISITOS LEGAIS, COMPROVAM A CONTRATAÇÃO DO CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC), BEM COMO DO EMPRÉSTIMO CONSIGNADO ORIUNDO DE TAL CONTRATO – IMPROCEDÊNCIA DOS PEDIDOS DE NULIDADE DE RELAÇÃO JURÍDICA, RESTITUIÇÃO DE VALORES EM DOBRO E INDENIZAÇÃO POR DANOS MORAIS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>55&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878433" cdForo="0" >
+										0803016-39.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878433" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878433);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878433" style="display: none;" >
+	<div id="textAreaDados_1878433" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DIREITO DO CONSUMIDOR. RECURSO DE APELA&Ccedil;&Atilde;O. INTERRUP&Ccedil;&Atilde;O NO FORNECIMENTO DE ENERGIA EL&Eacute;TRICA. RESPONSABILIDADE OBJETIVA E DANO MORAL IN RE IPSA. REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO PARCIALMENTE PROVIDO.
+CASO EM EXAME
+Recurso de apela&ccedil;&atilde;o interposto por Energisa Mato Grosso do Sul - Distribuidora de Energia S.A. contra senten&ccedil;a que julgou procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, condenando a concession&aacute;ria ao pagamento de R$ 20.000,00, com corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA a partir da senten&ccedil;a e juros morat&oacute;rios desde a cita&ccedil;&atilde;o.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) saber se a interrup&ccedil;&atilde;o do fornecimento de energia el&eacute;trica por dois dias, com alega&ccedil;&atilde;o de evento clim&aacute;tico, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o e enseja dano moral indeniz&aacute;vel; e (ii) saber se o valor fixado a t&iacute;tulo de dano moral (R$ 20.000,00) deve ser mantido ou reduzido.
+RAZ&Otilde;ES DE DECIDIR
+Rejeitou-se a tese de caso fortuito/for&ccedil;a maior e de aus&ecirc;ncia de nexo causal. Reconheceu-se a responsabilidade objetiva da concession&aacute;ria (CF/1988, art. 37, &sect; 6&ordm;) em rela&ccedil;&atilde;o de consumo (CDC, arts. 2&ordm; e 3&ordm;), com dever de presta&ccedil;&atilde;o cont&iacute;nua e adequada do servi&ccedil;o p&uacute;blico essencial (CDC, art. 22, p.u.). Embora evento clim&aacute;tico possa justificar a interrup&ccedil;&atilde;o inicial, a demora de dois dias para restabelecimento n&atilde;o foi adequadamente justificada, sobretudo diante do prazo do art. 362 da Resolu&ccedil;&atilde;o ANEEL n&ordm; 1.000/2021. Configurou-se falha do servi&ccedil;o (CDC, art. 14) e dano moral in re ipsa, conforme precedentes citados do TJMS e do STJ.
+Afastou-se a necessidade de prova espec&iacute;fica do abalo, pois o dano moral foi considerado presumido (in re ipsa) diante da falha na presta&ccedil;&atilde;o de servi&ccedil;o p&uacute;blico essencial e da priva&ccedil;&atilde;o ileg&iacute;tima da energia el&eacute;trica, com fundamento no CDC, art. 6&ordm;, VI, e nos precedentes citados do STJ e do TJMS.
+Acolheu-se o pedido de redu&ccedil;&atilde;o do quantum. Consideraram-se as circunst&acirc;ncias do caso (demora de dois dias), a condi&ccedil;&atilde;o econ&ocirc;mica das partes e a fun&ccedil;&atilde;o pedag&oacute;gica da indeniza&ccedil;&atilde;o. Concluiu-se que R$ 20.000,00 era excessivo e se reduziu a indeniza&ccedil;&atilde;o para R$ 5.000,00, em conson&acirc;ncia com precedentes do TJMS (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0855487-69.2024.8.12.0001, 1&ordf; C&acirc;mara C&iacute;vel, Rel. Ju&iacute;za D.B.D., j. 20/02/2026, p. 23/02/2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n.0838408-14.2023.8.12.0001, 2&ordf; C&acirc;mara C&iacute;vel, Rel. Juiz V.L.O.G., j. 26/02/2026, p. 03/03/2026).
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o parcialmente provido, para reduzir a indeniza&ccedil;&atilde;o por danos morais para R$ 5.000,00 (cinco mil reais).
+Dispositivos relevantes citados: CF/1988, art. 37, &sect; 6&ordm;; CPC, art. 487, inc. I; CC, art. 389, p.u.; CC, art. 406, &sect; 1&ordm;; CDC, arts. 2&ordm; e 3&ordm;; CDC, art. 6&ordm;, inc. VI; CDC, art. 14; CDC, art. 22, p.u.; e Resolu&ccedil;&atilde;o Normativa ANEEL n&ordm; 1.000/2021, art. 362.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no AREsp 166.040/RJ, Rel. Min. R.A., 4&ordf; Turma, j. 14.08.2012, DJe 31.08.2012; STJ, AgInt no AREsp 1.933.139/RJ, Rel. Min. R.A., 4&ordf; Turma, j. 13.12.2021, DJe 17.12.2021; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802848-11.2023.8.12.0001, 5&ordf; C&acirc;mara C&iacute;vel, Rel. Des. A.R., j. 09.02.2026, p. 10.02.2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0806680-64.2024.8.12.0018, 2&ordf; C&acirc;mara C&iacute;vel, Rel. Des&ordf; S.R.S. R. Artioli, j. 30.01.2026, p. 03.02.2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0855487-69.2024.8.12.0001, 1&ordf; C&acirc;mara C&iacute;vel, Rel. Ju&iacute;za D.B.D., j. 20.02.2026, p. 23.02.2026; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0838408-14.2023.8.12.0001, 2&ordf; C&acirc;mara C&iacute;vel, Rel. Juiz V.L.O.G., j. 26.02.2026, p. 03.03.2026. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803016-39.2025.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(35 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. RECURSO DE APELAÇÃO. INTERRUPÇÃO NO FORNECIMENTO DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E <em>DANO</em> <em>MORAL</em> IN RE IPSA. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Energisa Mato Grosso do Sul - Distribuidora de Energia S.A. contra sentença que julgou procedente ação de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. RECURSO DE APELAÇÃO. INTERRUPÇÃO NO FORNECIMENTO DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E <em>DANO</em> <em>MORAL</em> IN RE IPSA. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Energisa Mato Grosso do Sul - Distribuidora de Energia S.A. contra sentença que julgou procedente ação de indenização por danos morais, condenando a concessionária ao pagamento de R$ 20.000,00, com correção monetária pelo IPCA a partir da sentença e juros moratórios desde a citação.
+QUESTÃO EM DISCUSSÃO
+Há duas questões em discussão: (i) saber se a interrupção do fornecimento de energia elétrica por dois dias, com alegação de evento climático, configura falha na prestação do serviço e enseja <em>dano</em> <em>moral</em> indenizável; e (ii) saber se o valor fixado a título de <em>dano</em> <em>moral</em> (R$ 20.000,00) deve ser mantido ou reduzido.
+RAZÕES DE DECIDIR
+Rejeitou-se a tese de caso fortuito/força maior e de ausência de nexo causal. Reconheceu-se a responsabilidade objetiva da concessionária (CF/1988, art. 37, § 6º) em relação de consumo (CDC, arts. 2º e 3º), com dever de prestação contínua e adequada do serviço público essencial (CDC, art. 22, p.u.). Embora evento climático possa justificar a interrupção inicial, a demora de dois dias para restabelecimento não foi adequadamente justificada, sobretudo diante do prazo do art. 362 da Resolução ANEEL nº 1.000/2021. Configurou-se falha do serviço (CDC, art. 14) e <em>dano</em> <em>moral</em> in re ipsa, conforme precedentes citados do TJMS e do STJ.
+Afastou-se a necessidade de prova específica do abalo, pois o <em>dano</em> <em>moral</em> foi considerado presumido (in re ipsa) diante da falha na prestação de serviço público essencial e da privação ilegítima da energia elétrica, com fundamento no CDC, art. 6º, VI, e nos precedentes citados do STJ e do TJMS.
+Acolheu-se o pedido de redução do quantum. Consideraram-se as circunstâncias do caso (demora de dois dias), a condição econômica das partes e a função pedagógica da indenização. Concluiu-se que R$ 20.000,00 era excessivo e se reduziu a indenização para R$ 5.000,00, em consonância com precedentes do TJMS (TJMS, Apelação Cível n. 0855487-69.2024.8.12.0001, 1ª Câmara Cível, Rel. Juíza D.B.D., j. 20/02/2026, p. 23/02/2026; TJMS, Apelação Cível n.0838408-14.2023.8.12.0001, 2ª Câmara Cível, Rel. Juiz V.L.O.G., j. 26/02/2026, p. 03/03/2026).
+DISPOSITIVO
+Recurso de apelação parcialmente provido, para reduzir a indenização por danos morais para R$ 5.000,00 (cinco mil reais).
+Dispositivos relevantes citados: CF/1988, art. 37, § 6º; CPC, art. 487, inc. I; CC, art. 389, p.u.; CC, art. 406, § 1º; CDC, arts. 2º e 3º; CDC, art. 6º, inc. VI; CDC, art. 14; CDC, art. 22, p.u.; e Resolução Normativa ANEEL nº 1.000/2021, art. 362.
+Jurisprudência relevante citada: STJ, AgRg no AREsp 166.040/RJ, Rel. Min. R.A., 4ª Turma, j. 14.08.2012, DJe 31.08.2012; STJ, AgInt no AREsp 1.933.139/RJ, Rel. Min. R.A., 4ª Turma, j. 13.12.2021, DJe 17.12.2021; TJMS, Apelação Cível n. 0802848-11.2023.8.12.0001, 5ª Câmara Cível, Rel. Des. A.R., j. 09.02.2026, p. 10.02.2026; TJMS, Apelação Cível n. 0806680-64.2024.8.12.0018, 2ª Câmara Cível, Rel. Desª S.R.S. R. Artioli, j. 30.01.2026, p. 03.02.2026; TJMS, Apelação Cível n. 0855487-69.2024.8.12.0001, 1ª Câmara Cível, Rel. Juíza D.B.D., j. 20.02.2026, p. 23.02.2026; e TJMS, Apelação Cível n. 0838408-14.2023.8.12.0001, 2ª Câmara Cível, Rel. Juiz V.L.O.G., j. 26.02.2026, p. 03.03.2026.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>56&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878437" cdForo="0" >
+										0805917-77.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878437" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878437);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878437" style="display: none;" >
+	<div id="textAreaDados_1878437" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS C C PEDIDO DE TUTELA PROVIS&Oacute;RIA DE URG&Ecirc;NCIA. SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. APELO DO BANCO REQUERIDO: ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE RESPONSABILIDADE CIVIL &ndash; IMPOSSIBILIDADE &ndash; APLICA&Ccedil;&Atilde;O DA S&Uacute;MULA 479/STJ &ndash; AUS&Ecirc;NCIA DO DEVER DE CUIDADO NA ABERTURA DE CONTA DE SEUS CLIENTES &ndash; PERMISS&Atilde;O DE ABERTURA DE CONTA, POR TERCEIROS, COM DOCUMENTOS FALSOS &ndash; RECURSO CONHECIDO E DESPROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0805917-77.2025.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C C INDENIZAÇÃO POR DANOS MORAIS C C PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA. SENTENÇA DE PROCEDÊNCIA. APELO DO BANCO REQUERIDO: ALEGAÇÃO DE AUSÊNCIA DE RESPONSABILIDADE CIVIL – IMPOSSIBILIDADE – APLICAÇÃO DA SÚMULA 479/STJ – AUSÊNCIA DO DEVER DE CUIDADO NA ABERTURA DE CONTA DE SEUS CLIENTES – PERMISSÃO DE ABERTURA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C C INDENIZAÇÃO POR DANOS MORAIS C C PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA. SENTENÇA DE PROCEDÊNCIA. APELO DO BANCO REQUERIDO: ALEGAÇÃO DE AUSÊNCIA DE RESPONSABILIDADE CIVIL – IMPOSSIBILIDADE – APLICAÇÃO DA SÚMULA 479/STJ – AUSÊNCIA DO DEVER DE CUIDADO NA ABERTURA DE CONTA DE SEUS CLIENTES – PERMISSÃO DE ABERTURA DE CONTA, POR TERCEIROS, COM DOCUMENTOS FALSOS – RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>57&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878438" cdForo="0" >
+										0816423-57.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878438" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878438);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878438" style="display: none;" >
+	<div id="textAreaDados_1878438" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O A T&Iacute;TULO DE DANO MORAL, EST&Eacute;TICO E MATERIAL &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. ACIDENTE DE TR&Acirc;NSITO &ndash; CRUZAMENTO SEM SINALIZA&Ccedil;&Atilde;O &ndash; INCID&Ecirc;NCIA DO ART. 29, INCISO III, &quot;C&quot;, DO CTB &ndash; AUS&Ecirc;NCIA DE RESPONSABILIDADE DO R&Eacute;U. A SINALIZA&Ccedil;&Atilde;O NAS VIAS, ANOS DEPOIS DA OCORR&Ecirc;NCIA DO ACIDENTE, N&Atilde;O COMPROVAM CULPA DA PARTE REQUERIDA. SENTEN&Ccedil;A MANTIDA. RECURSO CONHECIDO E DESPROVIDO. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816423-57.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE INDENIZAÇÃO A TÍTULO DE <em>DANO</em> <em>MORAL</em>, ESTÉTICO E MATERIAL – SENTENÇA DE IMPROCEDÊNCIA. ACIDENTE DE TRÂNSITO – CRUZAMENTO SEM SINALIZAÇÃO – INCIDÊNCIA DO ART. 29, INCISO III, "C", DO CTB – AUSÊNCIA DE RESPONSABILIDADE DO RÉU. A SINALIZAÇÃO NAS VIAS, ANOS DEPOIS DA OCORRÊNCIA DO ACIDENTE, NÃO COMPROVAM CULPA DA PARTE REQUERIDA. SENTENÇA MANTIDA. RECURSO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE INDENIZAÇÃO A TÍTULO DE <em>DANO</em> <em>MORAL</em>, ESTÉTICO E MATERIAL – SENTENÇA DE IMPROCEDÊNCIA. ACIDENTE DE TRÂNSITO – CRUZAMENTO SEM SINALIZAÇÃO – INCIDÊNCIA DO ART. 29, INCISO III, "C", DO CTB – AUSÊNCIA DE RESPONSABILIDADE DO RÉU. A SINALIZAÇÃO NAS VIAS, ANOS DEPOIS DA OCORRÊNCIA DO ACIDENTE, NÃO COMPROVAM CULPA DA PARTE REQUERIDA. SENTENÇA MANTIDA. RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>58&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878439" cdForo="0" >
+										0800540-44.2025.8.12.0029
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878439" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878439);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878439" style="display: none;" >
+	<div id="textAreaDados_1878439" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E TUTELA DE URG&Ecirc;NCIA &ndash;&nbsp;CONCESSION&Aacute;RIA DE SERVI&Ccedil;O P&Uacute;BLICO &ndash;&nbsp; SANEAMENTO B&Aacute;SICO &ndash;&nbsp;INTERRUP&Ccedil;&Atilde;O DO&nbsp;FORNECIMENTO DE &Aacute;GUA&nbsp;POT&Aacute;VEL &ndash; &nbsp;C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash;&nbsp; RESPONSABILIDADE&nbsp;CIVIL OBJETIVA DO FORNECEDOR&nbsp;&ndash;&nbsp;DANO MORAL&nbsp;CONFIGURADO&nbsp; &ndash;&nbsp; VALOR MANTIDO &ndash;&nbsp;RAZOABILIDADE E PROPORCIONALIDADE &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+A rela&ccedil;&atilde;o havida entre concession&aacute;ria de servi&ccedil;o p&uacute;blico e o usu&aacute;rio final, para fornecimento de servi&ccedil;os p&uacute;blicos essenciais, a exemplo da &aacute;gua pot&aacute;vel, &eacute; regulada pelo C&oacute;digo de Defesa do Consumidor.
+Nos casos de danos oriundos de produtos ou servi&ccedil;os de consumo deve ser afastada a aplica&ccedil;&atilde;o do C&oacute;digo Civil, prevalecendo o regime especial do C&oacute;digo de Defesa do Consumidor. &Eacute; excepcional&iacute;ssima a aplica&ccedil;&atilde;o do C&oacute;digo Civil e desde que n&atilde;o contrarie o sistema e a principiologia do C&oacute;digo de Defesa do Consumidor.
+Apesar das reiteradas situa&ccedil;&otilde;es que trouxeram um desconforto significativo ao consumidor, compartilho da conclus&atilde;o da senten&ccedil;a, no sentido de que o valor de R$5.000,00 &eacute; suficiente para compensar os danos causados ao apelante, notadamente porque n&atilde;o h&aacute; prova nos autos de que o atendimento da empresa fornecedora de &aacute;gua foi negligente ou at&eacute; mesmo que esta n&atilde;o realizou os servi&ccedil;os requeridos, n&atilde;o havendo pedido administrativo comprovado deste &uacute;ltimo para que fosse realizada a implanta&ccedil;&atilde;o do encanamento de forma subterr&acirc;nea.
+Recurso conhecido e n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800540-44.2025.8.12.0029,&nbsp; Navira&iacute;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(43 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Naviraí
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS E TUTELA DE URGÊNCIA – CONCESSIONÁRIA DE SERVIÇO PÚBLICO –  SANEAMENTO BÁSICO – INTERRUPÇÃO DO FORNECIMENTO DE ÁGUA POTÁVEL –  CÓDIGO DE DEFESA DO CONSUMIDOR –  RESPONSABILIDADE CIVIL OBJETIVA DO FORNECEDOR – <em>DANO</em> <em>MORAL</em> CONFIGURADO  –  VALOR MANTIDO – RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA MANTIDA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS E TUTELA DE URGÊNCIA – CONCESSIONÁRIA DE SERVIÇO PÚBLICO –  SANEAMENTO BÁSICO – INTERRUPÇÃO DO FORNECIMENTO DE ÁGUA POTÁVEL –  CÓDIGO DE DEFESA DO CONSUMIDOR –  RESPONSABILIDADE CIVIL OBJETIVA DO FORNECEDOR – <em>DANO</em> <em>MORAL</em> CONFIGURADO  –  VALOR MANTIDO – RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA MANTIDA – RECURSO CONHECIDO E NÃO PROVIDO.
+A relação havida entre concessionária de serviço público e o usuário final, para fornecimento de serviços públicos essenciais, a exemplo da água potável, é regulada pelo Código de Defesa do Consumidor.
+Nos casos de danos oriundos de produtos ou serviços de consumo deve ser afastada a aplicação do Código Civil, prevalecendo o regime especial do Código de Defesa do Consumidor. É excepcionalíssima a aplicação do Código Civil e desde que não contrarie o sistema e a principiologia do Código de Defesa do Consumidor.
+Apesar das reiteradas situações que trouxeram um desconforto significativo ao consumidor, compartilho da conclusão da sentença, no sentido de que o valor de R$5.000,00 é suficiente para compensar os danos causados ao apelante, notadamente porque não há prova nos autos de que o atendimento da empresa fornecedora de água foi negligente ou até mesmo que esta não realizou os serviços requeridos, não havendo pedido administrativo comprovado deste último para que fosse realizada a implantação do encanamento de forma subterrânea.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>59&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878444" cdForo="0" >
+										0803090-95.2024.8.12.0045
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878444" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878444);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878444" style="display: none;" >
+	<div id="textAreaDados_1878444" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; DUPLICATAS MERCANTIS &ndash; CESS&Atilde;O DE CR&Eacute;DITO &ndash; AUS&Ecirc;NCIA DE NOTIFICA&Ccedil;&Atilde;O DO DEVEDOR (ART. 290, CC) &ndash; PAGAMENTO EFETUADO AO CREDOR PRIMITIVO (CEDENTE) &ndash; VALIDADE (ART. 292, CC) &ndash; PROTESTO POSTERIOR PELO BANCO (CESSION&Aacute;RIO) &ndash; ATO IL&Iacute;CITO CONFIGURADO &ndash; RESPONSABILIDADE SOLID&Aacute;RIA ENTRE CEDENTE E CESSION&Aacute;RIO &ndash; TEORIA DO RISCO DO EMPREENDIMENTO &ndash; DANO MORAL IN RE IPSA &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A cess&atilde;o de cr&eacute;dito apenas &eacute; eficaz em rela&ccedil;&atilde;o ao devedor quando este &eacute; formalmente notificado, nos termos do art. 290 do C&oacute;digo Civil. &Agrave; m&iacute;ngua de prova da notifica&ccedil;&atilde;o pr&eacute;via, &eacute; v&aacute;lido e eficaz o pagamento realizado pelo devedor ao credor primitivo (art. 292, CC), extinguindo-se a obriga&ccedil;&atilde;o.
+O protesto de t&iacute;tulos cujos valores j&aacute; haviam sido quitados perante a empresa cedente configura ato il&iacute;cito, ensejando o dever de indenizar.
+A responsabilidade entre a empresa cedente (que recebeu o pagamento e n&atilde;o informou imediatamente o banco) e a institui&ccedil;&atilde;o financeira cession&aacute;ria (que levou os t&iacute;tulos a protesto sem conferir a persist&ecirc;ncia do cr&eacute;dito) &eacute; solid&aacute;ria, pois ambas as condutas concorreram para o evento danoso (art. 942, CC).
+O dano moral decorrente de protesto indevido de t&iacute;tulo &eacute; in re ipsa, prescindindo de prova do preju&iacute;zo efetivo.
+O valor indenizat&oacute;rio de R$ 10.000,00 (dez mil reais) atende aos princ&iacute;pios da razoabilidade e proporcionalidade, bem como ao car&aacute;ter pedag&oacute;gico da medida.
+Senten&ccedil;a mantida. Recurso desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803090-95.2024.8.12.0045,&nbsp; Sidrol&acirc;ndia,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Sustação de Protesto
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sidrolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – DUPLICATAS MERCANTIS – CESSÃO DE CRÉDITO – AUSÊNCIA DE NOTIFICAÇÃO DO DEVEDOR (ART. 290, CC) – PAGAMENTO EFETUADO AO CREDOR PRIMITIVO (CEDENTE) – VALIDADE (ART. 292, CC) – PROTESTO POSTERIOR PELO BANCO (CESSIONÁRIO) – ATO ILÍCITO CONFIGURADO – RESPONSABILIDADE SOLIDÁRIA ENTRE CEDENTE E CESSIONÁRIO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – DUPLICATAS MERCANTIS – CESSÃO DE CRÉDITO – AUSÊNCIA DE NOTIFICAÇÃO DO DEVEDOR (ART. 290, CC) – PAGAMENTO EFETUADO AO CREDOR PRIMITIVO (CEDENTE) – VALIDADE (ART. 292, CC) – PROTESTO POSTERIOR PELO BANCO (CESSIONÁRIO) – ATO ILÍCITO CONFIGURADO – RESPONSABILIDADE SOLIDÁRIA ENTRE CEDENTE E CESSIONÁRIO – TEORIA DO RISCO DO EMPREENDIMENTO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – QUANTUM INDENIZATÓRIO MANTIDO – RECURSO CONHECIDO E DESPROVIDO.
+A cessão de crédito apenas é eficaz em relação ao devedor quando este é formalmente notificado, nos termos do art. 290 do Código Civil. À míngua de prova da notificação prévia, é válido e eficaz o pagamento realizado pelo devedor ao credor primitivo (art. 292, CC), extinguindo-se a obrigação.
+O protesto de títulos cujos valores já haviam sido quitados perante a empresa cedente configura ato ilícito, ensejando o dever de indenizar.
+A responsabilidade entre a empresa cedente (que recebeu o pagamento e não informou imediatamente o banco) e a instituição financeira cessionária (que levou os títulos a protesto sem conferir a persistência do crédito) é solidária, pois ambas as condutas concorreram para o evento danoso (art. 942, CC).
+O <em>dano</em> <em>moral</em> decorrente de protesto indevido de título é in re ipsa, prescindindo de prova do prejuízo efetivo.
+O valor indenizatório de R$ 10.000,00 (dez mil reais) atende aos princípios da razoabilidade e proporcionalidade, bem como ao caráter pedagógico da medida.
+Sentença mantida. Recurso desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>60&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878449" cdForo="0" >
+										0802044-57.2021.8.12.0019
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878449" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878449);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878449" style="display: none;" >
+	<div id="textAreaDados_1878449" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE/INEXIGIBILIDADE DE DESCONTO EM FOLHA DE PAGAMENTO CUMULADA COM REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; PRELIMINAR &ndash; JUNTADA EXTEMPOR&Acirc;NEA DE DOCUMENTOS &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; N&Atilde;O COMPROVADA &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; APLICA&Ccedil;&Atilde;O DA MODULA&Ccedil;&Atilde;O DOS EFEITOS DO EARESP N. 676.608/RS &ndash; DESCONTOS ANTERIORES A 30.3.2021 &ndash;  DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash;  DESCONTOS A PARTIR  30.3.2021 &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; ALTERADOS &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO. RECURSO DA PARTE R&Eacute; CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+A rela&ccedil;&atilde;o jur&iacute;dica vincula os sujeitos de direito em decorr&ecirc;ncia dos fatos jur&iacute;dicos suficientemente comprovados, que s&atilde;o a causa da instaura&ccedil;&atilde;o, da modifica&ccedil;&atilde;o ou da extin&ccedil;&atilde;o de obriga&ccedil;&otilde;es. Especificamente no contrato de m&uacute;tuo ou de empr&eacute;stimo, a tradi&ccedil;&atilde;o da coisa mutuada &eacute; suficiente para se concluir pela exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, cujos efeitos devem operar regulamente, nos termos do art. 586 do C&oacute;digo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que, nos termos art. 42, par&aacute;grafo &uacute;nico, da Lei n&ordm; 8.078/1990 (C&oacute;digo de Defesa do Consumidor), a restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe da natureza do elemento volitivo do fornecedor que realizou a cobran&ccedil;a indevida, revelando-se cab&iacute;vel quando a referida cobran&ccedil;a consubstanciar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva. N&atilde;o obstante, houve modula&ccedil;&atilde;o dos efeitos, impondo a aplica&ccedil;&atilde;o dessa tese a partir de 30.3.2021, data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o dos Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, e unicamente para as cobran&ccedil;as indevidas em contratos de consumo que n&atilde;o envolvam presta&ccedil;&atilde;o de servi&ccedil;os p&uacute;blicos pelo Estado ou por concession&aacute;rias, as quais apenas ser&atilde;o atingidas pelo novo entendimento quando pagas ap&oacute;s a data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a, nos julgamentos dos Recursos Especiais n&ordm; 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixa&ccedil;&atilde;o dos honor&aacute;rios por aprecia&ccedil;&atilde;o equitativa n&atilde;o &eacute; permitida quando os valores da condena&ccedil;&atilde;o ou da causa, ou o proveito econ&ocirc;mico da demanda, forem elevados. &Eacute; obrigat&oacute;ria, nesses casos, a observ&acirc;ncia dos percentuais previstos nos par&aacute;grafos 2&ordm; ou 3&ordm; do artigo 85 do C&oacute;digo de Processo Civil (CPC) &ndash; a depender da presen&ccedil;a da Fazenda P&uacute;blica na lide &ndash;, os quais ser&atilde;o subsequentemente calculados sobre o valor: (a) da condena&ccedil;&atilde;o; ou (b) do proveito econ&ocirc;mico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honor&aacute;rios por equidade quando, havendo ou n&atilde;o condena&ccedil;&atilde;o: (a) o proveito econ&ocirc;mico obtido pelo vencedor for inestim&aacute;vel ou irris&oacute;rio; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso da parte autora conhecido e provido. Recurso da parte r&eacute; conhecido e provido parcialmente. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802044-57.2021.8.12.0019,&nbsp; Ponta Por&atilde;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Ponta Porã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE/INEXIGIBILIDADE DE DESCONTO EM FOLHA DE PAGAMENTO CUMULADA COM REPETIÇÃO DE INDÉBITO E DANOS MORAIS – PRELIMINAR – JUNTADA EXTEMPORÂNEA DE DOCUMENTOS – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE/INEXIGIBILIDADE DE DESCONTO EM FOLHA DE PAGAMENTO CUMULADA COM REPETIÇÃO DE INDÉBITO E DANOS MORAIS – PRELIMINAR – JUNTADA EXTEMPORÂNEA DE DOCUMENTOS – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – HONORÁRIOS ADVOCATÍCIOS – ALTERADOS – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO. RECURSO DA PARTE RÉ CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+A relação jurídica vincula os sujeitos de direito em decorrência dos fatos jurídicos suficientemente comprovados, que são a causa da instauração, da modificação ou da extinção de obrigações. Especificamente no contrato de mútuo ou de empréstimo, a tradição da coisa mutuada é suficiente para se concluir pela existência da relação jurídica, cujos efeitos devem operar regulamente, nos termos do art. 586 do Código Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que, nos termos art. 42, parágrafo único, da Lei nº 8.078/1990 (Código de Defesa do Consumidor), a restituição em dobro do indébito independe da natureza do elemento volitivo do fornecedor que realizou a cobrança indevida, revelando-se cabível quando a referida cobrança consubstanciar conduta contrária à boa-fé objetiva. Não obstante, houve modulação dos efeitos, impondo a aplicação dessa tese a partir de 30.3.2021, data da publicação do acórdão dos Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, e unicamente para as cobranças indevidas em contratos de consumo que não envolvam prestação de serviços públicos pelo Estado ou por concessionárias, as quais apenas serão atingidas pelo novo entendimento quando pagas após a data da publicação do acórdão (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça, nos julgamentos dos Recursos Especiais nº 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixação dos honorários por apreciação equitativa não é permitida quando os valores da condenação ou da causa, ou o proveito econômico da demanda, forem elevados. É obrigatória, nesses casos, a observância dos percentuais previstos nos parágrafos 2º ou 3º do artigo 85 do Código de Processo Civil (CPC) – a depender da presença da Fazenda Pública na lide –, os quais serão subsequentemente calculados sobre o valor: (a) da condenação; ou (b) do proveito econômico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honorários por equidade quando, havendo ou não condenação: (a) o proveito econômico obtido pelo vencedor for inestimável ou irrisório; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso da parte autora conhecido e provido. Recurso da parte ré conhecido e provido parcialmente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>61&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878451" cdForo="0" >
+										0819344-81.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878451" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878451);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878451" style="display: none;" >
+	<div id="textAreaDados_1878451" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C REPARA&Ccedil;&Atilde;O &ndash; CONCESSION&Aacute;RIA DE SERVI&Ccedil;O P&Uacute;BLICO &ndash; PRETENS&Atilde;O DE RECONHECIMENTO DE IRREGULARIDADE NO REGISTRO DE CONSUMO DE ENERGIA EL&Eacute;TRICA &ndash; RESPONSABILIDADE OBJETIVA &ndash; D&Eacute;BITO DECLARADO INEXISTENTE &ndash; REVIS&Atilde;O DO FATURAMENTO &ndash; DANO MORAL IN RE IPSA &ndash; CONFIGURADO &ndash; INDENIZA&Ccedil;&Atilde;O FIXADA &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+As concession&aacute;rias de servi&ccedil;o p&uacute;blico est&atilde;o sujeitas &agrave; responsabilidade objetiva pelos danos causados a terceiros, conforme o art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal. Nesse sentido, o Supremo Tribunal Federal, no julgamento do Recurso Extraordin&aacute;rio n&ordm; 591.874, com repercuss&atilde;o geral reconhecida, fixou a seguinte tese (Tema n&ordm; 130): &quot;A responsabilidade civil das pessoas jur&iacute;dicas de direito privado prestadoras de servi&ccedil;o p&uacute;blico &eacute; objetiva relativamente a terceiros usu&aacute;rios e n&atilde;o usu&aacute;rios do servi&ccedil;o, segundo decorre do art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal&quot;.
+Tratando-se de hip&oacute;tese de responsabilidade objetiva e de invers&atilde;o legal do &ocirc;nus da prova (arts. 6&ordm;, VIII, CDC e art. 37, &sect; 6&ordm;, CF), competia &agrave; concession&aacute;ria fornecedora de energia el&eacute;trica comprovar a exist&ecirc;ncia de fato impeditivo, modificativo ou extintivo do direito do autor (art. 373, II, CPC) em raz&atilde;o da culpa exclusiva do consumidor ou de terceiro ou da inexist&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o (art. 14, &sect; 3&ordm;, CDC) &ndash; isto &eacute;, regularidade da medi&ccedil;&atilde;o da energia el&eacute;trica, regularidade da medi&ccedil;&atilde;o do consumo de energia el&eacute;trica, bem como normalidade do consumo na unidade consumidora, &ocirc;nus dos quais n&atilde;o se desincumbiu.
+Havendo irregularidade no faturamento da unidade consumidora e cobran&ccedil;a indevida &ndash; o que constitui falha na presta&ccedil;&atilde;o de servi&ccedil;o p&uacute;blico essencial &ndash; o dano moral configura-se in re ipsa. Observando-se as condi&ccedil;&otilde;es econ&ocirc;micas das partes, a extens&atilde;o do dano e o abalo ps&iacute;quico e emocional causados ao Apelante, conclui-se que a indeniza&ccedil;&atilde;o por dano moral deve ser fixada em R$5.000,00, uma vez que atende ao cen&aacute;rio dos autos e aos crit&eacute;rios de razoabilidade e proporcionalidade exigidos para que se compense adequadamente a v&iacute;tima, bem como o car&aacute;ter preventivo e pedag&oacute;gico da medida.
+Recurso conhecido e parcialmente provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0819344-81.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(54 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO – CONCESSIONÁRIA DE SERVIÇO PÚBLICO – PRETENSÃO DE RECONHECIMENTO DE IRREGULARIDADE NO REGISTRO DE CONSUMO DE ENERGIA ELÉTRICA – RESPONSABILIDADE OBJETIVA – DÉBITO DECLARADO INEXISTENTE – REVISÃO DO FATURAMENTO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – CONFIGURADO – INDENIZAÇÃO FIXADA – SENTENÇA REFORMADA – RECURSO CONHECIDO E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO – CONCESSIONÁRIA DE SERVIÇO PÚBLICO – PRETENSÃO DE RECONHECIMENTO DE IRREGULARIDADE NO REGISTRO DE CONSUMO DE ENERGIA ELÉTRICA – RESPONSABILIDADE OBJETIVA – DÉBITO DECLARADO INEXISTENTE – REVISÃO DO FATURAMENTO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – CONFIGURADO – INDENIZAÇÃO FIXADA – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+As concessionárias de serviço público estão sujeitas à responsabilidade objetiva pelos danos causados a terceiros, conforme o art. 37, § 6º, da Constituição Federal. Nesse sentido, o Supremo Tribunal Federal, no julgamento do Recurso Extraordinário nº 591.874, com repercussão geral reconhecida, fixou a seguinte tese (Tema nº 130): "A responsabilidade civil das pessoas jurídicas de direito privado prestadoras de serviço público é objetiva relativamente a terceiros usuários e não usuários do serviço, segundo decorre do art. 37, § 6º, da Constituição Federal".
+Tratando-se de hipótese de responsabilidade objetiva e de inversão legal do ônus da prova (arts. 6º, VIII, CDC e art. 37, § 6º, CF), competia à concessionária fornecedora de energia elétrica comprovar a existência de fato impeditivo, modificativo ou extintivo do direito do autor (art. 373, II, CPC) em razão da culpa exclusiva do consumidor ou de terceiro ou da inexistência de falha na prestação do serviço (art. 14, § 3º, CDC) – isto é, regularidade da medição da energia elétrica, regularidade da medição do consumo de energia elétrica, bem como normalidade do consumo na unidade consumidora, ônus dos quais não se desincumbiu.
+Havendo irregularidade no faturamento da unidade consumidora e cobrança indevida – o que constitui falha na prestação de serviço público essencial – o <em>dano</em> <em>moral</em> configura-se in re ipsa. Observando-se as condições econômicas das partes, a extensão do <em>dano</em> e o abalo psíquico e emocional causados ao Apelante, conclui-se que a indenização por <em>dano</em> <em>moral</em> deve ser fixada em R$5.000,00, uma vez que atende ao cenário dos autos e aos critérios de razoabilidade e proporcionalidade exigidos para que se compense adequadamente a vítima, bem como o caráter preventivo e pedagógico da medida.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>62&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878458" cdForo="0" >
+										0831263-72.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878458" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878458);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878458" style="display: none;" >
+	<div id="textAreaDados_1878458" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; INVAS&Atilde;O DE VIA PREFERENCIAL &ndash; CULPA EXCLUSIVA DO R&Eacute;U &ndash; AUS&Ecirc;NCIA DE CNH DA V&Iacute;TIMA &ndash; IRRELEV&Acirc;NCIA &ndash; PENS&Atilde;O VITAL&Iacute;CIA &ndash; REDU&Ccedil;&Atilde;O DA CAPACIDADE LABORATIVA &ndash; ADEQUA&Ccedil;&Atilde;O DO PERCENTUAL &ndash; DANOS MORAIS E EST&Eacute;TICOS &ndash; MANUTEN&Ccedil;&Atilde;O DO QUANTUM &ndash; SEGURO DPVAT &ndash; IMPOSSIBILIDADE DE COMPENSA&Ccedil;&Atilde;O COM DANOS MORAIS E EST&Eacute;TICOS &ndash; RECURSOS PARCIALMENTE PROVIDOS.
+
+CASO EM EXAME
+
+Apela&ccedil;&otilde;es c&iacute;veis interpostas por v&iacute;tima e r&eacute;u em a&ccedil;&atilde;o indenizat&oacute;ria decorrente de acidente de tr&acirc;nsito, na qual reconhecida a responsabilidade do requerido por colis&atilde;o em cruzamento com desrespeito &agrave; sinaliza&ccedil;&atilde;o de &quot;pare&quot;, com condena&ccedil;&atilde;o ao pagamento de pens&atilde;o vital&iacute;cia, danos morais e danos est&eacute;ticos, al&eacute;m de dedu&ccedil;&atilde;o de valores recebidos a t&iacute;tulo de seguro DPVAT.
+
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+(i) Verifica&ccedil;&atilde;o da responsabilidade pelo acidente e eventual culpa exclusiva ou concorrente da v&iacute;tima;
+(ii) Cabimento e quantum da pens&atilde;o vital&iacute;cia em raz&atilde;o de incapacidade parcial permanente;
+(iii) Adequa&ccedil;&atilde;o dos valores fixados a t&iacute;tulo de danos morais e est&eacute;ticos;
+(iv) Possibilidade de dedu&ccedil;&atilde;o do seguro DPVAT das indeniza&ccedil;&otilde;es por danos morais e est&eacute;ticos.
+
+RAZ&Otilde;ES DE DECIDIR
+Responsabilidade civil: Comprovado que o r&eacute;u avan&ccedil;ou sinaliza&ccedil;&atilde;o obrigat&oacute;ria e invadiu via preferencial, configurando culpa exclusiva pelo acidente. Alega&ccedil;&otilde;es de excesso de velocidade n&atilde;o comprovadas. A aus&ecirc;ncia de habilita&ccedil;&atilde;o da v&iacute;tima constitui mera infra&ccedil;&atilde;o administrativa, sem relev&acirc;ncia causal para o sinistro.
+Pens&atilde;o vital&iacute;cia: Demonstrada incapacidade parcial e permanente (perda funcional de 75% do p&eacute; direito), &eacute; devida pens&atilde;o nos termos do art. 950 do C&oacute;digo Civil. Ajuste do percentual para 15% do sal&aacute;rio m&iacute;nimo, proporcional &agrave; deprecia&ccedil;&atilde;o da capacidade laborativa.
+Danos morais: Evidente o abalo decorrente das graves les&otilde;es, cirurgias e limita&ccedil;&otilde;es permanentes. Valor de R$ 30.000,00 mantido por atender aos princ&iacute;pios da razoabilidade e proporcionalidade.
+Danos est&eacute;ticos: Comprovada altera&ccedil;&atilde;o morfol&oacute;gica permanente (cicatrizes e deformidade funcional), sendo cab&iacute;vel indeniza&ccedil;&atilde;o aut&ocirc;noma cumul&aacute;vel com danos morais. Quantum de R$ 15.000,00 mantido.
+Seguro DPVAT: A dedu&ccedil;&atilde;o prevista na S&uacute;mula 246 do STJ n&atilde;o se aplica automaticamente &agrave;s verbas de natureza extrapatrimonial. Invi&aacute;vel compensa&ccedil;&atilde;o com danos morais e est&eacute;ticos, por aus&ecirc;ncia de identidade de natureza e finalidade com o seguro obrigat&oacute;rio.
+DISPOSITIVO
+Recurso da autora: parcialmente provido para afastar a dedu&ccedil;&atilde;o do seguro DPVAT das indeniza&ccedil;&otilde;es por danos morais e est&eacute;ticos.
+Recurso do r&eacute;u: parcialmente provido para reduzir a pens&atilde;o vital&iacute;cia ao percentual de 15% do sal&aacute;rio m&iacute;nimo vigente, mantidos os demais termos da senten&ccedil;a.
+TESE
+A aus&ecirc;ncia de habilita&ccedil;&atilde;o da v&iacute;tima, por si s&oacute;, n&atilde;o configura culpa pelo acidente de tr&acirc;nsito, se n&atilde;o demonstrado nexo causal com o evento danoso.
+A pens&atilde;o vital&iacute;cia deve ser fixada proporcionalmente &agrave; redu&ccedil;&atilde;o da capacidade laborativa, ainda que parcial e permanente (art. 950 do CC).
+&Eacute; poss&iacute;vel a cumula&ccedil;&atilde;o de danos morais e est&eacute;ticos (S&uacute;mula 387 do STJ).
+O seguro DPVAT n&atilde;o pode ser compensado com indeniza&ccedil;&otilde;es por danos morais e est&eacute;ticos, por aus&ecirc;ncia de identidade de natureza jur&iacute;dica.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0831263-72.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(62 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – INVASÃO DE VIA PREFERENCIAL – CULPA EXCLUSIVA DO RÉU – AUSÊNCIA DE CNH DA VÍTIMA – IRRELEVÂNCIA – PENSÃO VITALÍCIA – REDUÇÃO DA CAPACIDADE LABORATIVA – ADEQUAÇÃO DO PERCENTUAL – DANOS MORAIS E ESTÉTICOS – MANUTENÇÃO DO QUANTUM – SEGURO DPVAT – IMPOSSIBILIDADE DE COMPENSAÇÃO COM DANOS MORAIS E ESTÉTICOS – RECURSOS PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – INVASÃO DE VIA PREFERENCIAL – CULPA EXCLUSIVA DO RÉU – AUSÊNCIA DE CNH DA VÍTIMA – IRRELEVÂNCIA – PENSÃO VITALÍCIA – REDUÇÃO DA CAPACIDADE LABORATIVA – ADEQUAÇÃO DO PERCENTUAL – DANOS MORAIS E ESTÉTICOS – MANUTENÇÃO DO QUANTUM – SEGURO DPVAT – IMPOSSIBILIDADE DE COMPENSAÇÃO COM DANOS MORAIS E ESTÉTICOS – RECURSOS PARCIALMENTE PROVIDOS.
+
+CASO EM EXAME
+
+Apelações cíveis interpostas por vítima e réu em ação indenizatória decorrente de acidente de trânsito, na qual reconhecida a responsabilidade do requerido por colisão em cruzamento com desrespeito à sinalização de "pare", com condenação ao pagamento de pensão vitalícia, danos morais e danos estéticos, além de dedução de valores recebidos a título de seguro DPVAT.
+
+QUESTÃO EM DISCUSSÃO
+
+(i) Verificação da responsabilidade pelo acidente e eventual culpa exclusiva ou concorrente da vítima;
+(ii) Cabimento e quantum da pensão vitalícia em razão de incapacidade parcial permanente;
+(iii) Adequação dos valores fixados a título de danos morais e estéticos;
+(iv) Possibilidade de dedução do seguro DPVAT das indenizações por danos morais e estéticos.
+
+RAZÕES DE DECIDIR
+Responsabilidade civil: Comprovado que o réu avançou sinalização obrigatória e invadiu via preferencial, configurando culpa exclusiva pelo acidente. Alegações de excesso de velocidade não comprovadas. A ausência de habilitação da vítima constitui mera infração administrativa, sem relevância causal para o sinistro.
+Pensão vitalícia: Demonstrada incapacidade parcial e permanente (perda funcional de 75% do pé direito), é devida pensão nos termos do art. 950 do Código Civil. Ajuste do percentual para 15% do salário mínimo, proporcional à depreciação da capacidade laborativa.
+Danos morais: Evidente o abalo decorrente das graves lesões, cirurgias e limitações permanentes. Valor de R$ 30.000,00 mantido por atender aos princípios da razoabilidade e proporcionalidade.
+Danos estéticos: Comprovada alteração morfológica permanente (cicatrizes e deformidade funcional), sendo cabível indenização autônoma cumulável com danos morais. Quantum de R$ 15.000,00 mantido.
+Seguro DPVAT: A dedução prevista na Súmula 246 do STJ não se aplica automaticamente às verbas de natureza extrapatrimonial. Inviável compensação com danos morais e estéticos, por ausência de identidade de natureza e finalidade com o seguro obrigatório.
+DISPOSITIVO
+Recurso da autora: parcialmente provido para afastar a dedução do seguro DPVAT das indenizações por danos morais e estéticos.
+Recurso do réu: parcialmente provido para reduzir a pensão vitalícia ao percentual de 15% do salário mínimo vigente, mantidos os demais termos da sentença.
+TESE
+A ausência de habilitação da vítima, por si só, não configura culpa pelo acidente de trânsito, se não demonstrado nexo causal com o evento danoso.
+A pensão vitalícia deve ser fixada proporcionalmente à redução da capacidade laborativa, ainda que parcial e permanente (art. 950 do CC).
+É possível a cumulação de danos morais e estéticos (Súmula 387 do STJ).
+O seguro DPVAT não pode ser compensado com indenizações por danos morais e estéticos, por ausência de identidade de natureza jurídica.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>63&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878461" cdForo="0" >
+										0841036-44.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878461" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878461);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878461" style="display: none;" >
+	<div id="textAreaDados_1878461" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash;  A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; ABORDAGEM EM SUPERMERCADO POR FUNCION&Aacute;RIO &Agrave; CLIENTE &ndash; ACUSA&Ccedil;&Atilde;O DE FURTO &ndash; DANO MORAL DEMONSTRADO &ndash; VALOR MANTIDO &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+O Enunciado n&ordm; 445 da V Jornada de Direito Civil disp&otilde;e que: &quot;O dano moral indeniz&aacute;vel n&atilde;o pressup&otilde;e necessariamente a verifica&ccedil;&atilde;o de sentimentos humanos desagrad&aacute;veis como dor ou sofrimento&quot;.
+Na indeniza&ccedil;&atilde;o por danos morais, o magistrado deve agir com equidade, analisando: a) a extens&atilde;o do dano; b) as condi&ccedil;&otilde;es socioecon&ocirc;micas e culturais dos envolvidos; c) as condi&ccedil;&otilde;es psicol&oacute;gicas das partes; d) o grau de culpa do agente, de terceiro ou da v&iacute;tima (TARTUCE, Fl&aacute;vio. Manual de Direito Civil: volume &uacute;nico. 12. ed. Rio de Janeiro: Forense; M&eacute;todo, 2022, p. 509).
+O caso concreto trata-se de abordagem por funcion&aacute;rio de supermercado &agrave; cliente, acusando-a de furto, sem discri&ccedil;&atilde;o ou cuidado no procedimento, bem como sem quaisquer suspeitas a fundamentar o ato realizado, causando constrangimento ao cliente, raz&atilde;o pela qual a indeniza&ccedil;&atilde;o pelos danos morais deve ser mantida, assim como o valor fixado, porquanto observada a finalidade compensat&oacute;ria do instituto e os princ&iacute;pios da razoabilidade e proporcionalidade.
+Recurso conhecido e n&atilde;o provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0841036-44.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(53 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ABORDAGEM EM SUPERMERCADO POR FUNCIONÁRIO À CLIENTE – ACUSAÇÃO DE FURTO – <em>DANO</em> <em>MORAL</em> DEMONSTRADO – VALOR MANTIDO – RECURSO CONHECIDO E NÃO PROVIDO.
+O Enunciado nº 445 da V Jornada de Direito Civil dispõe que: "O <em>dano</em> <em>moral</em> indenizável não pressupõe necessariamente a verificação de sentimentos humanos
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ABORDAGEM EM SUPERMERCADO POR FUNCIONÁRIO À CLIENTE – ACUSAÇÃO DE FURTO – <em>DANO</em> <em>MORAL</em> DEMONSTRADO – VALOR MANTIDO – RECURSO CONHECIDO E NÃO PROVIDO.
+O Enunciado nº 445 da V Jornada de Direito Civil dispõe que: "O <em>dano</em> <em>moral</em> indenizável não pressupõe necessariamente a verificação de sentimentos humanos desagradáveis como dor ou sofrimento".
+Na indenização por danos morais, o magistrado deve agir com equidade, analisando: a) a extensão do <em>dano</em>; b) as condições socioeconômicas e culturais dos envolvidos; c) as condições psicológicas das partes; d) o grau de culpa do agente, de terceiro ou da vítima (TARTUCE, Flávio. Manual de Direito Civil: volume único. 12. ed. Rio de Janeiro: Forense; Método, 2022, p. 509).
+O caso concreto trata-se de abordagem por funcionário de supermercado à cliente, acusando-a de furto, sem discrição ou cuidado no procedimento, bem como sem quaisquer suspeitas a fundamentar o ato realizado, causando constrangimento ao cliente, razão pela qual a indenização pelos danos morais deve ser mantida, assim como o valor fixado, porquanto observada a finalidade compensatória do instituto e os princípios da razoabilidade e proporcionalidade.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>64&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877112" cdForo="0" >
+										0800231-77.2021.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877112" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877112);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877112" style="display: none;" >
+	<div id="textAreaDados_1877112" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O REPARAT&Oacute;RIA DE DANOS &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; MOTOTAXISTA QUE PERDE O CONTROLE DA MOTOCICLETA - DANO MORAL  &ndash; VERIFICADO &ndash; QUANTUM INDENIZAT&Oacute;RIO REDUZIDO &ndash; DANOS MATERIAIS N&Atilde;O COMPROVADOS - LUCROS CESSANTES DEVIDOS - COMPENSA&Ccedil;&Atilde;O COM OS VALORES RECEBIDOS A T&Iacute;TULO DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO - IMPOSSIBILIDADE - NATUREZAS DISTINTAS - RECURSOS CONHECIDOS E PARCIALMENTE PROVIDOS.
+A fixa&ccedil;&atilde;o do quantum do dano moral deve ficar ao prudente arb&iacute;trio do julgador, devendo ser fixado de maneira equitativa, levando-se em considera&ccedil;&atilde;o as circunst&acirc;ncias do caso concreto e as condi&ccedil;&otilde;es socioecon&ocirc;micas das partes, n&atilde;o podendo ser irris&oacute;rio, de maneira que nada represente para o ofensor, nem exorbitante, de modo a provocar o enriquecimento il&iacute;cito por parte da v&iacute;tima. Valor reduzido pelas condi&ccedil;&otilde;es do ofensor.
+Inexiste veda&ccedil;&atilde;o &agrave; cumula&ccedil;&atilde;o de pens&atilde;o previdenci&aacute;ria com a pens&atilde;o mensal decorrente de ato il&iacute;cito, porquanto verbas de natureza distintas.
+&Eacute; dever da parte autora comprovar os danos materiais sofridos, o que n&atilde;o ocorreu nos autos, na forma do art. 373, I do CPC.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800231-77.2021.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO REPARATÓRIA DE DANOS – ACIDENTE DE TRÂNSITO – MOTOTAXISTA QUE PERDE O CONTROLE DA MOTOCICLETA - <em>DANO</em> <em>MORAL</em>  – VERIFICADO – QUANTUM INDENIZATÓRIO REDUZIDO – DANOS MATERIAIS NÃO COMPROVADOS - LUCROS CESSANTES DEVIDOS - COMPENSAÇÃO COM OS VALORES RECEBIDOS A TÍTULO DE BENEFÍCIO PREVIDENCIÁRIO - IMPOSSIBILIDADE - NATUREZAS DISTINTAS - RECURSOS CONHECIDOS E PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO REPARATÓRIA DE DANOS – ACIDENTE DE TRÂNSITO – MOTOTAXISTA QUE PERDE O CONTROLE DA MOTOCICLETA - <em>DANO</em> <em>MORAL</em>  – VERIFICADO – QUANTUM INDENIZATÓRIO REDUZIDO – DANOS MATERIAIS NÃO COMPROVADOS - LUCROS CESSANTES DEVIDOS - COMPENSAÇÃO COM OS VALORES RECEBIDOS A TÍTULO DE BENEFÍCIO PREVIDENCIÁRIO - IMPOSSIBILIDADE - NATUREZAS DISTINTAS - RECURSOS CONHECIDOS E PARCIALMENTE PROVIDOS.
+A fixação do quantum do <em>dano</em> <em>moral</em> deve ficar ao prudente arbítrio do julgador, devendo ser fixado de maneira equitativa, levando-se em consideração as circunstâncias do caso concreto e as condições socioeconômicas das partes, não podendo ser irrisório, de maneira que nada represente para o ofensor, nem exorbitante, de modo a provocar o enriquecimento ilícito por parte da vítima. Valor reduzido pelas condições do ofensor.
+Inexiste vedação à cumulação de pensão previdenciária com a pensão mensal decorrente de ato ilícito, porquanto verbas de natureza distintas.
+É dever da parte autora comprovar os danos materiais sofridos, o que não ocorreu nos autos, na forma do art. 373, I do CPC.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>65&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877119" cdForo="0" >
+										0800417-59.2023.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877119" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877119);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877119" style="display: none;" >
+	<div id="textAreaDados_1877119" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANO MATERIAL E MORAL &ndash; ACIDENTE DE TR&Acirc;NSITO - AUS&Ecirc;NCIA DE PROVA DE CULPA DO R&Eacute;U - CULPA&nbsp;EXCLUSIVA&nbsp;DA&nbsp;V&Iacute;TIMA&nbsp;CONFIGURADA - DEVER DE INDENIZAR AFASTADO &ndash; A&Ccedil;&Atilde;O IMPROCEDENTE &ndash; RECURSO DESPROVIDO.
+N&atilde;o tendo a autora obtido &ecirc;xito em demonstrar a culpa do demandado e, por outro norte, tendo o apelado demonstrado a culpa exclusiva da v&iacute;tima, conclui-se pela aus&ecirc;ncia dos requisitos ensejadores da responsabilidade civil aplicada ao caso.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800417-59.2023.8.12.0015,&nbsp; Miranda,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO DE INDENIZAÇÃO POR <em>DANO</em> MATERIAL E <em>MORAL</em> – ACIDENTE DE TRÂNSITO - AUSÊNCIA DE PROVA DE CULPA DO RÉU - CULPA EXCLUSIVA DA VÍTIMA CONFIGURADA - DEVER DE INDENIZAR AFASTADO – AÇÃO IMPROCEDENTE – RECURSO DESPROVIDO.
+Não tendo a autora obtido êxito em demonstrar a culpa do demandado e, por outro norte, tendo o apelado demonstrado a culpa exclusiva da vítima, conclui-se pela
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO DE INDENIZAÇÃO POR <em>DANO</em> MATERIAL E <em>MORAL</em> – ACIDENTE DE TRÂNSITO - AUSÊNCIA DE PROVA DE CULPA DO RÉU - CULPA EXCLUSIVA DA VÍTIMA CONFIGURADA - DEVER DE INDENIZAR AFASTADO – AÇÃO IMPROCEDENTE – RECURSO DESPROVIDO.
+Não tendo a autora obtido êxito em demonstrar a culpa do demandado e, por outro norte, tendo o apelado demonstrado a culpa exclusiva da vítima, conclui-se pela ausência dos requisitos ensejadores da responsabilidade civil aplicada ao caso.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>66&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877148" cdForo="0" >
+										0808139-29.2023.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877148" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877148);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877148" style="display: none;" >
+	<div id="textAreaDados_1877148" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE CONHECIMENTO &ndash; PRELIMINAR DE OFENSA AO PRINC&Iacute;PIO DA DIALETICIDADE, REJEITADA &ndash; PRELIMINAR DE INOVA&Ccedil;&Atilde;O RECURSAL, ACOLHIDA EM PARTE &ndash; M&Eacute;RITO &ndash;  SISTEMA DE PAGAMENTO POR CART&Atilde;O DE CR&Eacute;DITO &ndash; TRANSA&Ccedil;&Otilde;ES REALIZADAS POR LINK DE PAGAMENTO &ndash; POSTERIOR CONTESTA&Ccedil;&Atilde;O PELO TITULAR DO CART&Atilde;O (CHARGEBACK) &ndash; ESTORNO DOS VALORES &ndash; RESPONSABILIDADE DA CREDENCIADORA &ndash; APLICA&Ccedil;&Atilde;O DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; TEORIA FINALISTA MITIGADA &ndash; RESPONSABILIDADE OBJETIVA &ndash; RISCO DA ATIVIDADE &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; CL&Aacute;USULA CONTRATUAL QUE TRANSFERE O RISCO AO ESTABELECIMENTO COMERCIAL &ndash; ABUSIVIDADE &ndash; DANO MATERIAL &ndash; DEVER DE INDENIZAR &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO EM PARTE; NA PARTE CONHECIDA, DESPROVIDO.
+I - Se a parte combate os principais fundamentos da senten&ccedil;a, n&atilde;o h&aacute; espa&ccedil;o para discutir ofensa ao princ&iacute;pio da&nbsp;dialeticidade. Preliminar rejeitada.
+II - N&atilde;o se conhece da alega&ccedil;&atilde;o de inexist&ecirc;ncia de dano material por aus&ecirc;ncia de prova de entrega dos produtos, por configurar inova&ccedil;&atilde;o recursal, vedada pelo art. 1.014, CPC, uma vez que referida mat&eacute;ria n&atilde;o foi suscitada na contesta&ccedil;&atilde;o, tampouco analisada pelo ju&iacute;zo de origem.
+III - Aplica-se o C&oacute;digo de Defesa do Consumidor &agrave; rela&ccedil;&atilde;o jur&iacute;dica estabelecida entre credenciadora de cart&otilde;es e estabelecimento comercial, quando evidenciada a vulnerabilidade t&eacute;cnica deste, nos termos da teoria finalista mitigada.
+IV - A credenciadora de cart&atilde;o de cr&eacute;dito responde objetivamente pelos danos decorrentes de falha na presta&ccedil;&atilde;o do servi&ccedil;o, nos termos do art. 14, CDC, por se tratar de atividade que implica risco inerente.
+V - A autoriza&ccedil;&atilde;o pr&eacute;via das transa&ccedil;&otilde;es pela plataforma de pagamento gera leg&iacute;tima expectativa de validade e seguran&ccedil;a da opera&ccedil;&atilde;o, n&atilde;o sendo poss&iacute;vel transferir ao estabelecimento comercial os preju&iacute;zos decorrentes de posterior contesta&ccedil;&atilde;o pelo titular do cart&atilde;o (chargeback). Ademais, a demora na solu&ccedil;&atilde;o evidencia a falha na presta&ccedil;&atilde;o do servi&ccedil;o. Senten&ccedil;a mantida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0808139-29.2023.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE CONHECIMENTO – PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE, REJEITADA – PRELIMINAR DE INOVAÇÃO RECURSAL, ACOLHIDA EM PARTE – MÉRITO –  SISTEMA DE PAGAMENTO POR CARTÃO DE CRÉDITO – TRANSAÇÕES REALIZADAS POR LINK DE PAGAMENTO – POSTERIOR CONTESTAÇÃO PELO TITULAR DO CARTÃO (CHARGEBACK) – ESTORNO DOS VALORES – RESPONSABILIDADE DA CREDENCIADORA – APLICAÇÃO DO CÓDIGO DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE CONHECIMENTO – PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE, REJEITADA – PRELIMINAR DE INOVAÇÃO RECURSAL, ACOLHIDA EM PARTE – MÉRITO –  SISTEMA DE PAGAMENTO POR CARTÃO DE CRÉDITO – TRANSAÇÕES REALIZADAS POR LINK DE PAGAMENTO – POSTERIOR CONTESTAÇÃO PELO TITULAR DO CARTÃO (CHARGEBACK) – ESTORNO DOS VALORES – RESPONSABILIDADE DA CREDENCIADORA – APLICAÇÃO DO CÓDIGO DE DEFESA DO CONSUMIDOR – TEORIA FINALISTA MITIGADA – RESPONSABILIDADE OBJETIVA – RISCO DA ATIVIDADE – FALHA NA PRESTAÇÃO DO SERVIÇO – CLÁUSULA CONTRATUAL QUE TRANSFERE O RISCO AO ESTABELECIMENTO COMERCIAL – ABUSIVIDADE – <em>DANO</em> MATERIAL – DEVER DE INDENIZAR – SENTENÇA MANTIDA – RECURSO CONHECIDO EM PARTE; NA PARTE CONHECIDA, DESPROVIDO.
+I - Se a parte combate os principais fundamentos da sentença, não há espaço para discutir ofensa ao princípio da dialeticidade. Preliminar rejeitada.
+II - Não se conhece da alegação de inexistência de <em>dano</em> material por ausência de prova de entrega dos produtos, por configurar inovação recursal, vedada pelo art. 1.014, CPC, uma vez que referida matéria não foi suscitada na contestação, tampouco analisada pelo juízo de origem.
+III - Aplica-se o Código de Defesa do Consumidor à relação jurídica estabelecida entre credenciadora de cartões e estabelecimento comercial, quando evidenciada a vulnerabilidade técnica deste, nos termos da teoria finalista mitigada.
+IV - A credenciadora de cartão de crédito responde objetivamente pelos danos decorrentes de falha na prestação do serviço, nos termos do art. 14, CDC, por se tratar de atividade que implica risco inerente.
+V - A autorização prévia das transações pela plataforma de pagamento gera legítima expectativa de validade e segurança da operação, não sendo possível transferir ao estabelecimento comercial os prejuízos decorrentes de posterior contestação pelo titular do cartão (chargeback). Ademais, a demora na solução evidencia a falha na prestação do serviço. Sentença mantida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>67&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877155" cdForo="0" >
+										0800841-63.2025.8.12.0005
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877155" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877155);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877155" style="display: none;" >
+	<div id="textAreaDados_1877155" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; ALEGA&Ccedil;&Atilde;O DE V&Iacute;CIO NO AC&Oacute;RD&Atilde;O &ndash; OMISS&Atilde;O NA AN&Aacute;LISE DO PEDIDO DE RESTITUI&Ccedil;&Atilde;O SIMPLES DE VALORES &ndash; V&Iacute;CIO EXISTENTE &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO EM DOBRO &ndash; DEVIDA  A PARTIR DE 30/03/2021&ndash; MODULA&Ccedil;&Atilde;O DE EFEITOS NO EARESP N. 676.608/RS PELO STJ &ndash; REPETI&Ccedil;&Atilde;O SIMPLES EM RELA&Ccedil;&Atilde;O AO PER&Iacute;ODO ANTERIOR (25/02/2019 at&eacute; 30/03/2021) &ndash; EMBARGOS ACOLHIDOS.
+Acolhem-se os embargos de declara&ccedil;&atilde;o, se verificada qualquer das hip&oacute;teses previstas no artigo 1.022 do C&oacute;digo de Processo Civil, que no caso restou configurada a omiss&atilde;o, pela n&atilde;o an&aacute;lise do pedido de restitui&ccedil;&atilde;o simples de valores.
+O STJ definiu que a interpreta&ccedil;&atilde;o do art. 42 do CDC deve ser feita &agrave; luz dos princ&iacute;pios da vulnerabilidade e da boa-f&eacute; objetiva, mandamentos centrais da prote&ccedil;&atilde;o ao consumidor, de modo que a restitui&ccedil;&atilde;o simples somente ser&aacute; admitida quando o fornecedor de produtos ou servi&ccedil;os comprovar a ocorr&ecirc;ncia de engano justific&aacute;vel para a cobran&ccedil;a indevida.
+Conforme modula&ccedil;&atilde;o dos efeitos da decis&atilde;o proferida pelo STJ, no julgamento do EAREsp n. 676.608/RS, a altera&ccedil;&atilde;o do entendimento somente ser&aacute; aplicada para os descontos indevidos ocorridos a partir da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (30/03/2021). No caso, os descontos que ocorreram a partir de 30/03/2021  &eacute; aplic&aacute;vel a restitui&ccedil;&atilde;o em dobro. No que tange os valores cobrados indevidamente do per&iacute;odo anterior a 30/03/2021 dever&atilde;o ser restitu&iacute;dos de forma simples.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0800841-63.2025.8.12.0005,&nbsp; Aquidauana,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aquidauana
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800841632025812000550000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – ALEGAÇÃO DE VÍCIO NO ACÓRDÃO – OMISSÃO NA ANÁLISE DO PEDIDO DE RESTITUIÇÃO SIMPLES DE VALORES – VÍCIO EXISTENTE – REPETIÇÃO DE INDÉBITO EM DOBRO – DEVIDA  A PARTIR DE 30/03/2021– MODULAÇÃO DE EFEITOS NO EARESP N. 676.608/RS PELO STJ – REPETIÇÃO SIMPLES EM RELAÇÃO AO PERÍODO ANTERIOR (25/02/2019 até 30/03/2021) – EMBARGOS ACOLHIDOS.
+Acolhem-se os
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – ALEGAÇÃO DE VÍCIO NO ACÓRDÃO – OMISSÃO NA ANÁLISE DO PEDIDO DE RESTITUIÇÃO SIMPLES DE VALORES – VÍCIO EXISTENTE – REPETIÇÃO DE INDÉBITO EM DOBRO – DEVIDA  A PARTIR DE 30/03/2021– MODULAÇÃO DE EFEITOS NO EARESP N. 676.608/RS PELO STJ – REPETIÇÃO SIMPLES EM RELAÇÃO AO PERÍODO ANTERIOR (25/02/2019 até 30/03/2021) – EMBARGOS ACOLHIDOS.
+Acolhem-se os embargos de declaração, se verificada qualquer das hipóteses previstas no artigo 1.022 do Código de Processo Civil, que no caso restou configurada a omissão, pela não análise do pedido de restituição simples de valores.
+O STJ definiu que a interpretação do art. 42 do CDC deve ser feita à luz dos princípios da vulnerabilidade e da boa-fé objetiva, mandamentos centrais da proteção ao consumidor, de modo que a restituição simples somente será admitida quando o fornecedor de produtos ou serviços comprovar a ocorrência de engano justificável para a cobrança indevida.
+Conforme modulação dos efeitos da decisão proferida pelo STJ, no julgamento do EAREsp n. 676.608/RS, a alteração do entendimento somente será aplicada para os descontos indevidos ocorridos a partir da publicação do acórdão (30/03/2021). No caso, os descontos que ocorreram a partir de 30/03/2021  é aplicável a restituição em dobro. No que tange os valores cobrados indevidamente do período anterior a 30/03/2021 deverão ser restituídos de forma simples.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>68&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877161" cdForo="0" >
+										1421692-89.2025.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877161" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877161);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877161" style="display: none;" >
+	<div id="textAreaDados_1877161" class="mensagemSemFormatacao" >
+		AGRAVO INTERNO EM AGRAVO DE INSTRUMENTO &ndash; OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; PLANO DE SA&Uacute;DE &ndash; TRATAMENTO MULTIDISCIPLINAR PARA TRANSTORNO DO ESPECTRO AUTISTA &ndash; TUTELA DE URG&Ecirc;NCIA PARCIALMENTE DEFERIDA &ndash; COBERTURA DE EQUOTERAPIA E TERAPIA ABA EM LOCALIDADE DA BENEFICI&Aacute;RIA &ndash; NECESSIDADE TERAP&Ecirc;UTICA E IMPRESCINDIBILIDADE DO TRATAMENTO &ndash; PRECEDENTES DO STJ &ndash; AUS&Ecirc;NCIA DE ARGUMENTOS NOVOS APTOS A INFIRMAR A DECIS&Atilde;O AGRAVADA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+No presente Agravo Interno, a Agravante apenas reitera os fundamentos anteriormente apresentados e insuficientes para afastar a probabilidade do direito e o perigo de dano j&aacute; reconhecidos, raz&atilde;o pela qual devem ser igualmente mantidas as raz&otilde;es de decidir da decis&atilde;o monocr&aacute;tica, o que n&atilde;o constitui viola&ccedil;&atilde;o ao disposto no &sect; 3&ordm; do artigo 1.021 do CPC.
+No Tema Repetitivo n&ordm; 1306, o STJ fixou a tese de que &quot;A reprodu&ccedil;&atilde;o dos fundamentos da decis&atilde;o agravada como raz&otilde;es de decidir para negar provimento ao agravo interno, na hip&oacute;tese do &sect;3&ordm; do artigo 1.021 do CPC, &eacute; admitida quando a parte deixa de apresentar argumento novo e relevante a ser apreciado pelo colegiado&quot;.
+No caso, os elementos f&aacute;ticos e jur&iacute;dicos apresentados pela parte Requerente/Agravada se mostram aptos a preencher os requisitos da tutela de urg&ecirc;ncia para a concess&atilde;o da equoterapia e da terapia ABA na localidade da benefici&aacute;ria, dada a especificidade do tratamento de TEA em infante, a jurisprud&ecirc;ncia consolidada do STJ e a inviabilidade de deslocamento. Logo, n&atilde;o h&aacute; falar em reforma da decis&atilde;o agravada.
+Recurso conhecido e desprovido.
+ <br><br>(<b>TJMS</b>. Agravo Interno C&iacute;vel n. 1421692-89.2025.8.12.0000,&nbsp; Sidrol&acirc;ndia,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sidrolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO INTERNO EM AGRAVO DE INSTRUMENTO – OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – TRATAMENTO MULTIDISCIPLINAR PARA TRANSTORNO DO ESPECTRO AUTISTA – TUTELA DE URGÊNCIA PARCIALMENTE DEFERIDA – COBERTURA DE EQUOTERAPIA E TERAPIA ABA EM LOCALIDADE DA BENEFICIÁRIA – NECESSIDADE TERAPÊUTICA E IMPRESCINDIBILIDADE DO TRATAMENTO – PRECEDENTES DO STJ – AUSÊNCIA DE ARGUMENTOS NOVOS APTOS A INFIRMAR A DECISÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO INTERNO EM AGRAVO DE INSTRUMENTO – OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – TRATAMENTO MULTIDISCIPLINAR PARA TRANSTORNO DO ESPECTRO AUTISTA – TUTELA DE URGÊNCIA PARCIALMENTE DEFERIDA – COBERTURA DE EQUOTERAPIA E TERAPIA ABA EM LOCALIDADE DA BENEFICIÁRIA – NECESSIDADE TERAPÊUTICA E IMPRESCINDIBILIDADE DO TRATAMENTO – PRECEDENTES DO STJ – AUSÊNCIA DE ARGUMENTOS NOVOS APTOS A INFIRMAR A DECISÃO AGRAVADA – RECURSO CONHECIDO E DESPROVIDO.
+No presente Agravo Interno, a Agravante apenas reitera os fundamentos anteriormente apresentados e insuficientes para afastar a probabilidade do direito e o perigo de <em>dano</em> já reconhecidos, razão pela qual devem ser igualmente mantidas as razões de decidir da decisão monocrática, o que não constitui violação ao disposto no § 3º do artigo 1.021 do CPC.
+No Tema Repetitivo nº 1306, o STJ fixou a tese de que "A reprodução dos fundamentos da decisão agravada como razões de decidir para negar provimento ao agravo interno, na hipótese do §3º do artigo 1.021 do CPC, é admitida quando a parte deixa de apresentar argumento novo e relevante a ser apreciado pelo colegiado".
+No caso, os elementos fáticos e jurídicos apresentados pela parte Requerente/Agravada se mostram aptos a preencher os requisitos da tutela de urgência para a concessão da equoterapia e da terapia ABA na localidade da beneficiária, dada a especificidade do tratamento de TEA em infante, a jurisprudência consolidada do STJ e a inviabilidade de deslocamento. Logo, não há falar em reforma da decisão agravada.
+Recurso conhecido e desprovido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>69&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877186" cdForo="0" >
+										0817163-46.2020.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877186" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877186);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877186" style="display: none;" >
+	<div id="textAreaDados_1877186" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; INEXIST&Ecirc;NCIA DOS V&Iacute;CIOS PREVISTOS NO ARTIGO 1.022, DO CPC &ndash; PREQUESTIONAMENTO &ndash; EMBARGOS DECLARAT&Oacute;RIOS REJEITADOS.
+Nos termos do artigo 1.022, do CPC/2015, cabem embargos de declara&ccedil;&atilde;o para esclarecer obscuridade, eliminar contradi&ccedil;&atilde;o ou suprir omiss&atilde;o de ponto ou quest&atilde;o sobre o qual devia se pronunciar o juiz de of&iacute;cio ou a requerimento, ou corrigir erro material.   <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0817163-46.2020.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									817163462020812000250001
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – INEXISTÊNCIA DOS VÍCIOS PREVISTOS NO ARTIGO 1.022, DO CPC – PREQUESTIONAMENTO – EMBARGOS DECLARATÓRIOS REJEITADOS.
+Nos termos do artigo 1.022, do CPC/2015, cabem embargos de declaração para esclarecer obscuridade, eliminar contradição ou suprir omissão de ponto ou questão sobre o qual devia se pronunciar o juiz de ofício ou
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – INEXISTÊNCIA DOS VÍCIOS PREVISTOS NO ARTIGO 1.022, DO CPC – PREQUESTIONAMENTO – EMBARGOS DECLARATÓRIOS REJEITADOS.
+Nos termos do artigo 1.022, do CPC/2015, cabem embargos de declaração para esclarecer obscuridade, eliminar contradição ou suprir omissão de ponto ou questão sobre o qual devia se pronunciar o juiz de ofício ou a requerimento, ou corrigir erro material.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>70&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877203" cdForo="0" >
+										1421885-07.2025.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877203" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877203);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877203" style="display: none;" >
+	<div id="textAreaDados_1877203" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DE NULIDADE DE DECIS&Atilde;O ADMINISTRATIVA C/C PEDIDO LIMINAR DE URG&Ecirc;NCIA PARA INSCRI&Ccedil;&Atilde;O DE CHAPA EM CAR&Aacute;TER SUBJUDICE - CONDOM&Iacute;NIO &ndash; ELEI&Ccedil;&Atilde;O DE S&Iacute;NDICO &ndash; TUTELA DE URG&Ecirc;NCIA DEFERIDA NA ORIGEM PARA SUSPENDER A POSSE DOS ELEITOS &ndash; PRELIMINARES DE FALTA DE CONDI&Ccedil;&Atilde;O DA A&Ccedil;&Atilde;O E AUS&Ecirc;NCIA DE CAUSA DE PEDIR &ndash; REJEITADAS &ndash; M&Eacute;RITO &ndash; INTERVEN&Ccedil;&Atilde;O JUDICIAL EM QUEST&Otilde;ES INTERNA CORPORIS &ndash; EXCEPCIONALIDADE &ndash; SOBERANIA DA ASSEMBLEIA GERAL &ndash; ART. 1.355 DO C&Oacute;DIGO CIVIL &ndash; AUS&Ecirc;NCIA DE PROBABILIDADE DO DIREITO &ndash; PERICULUM IN MORA INVERSO CONFIGURADO &ndash; DECIS&Atilde;O REFORMADA &ndash; RECURSO CONHECIDO E PROVIDO.
+I - A propositura de a&ccedil;&atilde;o anulat&oacute;ria pela atual s&iacute;ndica, em nome pr&oacute;prio (pessoa f&iacute;sica), para tutelar o direito individual de ter sua candidatura registrada no pleito eleitoral n&atilde;o configura confus&atilde;o entre as partes, tampouco h&aacute; falar em aus&ecirc;ncia de causa de pedir quando a inicial descreve de forma clara os fatos e os fundamentos jur&iacute;dicos da suposta nulidade.
+II - As delibera&ccedil;&otilde;es tomadas em assembleia condominial s&atilde;o soberanas e possuem for&ccedil;a cogente, nos termos do art. 1.355 do C&oacute;digo Civil, de modo que a interven&ccedil;&atilde;o do Poder Judici&aacute;rio em quest&otilde;es interna corporis deve ser excepcional, limitando-se a casos de flagrante ilegalidade ou inobserv&acirc;ncia da conven&ccedil;&atilde;o e do edital.
+III - O indeferimento de candidatura pela comiss&atilde;o eleitoral com base em regras objetivas do edital, de intempestividade do registro e de an&aacute;lise de idoneidade curricular, demanda dila&ccedil;&atilde;o probat&oacute;ria sob o crivo do contradit&oacute;rio, n&atilde;o evidenciando, em cogni&ccedil;&atilde;o sum&aacute;ria, a probabilidade do direito apta a suspender os efeitos de pleito eleitoral em que a chapa vencedora obteve a maioria absoluta dos votos dos presentes.
+IV - A manuten&ccedil;&atilde;o de tutela de urg&ecirc;ncia que suspende a posse de chapa democraticamente eleita e imp&otilde;e a continuidade de gest&atilde;o cujo mandato se encerrou configura evidente periculum in mora inverso, gerando grave instabilidade administrativa, financeira e inseguran&ccedil;a jur&iacute;dica para a coletividade condominial.
+V - Decis&atilde;o reformada. Recurso conhecido e provido.
+  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1421885-07.2025.8.12.0000,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Assembléia
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DE NULIDADE DE DECISÃO ADMINISTRATIVA C/C PEDIDO LIMINAR DE URGÊNCIA PARA INSCRIÇÃO DE CHAPA EM CARÁTER SUBJUDICE - CONDOMÍNIO – ELEIÇÃO DE SÍNDICO – TUTELA DE URGÊNCIA DEFERIDA NA ORIGEM PARA SUSPENDER A POSSE DOS ELEITOS – PRELIMINARES DE FALTA DE CONDIÇÃO DA AÇÃO E AUSÊNCIA DE CAUSA DE PEDIR – REJEITADAS – MÉRITO – INTERVENÇÃO JUDICIAL EM QUESTÕES INTERNA CORPORIS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DE NULIDADE DE DECISÃO ADMINISTRATIVA C/C PEDIDO LIMINAR DE URGÊNCIA PARA INSCRIÇÃO DE CHAPA EM CARÁTER SUBJUDICE - CONDOMÍNIO – ELEIÇÃO DE SÍNDICO – TUTELA DE URGÊNCIA DEFERIDA NA ORIGEM PARA SUSPENDER A POSSE DOS ELEITOS – PRELIMINARES DE FALTA DE CONDIÇÃO DA AÇÃO E AUSÊNCIA DE CAUSA DE PEDIR – REJEITADAS – MÉRITO – INTERVENÇÃO JUDICIAL EM QUESTÕES INTERNA CORPORIS – EXCEPCIONALIDADE – SOBERANIA DA ASSEMBLEIA GERAL – ART. 1.355 DO CÓDIGO CIVIL – AUSÊNCIA DE PROBABILIDADE DO DIREITO – PERICULUM IN MORA INVERSO CONFIGURADO – DECISÃO REFORMADA – RECURSO CONHECIDO E PROVIDO.
+I - A propositura de ação anulatória pela atual síndica, em nome próprio (pessoa física), para tutelar o direito individual de ter sua candidatura registrada no pleito eleitoral não configura confusão entre as partes, tampouco há falar em ausência de causa de pedir quando a inicial descreve de forma clara os fatos e os fundamentos jurídicos da suposta nulidade.
+II - As deliberações tomadas em assembleia condominial são soberanas e possuem força cogente, nos termos do art. 1.355 do Código Civil, de modo que a intervenção do Poder Judiciário em questões interna corporis deve ser excepcional, limitando-se a casos de flagrante ilegalidade ou inobservância da convenção e do edital.
+III - O indeferimento de candidatura pela comissão eleitoral com base em regras objetivas do edital, de intempestividade do registro e de análise de idoneidade curricular, demanda dilação probatória sob o crivo do contraditório, não evidenciando, em cognição sumária, a probabilidade do direito apta a suspender os efeitos de pleito eleitoral em que a chapa vencedora obteve a maioria absoluta dos votos dos presentes.
+IV - A manutenção de tutela de urgência que suspende a posse de chapa democraticamente eleita e impõe a continuidade de gestão cujo mandato se encerrou configura evidente periculum in mora inverso, gerando grave instabilidade administrativa, financeira e insegurança jurídica para a coletividade condominial.
+V - Decisão reformada. Recurso conhecido e provido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>71&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877225" cdForo="0" >
+										0931297-50.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877225" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877225);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877225" style="display: none;" >
+	<div id="textAreaDados_1877225" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL &ndash; APELA&Ccedil;&Atilde;O CRIMINAL DEFENSIVA &ndash; LES&Atilde;O CORPORAL GRAVE &ndash; DOSIMETRIA DA PENA &ndash; CIRCUNST&Acirc;NCIAS JUDICIAIS &ndash; FRA&Ccedil;&Atilde;O EXCESSIVA &ndash; ADEQUA&Ccedil;&Atilde;O DA FRA&Ccedil;&Atilde;O RELATIVA &Agrave; CONFISS&Atilde;O ESPONT&Acirc;NEA &ndash; INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; MANUTEN&Ccedil;&Atilde;O &ndash;  RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1) Recurso de Apela&ccedil;&atilde;o Criminal interposto contra Senten&ccedil;a que condenou o R&eacute;u pela pr&aacute;tica do crime de les&atilde;o corporal grave (art. 129, &sect; 1&ordm;, incisos I e II, do C&oacute;digo Penal), com reconhecimento da atenuante da confiss&atilde;o espont&acirc;nea, fixando pena privativa de liberdade e valor m&iacute;nimo de indeniza&ccedil;&atilde;o por danos morais em favor da v&iacute;tima.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (2.1) definir se a exaspera&ccedil;&atilde;o da pena-base observou crit&eacute;rio proporcional ao n&uacute;mero de circunst&acirc;ncias judiciais negativadas; (2.2) estabelecer se a fra&ccedil;&atilde;o aplicada &agrave; atenuante da confiss&atilde;o espont&acirc;nea deve ser majorada; e (2.3) determinar se &eacute; cab&iacute;vel a fixa&ccedil;&atilde;o e manuten&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima por danos morais na senten&ccedil;a penal condenat&oacute;ria.
+III. RAZ&Otilde;ES DE DECIDIR
+3)  O C&oacute;digo Penal n&atilde;o estabelece crit&eacute;rios objetivos para a fixa&ccedil;&atilde;o da pena-base, mas a jurisprud&ecirc;ncia do STJ adota, como par&acirc;metro, a fra&ccedil;&atilde;o de 1/8 sobre o intervalo entre as penas m&iacute;nima e m&aacute;xima cominadas ao tipo para cada circunst&acirc;ncia judicial negativada, por possu&iacute;rem id&ecirc;ntico grau de import&acirc;ncia (art. 59 do CP).
+4) O Ju&iacute;zo de origem negativou tr&ecirc;s circunst&acirc;ncias judiciais (motivo torpe, circunst&acirc;ncias do crime e consequ&ecirc;ncias do delito), mas exasperou a pena-base em patamar superior ao correspondente &agrave; fra&ccedil;&atilde;o de 1/8 para cada vetor, impondo aumento desproporcional.
+5) A readequa&ccedil;&atilde;o da pena-base com a incid&ecirc;ncia de 1/8 sobre o intervalo legal para cada circunst&acirc;ncia desfavor&aacute;vel conduz &agrave; fixa&ccedil;&atilde;o da pena-base em 2 anos e 6 meses de reclus&atilde;o.
+6) A confiss&atilde;o espont&acirc;nea, ainda que parcial, configura atenuante (art. 65, III, &quot;d&quot;, do CP), sendo cab&iacute;vel sua valora&ccedil;&atilde;o na segunda fase da dosimetria.
+7) A jurisprud&ecirc;ncia do STJ e do STF adota, como par&acirc;metro ordin&aacute;rio para agravantes e atenuantes, a fra&ccedil;&atilde;o de 1/6, admitindo-se percentual diverso desde que fundamentado e proporcional ao caso concreto.
+8) Considerando que o R&eacute;u confessou apenas parcialmente os fatos e que a autoria foi corroborada por prova testemunhal e pela palavra da v&iacute;tima, revela-se adequado fixar a redu&ccedil;&atilde;o em 1/7, em observ&acirc;ncia aos princ&iacute;pios da proporcionalidade e da individualiza&ccedil;&atilde;o da pena.
+9) O art. 387, IV, do CPP imp&otilde;e ao Juiz o dever de fixar valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos causados pela infra&ccedil;&atilde;o, abrangendo danos morais.
+10) A exist&ecirc;ncia de pedido expresso na den&uacute;ncia e a comprova&ccedil;&atilde;o da pr&aacute;tica delitiva autorizam a fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima, sendo o dano moral, na hip&oacute;tese de viol&ecirc;ncia com efetivo perigo de vida e incapacidade por mais de 30 dias, evidente diante da gravidade da conduta.
+11) O valor de R$ 5.000,00 mostra-se proporcional &agrave;s circunst&acirc;ncias do caso, &agrave; extens&atilde;o do dano e ao car&aacute;ter pedag&oacute;gico da medida, n&atilde;o configurando enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+12) Em parte com o parecer, Recurso parcialmente provido.
+Tese de julgamento:
+a) Na aus&ecirc;ncia de crit&eacute;rio legal espec&iacute;fico, aplica-se a fra&ccedil;&atilde;o de 1/8 sobre o intervalo entre as penas m&iacute;nima e m&aacute;xima do tipo penal para cada circunst&acirc;ncia judicial negativada, salvo fundamenta&ccedil;&atilde;o concreta que justifique patamar diverso.
+b) A atenuante da confiss&atilde;o espont&acirc;nea admite redu&ccedil;&atilde;o em fra&ccedil;&atilde;o diversa de 1/6, desde que o percentual fixado observe a proporcionalidade e a relev&acirc;ncia da colabora&ccedil;&atilde;o do R&eacute;u.
+c) &Eacute; cab&iacute;vel a fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o de danos morais na senten&ccedil;a penal condenat&oacute;ria, nos termos do art. 387, IV, do CPP, desde que haja pedido expresso e elementos suficientes nos autos.
+Dispositivos relevantes citados: CP, arts. 59, 65, III, &quot;d&quot;, e 68; CP, art. 129, &sect; 1&ordm;, I e II; CPP, art. 387, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, HC 367.917/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 14.02.2017; STJ, HC 381.179/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 16.02.2017; STJ, REsp 1.819.504/MS, Rel. Min. Laurita Vaz, Sexta Turma, j. 10.09.2019. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0931297-50.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. L&uacute;cio R. da Silveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Grave
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Lúcio R. da Silveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL – APELAÇÃO CRIMINAL DEFENSIVA – LESÃO CORPORAL GRAVE – DOSIMETRIA DA PENA – CIRCUNSTÂNCIAS JUDICIAIS – FRAÇÃO EXCESSIVA – ADEQUAÇÃO DA FRAÇÃO RELATIVA À CONFISSÃO ESPONTÂNEA – INDENIZAÇÃO POR DANOS MORAIS – MANUTENÇÃO –  RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1) Recurso de Apelação Criminal interposto contra Sentença que condenou o Réu pela prática do
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL – APELAÇÃO CRIMINAL DEFENSIVA – LESÃO CORPORAL GRAVE – DOSIMETRIA DA PENA – CIRCUNSTÂNCIAS JUDICIAIS – FRAÇÃO EXCESSIVA – ADEQUAÇÃO DA FRAÇÃO RELATIVA À CONFISSÃO ESPONTÂNEA – INDENIZAÇÃO POR DANOS MORAIS – MANUTENÇÃO –  RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1) Recurso de Apelação Criminal interposto contra Sentença que condenou o Réu pela prática do crime de lesão corporal grave (art. 129, § 1º, incisos I e II, do Código Penal), com reconhecimento da atenuante da confissão espontânea, fixando pena privativa de liberdade e valor mínimo de indenização por danos morais em favor da vítima.
+II. QUESTÃO EM DISCUSSÃO
+2) Há três questões em discussão: (2.1) definir se a exasperação da pena-base observou critério proporcional ao número de circunstâncias judiciais negativadas; (2.2) estabelecer se a fração aplicada à atenuante da confissão espontânea deve ser majorada; e (2.3) determinar se é cabível a fixação e manutenção de indenização mínima por danos morais na sentença penal condenatória.
+III. RAZÕES DE DECIDIR
+3)  O Código Penal não estabelece critérios objetivos para a fixação da pena-base, mas a jurisprudência do STJ adota, como parâmetro, a fração de 1/8 sobre o intervalo entre as penas mínima e máxima cominadas ao tipo para cada circunstância judicial negativada, por possuírem idêntico grau de importância (art. 59 do CP).
+4) O Juízo de origem negativou três circunstâncias judiciais (motivo torpe, circunstâncias do crime e consequências do delito), mas exasperou a pena-base em patamar superior ao correspondente à fração de 1/8 para cada vetor, impondo aumento desproporcional.
+5) A readequação da pena-base com a incidência de 1/8 sobre o intervalo legal para cada circunstância desfavorável conduz à fixação da pena-base em 2 anos e 6 meses de reclusão.
+6) A confissão espontânea, ainda que parcial, configura atenuante (art. 65, III, "d", do CP), sendo cabível sua valoração na segunda fase da dosimetria.
+7) A jurisprudência do STJ e do STF adota, como parâmetro ordinário para agravantes e atenuantes, a fração de 1/6, admitindo-se percentual diverso desde que fundamentado e proporcional ao caso concreto.
+8) Considerando que o Réu confessou apenas parcialmente os fatos e que a autoria foi corroborada por prova testemunhal e pela palavra da vítima, revela-se adequado fixar a redução em 1/7, em observância aos princípios da proporcionalidade e da individualização da pena.
+9) O art. 387, IV, do CPP impõe ao Juiz o dever de fixar valor mínimo para reparação dos danos causados pela infração, abrangendo danos morais.
+10) A existência de pedido expresso na denúncia e a comprovação da prática delitiva autorizam a fixação de indenização mínima, sendo o <em>dano</em> <em>moral</em>, na hipótese de violência com efetivo perigo de vida e incapacidade por mais de 30 dias, evidente diante da gravidade da conduta.
+11) O valor de R$ 5.000,00 mostra-se proporcional às circunstâncias do caso, à extensão do <em>dano</em> e ao caráter pedagógico da medida, não configurando enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+12) Em parte com o parecer, Recurso parcialmente provido.
+Tese de julgamento:
+a) Na ausência de critério legal específico, aplica-se a fração de 1/8 sobre o intervalo entre as penas mínima e máxima do tipo penal para cada circunstância judicial negativada, salvo fundamentação concreta que justifique patamar diverso.
+b) A atenuante da confissão espontânea admite redução em fração diversa de 1/6, desde que o percentual fixado observe a proporcionalidade e a relevância da colaboração do Réu.
+c) É cabível a fixação de valor mínimo para reparação de danos morais na sentença penal condenatória, nos termos do art. 387, IV, do CPP, desde que haja pedido expresso e elementos suficientes nos autos.
+Dispositivos relevantes citados: CP, arts. 59, 65, III, "d", e 68; CP, art. 129, § 1º, I e II; CPP, art. 387, IV.
+Jurisprudência relevante citada: STJ, HC 367.917/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 14.02.2017; STJ, HC 381.179/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 16.02.2017; STJ, REsp 1.819.504/MS, Rel. Min. Laurita Vaz, Sexta Turma, j. 10.09.2019.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>72&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877235" cdForo="0" >
+										0800797-14.2025.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877235" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877235);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877235" style="display: none;" >
+	<div id="textAreaDados_1877235" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O DE DANOS MATERIAIS E MORAIS C C OBRIGA&Ccedil;&Atilde;O DE FAZER COM PEDIDO DE TUTELA PROVIS&Oacute;RIA DE URG&Ecirc;NCIA.  DIREITO DO CONSUMIDOR E DIREITO PROCESSUAL CIVIL. SENTEN&Ccedil;A QUE INDEFERE INICIAL.  INDEFERIMENTO DA PETI&Ccedil;&Atilde;O INICIAL POR EXIG&Ecirc;NCIA DE PROVA PR&Eacute;VIA DE CONTRATA&Ccedil;&Atilde;O SUPOSTAMENTE FRAUDULENTA. SENTEN&Ccedil;A ANULADA. RECURSO PROVIDO.
+CASO EM EXAME.
+Recurso de apela&ccedil;&atilde;o interposto contra senten&ccedil;a que indeferiu a peti&ccedil;&atilde;o inicial em a&ccedil;&atilde;o de repara&ccedil;&atilde;o de danos materiais e morais c/c obriga&ccedil;&atilde;o de fazer e pedido de tutela, fundada em alega&ccedil;&atilde;o de financiamento de ve&iacute;culo realizado de forma fraudulenta em nome do autor.
+ QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em saber se &eacute; poss&iacute;vel indeferir a peti&ccedil;&atilde;o inicial e condicionar o regular processamento da demanda &agrave; apresenta&ccedil;&atilde;o, pelo consumidor, de contrato de compra, venda e financiamento, em hip&oacute;tese de alega&ccedil;&atilde;o de inexist&ecirc;ncia de contrata&ccedil;&atilde;o por suposta fraude, &agrave; luz do CPC e do CDC.
+RAZ&Otilde;ES DE DECIDIR
+Deu-se provimento ao recurso para anular a senten&ccedil;a e afastar o indeferimento da inicial, porque a peti&ccedil;&atilde;o inicial preenchia os requisitos dos arts. 319 e 320 do CPC e o indeferimento &eacute; excepcional e restrito &agrave;s hip&oacute;teses do art. 330 do CPC. O ju&iacute;zo de origem condicionou o prosseguimento &agrave; prova pr&eacute;via do fato constitutivo, confundindo aus&ecirc;ncia de documento indispens&aacute;vel com insufici&ecirc;ncia probat&oacute;ria, o que s&oacute; pode ser avaliado ap&oacute;s contradit&oacute;rio e instru&ccedil;&atilde;o. Considerou-se, ainda, que o autor alegou fato negativo (inexist&ecirc;ncia de contrata&ccedil;&atilde;o) em contexto de poss&iacute;vel fraude, o que torna irrazo&aacute;vel exigir a juntada do contrato, sobretudo em rela&ccedil;&atilde;o de consumo, na qual se admite a invers&atilde;o do &ocirc;nus da prova (CDC, art. 6&ordm;, VIII). O voto tamb&eacute;m assentou que condicionar o andamento da a&ccedil;&atilde;o &agrave; pr&eacute;via comprova&ccedil;&atilde;o viola a inafastabilidade da jurisdi&ccedil;&atilde;o (CF/1988, art. 5&ordm;, XXXV) e citou precedentes do TJMS sobre cerceamento de defesa e necessidade de oportunizar prova, inclusive com refer&ecirc;ncia ao CPC, art. 370 (TJMS. Apela&ccedil;&atilde;o C&iacute;vel n. 0810514-66.2024.8.12.0021, 1&ordf; C&acirc;mara C&iacute;vel, Rel. Des. M.C.R., j. 26/02/2026, p. 02/03/2026).
+
+
+
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o conhecido e provido para anular a senten&ccedil;a, afastar o indeferimento da peti&ccedil;&atilde;o inicial e determinar o regular prosseguimento do feito, com intima&ccedil;&atilde;o da requerida para contestar, nos termos do art. 331, &sect; 2&ordm;, do CPC.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, XXXV; CPC, arts. 319 e 320; CPC, art.330; CPC, art. 331, &sect; 2&ordm;; CPC, art. 370; CDC, art. 6&ordm;, VIII; CPC, art. 373, II; e CPC, art. 85, &sect; 11.
+Jurisprud&ecirc;ncia relevante citada: TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0810514-66.2024.8.12.0021, Rel. Des. M.C.R., 1&ordf; C&acirc;mara C&iacute;vel, j. 26.02.2026, p. 02.03.2026; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0804923-83.2024.8.12.0002, Rel. Des&ordf; E.R.B., 4&ordf; C&acirc;mara C&iacute;vel, j. 25.02.2026, p. 27.02.2026.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800797-14.2025.8.12.0015,&nbsp; Miranda,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE REPARAÇÃO DE DANOS MATERIAIS E MORAIS C C OBRIGAÇÃO DE FAZER COM PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA.  DIREITO DO CONSUMIDOR E DIREITO PROCESSUAL CIVIL. SENTENÇA QUE INDEFERE INICIAL.  INDEFERIMENTO DA PETIÇÃO INICIAL POR EXIGÊNCIA DE PROVA PRÉVIA DE CONTRATAÇÃO SUPOSTAMENTE FRAUDULENTA. SENTENÇA ANULADA. RECURSO PROVIDO.
+CASO EM EXAME.
+Recurso de apelação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE REPARAÇÃO DE DANOS MATERIAIS E MORAIS C C OBRIGAÇÃO DE FAZER COM PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA.  DIREITO DO CONSUMIDOR E DIREITO PROCESSUAL CIVIL. SENTENÇA QUE INDEFERE INICIAL.  INDEFERIMENTO DA PETIÇÃO INICIAL POR EXIGÊNCIA DE PROVA PRÉVIA DE CONTRATAÇÃO SUPOSTAMENTE FRAUDULENTA. SENTENÇA ANULADA. RECURSO PROVIDO.
+CASO EM EXAME.
+Recurso de apelação interposto contra sentença que indeferiu a petição inicial em ação de reparação de danos materiais e morais c/c obrigação de fazer e pedido de tutela, fundada em alegação de financiamento de veículo realizado de forma fraudulenta em nome do autor.
+ QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em saber se é possível indeferir a petição inicial e condicionar o regular processamento da demanda à apresentação, pelo consumidor, de contrato de compra, venda e financiamento, em hipótese de alegação de inexistência de contratação por suposta fraude, à luz do CPC e do CDC.
+RAZÕES DE DECIDIR
+Deu-se provimento ao recurso para anular a sentença e afastar o indeferimento da inicial, porque a petição inicial preenchia os requisitos dos arts. 319 e 320 do CPC e o indeferimento é excepcional e restrito às hipóteses do art. 330 do CPC. O juízo de origem condicionou o prosseguimento à prova prévia do fato constitutivo, confundindo ausência de documento indispensável com insuficiência probatória, o que só pode ser avaliado após contraditório e instrução. Considerou-se, ainda, que o autor alegou fato negativo (inexistência de contratação) em contexto de possível fraude, o que torna irrazoável exigir a juntada do contrato, sobretudo em relação de consumo, na qual se admite a inversão do ônus da prova (CDC, art. 6º, VIII). O voto também assentou que condicionar o andamento da ação à prévia comprovação viola a inafastabilidade da jurisdição (CF/1988, art. 5º, XXXV) e citou precedentes do TJMS sobre cerceamento de defesa e necessidade de oportunizar prova, inclusive com referência ao CPC, art. 370 (TJMS. Apelação Cível n. 0810514-66.2024.8.12.0021, 1ª Câmara Cível, Rel. Des. M.C.R., j. 26/02/2026, p. 02/03/2026).
+
+
+
+DISPOSITIVO
+Recurso de apelação conhecido e provido para anular a sentença, afastar o indeferimento da petição inicial e determinar o regular prosseguimento do feito, com intimação da requerida para contestar, nos termos do art. 331, § 2º, do CPC.
+Dispositivos relevantes citados: CF/1988, art. 5º, XXXV; CPC, arts. 319 e 320; CPC, art.330; CPC, art. 331, § 2º; CPC, art. 370; CDC, art. 6º, VIII; CPC, art. 373, II; e CPC, art. 85, § 11.
+Jurisprudência relevante citada: TJMS, Apelação Cível n. 0810514-66.2024.8.12.0021, Rel. Des. M.C.R., 1ª Câmara Cível, j. 26.02.2026, p. 02.03.2026; e TJMS, Apelação Cível n. 0804923-83.2024.8.12.0002, Rel. Desª E.R.B., 4ª Câmara Cível, j. 25.02.2026, p. 27.02.2026.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>73&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877239" cdForo="0" >
+										0803245-24.2020.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877239" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877239);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877239" style="display: none;" >
+	<div id="textAreaDados_1877239" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash;  RESPONSABILIDADE CIVIL OBJETIVA &ndash; CONCESSION&Aacute;RIA DE SERVI&Ccedil;OS P&Uacute;BLICOS &ndash; ESTA&Ccedil;&Atilde;O DE TRATAMENTO DE ESGOTO (ETE) &ndash; EMISS&Atilde;O DE GASES DECORRENTES DA OPERA&Ccedil;&Atilde;O &ndash; MAU CHEIRO PROVENIENTE DO EMPREENDIMENTO &ndash; LAUDO PERICIAL &ndash; VEDA&Ccedil;&Atilde;O PREC&Aacute;RIA E CORTINA ARB&Oacute;REA INSUFICIENTE &ndash; OCUPA&Ccedil;&Atilde;O RESIDENCIAL POSTERIOR &Agrave; INSTALA&Ccedil;&Atilde;O DA ETE &ndash; INDIFERENTE &ndash; DIREITO CONSTITUCIONAL &Agrave; MORADIA ADEQUADA, SA&Uacute;DE E MEIO AMBIENTE &ndash; RACISMO AMBIENTAL &ndash; PROTOCOLO POR PERSPECTIVA RACIAL &ndash; DANOS MORAIS CONFIGURADOS &ndash; RECURSO CONHECIDO E PROVIDO.
+Cinge-se a controv&eacute;rsia em definir se a Requerente/Apelante det&eacute;m o direito &agrave; fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais decorrentes de supostos odores provenientes de Esta&ccedil;&atilde;o de Tratamento de Esgoto operacionalizado pela Requerida/Apelada na cidade de Parana&iacute;ba/MS.
+Os fatos narrados nos autos devem ser analisados sob a &oacute;tica da responsabilidade objetiva, conforme o disposto no art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal, &agrave; luz da Teoria do Risco Administrativo em que a obriga&ccedil;&atilde;o de indenizar existe ainda que a conduta n&atilde;o seja culposa, na medida em que o polo passivo &eacute; ocupado por concession&aacute;ria de servi&ccedil;os p&uacute;blicos.
+N&atilde;o h&aacute; controv&eacute;rsia sobre a exist&ecirc;ncia da Esta&ccedil;&atilde;o de Tratamento de Esgoto em local pr&oacute;ximo &agrave; resid&ecirc;ncia da parte autora, sendo que, de acordo com a prova pericial, a despeito do mau cheiro pr&oacute;prio da atividade desenvolvida, h&aacute; falhas na veda&ccedil;&atilde;o das tampas de um dos reatores e na &quot;cortina arb&oacute;rea&quot;, as quais, se em pleno funcionamento, poderiam mitigar o forte odor percebido pelos moradores da regi&atilde;o.
+A par do direito &agrave; sa&uacute;de e meio ambiente equilibrado, a parte autora det&eacute;m direito &agrave; moradia (art. 6&ordm; da CF), que n&atilde;o se limita &agrave; exist&ecirc;ncia de um teto, mas ao padr&atilde;o de vida adequado dentro desse local de habita&ccedil;&atilde;o cont&iacute;nua, conforme reconhecido no cen&aacute;rio internacional pelo Protocolo Internacional dos Direitos Econ&ocirc;micos, Sociais e Culturais e no Coment&aacute;rio Geral n&ordm; 04, do PIDESC.
+Indiferente o fato de a parte autora ter passado a residir no local ap&oacute;s a instala&ccedil;&atilde;o da ETE, pois n&atilde;o h&aacute; uma simples &quot;op&ccedil;&atilde;o&quot; de residir num local perif&eacute;rico, mas a jun&ccedil;&atilde;o de fatores sociais que fazem com que a popula&ccedil;&atilde;o de baixa renda seja deslocada para &aacute;reas urbanas desprovidas de recursos.
+Obstar o direito &agrave; repara&ccedil;&atilde;o &eacute; refor&ccedil;ar um cen&aacute;rio de racismo ambiental, consistente no agravamento da situa&ccedil;&atilde;o de vida das pessoas carentes que vivem em locais perif&eacute;ricos e sofrem, de maneira mais acentuada, com eventos da natureza por for&ccedil;a do desenvolvimento e a explora&ccedil;&atilde;o de atividades empresariais (Resolu&ccedil;&atilde;o n&ordm; 598/2024, do CNJ, que instituiu o &quot;Protocolo para Julgamento com Perspectiva Racial do CNJ&quot;).
+O dano moral caracteriza-se pela les&atilde;o aos direitos de personalidade, pertencentes a uma esfera extrapatrimonial do indiv&iacute;duo e, no caso, n&atilde;o houve simples aborrecimento, pois a presen&ccedil;a constante de odor pela regi&atilde;o n&atilde;o pode ser compreendido como indiferente, mas como causador de les&atilde;o em decorr&ecirc;ncia da viola&ccedil;&atilde;o &agrave; integridade f&iacute;sica e psicol&oacute;gica da moradora.
+Quanto ao valor da indeniza&ccedil;&atilde;o, destaca-se que n&atilde;o existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercuss&atilde;o dos fatos, estabelecer a indeniza&ccedil;&atilde;o que venha ressarcir a parte lesada (car&aacute;ter indenizat&oacute;rio) e que tamb&eacute;m iniba a reitera&ccedil;&atilde;o de condutas an&aacute;logas (aspecto pedag&oacute;gico).
+Diante desses par&acirc;metros, mostra-se adequada a fixa&ccedil;&atilde;o de R$ 4.000,00 (quatro mil reais), levando em considera&ccedil;&atilde;o tamb&eacute;m o n&uacute;mero de pessoas que buscam id&ecirc;ntica repara&ccedil;&atilde;o.
+Recurso conhecido e provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803245-24.2020.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA –  RESPONSABILIDADE CIVIL OBJETIVA – CONCESSIONÁRIA DE SERVIÇOS PÚBLICOS – ESTAÇÃO DE TRATAMENTO DE ESGOTO (ETE) – EMISSÃO DE GASES DECORRENTES DA OPERAÇÃO – MAU CHEIRO PROVENIENTE DO EMPREENDIMENTO – LAUDO PERICIAL – VEDAÇÃO PRECÁRIA E CORTINA ARBÓREA INSUFICIENTE – OCUPAÇÃO RESIDENCIAL POSTERIOR À INSTALAÇÃO DA ETE – INDIFERENTE – DIREITO CONSTITUCIONAL À
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA –  RESPONSABILIDADE CIVIL OBJETIVA – CONCESSIONÁRIA DE SERVIÇOS PÚBLICOS – ESTAÇÃO DE TRATAMENTO DE ESGOTO (ETE) – EMISSÃO DE GASES DECORRENTES DA OPERAÇÃO – MAU CHEIRO PROVENIENTE DO EMPREENDIMENTO – LAUDO PERICIAL – VEDAÇÃO PRECÁRIA E CORTINA ARBÓREA INSUFICIENTE – OCUPAÇÃO RESIDENCIAL POSTERIOR À INSTALAÇÃO DA ETE – INDIFERENTE – DIREITO CONSTITUCIONAL À MORADIA ADEQUADA, SAÚDE E MEIO AMBIENTE – RACISMO AMBIENTAL – PROTOCOLO POR PERSPECTIVA RACIAL – DANOS MORAIS CONFIGURADOS – RECURSO CONHECIDO E PROVIDO.
+Cinge-se a controvérsia em definir se a Requerente/Apelante detém o direito à fixação de indenização por danos morais decorrentes de supostos odores provenientes de Estação de Tratamento de Esgoto operacionalizado pela Requerida/Apelada na cidade de Paranaíba/MS.
+Os fatos narrados nos autos devem ser analisados sob a ótica da responsabilidade objetiva, conforme o disposto no art. 37, § 6º, da Constituição Federal, à luz da Teoria do Risco Administrativo em que a obrigação de indenizar existe ainda que a conduta não seja culposa, na medida em que o polo passivo é ocupado por concessionária de serviços públicos.
+Não há controvérsia sobre a existência da Estação de Tratamento de Esgoto em local próximo à residência da parte autora, sendo que, de acordo com a prova pericial, a despeito do mau cheiro próprio da atividade desenvolvida, há falhas na vedação das tampas de um dos reatores e na "cortina arbórea", as quais, se em pleno funcionamento, poderiam mitigar o forte odor percebido pelos moradores da região.
+A par do direito à saúde e meio ambiente equilibrado, a parte autora detém direito à moradia (art. 6º da CF), que não se limita à existência de um teto, mas ao padrão de vida adequado dentro desse local de habitação contínua, conforme reconhecido no cenário internacional pelo Protocolo Internacional dos Direitos Econômicos, Sociais e Culturais e no Comentário Geral nº 04, do PIDESC.
+Indiferente o fato de a parte autora ter passado a residir no local após a instalação da ETE, pois não há uma simples "opção" de residir num local periférico, mas a junção de fatores sociais que fazem com que a população de baixa renda seja deslocada para áreas urbanas desprovidas de recursos.
+Obstar o direito à reparação é reforçar um cenário de racismo ambiental, consistente no agravamento da situação de vida das pessoas carentes que vivem em locais periféricos e sofrem, de maneira mais acentuada, com eventos da natureza por força do desenvolvimento e a exploração de atividades empresariais (Resolução nº 598/2024, do CNJ, que instituiu o "Protocolo para Julgamento com Perspectiva Racial do CNJ").
+O <em>dano</em> <em>moral</em> caracteriza-se pela lesão aos direitos de personalidade, pertencentes a uma esfera extrapatrimonial do indivíduo e, no caso, não houve simples aborrecimento, pois a presença constante de odor pela região não pode ser compreendido como indiferente, mas como causador de lesão em decorrência da violação à integridade física e psicológica da moradora.
+Quanto ao valor da indenização, destaca-se que não existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercussão dos fatos, estabelecer a indenização que venha ressarcir a parte lesada (caráter indenizatório) e que também iniba a reiteração de condutas análogas (aspecto pedagógico).
+Diante desses parâmetros, mostra-se adequada a fixação de R$ 4.000,00 (quatro mil reais), levando em consideração também o número de pessoas que buscam idêntica reparação.
+Recurso conhecido e provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>74&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877248" cdForo="0" >
+										0811321-49.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877248" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877248);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877248" style="display: none;" >
+	<div id="textAreaDados_1877248" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER CUMULADA COM INDENIZAT&Oacute;RIA &ndash; CONTA DO APLICATIVO INSTAGRAM HACKEADA POR CRIMINOSO &ndash; AUS&Ecirc;NCIA DE ATO IL&Iacute;CITO DA R&Eacute; &ndash; DANO MORAL N&Atilde;O CONFIGURADO &ndash; MANTIDA A OBRIGA&Ccedil;&Atilde;O DE FAZER DE EXCLUS&Atilde;O DA CONTA &ndash; SUCUMB&Ecirc;NCIA REC&Iacute;PROCA &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A an&aacute;lise dos autos demonstra que o dano alegado pelo autor foi praticado por terceiro, um criminoso que invadiu e tomou conta do seu perfil no Instagram, sendo que a plataforma digital possui ferramentas pr&oacute;prias para a recupera&ccedil;&atilde;o do perfil e, no caso, n&atilde;o comprovado que o autor seguiu os protocolos necess&aacute;rios para a retomada ou exclus&atilde;o da sua conta.
+Logo, n&atilde;o se pode dizer que houve a pr&aacute;tica de ato il&iacute;cito pela r&eacute;, que n&atilde;o foi devidamente informada na seara administrativa sobre o infort&uacute;nio sofrido pelo autor, a fim de que pudesse providenciar a r&aacute;pida solu&ccedil;&atilde;o do problema. Nesse contexto, tem-se que n&atilde;o configurada a responsabilidade civil da r&eacute;-apelante pelo dano suportado pelo autor, pois n&atilde;o praticou ato il&iacute;cito, o que afasta o dever de indenizar.
+Manuten&ccedil;&atilde;o da obriga&ccedil;&atilde;o de fazer de cancelamento da conta.
+A sucumb&ecirc;ncia deve ser distribu&iacute;da igualmente entre as partes, ante a exist&ecirc;ncia de sucumb&ecirc;ncia rec&iacute;proca, nos termos do artigo 86, do CPC. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0811321-49.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – CONTA DO APLICATIVO INSTAGRAM HACKEADA POR CRIMINOSO – AUSÊNCIA DE ATO ILÍCITO DA RÉ – <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO – MANTIDA A OBRIGAÇÃO DE FAZER DE EXCLUSÃO DA CONTA – SUCUMBÊNCIA RECÍPROCA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A análise dos autos demonstra que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – CONTA DO APLICATIVO INSTAGRAM HACKEADA POR CRIMINOSO – AUSÊNCIA DE ATO ILÍCITO DA RÉ – <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO – MANTIDA A OBRIGAÇÃO DE FAZER DE EXCLUSÃO DA CONTA – SUCUMBÊNCIA RECÍPROCA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A análise dos autos demonstra que o <em>dano</em> alegado pelo autor foi praticado por terceiro, um criminoso que invadiu e tomou conta do seu perfil no Instagram, sendo que a plataforma digital possui ferramentas próprias para a recuperação do perfil e, no caso, não comprovado que o autor seguiu os protocolos necessários para a retomada ou exclusão da sua conta.
+Logo, não se pode dizer que houve a prática de ato ilícito pela ré, que não foi devidamente informada na seara administrativa sobre o infortúnio sofrido pelo autor, a fim de que pudesse providenciar a rápida solução do problema. Nesse contexto, tem-se que não configurada a responsabilidade civil da ré-apelante pelo <em>dano</em> suportado pelo autor, pois não praticou ato ilícito, o que afasta o dever de indenizar.
+Manutenção da obrigação de fazer de cancelamento da conta.
+A sucumbência deve ser distribuída igualmente entre as partes, ante a existência de sucumbência recíproca, nos termos do artigo 86, do CPC.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>75&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877280" cdForo="0" >
+										0800922-23.2023.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877280" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877280);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877280" style="display: none;" >
+	<div id="textAreaDados_1877280" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash; RESPONSABILIDADE CIVIL OBJETIVA. RECURSO DO REQUERIDO &ndash; DONO DOS ANIMAIS &ndash; ATAQUE DE C&Atilde;ES A ANIMAL DE ESTIMA&Ccedil;&Atilde;O &ndash; NEXO DE CAUSALIDADE EVIDENTE ENTRE O ACIDENTE E MORTE DO FELINO &ndash;  ROMPIMENTO DO NEXO CAUSAL N&Atilde;O DEMONSTRADO &ndash; EXCLUDENTE  DE RESPONSABILIDADE CIVIL N&Atilde;O COMPROVADO. ALEGADA FOR&Ccedil;A MAIOR &ndash; N&Atilde;O EVIDENCIADA. EVENTO PREVIS&Iacute;VEL. PENA DE CONFESSO &ndash; SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.
+
+EMENTA &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash; RESPONSABILIDADE CIVIL OBJETIVA. RECURSO AUTORAL &ndash; PEDIDO DE MAJORA&Ccedil;&Atilde;O &ndash; ART. 936 CC &ndash; ARBITRAMENTO EM CONSON&Acirc;NCIA COM OS PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE &ndash; QUANTUM INDENIZAT&Oacute;RIO ADEQUADO E JUSTO &ndash; SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800922-23.2023.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – RESPONSABILIDADE CIVIL OBJETIVA. RECURSO DO REQUERIDO – DONO DOS ANIMAIS – ATAQUE DE CÃES A ANIMAL DE ESTIMAÇÃO – NEXO DE CAUSALIDADE EVIDENTE ENTRE O ACIDENTE E MORTE DO FELINO –  ROMPIMENTO DO NEXO CAUSAL NÃO DEMONSTRADO – EXCLUDENTE  DE RESPONSABILIDADE CIVIL NÃO COMPROVADO. ALEGADA FORÇA MAIOR – NÃO EVIDENCIADA. EVENTO PREVISÍVEL. PENA DE CONFESSO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – RESPONSABILIDADE CIVIL OBJETIVA. RECURSO DO REQUERIDO – DONO DOS ANIMAIS – ATAQUE DE CÃES A ANIMAL DE ESTIMAÇÃO – NEXO DE CAUSALIDADE EVIDENTE ENTRE O ACIDENTE E MORTE DO FELINO –  ROMPIMENTO DO NEXO CAUSAL NÃO DEMONSTRADO – EXCLUDENTE  DE RESPONSABILIDADE CIVIL NÃO COMPROVADO. ALEGADA FORÇA MAIOR – NÃO EVIDENCIADA. EVENTO PREVISÍVEL. PENA DE CONFESSO – SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+
+EMENTA – APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – RESPONSABILIDADE CIVIL OBJETIVA. RECURSO AUTORAL – PEDIDO DE MAJORAÇÃO – ART. 936 CC – ARBITRAMENTO EM CONSONÂNCIA COM OS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE – QUANTUM INDENIZATÓRIO ADEQUADO E JUSTO – SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>76&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877292" cdForo="0" >
+										0900161-39.2023.8.12.0011
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877292" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877292);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877292" style="display: none;" >
+	<div id="textAreaDados_1877292" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. FURTO QUALIFICADO (ROMPIMENTO DE OBST&Aacute;CULO E ESCALADA). RECEPTA&Ccedil;&Atilde;O DOLOSA. NULIDADE POR REVELIA. INOCORR&Ecirc;NCIA. PROVA SUFICIENTE. LAUDO PERICIAL INCONCLUSIVO. AFASTAMENTO DAS QUALIFICADORAS. DESCLASSIFICA&Ccedil;&Atilde;O PARA FURTO SIMPLES MAJORADO PELO REPOUSO NOTURNO. INDENIZA&Ccedil;&Atilde;O M&Iacute;NIMA. AUS&Ecirc;NCIA DE INSTRU&Ccedil;&Atilde;O ESPEC&Iacute;FICA. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a que condenou um dos r&eacute;us como incurso no art. 155, &sect; 4&ordm;, I e II, do C&oacute;digo Penal, e outro r&eacute;u como incurso no art. 180, caput, do C&oacute;digo Penal.
+Em grau recursal, a defesa apresentou as seguintes teses: a) nulidade por cerceamento de defesa (revelia indevida); b) absolvi&ccedil;&atilde;o por insufici&ecirc;ncia probat&oacute;ria; c) afastamento das qualificadoras; d) desclassifica&ccedil;&atilde;o da recepta&ccedil;&atilde;o para modalidade culposa; e) exclus&atilde;o da indeniza&ccedil;&atilde;o fixada.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+As controv&eacute;rsias consistem em definir: a) se houve nulidade processual pela decreta&ccedil;&atilde;o da revelia; b) se a prova produzida &eacute; suficiente para a condena&ccedil;&atilde;o; c) se restaram comprovadas as qualificadoras do rompimento de obst&aacute;culo e da escalada; d) se a conduta configura recepta&ccedil;&atilde;o dolosa ou culposa; e) se &eacute; v&aacute;lida a fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima sem instru&ccedil;&atilde;o espec&iacute;fica.
+III. RAZ&Otilde;ES DE DECIDIR
+Preliminar de nulidade: A revelia foi decretada ap&oacute;s intima&ccedil;&atilde;o pessoal do acusado em audi&ecirc;ncia, nos termos do art. 367 do C&oacute;digo de Processo Penal. A aus&ecirc;ncia injustificada do r&eacute;u, regularmente cientificado, autoriza a decreta&ccedil;&atilde;o da revelia, inexistindo cerceamento de defesa, sobretudo porque a defesa t&eacute;cnica permaneceu atuante e n&atilde;o houve demonstra&ccedil;&atilde;o de preju&iacute;zo. Preliminar rejeitada.
+Autoria e materialidade do furto: A condena&ccedil;&atilde;o n&atilde;o se baseou exclusivamente em reconhecimento informal. Ainda que se considere a orienta&ccedil;&atilde;o firmada pelo Superior Tribunal de Justi&ccedil;a no HC 598.886/SC quanto &agrave; invalidade do reconhecimento realizado em desacordo com o art. 226 do CPP, h&aacute; nos autos conjunto probat&oacute;rio aut&ocirc;nomo e harm&ocirc;nico: a) confiss&atilde;o extrajudicial detalhada; b) apreens&atilde;o dos bens na resid&ecirc;ncia do corr&eacute;u; c) depoimentos judiciais dos policiais e da v&iacute;tima. A confiss&atilde;o extrajudicial foi corroborada por provas judicializadas, n&atilde;o havendo not&iacute;cia de coa&ccedil;&atilde;o. Mantida a condena&ccedil;&atilde;o.
+Afastamento das qualificadoras: O art. 158 do CPP exige exame pericial quando a infra&ccedil;&atilde;o deixa vest&iacute;gios. O laudo pericial indireto concluiu ser imposs&iacute;vel atestar o rompimento da cerca el&eacute;trica ou a ocorr&ecirc;ncia de escalada. N&atilde;o se trata de desaparecimento de vest&iacute;gios (art. 167 do CPP), mas de laudo inconclusivo. Diante da d&uacute;vida t&eacute;cnica, aplica-se o princ&iacute;pio do in dubio pro reo. Afastadas as qualificadoras dos incisos I e II do &sect; 4&ordm; do art. 155 do C&oacute;digo Penal.
+Recepta&ccedil;&atilde;o &ndash; modalidade dolosa: As circunst&acirc;ncias da aquisi&ccedil;&atilde;o evidenciam ci&ecirc;ncia da proced&ecirc;ncia criminosa. Invi&aacute;vel a desclassifica&ccedil;&atilde;o para recepta&ccedil;&atilde;o culposa (art. 180, &sect; 3&ordm;, do CP). Mantida a condena&ccedil;&atilde;o pelo art. 180, caput, do C&oacute;digo Penal.
+Indeniza&ccedil;&atilde;o m&iacute;nima: O art. 387, IV, do CPP exige pedido expresso e instru&ccedil;&atilde;o probat&oacute;ria que permita contradit&oacute;rio quanto ao quantum debeatur. Embora conste pedido gen&eacute;rico na den&uacute;ncia, n&atilde;o houve instru&ccedil;&atilde;o espec&iacute;fica quanto ao valor do preju&iacute;zo remanescente. Os bens foram apreendidos e n&atilde;o houve debate t&eacute;cnico sobre eventual dano material residual. &Agrave; luz da jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a, a fixa&ccedil;&atilde;o do valor m&iacute;nimo sem adequada instru&ccedil;&atilde;o viola o contradit&oacute;rio. Afastada a indeniza&ccedil;&atilde;o, sem preju&iacute;zo da discuss&atilde;o na seara c&iacute;vel.
+IV. DISPOSITIVO E TESE
+Recurso parcialmente provido.
+Tese de julgamento:
+A decreta&ccedil;&atilde;o da revelia do r&eacute;u regularmente intimado em audi&ecirc;ncia n&atilde;o configura cerceamento de defesa.
+A condena&ccedil;&atilde;o pode subsistir ainda que desconsiderado eventual reconhecimento irregular, quando fundada em conjunto probat&oacute;rio aut&ocirc;nomo e judicializado, incluindo confiss&atilde;o extrajudicial corroborada por outras provas.
+Laudo pericial inconclusivo quanto &agrave; ocorr&ecirc;ncia de rompimento de obst&aacute;culo e escalada impede o reconhecimento das qualificadoras, impondo-se sua exclus&atilde;o com fundamento no princ&iacute;pio do in dubio pro reo.
+Configura recepta&ccedil;&atilde;o dolosa a aquisi&ccedil;&atilde;o de bens em circunst&acirc;ncias que evidenciem ci&ecirc;ncia da origem criminosa, sendo invi&aacute;vel a desclassifica&ccedil;&atilde;o para modalidade culposa quando demonstrado o dolo.
+A fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o de danos materiais exige pedido expresso e instru&ccedil;&atilde;o probat&oacute;ria espec&iacute;fica quanto ao montante, sob pena de viola&ccedil;&atilde;o ao contradit&oacute;rio.
+Dispositivos relevantes citados: C&oacute;digo Penal, arts. 155, &sect; 1&ordm; e &sect; 4&ordm;, I e II; 180, caput e &sect; 3&ordm;; 59; C&oacute;digo de Processo Penal, arts. 155, 158, 167, 226, 367 e 387, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, HC 598.886/SC, Rel. Min. Rog&eacute;rio Schietti Cruz, Sexta Turma, DJe 18.12.2020; STJ, AgRg no HC 872.909/PR, Rel. Min. Jesu&iacute;no Rissato (Des. Conv.), Sexta Turma, DJe 27.5.2024; STJ, AgRg no REsp 2.142.318/DF, Rel. Min. Rog&eacute;rio Schietti Cruz, Sexta Turma, DJe 4.9.2024; STJ, AgRg no AREsp 2.068.728/MG, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, DJe 13.5.2022; STJ, AgRg no REsp 2.011.839/TO, Sexta Turma, DJe 15.12.2022. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0900161-39.2023.8.12.0011,&nbsp; Coxim,&nbsp; 1&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des&ordf; Elizabete Anache, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Desª Elizabete Anache
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Coxim
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO (ROMPIMENTO DE OBSTÁCULO E ESCALADA). RECEPTAÇÃO DOLOSA. NULIDADE POR REVELIA. INOCORRÊNCIA. PROVA SUFICIENTE. LAUDO PERICIAL INCONCLUSIVO. AFASTAMENTO DAS QUALIFICADORAS. DESCLASSIFICAÇÃO PARA FURTO SIMPLES MAJORADO PELO REPOUSO NOTURNO. INDENIZAÇÃO MÍNIMA. AUSÊNCIA DE INSTRUÇÃO ESPECÍFICA. PARCIAL PROVIMENTO.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO (ROMPIMENTO DE OBSTÁCULO E ESCALADA). RECEPTAÇÃO DOLOSA. NULIDADE POR REVELIA. INOCORRÊNCIA. PROVA SUFICIENTE. LAUDO PERICIAL INCONCLUSIVO. AFASTAMENTO DAS QUALIFICADORAS. DESCLASSIFICAÇÃO PARA FURTO SIMPLES MAJORADO PELO REPOUSO NOTURNO. INDENIZAÇÃO MÍNIMA. AUSÊNCIA DE INSTRUÇÃO ESPECÍFICA. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+Apelação criminal interposta contra sentença que condenou um dos réus como incurso no art. 155, § 4º, I e II, do Código Penal, e outro réu como incurso no art. 180, caput, do Código Penal.
+Em grau recursal, a defesa apresentou as seguintes teses: a) nulidade por cerceamento de defesa (revelia indevida); b) absolvição por insuficiência probatória; c) afastamento das qualificadoras; d) desclassificação da receptação para modalidade culposa; e) exclusão da indenização fixada.
+II. QUESTÃO EM DISCUSSÃO
+As controvérsias consistem em definir: a) se houve nulidade processual pela decretação da revelia; b) se a prova produzida é suficiente para a condenação; c) se restaram comprovadas as qualificadoras do rompimento de obstáculo e da escalada; d) se a conduta configura receptação dolosa ou culposa; e) se é válida a fixação de indenização mínima sem instrução específica.
+III. RAZÕES DE DECIDIR
+Preliminar de nulidade: A revelia foi decretada após intimação pessoal do acusado em audiência, nos termos do art. 367 do Código de Processo Penal. A ausência injustificada do réu, regularmente cientificado, autoriza a decretação da revelia, inexistindo cerceamento de defesa, sobretudo porque a defesa técnica permaneceu atuante e não houve demonstração de prejuízo. Preliminar rejeitada.
+Autoria e materialidade do furto: A condenação não se baseou exclusivamente em reconhecimento informal. Ainda que se considere a orientação firmada pelo Superior Tribunal de Justiça no HC 598.886/SC quanto à invalidade do reconhecimento realizado em desacordo com o art. 226 do CPP, há nos autos conjunto probatório autônomo e harmônico: a) confissão extrajudicial detalhada; b) apreensão dos bens na residência do corréu; c) depoimentos judiciais dos policiais e da vítima. A confissão extrajudicial foi corroborada por provas judicializadas, não havendo notícia de coação. Mantida a condenação.
+Afastamento das qualificadoras: O art. 158 do CPP exige exame pericial quando a infração deixa vestígios. O laudo pericial indireto concluiu ser impossível atestar o rompimento da cerca elétrica ou a ocorrência de escalada. Não se trata de desaparecimento de vestígios (art. 167 do CPP), mas de laudo inconclusivo. Diante da dúvida técnica, aplica-se o princípio do in dubio pro reo. Afastadas as qualificadoras dos incisos I e II do § 4º do art. 155 do Código Penal.
+Receptação – modalidade dolosa: As circunstâncias da aquisição evidenciam ciência da procedência criminosa. Inviável a desclassificação para receptação culposa (art. 180, § 3º, do CP). Mantida a condenação pelo art. 180, caput, do Código Penal.
+Indenização mínima: O art. 387, IV, do CPP exige pedido expresso e instrução probatória que permita contraditório quanto ao quantum debeatur. Embora conste pedido genérico na denúncia, não houve instrução específica quanto ao valor do prejuízo remanescente. Os bens foram apreendidos e não houve debate técnico sobre eventual <em>dano</em> material residual. À luz da jurisprudência do Superior Tribunal de Justiça, a fixação do valor mínimo sem adequada instrução viola o contraditório. Afastada a indenização, sem prejuízo da discussão na seara cível.
+IV. DISPOSITIVO E TESE
+Recurso parcialmente provido.
+Tese de julgamento:
+A decretação da revelia do réu regularmente intimado em audiência não configura cerceamento de defesa.
+A condenação pode subsistir ainda que desconsiderado eventual reconhecimento irregular, quando fundada em conjunto probatório autônomo e judicializado, incluindo confissão extrajudicial corroborada por outras provas.
+Laudo pericial inconclusivo quanto à ocorrência de rompimento de obstáculo e escalada impede o reconhecimento das qualificadoras, impondo-se sua exclusão com fundamento no princípio do in dubio pro reo.
+Configura receptação dolosa a aquisição de bens em circunstâncias que evidenciem ciência da origem criminosa, sendo inviável a desclassificação para modalidade culposa quando demonstrado o dolo.
+A fixação de valor mínimo para reparação de danos materiais exige pedido expresso e instrução probatória específica quanto ao montante, sob pena de violação ao contraditório.
+Dispositivos relevantes citados: Código Penal, arts. 155, § 1º e § 4º, I e II; 180, caput e § 3º; 59; Código de Processo Penal, arts. 155, 158, 167, 226, 367 e 387, IV.
+Jurisprudência relevante citada: STJ, HC 598.886/SC, Rel. Min. Rogério Schietti Cruz, Sexta Turma, DJe 18.12.2020; STJ, AgRg no HC 872.909/PR, Rel. Min. Jesuíno Rissato (Des. Conv.), Sexta Turma, DJe 27.5.2024; STJ, AgRg no REsp 2.142.318/DF, Rel. Min. Rogério Schietti Cruz, Sexta Turma, DJe 4.9.2024; STJ, AgRg no AREsp 2.068.728/MG, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, DJe 13.5.2022; STJ, AgRg no REsp 2.011.839/TO, Sexta Turma, DJe 15.12.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>77&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877304" cdForo="0" >
+										1402580-03.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877304" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877304);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877304" style="display: none;" >
+	<div id="textAreaDados_1877304" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. AGRAVO INTERNO EM MANDADO DE SEGURAN&Ccedil;A CRIMINAL. SEQUESTRO DE BEM IM&Oacute;VEL. ALEGA&Ccedil;&Atilde;O DE BOA-F&Eacute; DE TERCEIRO ADQUIRENTE. NECESSIDADE DE DILA&Ccedil;&Atilde;O PROBAT&Oacute;RIA. INADEQUA&Ccedil;&Atilde;O DA VIA MANDAMENTAL. AUS&Ecirc;NCIA DE DIREITO L&Iacute;QUIDO E CERTO. MANUTEN&Ccedil;&Atilde;O DA DECIS&Atilde;O. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que, em Mandado de Seguran&ccedil;a Criminal, indeferiu pedido liminar destinado &agrave; suspens&atilde;o do sequestro incidente sobre im&oacute;vel adquirido pela impetrante, bem como &agrave; retomada da posse direta e continuidade de obras, sob o fundamento de inadequa&ccedil;&atilde;o da via eleita diante da necessidade de dila&ccedil;&atilde;o probat&oacute;ria.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se est&atilde;o presentes os requisitos para concess&atilde;o de liminar em mandado de seguran&ccedil;a, notadamente a demonstra&ccedil;&atilde;o de direito l&iacute;quido e certo; (ii) estabelecer se a controv&eacute;rsia acerca da boa-f&eacute; da adquirente e da origem l&iacute;cita do bem pode ser apreciada na via mandamental, sem necessidade de dila&ccedil;&atilde;o probat&oacute;ria.
+III. RAZ&Otilde;ES DE DECIDIR
+3) A concess&atilde;o de liminar em mandado de seguran&ccedil;a exige a presen&ccedil;a concomitante do fumus boni iuris e do periculum in mora, nos termos do art. 7&ordm;, III, da Lei n&ordm; 12.016/2009.
+4) A controv&eacute;rsia envolve elementos f&aacute;ticos relevantes, como a cronologia da aquisi&ccedil;&atilde;o, a eventual vincula&ccedil;&atilde;o do bem aos fatos delitivos e a alegada boa-f&eacute; da adquirente, os quais demandam dila&ccedil;&atilde;o probat&oacute;ria incompat&iacute;vel com a via mandamental.
+5) A exist&ecirc;ncia de embargos de terceiro em tr&acirc;mite na origem evidencia a adequa&ccedil;&atilde;o de via pr&oacute;pria para a an&aacute;lise aprofundada da mat&eacute;ria f&aacute;tica e probat&oacute;ria.
+6) A presen&ccedil;a de terceiro interessado e de impugna&ccedil;&atilde;o quanto &agrave; licitude da aquisi&ccedil;&atilde;o refor&ccedil;a a necessidade de preserva&ccedil;&atilde;o do contradit&oacute;rio e da ampla defesa.
+7) N&atilde;o se verifica, de plano, direito l&iacute;quido e certo apto a justificar o levantamento imediato da constri&ccedil;&atilde;o, nem ilegalidade manifesta ou teratologia na decis&atilde;o impugnada.
+8) A possibilidade de substitui&ccedil;&atilde;o da constri&ccedil;&atilde;o por cau&ccedil;&atilde;o, prevista no art. 131 do CPP, n&atilde;o foi apreciada definitivamente na origem, de modo que a interven&ccedil;&atilde;o do Tribunal implicaria supress&atilde;o de inst&acirc;ncia.
+IV. DISPOSITIVO E TESE
+9) Recurso desprovido.
+Tese de julgamento:
+1. A concess&atilde;o de liminar em mandado de seguran&ccedil;a exige demonstra&ccedil;&atilde;o inequ&iacute;voca de direito l&iacute;quido e certo, n&atilde;o sendo admitida quando a controv&eacute;rsia demanda dila&ccedil;&atilde;o probat&oacute;ria.
+2. A discuss&atilde;o sobre boa-f&eacute; de terceiro adquirente e origem de bem sequestrado deve ser realizada em via pr&oacute;pria, como embargos de terceiro, e n&atilde;o em mandado de seguran&ccedil;a.
+3. A aus&ecirc;ncia de ilegalidade manifesta ou teratologia na decis&atilde;o impugnada impede a concess&atilde;o de medida liminar na via mandamental.
+Dispositivos relevantes citados: Lei n&ordm; 12.016/2009, art. 7&ordm;, III; CPP, art. 131.
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) Magistrados(as) do(a) 1&ordf; Se&ccedil;&atilde;o Criminal do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade e contra o parecer, negaram provimento ao agravo interno, nos termos do voto do Relator.  <br><br>(<b>TJMS</b>. Agravo Interno Criminal n. 1402580-03.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 1&ordf; Se&ccedil;&atilde;o Criminal, Relator (a):&nbsp; Des. L&uacute;cio R. da Silveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Criminal / Liminar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Lúcio R. da Silveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Seção Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. AGRAVO INTERNO EM MANDADO DE SEGURANÇA CRIMINAL. SEQUESTRO DE BEM IMÓVEL. ALEGAÇÃO DE BOA-FÉ DE TERCEIRO ADQUIRENTE. NECESSIDADE DE DILAÇÃO PROBATÓRIA. INADEQUAÇÃO DA VIA MANDAMENTAL. AUSÊNCIA DE DIREITO LÍQUIDO E CERTO. MANUTENÇÃO DA DECISÃO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Agravo Interno interposto contra decisão monocrática que, em Mandado de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. AGRAVO INTERNO EM MANDADO DE SEGURANÇA CRIMINAL. SEQUESTRO DE BEM IMÓVEL. ALEGAÇÃO DE BOA-FÉ DE TERCEIRO ADQUIRENTE. NECESSIDADE DE DILAÇÃO PROBATÓRIA. INADEQUAÇÃO DA VIA MANDAMENTAL. AUSÊNCIA DE DIREITO LÍQUIDO E CERTO. MANUTENÇÃO DA DECISÃO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Agravo Interno interposto contra decisão monocrática que, em Mandado de Segurança Criminal, indeferiu pedido liminar destinado à suspensão do sequestro incidente sobre imóvel adquirido pela impetrante, bem como à retomada da posse direta e continuidade de obras, sob o fundamento de inadequação da via eleita diante da necessidade de dilação probatória.
+II. QUESTÃO EM DISCUSSÃO
+2) Há duas questões em discussão: (i) definir se estão presentes os requisitos para concessão de liminar em mandado de segurança, notadamente a demonstração de direito líquido e certo; (ii) estabelecer se a controvérsia acerca da boa-fé da adquirente e da origem lícita do bem pode ser apreciada na via mandamental, sem necessidade de dilação probatória.
+III. RAZÕES DE DECIDIR
+3) A concessão de liminar em mandado de segurança exige a presença concomitante do fumus boni iuris e do periculum in mora, nos termos do art. 7º, III, da Lei nº 12.016/2009.
+4) A controvérsia envolve elementos fáticos relevantes, como a cronologia da aquisição, a eventual vinculação do bem aos fatos delitivos e a alegada boa-fé da adquirente, os quais demandam dilação probatória incompatível com a via mandamental.
+5) A existência de embargos de terceiro em trâmite na origem evidencia a adequação de via própria para a análise aprofundada da matéria fática e probatória.
+6) A presença de terceiro interessado e de impugnação quanto à licitude da aquisição reforça a necessidade de preservação do contraditório e da ampla defesa.
+7) Não se verifica, de plano, direito líquido e certo apto a justificar o levantamento imediato da constrição, nem ilegalidade manifesta ou teratologia na decisão impugnada.
+8) A possibilidade de substituição da constrição por caução, prevista no art. 131 do CPP, não foi apreciada definitivamente na origem, de modo que a intervenção do Tribunal implicaria supressão de instância.
+IV. DISPOSITIVO E TESE
+9) Recurso desprovido.
+Tese de julgamento:
+1. A concessão de liminar em mandado de segurança exige demonstração inequívoca de direito líquido e certo, não sendo admitida quando a controvérsia demanda dilação probatória.
+2. A discussão sobre boa-fé de terceiro adquirente e origem de bem sequestrado deve ser realizada em via própria, como embargos de terceiro, e não em mandado de segurança.
+3. A ausência de ilegalidade manifesta ou teratologia na decisão impugnada impede a concessão de medida liminar na via mandamental.
+Dispositivos relevantes citados: Lei nº 12.016/2009, art. 7º, III; CPP, art. 131.
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) Magistrados(as) do(a) 1ª Seção Criminal do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade e contra o parecer, negaram provimento ao agravo interno, nos termos do voto do Relator.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>78&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877319" cdForo="0" >
+										0801737-10.2024.8.12.0016
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877319" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877319);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877319" style="display: none;" >
+	<div id="textAreaDados_1877319" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E PEDIDO DE REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; RECURSO DA PARTE REQUERIDA &ndash; INDEFERIMENTO DA JUSTI&Ccedil;A GRATUITA &ndash; AUS&Ecirc;NCIA DE RECOLHIMENTO DE PREPARO &ndash; DESER&Ccedil;&Atilde;O &ndash; RECURSO N&Atilde;O CONHECIDO.
+Ap&oacute;s o indeferimento da justi&ccedil;a gratuita, a r&eacute; n&atilde;o procedeu ao recolhimento do preparo recursal, sendo imperioso o reconhecimento da deser&ccedil;&atilde;o.
+Recurso n&atilde;o conhecido.
+RECURSO DA PARTE AUTORA &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA INEXISTENTE &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA PELA ASSOCIA&Ccedil;&Atilde;O R&Eacute; &ndash; ATO IL&Iacute;CITO CONFIGURADO &ndash; INEXIST&Ecirc;NCIA DE DANO MORAL &ndash; MERO ABORRECIMENTO &ndash; REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO EM DOBRO &ndash; OBSERV&Acirc;NCIA DOS EMBARGOS DE DIVERG&Ecirc;NCIA EM AGRAVO EM RECURSO ESPECIAL N&ordm; 676.608/RS &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O mero aborrecimento n&atilde;o pode ser tratado como dano moral, raz&atilde;o pela qual n&atilde;o se pode consubstanciar um dano moral capaz de gerar sofrimento ou atentar contra a reputa&ccedil;&atilde;o, a integridade psicol&oacute;gica ou a honra, tampouco, repita-se, que a situa&ccedil;&atilde;o influenciou negativamente em seu sustento, de modo que o ocorrido n&atilde;o ultrapassa o mero dissabor ou aborrecimento da vida cotidiana.
+Inexistindo comprova&ccedil;&atilde;o acerca da exist&ecirc;ncia de contrato que autorizasse os descontos diretamente dos proventos da parte autora e, considerando que os descontos indevidos ocorreram a partir de novembro de 2022, revela-se devido a repeti&ccedil;&atilde;o em dobro dos valores indevidamente abatidos apenas a partir da modula&ccedil;&atilde;o dos efeitos da decis&atilde;o pela Corte Especial do Superior Tribunal de Justi&ccedil;a, por meio do julgamento do Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, ou seja, a partir de 30/03/2021.
+Recurso conhecido e provido em parte.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801737-10.2024.8.12.0016,&nbsp; Mundo Novo,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(35 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Descontos dos benefícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mundo Novo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E PEDIDO DE REPARAÇÃO POR DANOS MORAIS – RECURSO DA PARTE REQUERIDA – INDEFERIMENTO DA JUSTIÇA GRATUITA – AUSÊNCIA DE RECOLHIMENTO DE PREPARO – DESERÇÃO – RECURSO NÃO CONHECIDO.
+Após o indeferimento da justiça gratuita, a ré não procedeu ao recolhimento do preparo recursal, sendo imperioso o reconhecimento
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E PEDIDO DE REPARAÇÃO POR DANOS MORAIS – RECURSO DA PARTE REQUERIDA – INDEFERIMENTO DA JUSTIÇA GRATUITA – AUSÊNCIA DE RECOLHIMENTO DE PREPARO – DESERÇÃO – RECURSO NÃO CONHECIDO.
+Após o indeferimento da justiça gratuita, a ré não procedeu ao recolhimento do preparo recursal, sendo imperioso o reconhecimento da deserção.
+Recurso não conhecido.
+RECURSO DA PARTE AUTORA – RELAÇÃO JURÍDICA INEXISTENTE – CONTRATAÇÃO NÃO COMPROVADA PELA ASSOCIAÇÃO RÉ – ATO ILÍCITO CONFIGURADO – INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em> – MERO ABORRECIMENTO – REPETIÇÃO DO INDÉBITO EM DOBRO – OBSERVÂNCIA DOS EMBARGOS DE DIVERGÊNCIA EM AGRAVO EM RECURSO ESPECIAL Nº 676.608/RS – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O mero aborrecimento não pode ser tratado como <em>dano</em> <em>moral</em>, razão pela qual não se pode consubstanciar um <em>dano</em> <em>moral</em> capaz de gerar sofrimento ou atentar contra a reputação, a integridade psicológica ou a honra, tampouco, repita-se, que a situação influenciou negativamente em seu sustento, de modo que o ocorrido não ultrapassa o mero dissabor ou aborrecimento da vida cotidiana.
+Inexistindo comprovação acerca da existência de contrato que autorizasse os descontos diretamente dos proventos da parte autora e, considerando que os descontos indevidos ocorreram a partir de novembro de 2022, revela-se devido a repetição em dobro dos valores indevidamente abatidos apenas a partir da modulação dos efeitos da decisão pela Corte Especial do Superior Tribunal de Justiça, por meio do julgamento do Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, ou seja, a partir de 30/03/2021.
+Recurso conhecido e provido em parte.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>79&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877327" cdForo="0" >
+										1403005-30.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877327" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877327);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877327" style="display: none;" >
+	<div id="textAreaDados_1877327" class="mensagemSemFormatacao" >
+		DIREITO DE FAM&Iacute;LIA &ndash; AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DE DISSOLU&Ccedil;&Atilde;O DE UNI&Atilde;O EST&Aacute;VEL C/C PARTILHA DE BENS, PENS&Atilde;O ALIMENT&Iacute;CIA, OBRIGA&Ccedil;&Atilde;O DE FAZER E REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; TUTELA DE URG&Ecirc;NCIA  &ndash; FIXA&Ccedil;&Atilde;O DE ALIMENTOS PROVIS&Oacute;RIOS &ndash;  CONTROV&Eacute;RSIA SOBRE EXIST&Ecirc;NCIA ATUAL DE UNI&Atilde;O EST&Aacute;VEL &ndash;  AUS&Ecirc;NCIA DE PROVA ROBUSTA DA DEPEND&Ecirc;NCIA ECON&Ocirc;MICA &ndash; AUS&Ecirc;NCIA DE PREENCHIMENTO DOS REQUISITOS &ndash; INDEFERIMENTO &ndash; DECIS&Atilde;O REFORMADA &ndash; RECURSO CONHECIDO E  PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento contra decis&atilde;o que deferiu parcialmente tutela de urg&ecirc;ncia para fixar alimentos provis&oacute;rios em favor da autora e determinar sua manuten&ccedil;&atilde;o em plano de sa&uacute;de e assist&ecirc;ncia funer&aacute;ria.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso o preenchimento, ou n&atilde;o, dos requisitos legais para o deferimento de tutela provis&oacute;ria de natureza antecipada, consistente na fixa&ccedil;&atilde;o de alimentos provis&oacute;rios entre ex-conviventes e na manuten&ccedil;&atilde;o da agravada como dependente em plano de sa&uacute;de.
+III. RAZ&Otilde;ES DE DECIDIR
+3.  O art. 300, do CPC/2015, prev&ecirc; que a tutela de urg&ecirc;ncia, esp&eacute;cie de tutela provis&oacute;ria (art. 294, CPC/15), ser&aacute; concedida quando houver elementos  que  evidenciem  a  probabilidade  do  direito  e  o perigo de dano, ou  de  risco ao resultado &uacute;til do processo, podendo ser de natureza cautelar  ou  antecipada.
+4.  N&atilde;o estando  presente,  simultaneamente,  a  verossimilhan&ccedil;a das   alega&ccedil;&otilde;es  (fumus boni iuris)  e  o  perigo  de   les&atilde;o   grave   e  de dif&iacute;cil repara&ccedil;&atilde;o ao direito da parte  (periculum in mora), e n&atilde;o havendo,  ainda,  risco  de irreversibilidade  da   medida,   &eacute;  de  ser   indeferida   a    antecipa&ccedil;&atilde;o dos  efeitos  da  tutela pleiteada pela parte autora-agravada.
+5. A fixa&ccedil;&atilde;o de alimentos provis&oacute;rios entre ex-companheiros possui natureza excepcional e exige demonstra&ccedil;&atilde;o m&iacute;nima da probabilidade do direito, especialmente quanto &agrave; exist&ecirc;ncia atual de v&iacute;nculo familiar ou de depend&ecirc;ncia econ&ocirc;mica, o que n&atilde;o se verificou no caso, diante da controv&eacute;rsia acerca da cessa&ccedil;&atilde;o da conviv&ecirc;ncia e da insufici&ecirc;ncia probat&oacute;ria. Assim, imp&otilde;e-se a reforma da decis&atilde;o recorrida.
+IV. DISPOSITIVO
+6. Agravo de Instrumento conhecido e provido. <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1403005-30.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Fixação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DE FAMÍLIA – AGRAVO DE INSTRUMENTO – AÇÃO DE DISSOLUÇÃO DE UNIÃO ESTÁVEL C/C PARTILHA DE BENS, PENSÃO ALIMENTÍCIA, OBRIGAÇÃO DE FAZER E REPARAÇÃO POR DANOS MORAIS – TUTELA DE URGÊNCIA  – FIXAÇÃO DE ALIMENTOS PROVISÓRIOS –  CONTROVÉRSIA SOBRE EXISTÊNCIA ATUAL DE UNIÃO ESTÁVEL –  AUSÊNCIA DE PROVA ROBUSTA DA DEPENDÊNCIA ECONÔMICA – AUSÊNCIA DE PREENCHIMENTO DOS REQUISITOS – INDEFERIMENTO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DE FAMÍLIA – AGRAVO DE INSTRUMENTO – AÇÃO DE DISSOLUÇÃO DE UNIÃO ESTÁVEL C/C PARTILHA DE BENS, PENSÃO ALIMENTÍCIA, OBRIGAÇÃO DE FAZER E REPARAÇÃO POR DANOS MORAIS – TUTELA DE URGÊNCIA  – FIXAÇÃO DE ALIMENTOS PROVISÓRIOS –  CONTROVÉRSIA SOBRE EXISTÊNCIA ATUAL DE UNIÃO ESTÁVEL –  AUSÊNCIA DE PROVA ROBUSTA DA DEPENDÊNCIA ECONÔMICA – AUSÊNCIA DE PREENCHIMENTO DOS REQUISITOS – INDEFERIMENTO – DECISÃO REFORMADA – RECURSO CONHECIDO E  PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento contra decisão que deferiu parcialmente tutela de urgência para fixar alimentos provisórios em favor da autora e determinar sua manutenção em plano de saúde e assistência funerária.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso o preenchimento, ou não, dos requisitos legais para o deferimento de tutela provisória de natureza antecipada, consistente na fixação de alimentos provisórios entre ex-conviventes e na manutenção da agravada como dependente em plano de saúde.
+III. RAZÕES DE DECIDIR
+3.  O art. 300, do CPC/2015, prevê que a tutela de urgência, espécie de tutela provisória (art. 294, CPC/15), será concedida quando houver elementos  que  evidenciem  a  probabilidade  do  direito  e  o perigo de <em>dano</em>, ou  de  risco ao resultado útil do processo, podendo ser de natureza cautelar  ou  antecipada.
+4.  Não estando  presente,  simultaneamente,  a  verossimilhança das   alegações  (fumus boni iuris)  e  o  perigo  de   lesão   grave   e  de difícil reparação ao direito da parte  (periculum in mora), e não havendo,  ainda,  risco  de irreversibilidade  da   medida,   é  de  ser   indeferida   a    antecipação dos  efeitos  da  tutela pleiteada pela parte autora-agravada.
+5. A fixação de alimentos provisórios entre ex-companheiros possui natureza excepcional e exige demonstração mínima da probabilidade do direito, especialmente quanto à existência atual de vínculo familiar ou de dependência econômica, o que não se verificou no caso, diante da controvérsia acerca da cessação da convivência e da insuficiência probatória. Assim, impõe-se a reforma da decisão recorrida.
+IV. DISPOSITIVO
+6. Agravo de Instrumento conhecido e provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>80&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877336" cdForo="0" >
+										0871112-46.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877336" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877336);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877336" style="display: none;" >
+	<div id="textAreaDados_1877336" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O &ndash; N&Atilde;O EXIST&Ecirc;NCIA DE OMISS&Atilde;O, CONTRADI&Ccedil;&Atilde;O, OBSCURIDADE OU ERRO MATERIAL &ndash; PRETENS&Atilde;O DE REDISCUTIR A MAT&Eacute;RIA &ndash; RECURSO CONHECIDO E N&Atilde;O ACOLHIDO.
+1. O embargos de declara&ccedil;&atilde;o visam ao aperfei&ccedil;oamento da decis&atilde;o ou ac&oacute;rd&atilde;o, nos termos dos arts. 1.008 e 1.026 do C&oacute;digo de Processo Civil.
+2. A mera rediscuss&atilde;o do decidido &eacute; vedada nos embargos de declara&ccedil;&atilde;o.
+3. Recurso conhecido e n&atilde;o acolhido.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0871112-46.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									871112462024812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO EXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO, OBSCURIDADE OU ERRO MATERIAL – PRETENSÃO DE REDISCUTIR A MATÉRIA – RECURSO CONHECIDO E NÃO ACOLHIDO.
+1. O embargos de declaração visam ao aperfeiçoamento da decisão ou acórdão, nos termos dos arts. 1.008 e 1.026 do Código de Processo Civil.
+2. A mera rediscussão do decidido é vedada nos embargos de declaração.
+3. Recurso
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO EXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO, OBSCURIDADE OU ERRO MATERIAL – PRETENSÃO DE REDISCUTIR A MATÉRIA – RECURSO CONHECIDO E NÃO ACOLHIDO.
+1. O embargos de declaração visam ao aperfeiçoamento da decisão ou acórdão, nos termos dos arts. 1.008 e 1.026 do Código de Processo Civil.
+2. A mera rediscussão do decidido é vedada nos embargos de declaração.
+3. Recurso conhecido e não acolhido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>81&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877339" cdForo="0" >
+										0816752-35.2022.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877339" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877339);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877339" style="display: none;" >
+	<div id="textAreaDados_1877339" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E LUCROS CESSANTES &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; DANOS MORAIS &ndash; N&Atilde;O CONFIGURADOS &ndash; ACIDENTE QUE CAUSOU APENAS DANOS MATERIAIS &ndash; INTEGRIDADE F&Iacute;SICA OU PS&Iacute;QUICA N&Atilde;O AFETADAS PELO EVENTO &ndash;LUCROS CESSANTES &ndash; RENDIMENTO MENSAL N&Atilde;O TOTALMENTE DEMONSTRADO &ndash; VALOR DA INDENIZA&Ccedil;&Atilde;O REDUZIDO &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+N&atilde;o caracteriza dano moral in re ipsa os danos decorrentes de acidentes de ve&iacute;culos automotores sem v&iacute;timas, os quais normalmente se resolvem por meio de repara&ccedil;&atilde;o de danos patrimoniais. De mais a mais, nesses casos, a condena&ccedil;&atilde;o &agrave; compensa&ccedil;&atilde;o de danos morais depende de comprova&ccedil;&atilde;o de circunst&acirc;ncias peculiares que demonstrem o extrapolamento da esfera exclusivamente patrimonial (STJ - REsp: 1653413 RJ 2016/0193046-6, Relator.: Ministro MARCO AUR&Eacute;LIO BELLIZZE, Data de Julgamento: 05/06/2018, T3 - TERCEIRA TURMA, Data de Publica&ccedil;&atilde;o: DJe 08/06/2018).
+No que concerne aos lucros cessantes, para o seu deferimento &eacute; indispens&aacute;vel que haja prova objetiva de sua ocorr&ecirc;ncia, n&atilde;o bastando mera expectativa, pois n&atilde;o se trata de dano hipot&eacute;tico, pelo que devem ter bases seguras, nos termos do artigo 402 do C&oacute;digo Civil.
+O relat&oacute;rio do Uber apresentado &eacute; referente apenas ao m&ecirc;s do acidente, fevereiro/2022, no qual o recorrido trabalhou apenas 7 dias. Em rela&ccedil;&atilde;o aos meses anteriores n&atilde;o restou demonstrado. Deve-se utilizar para aferir o rendimento m&eacute;dio mensal o valor informado pelo pr&oacute;prio apelado na emenda &agrave; inicial, qual seja, R$2.500,00.
+Logo, a renda m&eacute;dia mensal informada na emenda da inicial de R$2.500,00 equivale a R$83,33 por dia (R$2.500/30), o que multiplicado pelo per&iacute;odo em que o apelado ficou impossibilitado de utilizar o ve&iacute;culo como motorista de aplicativo, 9 dias, totaliza R$749,97.
+Recurso conhecido e parcialmente provido.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816752-35.2022.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(75 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E LUCROS CESSANTES – ACIDENTE DE TRÂNSITO – DANOS MORAIS – NÃO CONFIGURADOS – ACIDENTE QUE CAUSOU APENAS DANOS MATERIAIS – INTEGRIDADE FÍSICA OU PSÍQUICA NÃO AFETADAS PELO EVENTO –LUCROS CESSANTES – RENDIMENTO MENSAL NÃO TOTALMENTE DEMONSTRADO – VALOR DA INDENIZAÇÃO REDUZIDO – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Não
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E LUCROS CESSANTES – ACIDENTE DE TRÂNSITO – DANOS MORAIS – NÃO CONFIGURADOS – ACIDENTE QUE CAUSOU APENAS DANOS MATERIAIS – INTEGRIDADE FÍSICA OU PSÍQUICA NÃO AFETADAS PELO EVENTO –LUCROS CESSANTES – RENDIMENTO MENSAL NÃO TOTALMENTE DEMONSTRADO – VALOR DA INDENIZAÇÃO REDUZIDO – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Não caracteriza <em>dano</em> <em>moral</em> in re ipsa os danos decorrentes de acidentes de veículos automotores sem vítimas, os quais normalmente se resolvem por meio de reparação de danos patrimoniais. De mais a mais, nesses casos, a condenação à compensação de danos morais depende de comprovação de circunstâncias peculiares que demonstrem o extrapolamento da esfera exclusivamente patrimonial (STJ - REsp: 1653413 RJ 2016/0193046-6, Relator.: Ministro MARCO AURÉLIO BELLIZZE, Data de Julgamento: 05/06/2018, T3 - TERCEIRA TURMA, Data de Publicação: DJe 08/06/2018).
+No que concerne aos lucros cessantes, para o seu deferimento é indispensável que haja prova objetiva de sua ocorrência, não bastando mera expectativa, pois não se trata de <em>dano</em> hipotético, pelo que devem ter bases seguras, nos termos do artigo 402 do Código Civil.
+O relatório do Uber apresentado é referente apenas ao mês do acidente, fevereiro/2022, no qual o recorrido trabalhou apenas 7 dias. Em relação aos meses anteriores não restou demonstrado. Deve-se utilizar para aferir o rendimento médio mensal o valor informado pelo próprio apelado na emenda à inicial, qual seja, R$2.500,00.
+Logo, a renda média mensal informada na emenda da inicial de R$2.500,00 equivale a R$83,33 por dia (R$2.500/30), o que multiplicado pelo período em que o apelado ficou impossibilitado de utilizar o veículo como motorista de aplicativo, 9 dias, totaliza R$749,97.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>82&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877350" cdForo="0" >
+										0809166-13.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877350" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877350);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877350" style="display: none;" >
+	<div id="textAreaDados_1877350" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. DESCONTOS INDEVIDOS EM CONTA BANC&Aacute;RIA. RESPONSABILIDADE EXTRACONTRATUAL. TERMO INICIAL DOS JUROS MORAT&Oacute;RIOS. EVENTO DANOSO. S&Uacute;MULA 54 DO STJ. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+1. A senten&ccedil;a reconhece a inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica v&aacute;lida entre as partes e declara nulo o contrato que originou os descontos, por aus&ecirc;ncia de comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o, caracterizando falha na presta&ccedil;&atilde;o do servi&ccedil;o e ato il&iacute;cito.
+2. O reconhecimento de ato il&iacute;cito desvinculado de contrato v&aacute;lido enquadra a responsabilidade no &acirc;mbito extracontratual.
+3. Em hip&oacute;teses de responsabilidade extracontratual, os juros morat&oacute;rios incidem a partir do evento danoso, conforme a S&uacute;mula 54 do STJ.
+4. O preju&iacute;zo material se concretiza no momento de cada desconto indevido, ocasi&atilde;o em que ocorre diminui&ccedil;&atilde;o patrimonial imediata, configurando mora autom&aacute;tica.
+5. O valor fixado a t&iacute;tulo de danos morais observa os princ&iacute;pios da razoabilidade e da proporcionalidade, atende ao car&aacute;ter compensat&oacute;rio e pedag&oacute;gico da indeniza&ccedil;&atilde;o e se alinha aos par&acirc;metros adotados pelo Tribunal em casos an&aacute;logos.
+6. Recurso parcialmente provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0809166-13.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS. DESCONTOS INDEVIDOS EM CONTA BANCÁRIA. RESPONSABILIDADE EXTRACONTRATUAL. TERMO INICIAL DOS JUROS MORATÓRIOS. EVENTO DANOSO. SÚMULA 54 DO STJ. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+1. A sentença reconhece a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS. DESCONTOS INDEVIDOS EM CONTA BANCÁRIA. RESPONSABILIDADE EXTRACONTRATUAL. TERMO INICIAL DOS JUROS MORATÓRIOS. EVENTO DANOSO. SÚMULA 54 DO STJ. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+1. A sentença reconhece a inexistência de relação jurídica válida entre as partes e declara nulo o contrato que originou os descontos, por ausência de comprovação da contratação, caracterizando falha na prestação do serviço e ato ilícito.
+2. O reconhecimento de ato ilícito desvinculado de contrato válido enquadra a responsabilidade no âmbito extracontratual.
+3. Em hipóteses de responsabilidade extracontratual, os juros moratórios incidem a partir do evento danoso, conforme a Súmula 54 do STJ.
+4. O prejuízo material se concretiza no momento de cada desconto indevido, ocasião em que ocorre diminuição patrimonial imediata, configurando mora automática.
+5. O valor fixado a título de danos morais observa os princípios da razoabilidade e da proporcionalidade, atende ao caráter compensatório e pedagógico da indenização e se alinha aos parâmetros adotados pelo Tribunal em casos análogos.
+6. Recurso parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>83&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877352" cdForo="0" >
+										0802129-07.2025.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877352" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877352);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877352" style="display: none;" >
+	<div id="textAreaDados_1877352" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS COM TUTELA DE URG&Ecirc;NCIA &ndash; AUS&Ecirc;NCIA DE LAUDO PERICIAL &ndash; NULIDADE ARGUIDA DE OF&Iacute;CIO PELO JULGADOR &ndash; CERCEAMENTO DE DEFESA &ndash; NECESSIDADE DE DILA&Ccedil;&Atilde;O PROBAT&Oacute;RIA &ndash; PROVA PERICIAL IMPRESCIND&Iacute;VEL AO JULGAMENTO DO M&Eacute;RITO &ndash; ALEGA&Ccedil;&Atilde;O DE FRAUDE NA CONTRATA&Ccedil;&Atilde;O DIGITAL &ndash; SENTEN&Ccedil;A TORNADA INSUBSISTENTE &ndash; RECURSO PREJUDICADO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802129-07.2025.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS COM TUTELA DE URGÊNCIA – AUSÊNCIA DE LAUDO PERICIAL – NULIDADE ARGUIDA DE OFÍCIO PELO JULGADOR – CERCEAMENTO DE DEFESA – NECESSIDADE DE DILAÇÃO PROBATÓRIA – PROVA PERICIAL IMPRESCINDÍVEL AO JULGAMENTO DO MÉRITO – ALEGAÇÃO DE FRAUDE NA CONTRATAÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS COM TUTELA DE URGÊNCIA – AUSÊNCIA DE LAUDO PERICIAL – NULIDADE ARGUIDA DE OFÍCIO PELO JULGADOR – CERCEAMENTO DE DEFESA – NECESSIDADE DE DILAÇÃO PROBATÓRIA – PROVA PERICIAL IMPRESCINDÍVEL AO JULGAMENTO DO MÉRITO – ALEGAÇÃO DE FRAUDE NA CONTRATAÇÃO DIGITAL – SENTENÇA TORNADA INSUBSISTENTE – RECURSO PREJUDICADO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>84&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877354" cdForo="0" >
+										0800907-14.2024.8.12.0026
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877354" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877354);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877354" style="display: none;" >
+	<div id="textAreaDados_1877354" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL E RECURSO ADESIVO. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER CUMULADA COM REPARA&Ccedil;&Atilde;O DE DANOS. PLANO DE SA&Uacute;DE. CRIAN&Ccedil;A PORTADORA DE TRANSTORNO DO NEURODESENVOLVIMENTO (TDAH E DISLEXIA). RECURSO ADESIVO DA OPERADORA DE SA&Uacute;DE. COBERTURA OBRIGAT&Oacute;RIA PARA PSICOMOTRICIDADE. ROL DA ANS E LEI N.&ordm; 14.454/2022. COBERTURA DEVIDA. PRESCRI&Ccedil;&Atilde;O DO M&Eacute;DICO ASSISTENTE. RECURSO ADESIVO DESPROVIDO. APELA&Ccedil;&Atilde;O DO AUTOR. DANOS MORAIS DEVIDOS.  NEGATIVA DE COBERTURA DE TERAPIA ESSENCIAL PARA PACIENTE HIPERVULNER&Aacute;VEL. QUANTUM FIXADO EM R$ 5.000,00 (CINCO MIL REAIS). DANOS MATERIAIS. PEDIDO DE LIQUIDA&Ccedil;&Atilde;O FUTURA. IMPOSSIBILIDADE. AUS&Ecirc;NCIA DE PROVA DO DESEMBOLSO (AN DEBEATUR) NA FASE COGNITIVA. INDEFERIMENTO MANTIDO. SENTEN&Ccedil;A PARCIALMENTE REFORMADA. RECURSO DO AUTOR PROVIDO EM PARTE. RECURSO ADESIVO DESPROVIDO. DECIS&Atilde;O PARCIALMENTE COM O PARECER. 1. A Ag&ecirc;ncia Nacional de Sa&uacute;de tornou obrigat&oacute;ria a cobertura, pela operadora de plano de sa&uacute;de, de qualquer m&eacute;todo ou t&eacute;cnica indicada pelo profissional de sa&uacute;de respons&aacute;vel pelo tratamento de Transtornos Globais do Desenvolvimento (TEA&acute;s), dentre os quais a paralisia cerebral.&nbsp;2. A jurisprud&ecirc;ncia no Superior Tribunal de Justi&ccedil;a &eacute; assente no sentido de que, em regra, sendo desarrazoada a negativa de cobertura pela operadora do plano de sa&uacute;de do tratamento m&eacute;dico pleiteado, caracterizado fica o il&iacute;cito civil ensejador da repara&ccedil;&atilde;o por danos morais. 3. O valor indenizat&oacute;rio n&atilde;o pode ser insignificante a ponto de n&atilde;o ser capaz de mitigar ou amenizar os il&iacute;citos que atingem este setor de servi&ccedil;os da sociedade, tampouco deve revelar-se excessivo a tal ponto que venha a causar enriquecimento il&iacute;cito da parte requerente. No caso, considerando os par&acirc;metros apontados, entendo que o valor de R$ 5.000,00 (cinco mil reais) mostra-se razo&aacute;vel para reparar o dano infligido &agrave; paciente, al&eacute;m de mostrar-se em conson&acirc;ncia com os crit&eacute;rios indicados pela doutrina e pela jurisprud&ecirc;ncia. 4. A indeniza&ccedil;&atilde;o por danos materiais exige a demonstra&ccedil;&atilde;o efetiva do preju&iacute;zo patrimonial na fase de conhecimento (art. 373, I, do C&oacute;digo de Processo Civil). Inexistindo comprova&ccedil;&atilde;o do desembolso, &eacute; vedado relegar a mat&eacute;ria &agrave; fase de liquida&ccedil;&atilde;o de senten&ccedil;a. 5. Recurso do autor parcialmente provido. Recurso adesivo desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800907-14.2024.8.12.0026,&nbsp; Bataguassu,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. S&eacute;rgio Fernandes Martins, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Sérgio Fernandes Martins
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Bataguassu
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO. AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM REPARAÇÃO DE DANOS. PLANO DE SAÚDE. CRIANÇA PORTADORA DE TRANSTORNO DO NEURODESENVOLVIMENTO (TDAH E DISLEXIA). RECURSO ADESIVO DA OPERADORA DE SAÚDE. COBERTURA OBRIGATÓRIA PARA PSICOMOTRICIDADE. ROL DA ANS E LEI N.º 14.454/2022. COBERTURA DEVIDA. PRESCRIÇÃO DO MÉDICO ASSISTENTE. RECURSO ADESIVO DESPROVIDO. APELAÇÃO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO. AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM REPARAÇÃO DE DANOS. PLANO DE SAÚDE. CRIANÇA PORTADORA DE TRANSTORNO DO NEURODESENVOLVIMENTO (TDAH E DISLEXIA). RECURSO ADESIVO DA OPERADORA DE SAÚDE. COBERTURA OBRIGATÓRIA PARA PSICOMOTRICIDADE. ROL DA ANS E LEI N.º 14.454/2022. COBERTURA DEVIDA. PRESCRIÇÃO DO MÉDICO ASSISTENTE. RECURSO ADESIVO DESPROVIDO. APELAÇÃO DO AUTOR. DANOS MORAIS DEVIDOS.  NEGATIVA DE COBERTURA DE TERAPIA ESSENCIAL PARA PACIENTE HIPERVULNERÁVEL. QUANTUM FIXADO EM R$ 5.000,00 (CINCO MIL REAIS). DANOS MATERIAIS. PEDIDO DE LIQUIDAÇÃO FUTURA. IMPOSSIBILIDADE. AUSÊNCIA DE PROVA DO DESEMBOLSO (AN DEBEATUR) NA FASE COGNITIVA. INDEFERIMENTO MANTIDO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO DO AUTOR PROVIDO EM PARTE. RECURSO ADESIVO DESPROVIDO. DECISÃO PARCIALMENTE COM O PARECER. 1. A Agência Nacional de Saúde tornou obrigatória a cobertura, pela operadora de plano de saúde, de qualquer método ou técnica indicada pelo profissional de saúde responsável pelo tratamento de Transtornos Globais do Desenvolvimento (TEA´s), dentre os quais a paralisia cerebral. 2. A jurisprudência no Superior Tribunal de Justiça é assente no sentido de que, em regra, sendo desarrazoada a negativa de cobertura pela operadora do plano de saúde do tratamento médico pleiteado, caracterizado fica o ilícito civil ensejador da reparação por danos morais. 3. O valor indenizatório não pode ser insignificante a ponto de não ser capaz de mitigar ou amenizar os ilícitos que atingem este setor de serviços da sociedade, tampouco deve revelar-se excessivo a tal ponto que venha a causar enriquecimento ilícito da parte requerente. No caso, considerando os parâmetros apontados, entendo que o valor de R$ 5.000,00 (cinco mil reais) mostra-se razoável para reparar o <em>dano</em> infligido à paciente, além de mostrar-se em consonância com os critérios indicados pela doutrina e pela jurisprudência. 4. A indenização por danos materiais exige a demonstração efetiva do prejuízo patrimonial na fase de conhecimento (art. 373, I, do Código de Processo Civil). Inexistindo comprovação do desembolso, é vedado relegar a matéria à fase de liquidação de sentença. 5. Recurso do autor parcialmente provido. Recurso adesivo desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>85&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877363" cdForo="0" >
+										0862825-31.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877363" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877363);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877363" style="display: none;" >
+	<div id="textAreaDados_1877363" class="mensagemSemFormatacao" >
+		TR&Ecirc;S APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. PLANO DE SA&Uacute;DE. LEGITIMIDADE UNIMED CAMPO GRANDE, UNIMED RIO E UNIMED VALE DO SEPOTUBA CONFIRMADA. NEGATIVA DE COBERTURA DE ATENDIMENTOS. INDENIZA&Ccedil;&Atilde;O MATERIAL E MORAL CAB&Iacute;VEL. QUANTUM RAZO&Aacute;VEL. SENTEN&Ccedil;A MANTIDA. RECURSOS CONHECIDOS E DESPROVIDOS. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0862825-31.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1877363" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												TRÊS APELAÇÕES CÍVEIS. AÇÃO DE OBRIGAÇÃO DE FAZER. PLANO DE SAÚDE. LEGITIMIDADE UNIMED CAMPO GRANDE, UNIMED RIO E UNIMED VALE DO SEPOTUBA CONFIRMADA. NEGATIVA DE COBERTURA DE ATENDIMENTOS. INDENIZAÇÃO MATERIAL E <em>MORAL</em> CABÍVEL. QUANTUM RAZOÁVEL. SENTENÇA MANTIDA. RECURSOS CONHECIDOS E DESPROVIDOS.
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>86&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877365" cdForo="0" >
+										0816824-87.2020.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877365" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877365);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877365" style="display: none;" >
+	<div id="textAreaDados_1877365" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER COM PEDIDO DE INDENIZA&Ccedil;&Atilde;O DE DANOS MATERIAIS E MORAIS &ndash; CONTRATO DE FINANCIAMENTO COM GARANTIA FIDUCI&Aacute;RIA &ndash; AJUIZAMENTO INDEVIDO DE A&Ccedil;&Atilde;O DE BUSCA E APREENS&Atilde;O &ndash; EXTIN&Ccedil;&Atilde;O DA DEMANDA POR AUS&Ecirc;NCIA DE CONSTITUI&Ccedil;&Atilde;O V&Aacute;LIDA EM MORA &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; TRANSFER&Ecirc;NCIA DO VE&Iacute;CULO PARA OUTRA UNIDADE DA FEDERA&Ccedil;&Atilde;O &ndash; ALTERA&Ccedil;&Atilde;O DE PLACA E AUS&Ecirc;NCIA DE PRONTA REGULARIZA&Ccedil;&Atilde;O DOCUMENTAL &ndash; DEVOLU&Ccedil;&Atilde;O DO BEM EM CONDI&Ccedil;&Otilde;ES DIVERSAS DAQUELAS EM QUE APREENDIDO &ndash; DANO MATERIAL N&Atilde;O COMPROVADO &ndash; DANOS MORAIS CONFIGURADOS &ndash; QUANTUM INDENIZAT&Oacute;RIO FIXADO CONFORME A RAZOABILIDADE E PROPORCIONALIDADE &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A apreens&atilde;o indevida de ve&iacute;culo em a&ccedil;&atilde;o de busca e apreens&atilde;o posteriormente extinta por aus&ecirc;ncia de constitui&ccedil;&atilde;o v&aacute;lida em mora afasta a tese de exerc&iacute;cio regular de direito e evidencia falha na presta&ccedil;&atilde;o do servi&ccedil;o, nos termos do art. 14, do C&oacute;digo de Defesa do Consumidor.
+Para a configura&ccedil;&atilde;o do dano material e consequente condena&ccedil;&atilde;o em indeniza&ccedil;&atilde;o, &eacute; indispens&aacute;vel a exist&ecirc;ncia de provas concretas sobre as perdas patrimoniais sofridas pela parte ofendida.
+Demonstrada a priva&ccedil;&atilde;o indevida do uso de ve&iacute;culo, somada &agrave; devolu&ccedil;&atilde;o do bem em situa&ccedil;&atilde;o irregular, por per&iacute;odo de tempo consider&aacute;vel, &eacute; evidente a caracteriza&ccedil;&atilde;o do dano moral, dado o sofrimento, a frustra&ccedil;&atilde;o e o sentimento de impot&ecirc;ncia vivenciados pela consumidora, que ultrapassa o mero dissabor cotidiano e atinge a esfera da dignidade do consumidor.
+O valor da indeniza&ccedil;&atilde;o deve atender aos princ&iacute;pios da razoabilidade e da proporcionalidade, cumprindo fun&ccedil;&atilde;o compensat&oacute;ria para a v&iacute;tima e pedag&oacute;gica para o ofensor, sem importar enriquecimento indevido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816824-87.2020.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER COM PEDIDO DE INDENIZAÇÃO DE DANOS MATERIAIS E MORAIS – CONTRATO DE FINANCIAMENTO COM GARANTIA FIDUCIÁRIA – AJUIZAMENTO INDEVIDO DE AÇÃO DE BUSCA E APREENSÃO – EXTINÇÃO DA DEMANDA POR AUSÊNCIA DE CONSTITUIÇÃO VÁLIDA EM MORA – FALHA NA PRESTAÇÃO DO SERVIÇO – TRANSFERÊNCIA DO VEÍCULO PARA OUTRA UNIDADE DA FEDERAÇÃO – ALTERAÇÃO DE PLACA E AUSÊNCIA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER COM PEDIDO DE INDENIZAÇÃO DE DANOS MATERIAIS E MORAIS – CONTRATO DE FINANCIAMENTO COM GARANTIA FIDUCIÁRIA – AJUIZAMENTO INDEVIDO DE AÇÃO DE BUSCA E APREENSÃO – EXTINÇÃO DA DEMANDA POR AUSÊNCIA DE CONSTITUIÇÃO VÁLIDA EM MORA – FALHA NA PRESTAÇÃO DO SERVIÇO – TRANSFERÊNCIA DO VEÍCULO PARA OUTRA UNIDADE DA FEDERAÇÃO – ALTERAÇÃO DE PLACA E AUSÊNCIA DE PRONTA REGULARIZAÇÃO DOCUMENTAL – DEVOLUÇÃO DO BEM EM CONDIÇÕES DIVERSAS DAQUELAS EM QUE APREENDIDO – <em>DANO</em> MATERIAL NÃO COMPROVADO – DANOS MORAIS CONFIGURADOS – QUANTUM INDENIZATÓRIO FIXADO CONFORME A RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A apreensão indevida de veículo em ação de busca e apreensão posteriormente extinta por ausência de constituição válida em mora afasta a tese de exercício regular de direito e evidencia falha na prestação do serviço, nos termos do art. 14, do Código de Defesa do Consumidor.
+Para a configuração do <em>dano</em> material e consequente condenação em indenização, é indispensável a existência de provas concretas sobre as perdas patrimoniais sofridas pela parte ofendida.
+Demonstrada a privação indevida do uso de veículo, somada à devolução do bem em situação irregular, por período de tempo considerável, é evidente a caracterização do <em>dano</em> <em>moral</em>, dado o sofrimento, a frustração e o sentimento de impotência vivenciados pela consumidora, que ultrapassa o mero dissabor cotidiano e atinge a esfera da dignidade do consumidor.
+O valor da indenização deve atender aos princípios da razoabilidade e da proporcionalidade, cumprindo função compensatória para a vítima e pedagógica para o ofensor, sem importar enriquecimento indevido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>87&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877375" cdForo="0" >
+										0800803-45.2021.8.12.0020
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877375" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877375);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877375" style="display: none;" >
+	<div id="textAreaDados_1877375" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; EMPR&Eacute;STIMO CONSIGNADO &ndash; PRELIMINAR DE ILEGITIMIDADE AFASTADA - CONTRATA&Ccedil;&Atilde;O VIA TELEFONE &ndash; PER&Iacute;CIA FON&Eacute;TICA REALIZADA &ndash; VONTADE DO CONSUMIDOR N&Atilde;O DEMONSTRADA &ndash; VOZ QUE N&Atilde;O PERTENCE AO AUTOR &ndash; FRAUDE CONFIGURADA &ndash; INEXIST&Ecirc;NCIA DO D&Eacute;BITO MANTIDA &ndash; DANOS MORAIS CONFIGURADOS &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO NA FORMA SIMPLES &ndash; AUS&Ecirc;NCIA DE PROVA DE M&Aacute;-F&Eacute; DO BANCO &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Restando comprovado por per&iacute;cia t&eacute;cnica fon&eacute;tica que a voz constante na grava&ccedil;&atilde;o utilizada para a contrata&ccedil;&atilde;o do empr&eacute;stimo n&atilde;o pertence ao consumidor, deve ser mantida a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito e do contrato.
+A contrata&ccedil;&atilde;o fraudulenta que enseja descontos indevidos em verba alimentar de pessoa idosa ultrapassa o mero aborrecimento, configurando dano moral in re ipsa.
+O valor da indeniza&ccedil;&atilde;o deve ser mantido em R$ 5.000,00, por estar em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e proporcionalidade.
+A repeti&ccedil;&atilde;o do ind&eacute;bito deve ocorrer na forma simples, uma vez que a dobra prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC, pressup&otilde;e a exist&ecirc;ncia de m&aacute;-f&eacute;, a qual n&atilde;o restou cabalmente demonstrada no caso, tratando-se de falha na seguran&ccedil;a do sistema banc&aacute;rio diante de fraude de terceiros. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800803-45.2021.8.12.0020,&nbsp; Rio Brilhante,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Brilhante
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – PRELIMINAR DE ILEGITIMIDADE AFASTADA - CONTRATAÇÃO VIA TELEFONE – PERÍCIA FONÉTICA REALIZADA – VONTADE DO CONSUMIDOR NÃO DEMONSTRADA – VOZ QUE NÃO PERTENCE AO AUTOR – FRAUDE CONFIGURADA – INEXISTÊNCIA DO DÉBITO MANTIDA – DANOS MORAIS CONFIGURADOS – QUANTUM INDENIZATÓRIO MANTIDO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – PRELIMINAR DE ILEGITIMIDADE AFASTADA - CONTRATAÇÃO VIA TELEFONE – PERÍCIA FONÉTICA REALIZADA – VONTADE DO CONSUMIDOR NÃO DEMONSTRADA – VOZ QUE NÃO PERTENCE AO AUTOR – FRAUDE CONFIGURADA – INEXISTÊNCIA DO DÉBITO MANTIDA – DANOS MORAIS CONFIGURADOS – QUANTUM INDENIZATÓRIO MANTIDO – REPETIÇÃO DO INDÉBITO NA FORMA SIMPLES – AUSÊNCIA DE PROVA DE MÁ-FÉ DO BANCO – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Restando comprovado por perícia técnica fonética que a voz constante na gravação utilizada para a contratação do empréstimo não pertence ao consumidor, deve ser mantida a declaração de inexistência do débito e do contrato.
+A contratação fraudulenta que enseja descontos indevidos em verba alimentar de pessoa idosa ultrapassa o mero aborrecimento, configurando <em>dano</em> <em>moral</em> in re ipsa.
+O valor da indenização deve ser mantido em R$ 5.000,00, por estar em consonância com os princípios da razoabilidade e proporcionalidade.
+A repetição do indébito deve ocorrer na forma simples, uma vez que a dobra prevista no art. 42, parágrafo único, do CDC, pressupõe a existência de má-fé, a qual não restou cabalmente demonstrada no caso, tratando-se de falha na segurança do sistema bancário diante de fraude de terceiros.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>88&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877378" cdForo="0" >
+										0016419-92.2017.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877378" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877378);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877378" style="display: none;" >
+	<div id="textAreaDados_1877378" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O COMUM &ndash; V&Iacute;CIOS EM IM&Oacute;VEL RESIDENCIAL OBJETO DE COMPRA E VENDA ENTRE AS PARTES LITIGANTES &ndash; PRECLUS&Atilde;O CONSUMATIVA DA SEGUNDA CONTESTA&Ccedil;&Atilde;O REJEITADA &ndash; AUS&Ecirc;NCIA DE PREJU&Iacute;ZO &ndash; ALEGA&Ccedil;&Atilde;O DE REVELIA &ndash; EFEITOS AFASTADOS &ndash; APLICA&Ccedil;&Atilde;O DO ARTIGO 345, I, DO CPC &ndash; M&Eacute;RITO &ndash; DANOS MATERIAIS J&Aacute; ABRANGIDOS POR ACORDO &ndash; IMPOSSIBILIDADE DE NOVA CONDENA&Ccedil;&Atilde;O &ndash; PERDAS E DANOS &ndash; LIMITES DO PEDIDO E DA CAUSA DE PEDIR CORRETAMENTE DEFINIDOS NA SENTEN&Ccedil;A &ndash; DANO MORAL CONFIGURADO &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; JUROS MORAT&Oacute;RIOS &ndash; TERMO INICIAL &ndash; PRIMEIRA CITA&Ccedil;&Atilde;O V&Aacute;LIDA &ndash; RESPONSABILIDADE SOLID&Aacute;RIA &ndash; RECURSO DA AUTORA CONHECIDO E PARCIALMENTE PROVIDO &ndash; RECURSO DO REQUERIDO CONHECIDO E DESPROVIDO.
+A apresenta&ccedil;&atilde;o da segunda pe&ccedil;a de contesta&ccedil;&atilde;o, embora atraia, em tese, a preclus&atilde;o consumativa, n&atilde;o enseja a reforma da senten&ccedil;a se ausente demonstra&ccedil;&atilde;o de preju&iacute;zo e quando o julgamento se apoia em todo o conjunto probat&oacute;rio produzido nos autos.
+Em havendo pluralidade de r&eacute;us, a contesta&ccedil;&atilde;o apresentada por um deles, com impugna&ccedil;&atilde;o de fatos comuns, afasta os efeitos materiais da revelia, nos termos do art. 345, I, do CPC. Invi&aacute;vel, ademais, o reconhecimento da revelia sem cita&ccedil;&atilde;o v&aacute;lida.
+A condena&ccedil;&atilde;o deve observar os limites do pedido e da causa de pedir, n&atilde;o sendo poss&iacute;vel a convers&atilde;o ampla da obriga&ccedil;&atilde;o em perdas e danos por v&iacute;cios n&atilde;o deduzidos originariamente na peti&ccedil;&atilde;o inicial.
+N&atilde;o h&aacute; falar em mero aborrecimento na aquisi&ccedil;&atilde;o de im&oacute;vel residencial com v&iacute;cios, em que constatado por laudo pericial o retorno de esgoto para o interior da resid&ecirc;ncia, mau cheiro e alagamento de &aacute;reas do im&oacute;vel, por se tratarem de circunst&acirc;ncias que ultrapassam os dissabores cotidianos, gerando enorme frustra&ccedil;&atilde;o por quem adquire casa nova esperando condi&ccedil;&otilde;es m&iacute;nimas de moradia adequada.
+O quantum indenizat&oacute;rio deve ser fixado de forma proporcional &agrave; gravidade do dano e &agrave;s peculiaridades do caso concreto, sem causar enriquecimento il&iacute;cito.
+Havendo condena&ccedil;&atilde;o solid&aacute;ria imposta aos r&eacute;us, os juros morat&oacute;rios sobre indeniza&ccedil;&atilde;o por dano moral devem incidir a partir da primeira cita&ccedil;&atilde;o v&aacute;lida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0016419-92.2017.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Vícios de Construção
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO COMUM – VÍCIOS EM IMÓVEL RESIDENCIAL OBJETO DE COMPRA E VENDA ENTRE AS PARTES LITIGANTES – PRECLUSÃO CONSUMATIVA DA SEGUNDA CONTESTAÇÃO REJEITADA – AUSÊNCIA DE PREJUÍZO – ALEGAÇÃO DE REVELIA – EFEITOS AFASTADOS – APLICAÇÃO DO ARTIGO 345, I, DO CPC – MÉRITO – DANOS MATERIAIS JÁ ABRANGIDOS POR ACORDO – IMPOSSIBILIDADE DE NOVA CONDENAÇÃO – PERDAS E DANOS – LIMITES DO PEDIDO E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO COMUM – VÍCIOS EM IMÓVEL RESIDENCIAL OBJETO DE COMPRA E VENDA ENTRE AS PARTES LITIGANTES – PRECLUSÃO CONSUMATIVA DA SEGUNDA CONTESTAÇÃO REJEITADA – AUSÊNCIA DE PREJUÍZO – ALEGAÇÃO DE REVELIA – EFEITOS AFASTADOS – APLICAÇÃO DO ARTIGO 345, I, DO CPC – MÉRITO – DANOS MATERIAIS JÁ ABRANGIDOS POR ACORDO – IMPOSSIBILIDADE DE NOVA CONDENAÇÃO – PERDAS E DANOS – LIMITES DO PEDIDO E DA CAUSA DE PEDIR CORRETAMENTE DEFINIDOS NA SENTENÇA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM INDENIZATÓRIO MANTIDO – JUROS MORATÓRIOS – TERMO INICIAL – PRIMEIRA CITAÇÃO VÁLIDA – RESPONSABILIDADE SOLIDÁRIA – RECURSO DA AUTORA CONHECIDO E PARCIALMENTE PROVIDO – RECURSO DO REQUERIDO CONHECIDO E DESPROVIDO.
+A apresentação da segunda peça de contestação, embora atraia, em tese, a preclusão consumativa, não enseja a reforma da sentença se ausente demonstração de prejuízo e quando o julgamento se apoia em todo o conjunto probatório produzido nos autos.
+Em havendo pluralidade de réus, a contestação apresentada por um deles, com impugnação de fatos comuns, afasta os efeitos materiais da revelia, nos termos do art. 345, I, do CPC. Inviável, ademais, o reconhecimento da revelia sem citação válida.
+A condenação deve observar os limites do pedido e da causa de pedir, não sendo possível a conversão ampla da obrigação em perdas e danos por vícios não deduzidos originariamente na petição inicial.
+Não há falar em mero aborrecimento na aquisição de imóvel residencial com vícios, em que constatado por laudo pericial o retorno de esgoto para o interior da residência, mau cheiro e alagamento de áreas do imóvel, por se tratarem de circunstâncias que ultrapassam os dissabores cotidianos, gerando enorme frustração por quem adquire casa nova esperando condições mínimas de moradia adequada.
+O quantum indenizatório deve ser fixado de forma proporcional à gravidade do <em>dano</em> e às peculiaridades do caso concreto, sem causar enriquecimento ilícito.
+Havendo condenação solidária imposta aos réus, os juros moratórios sobre indenização por <em>dano</em> <em>moral</em> devem incidir a partir da primeira citação válida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>89&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877400" cdForo="0" >
+										0800893-68.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877400" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877400);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877400" style="display: none;" >
+	<div id="textAreaDados_1877400" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER CUMULADA COM INDENIZAT&Oacute;RIA &ndash; PLANO DE SA&Uacute;DE &ndash; MANUTEN&Ccedil;&Atilde;O DO VALOR DA CAUSA - RECUSA DO FORNECIMENTO DO MEDICAMENTO Rituximabe &ndash; DEVER DE COBERTURA - DANOS MORAIS N&Atilde;O CONFIGURADOS &ndash;  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+&Eacute; abusiva a recusa&nbsp;de&nbsp;cobertura&nbsp;de&nbsp;medicamento regularmente registrado na ANVISA, prescrito por profissional habilitado, ainda que utilizado em car&aacute;ter off-label ou fora das diretrizes da ANS, desde que demonstrada sua efic&aacute;cia e necessidade cl&iacute;nica.
+A simples recusa indevida de cobertura m&eacute;dico-assistencial por operadora de plano de sa&uacute;de n&atilde;o gera, por si s&oacute;, dano moral presumido (in re ipsa), sendo imprescind&iacute;vel a presen&ccedil;a de outros elementos que permitam constatar a altera&ccedil;&atilde;o an&iacute;mica da v&iacute;tima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo&nbsp;n.&ordm; 1365, do STJ).
+N&atilde;o comprovados os danos morais sofridos pela parte autora, o que afasta o dever de indenizar. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800893-68.2025.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Fornecimento de medicamentos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – PLANO DE SAÚDE – MANUTENÇÃO DO VALOR DA CAUSA - RECUSA DO FORNECIMENTO DO MEDICAMENTO Rituximabe – DEVER DE COBERTURA - DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+É abusiva a recusa de cobertura de medicamento regularmente registrado na ANVISA, prescrito por profissional habilitado,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – PLANO DE SAÚDE – MANUTENÇÃO DO VALOR DA CAUSA - RECUSA DO FORNECIMENTO DO MEDICAMENTO Rituximabe – DEVER DE COBERTURA - DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+É abusiva a recusa de cobertura de medicamento regularmente registrado na ANVISA, prescrito por profissional habilitado, ainda que utilizado em caráter off-label ou fora das diretrizes da ANS, desde que demonstrada sua eficácia e necessidade clínica.
+A simples recusa indevida de cobertura médico-assistencial por operadora de plano de saúde não gera, por si só, <em>dano</em> <em>moral</em> presumido (in re ipsa), sendo imprescindível a presença de outros elementos que permitam constatar a alteração anímica da vítima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo n.º 1365, do STJ).
+Não comprovados os danos morais sofridos pela parte autora, o que afasta o dever de indenizar.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>90&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877415" cdForo="0" >
+										0843605-52.2020.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877415" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877415);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877415" style="display: none;" >
+	<div id="textAreaDados_1877415" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; PLANO DE SA&Uacute;DE &ndash; FORNECIMENTO DE TRATAMENTOS M&Eacute;DICOS &ndash; TRANSTORNO DO ESPECTRO AUTISTA &ndash; COBERTURA EXPRESSA PARA A DOEN&Ccedil;A (TRANSTORNO DO ESPECTRO DO&nbsp;AUTISMO&nbsp;- TEA) &ndash; AUS&Ecirc;NCIA DE EXCLUS&Atilde;O CONTRATUAL ESPEC&Iacute;FICA DAS TERAP&Ecirc;UTICAS PRETENDIDAS PELA AUTORA &ndash;  IMPOSSIBILIDADE DE SE IMPOR LIMITA&Ccedil;&Otilde;ES A DETERMINADO M&Eacute;TODO DE TRATAMENTO &ndash; ROL DE  PROCEDIMENTOS E EVENTOS EM SA&Uacute;DE DA AG&Ecirc;NCIA NACIONAL DE SA&Uacute;DE SUPLEMENTAR (ANS) &ndash; EXEMPLIFICATIVO - ADI n. 7265 &ndash; SUPRESS&Atilde;O DE INST&Acirc;NCIA - SENTEN&Ccedil;A MANTIDA - RECURSO CONHECIDO EM PARTE E NA PARTE CONHECIDA N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte autora contra senten&ccedil;a que julgou procedentes os pedidos formulados em A&ccedil;&atilde;o de Obriga&ccedil;&atilde;o de Fazer.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso a (im)possibilidade de fornecimento, pela operadora de plano de sa&uacute;de, do tratamento com terapia pelo m&eacute;todo ABA, terapia fonoaudiol&oacute;gica especializada no m&eacute;todo PROMPT e de terapia ocupacional especializada em integra&ccedil;&atilde;o sensorial, para crian&ccedil;a portadora de Transtorno do Espectro Autista (TEA).
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os contratos de plano de sa&uacute;de est&atilde;o submetidos ao C&oacute;digo de Defesa do Consumidor (S&uacute;mula 469/STJ), devendo ser afastadas cl&aacute;usulas abusivas que contrariem a boa-f&eacute; objetiva e o equil&iacute;brio contratual (arts. 6&ordm;, III, IV; 46; 51; 54, CDC).
+4. O Superior Tribunal de Justi&ccedil;a entende que  &quot;ainda que admitida a possibilidade de o contrato de plano de sa&uacute;de conter cl&aacute;usulas limitativas dos direitos do consumidor, revela-se abusiva a que exclui o custeio dos meios e materiais necess&aacute;rios ao melhor desempenho do tratamento da doen&ccedil;a coberta pelo plano&quot; (STJ - AgRg no AREsp 740203 / RJ, Ministro Marco Buzzi, Quarta Turma, DJe 14/12/2016),   sendo  que  &quot;revela-se  abusiva  a recusa de custeio do medicamento prescrito pelo  m&eacute;dico  respons&aacute;vel pelo tratamento do benefici&aacute;rio,  ainda que ministrado em ambiente domiciliar. Precedentes do STJ.&quot; (STJ - AgInt no AREsp 1064435 / GO, Ministra Maria Isabel Gallotti, 4&ordf; Turma,  DJe 23/11/2017).
+5.  Assim, em havendo cobertura expressa para a doen&ccedil;a, aliada &agrave; aus&ecirc;ncia de exclus&atilde;o contratual espec&iacute;fica das terap&ecirc;uticas pretendidas pela autora, n&atilde;o pode a r&eacute; impor limita&ccedil;&otilde;es a determinado m&eacute;todo de tratamento, pois &eacute; o m&eacute;dico ou o profissional habilitado, e n&atilde;o o plano de sa&uacute;de, quem estabelece, na busca da cura, a orienta&ccedil;&atilde;o terap&ecirc;utica a ser dada ao usu&aacute;rio acometido de doen&ccedil;a coberta. Precedentes do STJ.
+6. O fato de o tratamento prescrito n&atilde;o constar no rol da Ag&ecirc;ncia Nacional de Sa&uacute;de Suplementar (ANS) n&atilde;o significa que n&atilde;o possa ser exigido pelo usu&aacute;rio, uma vez que se trata de rol exemplificativo. Precedentes do STJ.
+7. No caso da patologia Transtorno do Espectro do&nbsp;Autismo&nbsp;(TEA), as rotinas do tratamento n&atilde;o podem ser modificadas de forma repentina pelo plano de sa&uacute;de. Al&eacute;m disso, especialmente quanto ao tratamento pelo m&eacute;todo ABA&nbsp;(Applied&nbsp;Behavior Analysis), o v&iacute;nculo com o profissional &eacute; muito importante para a evolu&ccedil;&atilde;o como ser humano e cada profissional contribui para o desenvolvimento e a socializa&ccedil;&atilde;o das pessoas com autismo. Precedentes do TJMS.
+8. A prop&oacute;sito, o mesmo se diga acerca da continuidade do tratamento com os profissionais que est&atilde;o incumbidos da fonoterapia e da terapia ocupacional com integra&ccedil;&atilde;o sensorial, n&atilde;o sendo aconselh&aacute;vel, portanto, que haja altera&ccedil;&atilde;o nessa rotina.
+9. Al&eacute;m disso, as especialidades requeridas pela autora (terapia fonoaudiol&oacute;gica especializada no m&eacute;todo PROMPT e de terapia ocupacional especializada em integra&ccedil;&atilde;o sensorial), ao que parece, tamb&eacute;m n&atilde;o foram deferidas pela r&eacute;, apesar da cobertura contratual para a patologia Transtorno do Espectro do&nbsp;Autismo&nbsp;(TEA), o que se afigura inadequado, j&aacute; que &eacute; vedado &agrave;s operadoras de plano de sa&uacute;de limitar os tratamentos recomendados pelo m&eacute;dico do consumidor, quando a doen&ccedil;a em si &eacute; coberta pelo plano de sa&uacute;de.
+10. Por fim, pelos mesmos fundamentos, n&atilde;o subsiste o pedido subsidi&aacute;rio, de custeio dos tratamentos no limite da tabela de procedimentos da r&eacute;-agravante, bem para que os servi&ccedil;os sejam prestados por profissionais por esta credenciados, pois, al&eacute;m de ser obriga&ccedil;&atilde;o contratual a cobertura do tratamento indicado pelo m&eacute;dico da autora, quaisquer destas limita&ccedil;&otilde;es podem, em tese, comprometer a efic&aacute;cia do tratamento pleiteado, o que, &agrave; luz dos valores fundamentais que est&atilde;o em jogo, n&atilde;o se afigura razo&aacute;vel, tampouco recomend&aacute;vel.
+IV. DISPOSITIVO
+12. Apela&ccedil;&atilde;o C&iacute;vel conhecida em parte e na parte conhecida n&atilde;o provida.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0843605-52.2020.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – FORNECIMENTO DE TRATAMENTOS MÉDICOS – TRANSTORNO DO ESPECTRO AUTISTA – COBERTURA EXPRESSA PARA A DOENÇA (TRANSTORNO DO ESPECTRO DO AUTISMO - TEA) – AUSÊNCIA DE EXCLUSÃO CONTRATUAL ESPECÍFICA DAS TERAPÊUTICAS PRETENDIDAS PELA AUTORA –  IMPOSSIBILIDADE DE SE IMPOR LIMITAÇÕES A DETERMINADO MÉTODO DE TRATAMENTO – ROL DE  PROCEDIMENTOS E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – FORNECIMENTO DE TRATAMENTOS MÉDICOS – TRANSTORNO DO ESPECTRO AUTISTA – COBERTURA EXPRESSA PARA A DOENÇA (TRANSTORNO DO ESPECTRO DO AUTISMO - TEA) – AUSÊNCIA DE EXCLUSÃO CONTRATUAL ESPECÍFICA DAS TERAPÊUTICAS PRETENDIDAS PELA AUTORA –  IMPOSSIBILIDADE DE SE IMPOR LIMITAÇÕES A DETERMINADO MÉTODO DE TRATAMENTO – ROL DE  PROCEDIMENTOS E EVENTOS EM SAÚDE DA AGÊNCIA NACIONAL DE SAÚDE SUPLEMENTAR (ANS) – EXEMPLIFICATIVO - ADI n. 7265 – SUPRESSÃO DE INSTÂNCIA - SENTENÇA MANTIDA - RECURSO CONHECIDO EM PARTE E NA PARTE CONHECIDA NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta pela parte autora contra sentença que julgou procedentes os pedidos formulados em Ação de Obrigação de Fazer.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso a (im)possibilidade de fornecimento, pela operadora de plano de saúde, do tratamento com terapia pelo método ABA, terapia fonoaudiológica especializada no método PROMPT e de terapia ocupacional especializada em integração sensorial, para criança portadora de Transtorno do Espectro Autista (TEA).
+III. RAZÕES DE DECIDIR
+3. Os contratos de plano de saúde estão submetidos ao Código de Defesa do Consumidor (Súmula 469/STJ), devendo ser afastadas cláusulas abusivas que contrariem a boa-fé objetiva e o equilíbrio contratual (arts. 6º, III, IV; 46; 51; 54, CDC).
+4. O Superior Tribunal de Justiça entende que  "ainda que admitida a possibilidade de o contrato de plano de saúde conter cláusulas limitativas dos direitos do consumidor, revela-se abusiva a que exclui o custeio dos meios e materiais necessários ao melhor desempenho do tratamento da doença coberta pelo plano" (STJ - AgRg no AREsp 740203 / RJ, Ministro Marco Buzzi, Quarta Turma, DJe 14/12/2016),   sendo  que  "revela-se  abusiva  a recusa de custeio do medicamento prescrito pelo  médico  responsável pelo tratamento do beneficiário,  ainda que ministrado em ambiente domiciliar. Precedentes do STJ." (STJ - AgInt no AREsp 1064435 / GO, Ministra Maria Isabel Gallotti, 4ª Turma,  DJe 23/11/2017).
+5.  Assim, em havendo cobertura expressa para a doença, aliada à ausência de exclusão contratual específica das terapêuticas pretendidas pela autora, não pode a ré impor limitações a determinado método de tratamento, pois é o médico ou o profissional habilitado, e não o plano de saúde, quem estabelece, na busca da cura, a orientação terapêutica a ser dada ao usuário acometido de doença coberta. Precedentes do STJ.
+6. O fato de o tratamento prescrito não constar no rol da Agência Nacional de Saúde Suplementar (ANS) não significa que não possa ser exigido pelo usuário, uma vez que se trata de rol exemplificativo. Precedentes do STJ.
+7. No caso da patologia Transtorno do Espectro do Autismo (TEA), as rotinas do tratamento não podem ser modificadas de forma repentina pelo plano de saúde. Além disso, especialmente quanto ao tratamento pelo método ABA (Applied Behavior Analysis), o vínculo com o profissional é muito importante para a evolução como ser humano e cada profissional contribui para o desenvolvimento e a socialização das pessoas com autismo. Precedentes do TJMS.
+8. A propósito, o mesmo se diga acerca da continuidade do tratamento com os profissionais que estão incumbidos da fonoterapia e da terapia ocupacional com integração sensorial, não sendo aconselhável, portanto, que haja alteração nessa rotina.
+9. Além disso, as especialidades requeridas pela autora (terapia fonoaudiológica especializada no método PROMPT e de terapia ocupacional especializada em integração sensorial), ao que parece, também não foram deferidas pela ré, apesar da cobertura contratual para a patologia Transtorno do Espectro do Autismo (TEA), o que se afigura inadequado, já que é vedado às operadoras de plano de saúde limitar os tratamentos recomendados pelo médico do consumidor, quando a doença em si é coberta pelo plano de saúde.
+10. Por fim, pelos mesmos fundamentos, não subsiste o pedido subsidiário, de custeio dos tratamentos no limite da tabela de procedimentos da ré-agravante, bem para que os serviços sejam prestados por profissionais por esta credenciados, pois, além de ser obrigação contratual a cobertura do tratamento indicado pelo médico da autora, quaisquer destas limitações podem, em tese, comprometer a eficácia do tratamento pleiteado, o que, à luz dos valores fundamentais que estão em jogo, não se afigura razoável, tampouco recomendável.
+IV. DISPOSITIVO
+12. Apelação Cível conhecida em parte e na parte conhecida não provida.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>91&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877422" cdForo="0" >
+										0801823-51.2023.8.12.0004
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877422" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877422);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877422" style="display: none;" >
+	<div id="textAreaDados_1877422" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA  C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANO MORAL &ndash; EMPR&Eacute;STIMOS &ndash; CONTRATA&Ccedil;&Atilde;O  N&Atilde;O COMPROVADA &ndash;  VIOLA&Ccedil;&Atilde;O AO DIREITO DA PERSONALIDADE &ndash; DANOS MORAIS CONFIGURADOS &ndash; FIXA&Ccedil;&Atilde;O EM OBSERV&Acirc;NCIA AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE   &ndash;  RECURSO CONHECIDO E  DESPROVIDO.
+Para que o dano moral seja caracterizado &eacute; necess&aacute;rio que se demonstre, pela prova dos autos, que dos fatos e provas trazidos ao conhecimento do Poder Judici&aacute;rio emana o nexo de causalidade necess&aacute;rio para sua configura&ccedil;&atilde;o. Restando patente a responsabilidade do recorrente pelo evento danoso suportado pela recorrida, a indeniza&ccedil;&atilde;o por danos morais &eacute; medida que se imp&otilde;e.
+Quanto ao valor da indeniza&ccedil;&atilde;o, destaca-se que n&atilde;o existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercuss&atilde;o dos fatos, estabelecer a indeniza&ccedil;&atilde;o que venha ressarcir a parte lesada (car&aacute;ter indenizat&oacute;rio) e que tamb&eacute;m iniba a reitera&ccedil;&atilde;o de condutas an&aacute;logas (aspecto pedag&oacute;gico).
+ Na quantifica&ccedil;&atilde;o do dano moral foram considerados os crit&eacute;rios de razoabilidade e da proporcionalidade, observando-se o conjunto f&aacute;tico-probat&oacute;rio reunido, raz&atilde;o pela qual o quantum fixado deve ser mantido.
+ Recurso conhecido e desprovido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801823-51.2023.8.12.0004,&nbsp; Amambai,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Amambai
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA  C/C REPETIÇÃO DE INDÉBITO E <em>DANO</em> <em>MORAL</em> – EMPRÉSTIMOS – CONTRATAÇÃO  NÃO COMPROVADA –  VIOLAÇÃO AO DIREITO DA PERSONALIDADE – DANOS MORAIS CONFIGURADOS – FIXAÇÃO EM OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE   –  RECURSO CONHECIDO E  DESPROVIDO.
+Para que o <em>dano</em> <em>moral</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA  C/C REPETIÇÃO DE INDÉBITO E <em>DANO</em> <em>MORAL</em> – EMPRÉSTIMOS – CONTRATAÇÃO  NÃO COMPROVADA –  VIOLAÇÃO AO DIREITO DA PERSONALIDADE – DANOS MORAIS CONFIGURADOS – FIXAÇÃO EM OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE   –  RECURSO CONHECIDO E  DESPROVIDO.
+Para que o <em>dano</em> <em>moral</em> seja caracterizado é necessário que se demonstre, pela prova dos autos, que dos fatos e provas trazidos ao conhecimento do Poder Judiciário emana o nexo de causalidade necessário para sua configuração. Restando patente a responsabilidade do recorrente pelo evento danoso suportado pela recorrida, a indenização por danos morais é medida que se impõe.
+Quanto ao valor da indenização, destaca-se que não existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercussão dos fatos, estabelecer a indenização que venha ressarcir a parte lesada (caráter indenizatório) e que também iniba a reiteração de condutas análogas (aspecto pedagógico).
+ Na quantificação do <em>dano</em> <em>moral</em> foram considerados os critérios de razoabilidade e da proporcionalidade, observando-se o conjunto fático-probatório reunido, razão pela qual o quantum fixado deve ser mantido.
+ Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>92&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877440" cdForo="0" >
+										0802552-80.2024.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877440" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877440);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877440" style="display: none;" >
+	<div id="textAreaDados_1877440" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E RESPONSABILIDADE CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. AUS&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. DANO MORAL IN RE IPSA. MAJORA&Ccedil;&Atilde;O DA INDENIZA&Ccedil;&Atilde;O PARA VALOR RAZO&Aacute;VEL E PROPORCIONAL. RECURSO PROVIDO.
+1. A responsabilidade civil do fornecedor de servi&ccedil;os nas rela&ccedil;&otilde;es de consumo &eacute; objetiva, bastando a demonstra&ccedil;&atilde;o da conduta il&iacute;cita, do dano e do nexo causal para a configura&ccedil;&atilde;o do dever de indenizar.
+2. A inexist&ecirc;ncia de contrata&ccedil;&atilde;o v&aacute;lida que justificasse os descontos evidencia falha na presta&ccedil;&atilde;o do servi&ccedil;o e caracteriza ato il&iacute;cito.
+3. Descontos indevidos em benef&iacute;cio previdenci&aacute;rio, verba de natureza alimentar, ultrapassam o mero dissabor cotidiano e configuram dano moral presumido, sobretudo quando atingem consumidor aposentado.
+4. A fixa&ccedil;&atilde;o do valor da indeniza&ccedil;&atilde;o por dano moral deve observar os princ&iacute;pios da razoabilidade e da proporcionalidade, considerando a gravidade da conduta, a extens&atilde;o do dano e as fun&ccedil;&otilde;es compensat&oacute;ria e pedag&oacute;gica da condena&ccedil;&atilde;o.
+5. Recurso provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802552-80.2024.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(29 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E RESPONSABILIDADE CIVIL. APELAÇÃO CÍVEL. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE CONTRATAÇÃO. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MAJORAÇÃO DA INDENIZAÇÃO PARA VALOR RAZOÁVEL E PROPORCIONAL. RECURSO PROVIDO.
+1. A responsabilidade civil do fornecedor de serviços nas relações de consumo é objetiva, bastando a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E RESPONSABILIDADE CIVIL. APELAÇÃO CÍVEL. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE CONTRATAÇÃO. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MAJORAÇÃO DA INDENIZAÇÃO PARA VALOR RAZOÁVEL E PROPORCIONAL. RECURSO PROVIDO.
+1. A responsabilidade civil do fornecedor de serviços nas relações de consumo é objetiva, bastando a demonstração da conduta ilícita, do <em>dano</em> e do nexo causal para a configuração do dever de indenizar.
+2. A inexistência de contratação válida que justificasse os descontos evidencia falha na prestação do serviço e caracteriza ato ilícito.
+3. Descontos indevidos em benefício previdenciário, verba de natureza alimentar, ultrapassam o mero dissabor cotidiano e configuram <em>dano</em> <em>moral</em> presumido, sobretudo quando atingem consumidor aposentado.
+4. A fixação do valor da indenização por <em>dano</em> <em>moral</em> deve observar os princípios da razoabilidade e da proporcionalidade, considerando a gravidade da conduta, a extensão do <em>dano</em> e as funções compensatória e pedagógica da condenação.
+5. Recurso provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>93&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877445" cdForo="0" >
+										0800191-41.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877445" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877445);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877445" style="display: none;" >
+	<div id="textAreaDados_1877445" class="mensagemSemFormatacao" >
+		DIREITO ADMINISTRATIVO E CONSTITUCIONAL &ndash; Apela&ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; PRELIMINAR &ndash; CERCEAMENTO DEFESA &ndash; REJEITADA &ndash;   M&Eacute;RITO &ndash; RESPONSABILIDADE CIVIL DO ESTADO &ndash; SUPERLOTA&Ccedil;&Atilde;O CARCER&Aacute;RIA &ndash; DANOS MORAIS &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DE DANO INDIVIDUALIZADO &ndash; TEMA 365 DO STF &ndash; IMPROCED&Ecirc;NCIA &ndash; SENTEN&Ccedil;A MANTIDA &ndash;  RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o C&iacute;vel interposta pela parte autora contra senten&ccedil;a que julgou improcedente pedido de indeniza&ccedil;&atilde;o por danos morais decorrentes de alegadas condi&ccedil;&otilde;es degradantes no Estabelecimento Penal Masculino de Corumb&aacute;, notadamente superlota&ccedil;&atilde;o e insalubridade.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) em preliminar, se houve cerceamento de defesa em raz&atilde;o do indeferimento de provas; e b) no m&eacute;rito, a exist&ecirc;ncia de responsabilidade civil do Estado decorrente da alegada superlota&ccedil;&atilde;o carcer&aacute;ria e das condi&ccedil;&otilde;es insalubres do estabelecimento prisional.
+III. RAZ&Otilde;ES DE DECIDIR
+3. N&atilde;o h&aacute; cerceamento de defesa quando o Magistrado indefere, de forma fundamentada, a produ&ccedil;&atilde;o de provas consideradas desnecess&aacute;rias, diante da sufici&ecirc;ncia do conjunto probat&oacute;rio, nos termos dos arts. 369 e 370 do CPC/15. Preliminar Rejeitada.
+4. A responsabilidade civil do Estado, nos termos do art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal, &eacute; objetiva, exigindo a comprova&ccedil;&atilde;o do dano e do nexo causal.
+5. O Supremo Tribunal Federal, no julgamento do Tema 365, firmou entendimento de que n&atilde;o h&aacute; dano moral presumido em raz&atilde;o de condi&ccedil;&otilde;es prec&aacute;rias do sistema prisional, sendo necess&aacute;ria a demonstra&ccedil;&atilde;o concreta e individualizada do preju&iacute;zo suportado pelo detento  (RE 580252, Relator(a): TEORI ZAVASCKI, Relator(a) p/ Ac&oacute;rd&atilde;o: GILMAR MENDES, Tribunal Pleno, julgado em 16-02-2017, AC&Oacute;RD&Atilde;O ELETR&Ocirc;NICO REPERCUSS&Atilde;O GERAL - M&Eacute;RITO DJe-204  DIVULG 08-09-2017  PUBLIC 11-09-2017).
+6. Alega&ccedil;&otilde;es gen&eacute;ricas de superlota&ccedil;&atilde;o e insalubridade, desacompanhadas de prova de repercuss&atilde;o espec&iacute;fica na esfera pessoal do autor, s&atilde;o insuficientes para ensejar indeniza&ccedil;&atilde;o por danos morais.
+IV. DISPOSITIVO
+7. Apela&ccedil;&atilde;o C&iacute;vel conhecida e n&atilde;o provida, com majora&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800191-41.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(66 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO E CONSTITUCIONAL – ApelaçÃO CÍVEL – AÇÃO DE REPARAÇÃO POR DANOS MORAIS – PRELIMINAR – CERCEAMENTO DEFESA – REJEITADA –   MÉRITO – RESPONSABILIDADE CIVIL DO ESTADO – SUPERLOTAÇÃO CARCERÁRIA – DANOS MORAIS – AUSÊNCIA DE COMPROVAÇÃO DE <em>DANO</em> INDIVIDUALIZADO – TEMA 365 DO STF – IMPROCEDÊNCIA – SENTENÇA MANTIDA –  RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO E CONSTITUCIONAL – ApelaçÃO CÍVEL – AÇÃO DE REPARAÇÃO POR DANOS MORAIS – PRELIMINAR – CERCEAMENTO DEFESA – REJEITADA –   MÉRITO – RESPONSABILIDADE CIVIL DO ESTADO – SUPERLOTAÇÃO CARCERÁRIA – DANOS MORAIS – AUSÊNCIA DE COMPROVAÇÃO DE <em>DANO</em> INDIVIDUALIZADO – TEMA 365 DO STF – IMPROCEDÊNCIA – SENTENÇA MANTIDA –  RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta pela parte autora contra sentença que julgou improcedente pedido de indenização por danos morais decorrentes de alegadas condições degradantes no Estabelecimento Penal Masculino de Corumbá, notadamente superlotação e insalubridade.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso: a) em preliminar, se houve cerceamento de defesa em razão do indeferimento de provas; e b) no mérito, a existência de responsabilidade civil do Estado decorrente da alegada superlotação carcerária e das condições insalubres do estabelecimento prisional.
+III. RAZÕES DE DECIDIR
+3. Não há cerceamento de defesa quando o Magistrado indefere, de forma fundamentada, a produção de provas consideradas desnecessárias, diante da suficiência do conjunto probatório, nos termos dos arts. 369 e 370 do CPC/15. Preliminar Rejeitada.
+4. A responsabilidade civil do Estado, nos termos do art. 37, § 6º, da Constituição Federal, é objetiva, exigindo a comprovação do <em>dano</em> e do nexo causal.
+5. O Supremo Tribunal Federal, no julgamento do Tema 365, firmou entendimento de que não há <em>dano</em> <em>moral</em> presumido em razão de condições precárias do sistema prisional, sendo necessária a demonstração concreta e individualizada do prejuízo suportado pelo detento  (RE 580252, Relator(a): TEORI ZAVASCKI, Relator(a) p/ Acórdão: GILMAR MENDES, Tribunal Pleno, julgado em 16-02-2017, ACÓRDÃO ELETRÔNICO REPERCUSSÃO GERAL - MÉRITO DJe-204  DIVULG 08-09-2017  PUBLIC 11-09-2017).
+6. Alegações genéricas de superlotação e insalubridade, desacompanhadas de prova de repercussão específica na esfera pessoal do autor, são insuficientes para ensejar indenização por danos morais.
+IV. DISPOSITIVO
+7. Apelação Cível conhecida e não provida, com majoração dos honorários sucumbenciais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>94&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877459" cdForo="0" >
+										0803978-39.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877459" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877459);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877459" style="display: none;" >
+	<div id="textAreaDados_1877459" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; EXECU&Ccedil;&Atilde;O DE T&Iacute;TULO EXTRAJUDICIAL &ndash; SENTEN&Ccedil;A DE EXTIN&Ccedil;&Atilde;O DO FEITO &ndash; APLICA&Ccedil;&Atilde;O INCORRETA DA LITISPEND&Ecirc;NCIA &ndash; PROCESSO ANTERIOR EXTINTO POR DESIST&Ecirc;NCIA - ERRO IN PROCEDENDO &ndash; SENTEN&Ccedil;A CASSADA &ndash; RECURSO CONHECIDO E PROVIDO.
+Embora a parte autora tenha ajuizado a&ccedil;&atilde;o id&ecirc;ntica n&ordm; 0805195-20.2024.8.12.0021, requereu a sua desist&ecirc;ncia, diante da constata&ccedil;&atilde;o de duplicidade de demandas, o que foi devidamente homologado pelo ju&iacute;zo.
+Assim, indevida a extin&ccedil;&atilde;o desta a&ccedil;&atilde;o, configurado o error&nbsp;in&nbsp;procedendo, a justificar a cassa&ccedil;&atilde;o da senten&ccedil;a prolatada.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803978-39.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Assinatura Básica Mensal
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – EXECUÇÃO DE TÍTULO EXTRAJUDICIAL – SENTENÇA DE EXTINÇÃO DO FEITO – APLICAÇÃO INCORRETA DA LITISPENDÊNCIA – PROCESSO ANTERIOR EXTINTO POR DESISTÊNCIA - ERRO IN PROCEDENDO – SENTENÇA CASSADA – RECURSO CONHECIDO E PROVIDO.
+Embora a parte autora tenha ajuizado ação idêntica nº 0805195-20.2024.8.12.0021, requereu a sua desistência, diante da constatação de duplicidade de demandas, o
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – EXECUÇÃO DE TÍTULO EXTRAJUDICIAL – SENTENÇA DE EXTINÇÃO DO FEITO – APLICAÇÃO INCORRETA DA LITISPENDÊNCIA – PROCESSO ANTERIOR EXTINTO POR DESISTÊNCIA - ERRO IN PROCEDENDO – SENTENÇA CASSADA – RECURSO CONHECIDO E PROVIDO.
+Embora a parte autora tenha ajuizado ação idêntica nº 0805195-20.2024.8.12.0021, requereu a sua desistência, diante da constatação de duplicidade de demandas, o que foi devidamente homologado pelo juízo.
+Assim, indevida a extinção desta ação, configurado o error in procedendo, a justificar a cassação da sentença prolatada.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>95&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877462" cdForo="0" >
+										0802122-73.2024.8.12.0010
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877462" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877462);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877462" style="display: none;" >
+	<div id="textAreaDados_1877462" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash; PLANO DE SA&Uacute;DE &ndash; RECUSA DO FORNECIMENTO DE TRATAMENTO DOMICILIAR &ndash; DANOS MORAIS N&Atilde;O CONFIGURADOS &ndash;  RECURSO CONHECIDO E PROVIDO.
+A simples recusa indevida de cobertura m&eacute;dico-assistencial por operadora de plano de sa&uacute;de n&atilde;o gera, por si s&oacute;, dano moral presumido (in re ipsa), sendo imprescind&iacute;vel a presen&ccedil;a de outros elementos que permitam constatar a altera&ccedil;&atilde;o an&iacute;mica da v&iacute;tima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo&nbsp;n.&ordm; 1365 do STJ).
+N&atilde;o comprovados os danos morais sofrido pela parte autora, o que afasta o dever de indenizar. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802122-73.2024.8.12.0010,&nbsp; F&aacute;tima do Sul,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Serviços de Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fátima do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO INDENIZATÓRIA – PLANO DE SAÚDE – RECUSA DO FORNECIMENTO DE TRATAMENTO DOMICILIAR – DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PROVIDO.
+A simples recusa indevida de cobertura médico-assistencial por operadora de plano de saúde não gera, por si só, <em>dano</em> <em>moral</em> presumido (in re ipsa), sendo imprescindível a presença de outros elementos que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO INDENIZATÓRIA – PLANO DE SAÚDE – RECUSA DO FORNECIMENTO DE TRATAMENTO DOMICILIAR – DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PROVIDO.
+A simples recusa indevida de cobertura médico-assistencial por operadora de plano de saúde não gera, por si só, <em>dano</em> <em>moral</em> presumido (in re ipsa), sendo imprescindível a presença de outros elementos que permitam constatar a alteração anímica da vítima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo n.º 1365 do STJ).
+Não comprovados os danos morais sofrido pela parte autora, o que afasta o dever de indenizar.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>96&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877466" cdForo="0" >
+										1403132-65.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877466" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877466);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877466" style="display: none;" >
+	<div id="textAreaDados_1877466" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; FIXA&Ccedil;&Atilde;O DE MULTA DI&Aacute;RIA POR DESCUMPRIMENTO DE ORDEM &ndash; POSSIBILIDADE &ndash; VALOR RAZO&Aacute;VEL E PROPORCIONAL &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+Sopesando as particularidades da casu&iacute;stica, sobretudo as condi&ccedil;&otilde;es financeiras do agravante, que &eacute; institui&ccedil;&atilde;o financeira de grande porte, o objeto da a&ccedil;&atilde;o &ndash; qual seja, a suspens&atilde;o das cobran&ccedil;as com rela&ccedil;&atilde;o aos d&eacute;bitos questionados pelo agravada &ndash; e a import&acirc;ncia do bem jur&iacute;dico que se busca tutelar, bem como o valor fixado e a periodicidade estipulada para a incid&ecirc;ncia das astreintes &ndash; que incidir&atilde;o no valor de R$100,00 por dia de descumprimento, limitada a 100 vezes esse valor &ndash;, tenho que a multa arbitrada &eacute; razo&aacute;vel, necess&aacute;ria e suscet&iacute;vel de alcan&ccedil;ar o desiderato de compelir o agravante a cumprir a determina&ccedil;&atilde;o judicial.
+Recurso conhecido e n&atilde;o provido.   <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1403132-65.2026.8.12.0000,&nbsp; Parana&iacute;ba,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – FIXAÇÃO DE MULTA DIÁRIA POR DESCUMPRIMENTO DE ORDEM – POSSIBILIDADE – VALOR RAZOÁVEL E PROPORCIONAL – RECURSO CONHECIDO E NÃO PROVIDO.
+Sopesando as particularidades da casuística, sobretudo as condições financeiras do agravante, que é instituição financeira de grande porte, o objeto da ação –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – FIXAÇÃO DE MULTA DIÁRIA POR DESCUMPRIMENTO DE ORDEM – POSSIBILIDADE – VALOR RAZOÁVEL E PROPORCIONAL – RECURSO CONHECIDO E NÃO PROVIDO.
+Sopesando as particularidades da casuística, sobretudo as condições financeiras do agravante, que é instituição financeira de grande porte, o objeto da ação – qual seja, a suspensão das cobranças com relação aos débitos questionados pelo agravada – e a importância do bem jurídico que se busca tutelar, bem como o valor fixado e a periodicidade estipulada para a incidência das astreintes – que incidirão no valor de R$100,00 por dia de descumprimento, limitada a 100 vezes esse valor –, tenho que a multa arbitrada é razoável, necessária e suscetível de alcançar o desiderato de compelir o agravante a cumprir a determinação judicial.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>97&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877468" cdForo="0" >
+										0806338-25.2021.8.12.0029
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877468" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877468);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877468" style="display: none;" >
+	<div id="textAreaDados_1877468" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E ADMINISTRATIVO &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E EST&Eacute;TICOS DECORRENTES DE ACIDENTE DE TR&Acirc;NSITO &ndash;  M&Eacute;RITO - ACIDENTE DE TR&Acirc;NSITO  &ndash; COLIS&Atilde;O COM TUBO DE CONCRETO EM VIA P&Uacute;BLICA &ndash; RESPONSABILIDADE SUBJETIVA DA ADMINISTRA&Ccedil;&Atilde;O P&Uacute;BLICA &ndash; AUS&Ecirc;NCIA DE SINALIZA&Ccedil;&Atilde;O - - OMISS&Atilde;O DO ENTE P&Uacute;BLICO &ndash; OBRA P&Uacute;BLICA PROMOVIDA E EXECUTADA PELO ESTADO, E N&Atilde;O PELO MUNIC&Iacute;PIO R&Eacute;U &ndash; AUS&Ecirc;NCIA DE CONDUTA E DE NEXO CAUSAL DO MUNIC&Iacute;PIO R&Eacute;U -  SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA &ndash; RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte auto racontra a senten&ccedil;a que julgou IMprocedentes os pedidos formulados em A&ccedil;&atilde;o de Indeniza&ccedil;&atilde;o por Danos Morais e Est&eacute;ticos decorrentes de Acidente de Tr&acirc;nsito.
+II. HIP&Oacute;TESE EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a responsabilidade civil pelo evento danoso; b) a exist&ecirc;ncia de danos morais e est&eacute;ticos.
+III. RAZ&Otilde;ES DE DECIDIR
+3.  Em se tratando de omiss&atilde;o da Administra&ccedil;&atilde;o P&uacute;blica, a responsabilidade civil do Estado &eacute; subjetiva, fundada na teoria da  &quot;faute du service&quot; ou da falta do servi&ccedil;o,  exigindo-se a demonstra&ccedil;&atilde;o da culpa para ensejar a responsabiliza&ccedil;&atilde;o. No caso, responsabilidade civil configurada, visto que comprovado que o acidente de tr&acirc;nsito ocorreu  por culpa do ente p&uacute;blico, que por omiss&atilde;o e neglig&ecirc;ncia, n&atilde;o providenciou a correta manuten&ccedil;&atilde;o da via p&uacute;blica. Aquele que, por a&ccedil;&atilde;o ou omiss&atilde;o volunt&aacute;ria, neglig&ecirc;ncia ou imprud&ecirc;ncia, violar direito e causar dano a outrem, ainda que exclusivamente moral, comete ato il&iacute;cito. Por sua vez, aquele que, por ato il&iacute;cito, causar dano a outrem, fica obrigado a repar&aacute;-lo. (artigos 187 e 927 do CC/2002).
+4. O conjunto probat&oacute;rio demonstra de forma inequ&iacute;voca que a obra de canaliza&ccedil;&atilde;o de esgoto e drenagem foi promovida e executada exclusivamente pelo Estado de Mato Grosso do Sul, e n&atilde;o pelo Munic&iacute;pio de Navira&iacute;. Restando comprovado que a interven&ccedil;&atilde;o na via p&uacute;blica era de responsabilidade de terceiro, resta rompido o nexo causal em rela&ccedil;&atilde;o &agrave; municipalidade. N&atilde;o demonstrada qualquer conduta (omissiva ou comissiva) do Munic&iacute;pio que tenha concorrido para o evento danoso, a improced&ecirc;ncia do pleito indenizat&oacute;rio &eacute; medida que se imp&otilde;e.
+IV. DISPOSITIVO
+5. Apela&ccedil;&atilde;o C&iacute;vel conhecida e n&atilde;o provida.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806338-25.2021.8.12.0029,&nbsp; Navira&iacute;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Naviraí
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E ADMINISTRATIVO – APELAÇÃO CÍVEL - AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E ESTÉTICOS DECORRENTES DE ACIDENTE DE TRÂNSITO –  MÉRITO - ACIDENTE DE TRÂNSITO  – COLISÃO COM TUBO DE CONCRETO EM VIA PÚBLICA – RESPONSABILIDADE SUBJETIVA DA ADMINISTRAÇÃO PÚBLICA – AUSÊNCIA DE SINALIZAÇÃO - - OMISSÃO DO ENTE PÚBLICO – OBRA PÚBLICA PROMOVIDA E EXECUTADA PELO ESTADO, E NÃO PELO MUNICÍPIO RÉU –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E ADMINISTRATIVO – APELAÇÃO CÍVEL - AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E ESTÉTICOS DECORRENTES DE ACIDENTE DE TRÂNSITO –  MÉRITO - ACIDENTE DE TRÂNSITO  – COLISÃO COM TUBO DE CONCRETO EM VIA PÚBLICA – RESPONSABILIDADE SUBJETIVA DA ADMINISTRAÇÃO PÚBLICA – AUSÊNCIA DE SINALIZAÇÃO - - OMISSÃO DO ENTE PÚBLICO – OBRA PÚBLICA PROMOVIDA E EXECUTADA PELO ESTADO, E NÃO PELO MUNICÍPIO RÉU – AUSÊNCIA DE CONDUTA E DE NEXO CAUSAL DO MUNICÍPIO RÉU -  SENTENÇA DE IMPROCEDÊNCIA MANTIDA – RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta pela parte auto racontra a sentença que julgou IMprocedentes os pedidos formulados em Ação de Indenização por Danos Morais e Estéticos decorrentes de Acidente de Trânsito.
+II. HIPÓTESE EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a responsabilidade civil pelo evento danoso; b) a existência de danos morais e estéticos.
+III. RAZÕES DE DECIDIR
+3.  Em se tratando de omissão da Administração Pública, a responsabilidade civil do Estado é subjetiva, fundada na teoria da  "faute du service" ou da falta do serviço,  exigindo-se a demonstração da culpa para ensejar a responsabilização. No caso, responsabilidade civil configurada, visto que comprovado que o acidente de trânsito ocorreu  por culpa do ente público, que por omissão e negligência, não providenciou a correta manutenção da via pública. Aquele que, por ação ou omissão voluntária, negligência ou imprudência, violar direito e causar <em>dano</em> a outrem, ainda que exclusivamente <em>moral</em>, comete ato ilícito. Por sua vez, aquele que, por ato ilícito, causar <em>dano</em> a outrem, fica obrigado a repará-lo. (artigos 187 e 927 do CC/2002).
+4. O conjunto probatório demonstra de forma inequívoca que a obra de canalização de esgoto e drenagem foi promovida e executada exclusivamente pelo Estado de Mato Grosso do Sul, e não pelo Município de Naviraí. Restando comprovado que a intervenção na via pública era de responsabilidade de terceiro, resta rompido o nexo causal em relação à municipalidade. Não demonstrada qualquer conduta (omissiva ou comissiva) do Município que tenha concorrido para o evento danoso, a improcedência do pleito indenizatório é medida que se impõe.
+IV. DISPOSITIVO
+5. Apelação Cível conhecida e não provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>98&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877469" cdForo="0" >
+										0813070-98.2024.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877469" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877469);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877469" style="display: none;" >
+	<div id="textAreaDados_1877469" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CONTRATO DE SEGURO &ndash; DESCONTOS EM CONTA CORRENTE &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA &ndash;  RESTITUI&Ccedil;&Atilde;O DE VALORES DEVIDA &ndash; DANOS MORAIS CONFIGURADOS &ndash; PROCED&Ecirc;NCIA DOS PEDIDOS &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PROVIDO.
+CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte autora contra senten&ccedil;a que julgou improcedentes os pedidos iniciais formulados em A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de D&eacute;bito c/c Indeniza&ccedil;&atilde;o por Danos Morais e Materiais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a (i)legalidade da cobran&ccedil;a de mensalidades de contrato de seguro;  b) o cabimento da restitui&ccedil;&atilde;o dos valores pagos; e c) a ocorr&ecirc;ncia de danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O neg&oacute;cio jur&iacute;dico deve ser examinado sob o prisma de tr&ecirc;s (3) planos &ndash; exist&ecirc;ncia, validade e efic&aacute;cia &ndash;, com a finalidade de se verificar se ele obt&eacute;m plena realiza&ccedil;&atilde;o. No plano da exist&ecirc;ncia, verifica-se, t&atilde;o somente, se est&atilde;o presentes as condi&ccedil;&otilde;es m&iacute;nimas para que o neg&oacute;cio jur&iacute;dico possa produzir efeitos (v.g, agente; objeto; forma, e vontade exteriorizada), n&atilde;o se discutindo, desta forma, a validade ou invalidade do neg&oacute;cio e tampouco a sua efic&aacute;cia.
+4. Comprovada a ocorr&ecirc;ncia de descontos na conta banc&aacute;ria da parte autora e n&atilde;o demonstrada, pela parte r&eacute;, a regular contrata&ccedil;&atilde;o, resta caracterizado o descumprimento do &ocirc;nus probat&oacute;rio previsto no art. 373, II, do CPC/15.
+5. O par&aacute;grafo &uacute;nico, do art. 42, da Lei n&ordm; 8.078, de 11/09/1990 (C&oacute;digo de Defesa do Consumidor) disp&otilde;e que o consumidor cobrado em quantia indevida tem direito &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, por valor igual ao dobro do que pagou em excesso, acrescido de corre&ccedil;&atilde;o monet&aacute;ria e juros legais, salvo hip&oacute;tese de &quot;engano justific&aacute;vel&quot;.
+6. Inexistente contrato v&aacute;lido, s&atilde;o indevidos os descontos realizados, impondo-se a restitui&ccedil;&atilde;o em dobro dos valores indevidamente debitados.
+7. A realiza&ccedil;&atilde;o de descontos indevidos em conta banc&aacute;ria, decorrentes de contrata&ccedil;&atilde;o n&atilde;o comprovada, configura dano moral in re ipsa, conforme entendimento consolidado do STJ.
+8. Segundo o m&eacute;todo bif&aacute;sico de fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, na primeira etapa, deve-se estabelecer um valor b&aacute;sico, &agrave; luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jur&iacute;dico lesado; e, na segunda etapa, devem ser consideradas as circunst&acirc;ncias do caso, para a fixa&ccedil;&atilde;o definitiva do valor da indeniza&ccedil;&atilde;o, atendendo-se, assim, a determina&ccedil;&atilde;o legal de arbitramento equitativo pelo Juiz.
+9. Considerando-se o referido grupo de precedentes, e levando-se em conta a condi&ccedil;&atilde;o financeira das partes, a finalidade educativa e preventiva da condena&ccedil;&atilde;o, a razo&aacute;vel gravidade do dano, reputo ser adequado arbitrar o valor da indeniza&ccedil;&atilde;o por danos morais em R$ 5.000,00, montante que se afigura adequado e proporcional &agrave;s especificidades do caso em an&aacute;lise.
+IV. DISPOSITIVO
+10. Apela&ccedil;&atilde;o C&iacute;vel conhecida e provida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0813070-98.2024.8.12.0002,&nbsp; Dourados,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(65 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE SEGURO – DESCONTOS EM CONTA CORRENTE – CONTRATAÇÃO NÃO COMPROVADA –  RESTITUIÇÃO DE VALORES DEVIDA – DANOS MORAIS CONFIGURADOS – PROCEDÊNCIA DOS PEDIDOS – SENTENÇA REFORMADA – RECURSO CONHECIDO E PROVIDO.
+CASO EM EXAME
+1. Apelação interposta pela parte autora
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE SEGURO – DESCONTOS EM CONTA CORRENTE – CONTRATAÇÃO NÃO COMPROVADA –  RESTITUIÇÃO DE VALORES DEVIDA – DANOS MORAIS CONFIGURADOS – PROCEDÊNCIA DOS PEDIDOS – SENTENÇA REFORMADA – RECURSO CONHECIDO E PROVIDO.
+CASO EM EXAME
+1. Apelação interposta pela parte autora contra sentença que julgou improcedentes os pedidos iniciais formulados em Ação Declaratória de Inexistência de Débito c/c Indenização por Danos Morais e Materiais.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a (i)legalidade da cobrança de mensalidades de contrato de seguro;  b) o cabimento da restituição dos valores pagos; e c) a ocorrência de danos morais.
+III. RAZÕES DE DECIDIR
+3. O negócio jurídico deve ser examinado sob o prisma de três (3) planos – existência, validade e eficácia –, com a finalidade de se verificar se ele obtém plena realização. No plano da existência, verifica-se, tão somente, se estão presentes as condições mínimas para que o negócio jurídico possa produzir efeitos (v.g, agente; objeto; forma, e vontade exteriorizada), não se discutindo, desta forma, a validade ou invalidade do negócio e tampouco a sua eficácia.
+4. Comprovada a ocorrência de descontos na conta bancária da parte autora e não demonstrada, pela parte ré, a regular contratação, resta caracterizado o descumprimento do ônus probatório previsto no art. 373, II, do CPC/15.
+5. O parágrafo único, do art. 42, da Lei nº 8.078, de 11/09/1990 (Código de Defesa do Consumidor) dispõe que o consumidor cobrado em quantia indevida tem direito à repetição do indébito, por valor igual ao dobro do que pagou em excesso, acrescido de correção monetária e juros legais, salvo hipótese de "engano justificável".
+6. Inexistente contrato válido, são indevidos os descontos realizados, impondo-se a restituição em dobro dos valores indevidamente debitados.
+7. A realização de descontos indevidos em conta bancária, decorrentes de contratação não comprovada, configura <em>dano</em> <em>moral</em> in re ipsa, conforme entendimento consolidado do STJ.
+8. Segundo o método bifásico de fixação de indenização por danos morais, na primeira etapa, deve-se estabelecer um valor básico, à luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jurídico lesado; e, na segunda etapa, devem ser consideradas as circunstâncias do caso, para a fixação definitiva do valor da indenização, atendendo-se, assim, a determinação legal de arbitramento equitativo pelo Juiz.
+9. Considerando-se o referido grupo de precedentes, e levando-se em conta a condição financeira das partes, a finalidade educativa e preventiva da condenação, a razoável gravidade do <em>dano</em>, reputo ser adequado arbitrar o valor da indenização por danos morais em R$ 5.000,00, montante que se afigura adequado e proporcional às especificidades do caso em análise.
+IV. DISPOSITIVO
+10. Apelação Cível conhecida e provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>99&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877473" cdForo="0" >
+										0809261-43.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877473" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877473);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877473" style="display: none;" >
+	<div id="textAreaDados_1877473" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C PEDIDO DE TUTELA ANTECIPADA, INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; PRELIMINAR &ndash; AUS&Ecirc;NCIA DE INTERESSE DE AGIR &ndash; AFASTADA &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; N&Atilde;O COMPROVADA &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; APLICA&Ccedil;&Atilde;O DA MODULA&Ccedil;&Atilde;O DOS EFEITOS DO EARESP N. 676.608/RS &ndash; DESCONTOS ANTERIORES A 30.3.2021 &ndash;  DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash;  DESCONTOS A PARTIR  30.3.2021 &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; VALOR ALTERADO  &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+Nos termos do art. 17 do C&oacute;digo de Processo Civil, para postular em ju&iacute;zo &eacute; necess&aacute;rio ter interesse e legitimidade. O interesse processual ou interesse de agir &eacute; uma das condi&ccedil;&otilde;es da a&ccedil;&atilde;o, devendo ser analisado sob o aspecto da necessidade de obten&ccedil;&atilde;o da tutela jurisdicional pleiteada e da adequa&ccedil;&atilde;o da via eleita para alcan&ccedil;ar aquele fim.
+N&atilde;o bastasse, no pr&oacute;prio julgamento da tese supramencionada, o Supremo Tribunal Federal ressaltou que &quot;A exig&ecirc;ncia de pr&eacute;vio requerimento administrativo n&atilde;o deve prevalecer quando o entendimento da Administra&ccedil;&atilde;o for not&oacute;ria e reiteradamente contr&aacute;rio &agrave; postula&ccedil;&atilde;o do segurado&quot;, e tal conduta, evidentemente, se observa no caso presente, posto que, em todas as suas manifesta&ccedil;&otilde;es nestes autos, as r&eacute;s se posicionaram de forma contr&aacute;ria &agrave; pretens&atilde;o da parte autora.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+A rela&ccedil;&atilde;o jur&iacute;dica vincula os sujeitos de direito em decorr&ecirc;ncia dos fatos jur&iacute;dicos suficientemente comprovados, que s&atilde;o a causa da instaura&ccedil;&atilde;o, da modifica&ccedil;&atilde;o ou da extin&ccedil;&atilde;o de obriga&ccedil;&otilde;es. Especificamente no contrato de m&uacute;tuo ou de empr&eacute;stimo, a tradi&ccedil;&atilde;o da coisa mutuada &eacute; suficiente para se concluir pela exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, cujos efeitos devem operar regulamente, nos termos do art. 586 do C&oacute;digo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que, nos termos art. 42, par&aacute;grafo &uacute;nico, da Lei n&ordm; 8.078/1990 (C&oacute;digo de Defesa do Consumidor), a restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe da natureza do elemento volitivo do fornecedor que realizou a cobran&ccedil;a indevida, revelando-se cab&iacute;vel quando a referida cobran&ccedil;a consubstanciar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva. N&atilde;o obstante, houve modula&ccedil;&atilde;o dos efeitos, impondo a aplica&ccedil;&atilde;o dessa tese a partir de 30.3.2021, data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o dos Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, e unicamente para as cobran&ccedil;as indevidas em contratos de consumo que n&atilde;o envolvam presta&ccedil;&atilde;o de servi&ccedil;os p&uacute;blicos pelo Estado ou por concession&aacute;rias, as quais apenas ser&atilde;o atingidas pelo novo entendimento quando pagas ap&oacute;s a data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso conhecido e provido parcialmente. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0809261-43.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(27 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C PEDIDO DE TUTELA ANTECIPADA, INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR – AUSÊNCIA DE INTERESSE DE AGIR – AFASTADA – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C PEDIDO DE TUTELA ANTECIPADA, INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR – AUSÊNCIA DE INTERESSE DE AGIR – AFASTADA – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR ALTERADO  – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+Nos termos do art. 17 do Código de Processo Civil, para postular em juízo é necessário ter interesse e legitimidade. O interesse processual ou interesse de agir é uma das condições da ação, devendo ser analisado sob o aspecto da necessidade de obtenção da tutela jurisdicional pleiteada e da adequação da via eleita para alcançar aquele fim.
+Não bastasse, no próprio julgamento da tese supramencionada, o Supremo Tribunal Federal ressaltou que "A exigência de prévio requerimento administrativo não deve prevalecer quando o entendimento da Administração for notória e reiteradamente contrário à postulação do segurado", e tal conduta, evidentemente, se observa no caso presente, posto que, em todas as suas manifestações nestes autos, as rés se posicionaram de forma contrária à pretensão da parte autora.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+A relação jurídica vincula os sujeitos de direito em decorrência dos fatos jurídicos suficientemente comprovados, que são a causa da instauração, da modificação ou da extinção de obrigações. Especificamente no contrato de mútuo ou de empréstimo, a tradição da coisa mutuada é suficiente para se concluir pela existência da relação jurídica, cujos efeitos devem operar regulamente, nos termos do art. 586 do Código Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que, nos termos art. 42, parágrafo único, da Lei nº 8.078/1990 (Código de Defesa do Consumidor), a restituição em dobro do indébito independe da natureza do elemento volitivo do fornecedor que realizou a cobrança indevida, revelando-se cabível quando a referida cobrança consubstanciar conduta contrária à boa-fé objetiva. Não obstante, houve modulação dos efeitos, impondo a aplicação dessa tese a partir de 30.3.2021, data da publicação do acórdão dos Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, e unicamente para as cobranças indevidas em contratos de consumo que não envolvam prestação de serviços públicos pelo Estado ou por concessionárias, as quais apenas serão atingidas pelo novo entendimento quando pagas após a data da publicação do acórdão (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso conhecido e provido parcialmente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>100&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877474" cdForo="0" >
+										0800239-96.2022.8.12.0031
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877474" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877474);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877474" style="display: none;" >
+	<div id="textAreaDados_1877474" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE RESCIS&Atilde;O/ANULA&Ccedil;&Atilde;O DE RELA&Ccedil;&Atilde;O CONTRATUAL DE EMPR&Eacute;STIMO CONSIGNADO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E MATERIAIS &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; APLICA&Ccedil;&Atilde;O DA MODULA&Ccedil;&Atilde;O DOS EFEITOS DO EARESP N. 676.608/RS &ndash; DESCONTOS ANTERIORES A 30.3.2021 &ndash;  DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash;  DESCONTOS A PARTIR  30.3.2021 &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; ALTERADOS &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que, nos termos art. 42, par&aacute;grafo &uacute;nico, da Lei n&ordm; 8.078/1990 (C&oacute;digo de Defesa do Consumidor), a restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe da natureza do elemento volitivo do fornecedor que realizou a cobran&ccedil;a indevida, revelando-se cab&iacute;vel quando a referida cobran&ccedil;a consubstanciar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva. N&atilde;o obstante, houve modula&ccedil;&atilde;o dos efeitos, impondo a aplica&ccedil;&atilde;o dessa tese a partir de 30.3.2021, data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o dos Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, e unicamente para as cobran&ccedil;as indevidas em contratos de consumo que n&atilde;o envolvam presta&ccedil;&atilde;o de servi&ccedil;os p&uacute;blicos pelo Estado ou por concession&aacute;rias, as quais apenas ser&atilde;o atingidas pelo novo entendimento quando pagas ap&oacute;s a data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a, nos julgamentos dos Recursos Especiais n&ordm; 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixa&ccedil;&atilde;o dos honor&aacute;rios por aprecia&ccedil;&atilde;o equitativa n&atilde;o &eacute; permitida quando os valores da condena&ccedil;&atilde;o ou da causa, ou o proveito econ&ocirc;mico da demanda, forem elevados. &Eacute; obrigat&oacute;ria, nesses casos, a observ&acirc;ncia dos percentuais previstos nos par&aacute;grafos 2&ordm; ou 3&ordm; do artigo 85 do C&oacute;digo de Processo Civil (CPC) &ndash; a depender da presen&ccedil;a da Fazenda P&uacute;blica na lide &ndash;, os quais ser&atilde;o subsequentemente calculados sobre o valor: (a) da condena&ccedil;&atilde;o; ou (b) do proveito econ&ocirc;mico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honor&aacute;rios por equidade quando, havendo ou n&atilde;o condena&ccedil;&atilde;o: (a) o proveito econ&ocirc;mico obtido pelo vencedor for inestim&aacute;vel ou irris&oacute;rio; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso conhecido e provido parcialmente. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800239-96.2022.8.12.0031,&nbsp; Caarap&oacute;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(27 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Caarapó
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE RESCISÃO/ANULAÇÃO DE RELAÇÃO CONTRATUAL DE EMPRÉSTIMO CONSIGNADO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS E MATERIAIS – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE RESCISÃO/ANULAÇÃO DE RELAÇÃO CONTRATUAL DE EMPRÉSTIMO CONSIGNADO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS E MATERIAIS – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – HONORÁRIOS ADVOCATÍCIOS – ALTERADOS – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que, nos termos art. 42, parágrafo único, da Lei nº 8.078/1990 (Código de Defesa do Consumidor), a restituição em dobro do indébito independe da natureza do elemento volitivo do fornecedor que realizou a cobrança indevida, revelando-se cabível quando a referida cobrança consubstanciar conduta contrária à boa-fé objetiva. Não obstante, houve modulação dos efeitos, impondo a aplicação dessa tese a partir de 30.3.2021, data da publicação do acórdão dos Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, e unicamente para as cobranças indevidas em contratos de consumo que não envolvam prestação de serviços públicos pelo Estado ou por concessionárias, as quais apenas serão atingidas pelo novo entendimento quando pagas após a data da publicação do acórdão (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça, nos julgamentos dos Recursos Especiais nº 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixação dos honorários por apreciação equitativa não é permitida quando os valores da condenação ou da causa, ou o proveito econômico da demanda, forem elevados. É obrigatória, nesses casos, a observância dos percentuais previstos nos parágrafos 2º ou 3º do artigo 85 do Código de Processo Civil (CPC) – a depender da presença da Fazenda Pública na lide –, os quais serão subsequentemente calculados sobre o valor: (a) da condenação; ou (b) do proveito econômico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honorários por equidade quando, havendo ou não condenação: (a) o proveito econômico obtido pelo vencedor for inestimável ou irrisório; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso conhecido e provido parcialmente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			</div>
+		</td>
+		<td width="20px">
+			&nbsp;
+		</td>
+		<td valign="top" width="230px">
+			<div id="adicionarPesquisa-A">
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="RECURSO">
+									<label for="ckTermo1">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="APELAÇÃO">
+									<label for="ckTermo2">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="AÇÃO">
+									<label for="ckTermo3">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="CÍVEL">
+									<label for="ckTermo4">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="DANOS">
+									<label for="ckTermo5">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="EMENTA">
+									<label for="ckTermo6">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="MORAIS">
+									<label for="ckTermo7">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="INDENIZAÇÃO">
+									<label for="ckTermo8">
+										INDENIZAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="PROVIDO">
+									<label for="ckTermo9">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="CONHECIDO">
+									<label for="ckTermo10">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="DECLARATÓRIA">
+									<label for="ckTermo11">
+										DECLARATÓRIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="DANO">
+									<label for="ckTermo12">
+										DANO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="MORAL">
+									<label for="ckTermo13">
+										MORAL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="INEXISTÊNCIA">
+									<label for="ckTermo14">
+										INEXISTÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="danos">
+									<label for="ckTermo15">
+										danos
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			</div>
+
+		</td>
+	</tr>
+</table>
+<div id="paginacaoInferior-A">
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 100
+			</strong>
+			de 149138
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>
+&nbsp;
+</div>
+
+							<script>
+							$(function(){
+								$.saj.cjsg.bindsAbaInicial('A');
+							});
+							</script>
+
+
+
+						</div>
+
+				</div>
+
+			<!-- Resultado consulta -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+</td>
+</tr>
+</table>
+<table width="100%" border="0" cellpadding="0" cellspacing="0" class="esajTabelaRodape" summary=" " role="presentation">
+    <tr>
+        <td class="esajCelulaRodapeCentro">
+            Desenvolvido pela Softplan em parceria com o Tribunal de Justiça do Mato Grosso do Sul
+
+        </td>
+    </tr>
+</table>
+<link href="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/css/saj-popup-modal.css" rel="stylesheet" type="text/css">
+<link href="https://esaj.tjms.jus.br/esaj-layout/tema/padrao/css/popup-beta.css" rel="stylesheet" type="text/css">
+
+
+<script>
+    var appEsajLayout = appEsajLayout || {};
+    appEsajLayout.tituloCertificadoDigital = 'Certificado digital';
+    appEsajLayout.cliente = 'MS';
+    appEsajLayout.emailParaContato = '';
+    appEsajLayout.utilizarBotaoContato = 'true';
+    appEsajLayout.contexto = 'https://esaj.tjms.jus.br/esaj-layout';
+    appEsajLayout.webSignerParametro = 'https://cdn.lacunasoftware.com/libs/web-pki/lacuna-web-pki-2.14.8.min.js';
+
+    if(window.jQuery) {
+        jQuery.saj = jQuery.saj || {};
+        jQuery.saj.certificado = jQuery.saj.certificado || {};
+        jQuery.saj.certificado.cliente = 'MS';
+        jQuery.saj.certificado.urlConteudoAjudaWebSigner = appEsajLayout.contexto + '/ajudaWebSigner.do';
+        jQuery.saj.certificado.licenca = 'ATsCKi50am1zLmp1cy5iciwxMC4yMC4xMDAuMTIzLDEwLjIwLjEwMC4xMjQsMTAuMjAuMTAwLjEyNSwxMC4yMC4xMDAuMTI2LDEwLjIwLjEwMC4xMjcsMTAuMjAuMTAwLjEyOCwxMC4yMC4xMDAuNzIsMTAuMjAuMTAwLjczLDEwLjIwLjEwMC43NCwxMC4yMC4xMDAuNzUsMTAuMjAuMTAwLjc2LDEwLjIwLjEwMC43NywxMC4yMC4xMDAuNzgsMTAuMjAuMTAwLjc5LDE3Mi4yMy4yMC44MSwxNzIuMjMuMjEuMTM5LDE3Mi4yMy4yMS4xNDEsMTkyLjE2OC4xLjEyMCwxOTIuMTY4LjEuMTIxLDE5Mi4xNjguMS4xOTEsMTkyLjE2OC4xLjE5MiwxOTIuMTY4LjEuNzAsMTkyLjE2OC4xLjcxLDE5Mi4xNjguMS43MiwxOTIuMTY4LjEuNzMsMTkyLjE2OC4xLjc0LDE5Mi4xNjguMS43NSwxOTIuMTY4LjEuNzYsMTkyLjE2OC4xLjc3LDE5Mi4xNjguMS43OCwxOTIuMTY4LjEuNzksMTkyLjE2OC4xLjgwLDE5Mi4xNjguMS44MSwxOTIuMTY4LjEuODIsMTkyLjE2OC4xLjgzLDE5Mi4xNjguMS44NCwxOTIuMTY4LjEuODUsMTkyLjE2OC4xLjg2LDE5Mi4xNjguMS44NywxOTIuMTY4LjEuODgsMTkyLjE2OC4xLjg5LDE5Mi4xNjguMS45MAAAAAHAmb3Vqpkj+m/wfGbysS4YZZS2uY8jnt8MjGSa/N0JmZ2hlXJ8f/ZZiDmrElNO8SNi7qztigkK3tQycbZE18+I9C1cF9YpjBigMXm+9ZiaPykVtoR8g43//Q9VUlVRj3wSF2TFLALMIn4BBETz61pmyzDzQkdX3sjFMDW6yZ9a/9eR7OisBZ9dVK8eeKe8EyskfDAKT+wdSX8zutR79RyOx9ilLgkE2g1O04nTpablXcouvirvav64ugBDiCjOtHhI5y59rFu3NBfoWo7EIq8FZr05LhAPaqujxLoQ6dtDym9g1W32wI4wMRp6EF7yepE8eXN5QEaayXZm9oDaBkoe';
+        jQuery.saj.certificado.webSignerParametro = 'https://cdn.lacunasoftware.com/libs/web-pki/lacuna-web-pki-2.14.8.min.js';
+        jQuery.saj.certificado.cofreDigital = jQuery.saj.certificado.cofreDigital || {};
+        jQuery.saj.certificado.cofreDigital.habilitado = 'false' === 'true';
+        jQuery.saj.certificado.cofreDigital.enderecoBase = 'https://esaj.tjms.jus.br/esaj-layout';
+    }
+
+</script>
+<script src="https://esaj.tjms.jus.br/esaj-layout/js/app-bundle.js?n=2978165087"></script>
+<script src="https://esaj.tjms.jus.br/esaj-layout/seletorVersaoBeta.js?n=946a67f3-d884-4405-bd23-cbfbee0b207f&versao=1"></script>
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjms.jus.br/esaj-layout/js/softplan-websigner-2.5.1.js?n=736057767"></script>
+<script language="javascript" type="text/JavaScript" src="https://cdn.lacunasoftware.com/libs/web-pki/lacuna-web-pki-2.14.8.min.js"></script>
+
+<script language="javascript" type="text/JavaScript" src="https://esaj.tjms.jus.br/esaj-layout/js/saj-certificado.js?n=47741893"></script>
+
+
+
+<div id="webSignerNaoInstalado" style="display: none;">
+    <p>Para utilização do certificado digital no Portal e-SAJ é necessário a instalação do plug-in Web Signer. Por favor, realize a instalação antes de continuar.</p>
+    <div class="footer_certificado">
+        <button id="redirecionarParaPaginaInstalacao" class="actionPrincipal spwBotaoDefault">Instalar</button>
+        <button class="fecharModalInstalacao spwBotao">Cancelar</button>
+        <button class="spwBotao" onclick="window.open('https://esaj.tjms.jus.br/WebHelp//#id_instalacao_lacuna.htm','_blank')">Ajuda</button>
+    </div>
+</div>
+
+<div id="webSignerNaoSuportado" style="display: none;">
+    <p>O navegador utilizado não é compatível com a tecnologia (Web Signer) necessária para utilização do certificado digital. Por favor, utilize um dos navegadores homologados. Em caso de dúvidas, efetue a validação de requisitos <a href="https://esaj.tjms.jus.br/petpg/abrirVerificacaoRequisitosPet.do" target="_blank">aqui</a>.</p>
+    <div class="footer_certificado">
+        <button class="fecharModalInstalacao spwBotaoDefault actionPrincipal">OK</button>
+    </div>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+	</body>
+</html>

--- a/tests/tjms/samples/cjsg/results_normal_page_01.html
+++ b/tests/tjms/samples/cjsg/results_normal_page_01.html
@@ -1,0 +1,16111 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(149670)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="149670" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877970" cdForo="0" >
+										0800383-78.2024.8.12.0038
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877970" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877970);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877970" style="display: none;" >
+	<div id="textAreaDados_1877970" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C TUTELA DE URG&Ecirc;NCIA &ndash; REN&Uacute;NCIA DE MANDATO &ndash; INTIMA&Ccedil;&Atilde;O PARA REGULARIZA&Ccedil;&Atilde;O &ndash; IN&Eacute;RCIA &ndash; ARTIGO 76, &sect; 2&ordm;, I, DO CPC &ndash; AUS&Ecirc;NCIA DE PRESSUPOSTO DE CONSTITUI&Ccedil;&Atilde;O E DESENVOLVIMENTO V&Aacute;LIDO E REGULAR DO PROCESSO &ndash; RECURSO N&Atilde;O CONHECIDO.
+O n&atilde;o conhecimento do recurso &eacute; medida que se imp&otilde;e, uma vez que a parte apelante, intimada a regularizar a sua representa&ccedil;&atilde;o processual, quedou-se inerte. Aus&ecirc;ncia de pressuposto processual essencial ao processamento do recurso.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800383-78.2024.8.12.0038,&nbsp; Nioaque,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Fornecimento de medicamentos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Nioaque
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA – RENÚNCIA DE MANDATO – INTIMAÇÃO PARA REGULARIZAÇÃO – INÉRCIA – ARTIGO 76, § 2º, I, DO CPC – AUSÊNCIA DE PRESSUPOSTO DE CONSTITUIÇÃO E DESENVOLVIMENTO VÁLIDO E REGULAR DO PROCESSO – RECURSO NÃO CONHECIDO.
+O não conhecimento do recurso é medida que se impõe, uma vez que a parte apelante, intimada a regularizar a sua
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE OBRIGAÇÃO DE FAZER C/C TUTELA DE URGÊNCIA – RENÚNCIA DE MANDATO – INTIMAÇÃO PARA REGULARIZAÇÃO – INÉRCIA – ARTIGO 76, § 2º, I, DO CPC – AUSÊNCIA DE PRESSUPOSTO DE CONSTITUIÇÃO E DESENVOLVIMENTO VÁLIDO E REGULAR DO PROCESSO – RECURSO NÃO CONHECIDO.
+O não conhecimento do recurso é medida que se impõe, uma vez que a parte apelante, intimada a regularizar a sua representação processual, quedou-se inerte. Ausência de pressuposto processual essencial ao processamento do recurso.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877978" cdForo="0" >
+										0801841-78.2023.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877978" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877978);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877978" style="display: none;" >
+	<div id="textAreaDados_1877978" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE COBRAN&Ccedil;A SECURIT&Aacute;RIA &ndash; SEGURO&nbsp;AGR&Iacute;COLA&nbsp;&ndash; SEGURADO CONSUMIDOR FINAL &ndash; HIPOSSUFICI&Ecirc;NCIA T&Eacute;CNICA DO SEGURADO PERANTE A SEGURADORA &ndash; INCID&Ecirc;NCIA DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; INVERS&Atilde;O DO &Ocirc;NUS DA PROVA MANTIDA &ndash; DIVERG&Ecirc;NCIA DE INFORMA&Ccedil;&Otilde;ES ENTRE AS PROPOSTAS ACEITAS PELO SEGURADO E AS CL&Aacute;USULAS PREVISTAS NA AP&Oacute;LICE DE SEGURO AGR&Iacute;COLA &ndash; CONTRATO DE ADES&Atilde;O &ndash; INTERPRETA&Ccedil;&Atilde;O MAIS BEN&Eacute;FICA AO CONSUMIDOR  &ndash; CONTRATA&Ccedil;&Atilde;O DE SEGURO NA MODALIDADE POR ITEM COM PREVIS&Atilde;O DE TR&Ecirc;S ITENS &ndash; INDENIZA&Ccedil;&Atilde;O SECURIT&Aacute;RIA DE FORMA INDIVIDUALIZADA POR ITEM &ndash; C&Aacute;LCULO DO PERITO JUDICIAL QUE OBSERVOU AS CL&Aacute;USULAS CONTRATUAIS E AS PROPOSTAS CONSTANTES DOS AUTOS &ndash;APURA&Ccedil;&Atilde;O DE SALDO REMANESCENTE &ndash; PAGAMENTO DA DIFEREN&Ccedil;A DEVIDO &ndash; FORMA DE PAGAMENTO A SER DISCUTIDA NA FASE CUMPRIMENTO DE SENTEN&Ccedil;A &ndash; ALTERA&Ccedil;&Atilde;O DO TERMO INICIAL DA CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA E JUROS DE MORA &ndash; OBSERV&Acirc;NCIA DA S&Uacute;MULA 632, DO STJ E DO ART. 405, DO C&Oacute;DIGO CIVIL -  RECURSO  CONHECIDO E PARCIALMENTE PROVIDO.
+A rela&ccedil;&atilde;o jur&iacute;dica mantida entre as partes do contrato de seguro agr&iacute;cola &eacute;, efetivamente, de consumo, que n&atilde;o se confunde com insumo, porquanto o consumidor &eacute; o destinat&aacute;rio final do produto, j&aacute; que o eventual cumprimento do contrato pela recorrente verter&aacute; em benef&iacute;cio pr&oacute;prio do segurado.
+Sendo o autor consumidor a parte vulner&aacute;vel na rela&ccedil;&atilde;o, conforme preceitua o artigo 4&ordm;, do CDC, e presentes os requisitos previstos no artigo 6&ordm;, VIII, do referido c&oacute;digo, pode o juiz inverter o &ocirc;nus da prova.
+No caso, o autor pleiteia saldo remanescente da indeniza&ccedil;&atilde;o securit&aacute;ria paga administrativamente pela seguradora, sob o argumento de erro de c&aacute;lculo pela seguradora e inobserv&acirc;ncia das propostas aceitas pelo autor-consumidor e que antecederam a contrata&ccedil;&atilde;o da ap&oacute;lice de seguro agr&iacute;cola na modalidade por item.
+&Agrave; luz dos princ&iacute;pios da fun&ccedil;&atilde;o social do contrato e da boa-f&eacute; objetiva (arts. 421 e 422, do CC), bem como aplica&ccedil;&atilde;o do C&oacute;digo de Defesa do Consumidor, acertada a senten&ccedil;a do ju&iacute;zo singular ao interpretar a contrata&ccedil;&atilde;o do seguro agr&iacute;cola de maneira mais ben&eacute;fica ao segurado-consumidor (arts. 6&ordm;, III; 46; 47; 54, &sect;&sect; 3&ordm; e 4&ordm;, do CDC), mormente diante da diverg&ecirc;ncia entre as propostas aderidas pelo segurado-consumidor que antecederam a contrata&ccedil;&atilde;o e aquelas inseridas unilateralmente pela seguradora na ap&oacute;lice firmada ao final.
+Restou evidenciado que a inten&ccedil;&atilde;o do produtor rural era contratar seguro agr&iacute;cola por item, com divis&atilde;o da unidade segurada em tr&ecirc;s itens, consoante propostas juntadas aos autos e que antecederam a contrata&ccedil;&atilde;o da ap&oacute;lice de seguro, visando eventual pagamento de indeniza&ccedil;&atilde;o de forma individualizada de acordo com a produtividade e eventuais sinistros de cada item.
+O laudo da vistoria t&eacute;cnica realizada por empresa contratada pela pr&oacute;pria seguradora, que concluiu pela ocorr&ecirc;ncia do sinistro coberta pela ap&oacute;lice, constatando pela exist&ecirc;ncia de 2% de ervas daninhas apenas no item 2 (subdividido em talh&otilde;es 2A e 2B), com &aacute;rea de 159,93 ha e colheita do item 3, com &aacute;rea de 67,71ha, de modo que as ervas daninhas (2%) devem ser descontadas apenas do item 2, com &aacute;rea de 159,93 ha, por configurar Parcela Deduzida a t&iacute;tulo de Risco N&atilde;o Coberto &ndash; PRNC, enquanto que o item 3, com &aacute;rea de 67,71ha, n&atilde;o deve ser computado para fins de compensa&ccedil;&atilde;o da indeniza&ccedil;&atilde;o securit&aacute;ria.
+O c&aacute;lculo elaborado pelo perito nomeado pelo ju&iacute;zo observou detidamente as cl&aacute;usulas contratuais, especialmente a f&oacute;rmula prevista na ap&oacute;lice de seguro firmada entre as partes, bem como as propostas que antecederam aludida contrata&ccedil;&atilde;o e os laudos de vistorias t&eacute;cnicos elaborados por empresa contratada pela seguradora e que  previram o seguro agr&iacute;cola por item, especificando 3 itens, ou seja, item 1 com &aacute;rea de 67,71 ha,  item 2 com &aacute;rea total de 159,93 ha, subdividido em dois talh&otilde;es (2.1 com &aacute;rea de 78,43 e 2.2 com &aacute;rea de 81,5 ha) e item 3 com &aacute;rea de 67,71 ha. O valor total da indeniza&ccedil;&atilde;o securit&aacute;ria apurado pelo aludido c&aacute;lculo n&atilde;o ultrapassa o LMI &ndash; Limite M&aacute;ximo de Indeniza&ccedil;&atilde;o, pelo que &eacute; devida a diferen&ccedil;a apurada.
+A forma de pagamento do saldo remanescente da indeniza&ccedil;&atilde;o securit&aacute;ria, se ao segurado ou ao benefici&aacute;rio, &eacute; quest&atilde;o a ser resolvida na fase de cumprimento de senten&ccedil;a.
+Altera&ccedil;&atilde;o do termo inicial dos juros de mora e corre&ccedil;&atilde;o monet&aacute;ria fixado na senten&ccedil;a, a fim de observarem o disposto no art. 405, do C&oacute;digo Civil, e a S&uacute;mula 632, do STJ, mantidos os &iacute;ndices previstos no contrato.
+Recurso conhecido e parcialmente provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801841-78.2023.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO CÍVEL – AÇÃO DE COBRANÇA SECURITÁRIA – SEGURO AGRÍCOLA – SEGURADO CONSUMIDOR FINAL – HIPOSSUFICIÊNCIA TÉCNICA DO SEGURADO PERANTE A SEGURADORA – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – INVERSÃO DO ÔNUS DA PROVA MANTIDA – DIVERGÊNCIA DE INFORMAÇÕES ENTRE AS PROPOSTAS ACEITAS PELO SEGURADO E AS CLÁUSULAS PREVISTAS NA APÓLICE DE SEGURO AGRÍCOLA – CONTRATO DE ADESÃO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO CÍVEL – AÇÃO DE COBRANÇA SECURITÁRIA – SEGURO AGRÍCOLA – SEGURADO CONSUMIDOR FINAL – HIPOSSUFICIÊNCIA TÉCNICA DO SEGURADO PERANTE A SEGURADORA – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – INVERSÃO DO ÔNUS DA PROVA MANTIDA – DIVERGÊNCIA DE INFORMAÇÕES ENTRE AS PROPOSTAS ACEITAS PELO SEGURADO E AS CLÁUSULAS PREVISTAS NA APÓLICE DE SEGURO AGRÍCOLA – CONTRATO DE ADESÃO – INTERPRETAÇÃO MAIS BENÉFICA AO CONSUMIDOR  – CONTRATAÇÃO DE SEGURO NA MODALIDADE POR ITEM COM PREVISÃO DE TRÊS ITENS – INDENIZAÇÃO SECURITÁRIA DE FORMA INDIVIDUALIZADA POR ITEM – CÁLCULO DO PERITO JUDICIAL QUE OBSERVOU AS CLÁUSULAS CONTRATUAIS E AS PROPOSTAS CONSTANTES DOS AUTOS –APURAÇÃO DE SALDO REMANESCENTE – PAGAMENTO DA DIFERENÇA DEVIDO – FORMA DE PAGAMENTO A SER DISCUTIDA NA FASE CUMPRIMENTO DE SENTENÇA – ALTERAÇÃO DO TERMO INICIAL DA CORREÇÃO MONETÁRIA E JUROS DE MORA – OBSERVÂNCIA DA SÚMULA 632, DO STJ E DO ART. 405, DO CÓDIGO CIVIL -  RECURSO  CONHECIDO E PARCIALMENTE PROVIDO.
+A relação jurídica mantida entre as partes do contrato de seguro agrícola é, efetivamente, de consumo, que não se confunde com insumo, porquanto o consumidor é o destinatário final do produto, já que o eventual cumprimento do contrato pela recorrente verterá em benefício próprio do segurado.
+Sendo o autor consumidor a parte vulnerável na relação, conforme preceitua o artigo 4º, do CDC, e presentes os requisitos previstos no artigo 6º, VIII, do referido código, pode o juiz inverter o ônus da prova.
+No caso, o autor pleiteia saldo remanescente da indenização securitária paga administrativamente pela seguradora, sob o argumento de erro de cálculo pela seguradora e inobservância das propostas aceitas pelo autor-consumidor e que antecederam a contratação da apólice de seguro agrícola na modalidade por item.
+À luz dos princípios da função social do contrato e da boa-fé objetiva (arts. 421 e 422, do CC), bem como aplicação do Código de Defesa do Consumidor, acertada a sentença do juízo singular ao interpretar a contratação do seguro agrícola de maneira mais benéfica ao segurado-consumidor (arts. 6º, III; 46; 47; 54, §§ 3º e 4º, do CDC), mormente diante da divergência entre as propostas aderidas pelo segurado-consumidor que antecederam a contratação e aquelas inseridas unilateralmente pela seguradora na apólice firmada ao final.
+Restou evidenciado que a intenção do produtor rural era contratar seguro agrícola por item, com divisão da unidade segurada em três itens, consoante propostas juntadas aos autos e que antecederam a contratação da apólice de seguro, visando eventual pagamento de indenização de forma individualizada de acordo com a produtividade e eventuais sinistros de cada item.
+O laudo da vistoria técnica realizada por empresa contratada pela própria seguradora, que concluiu pela ocorrência do sinistro coberta pela apólice, constatando pela existência de 2% de ervas daninhas apenas no item 2 (subdividido em talhões 2A e 2B), com área de 159,93 ha e colheita do item 3, com área de 67,71ha, de modo que as ervas daninhas (2%) devem ser descontadas apenas do item 2, com área de 159,93 ha, por configurar Parcela Deduzida a título de Risco Não Coberto – PRNC, enquanto que o item 3, com área de 67,71ha, não deve ser computado para fins de compensação da indenização securitária.
+O cálculo elaborado pelo perito nomeado pelo juízo observou detidamente as cláusulas contratuais, especialmente a fórmula prevista na apólice de seguro firmada entre as partes, bem como as propostas que antecederam aludida contratação e os laudos de vistorias técnicos elaborados por empresa contratada pela seguradora e que  previram o seguro agrícola por item, especificando 3 itens, ou seja, item 1 com área de 67,71 ha,  item 2 com área total de 159,93 ha, subdividido em dois talhões (2.1 com área de 78,43 e 2.2 com área de 81,5 ha) e item 3 com área de 67,71 ha. O valor total da indenização securitária apurado pelo aludido cálculo não ultrapassa o LMI – Limite Máximo de Indenização, pelo que é devida a diferença apurada.
+A forma de pagamento do saldo remanescente da indenização securitária, se ao segurado ou ao beneficiário, é questão a ser resolvida na fase de cumprimento de sentença.
+Alteração do termo inicial dos juros de mora e correção monetária fixado na sentença, a fim de observarem o disposto no art. 405, do Código Civil, e a Súmula 632, do STJ, mantidos os índices previstos no contrato.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>3&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877984" cdForo="0" >
+										0870227-32.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877984" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877984);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877984" style="display: none;" >
+	<div id="textAreaDados_1877984" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O &ndash; N&Atilde;O   PROVIMENTO DO RECURSO DE APELA&Ccedil;&Atilde;O DA EMBARGANTE &ndash; OMISS&Atilde;O E CONTRADI&Ccedil;&Atilde;O &ndash; ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE AN&Aacute;LISE QUANTO &Agrave; INEXIST&Ecirc;NCIA DE BIOMETRIA &ndash; ALEGA&Ccedil;&Atilde;O DE OCORR&Ecirc;NCIA DE FORTUITO INTERNO &ndash; AN&Aacute;LISE ACERCA DA EXCLUDENTE DE RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; V&Iacute;CIOS N&Atilde;O IDENTIFICADOS &ndash; MERA REDISCUSS&Atilde;O DAS MAT&Eacute;RIAS &ndash; RECURSO REJEITADO.
+Os embargos de declara&ccedil;&atilde;o t&ecirc;m por escopo a supress&atilde;o no ac&oacute;rd&atilde;o de eventual contradi&ccedil;&atilde;o, obscuridade ou omiss&atilde;o, e n&atilde;o servem de instrumento para ensejar a rediscuss&atilde;o da mat&eacute;ria ou o simples reexame de quest&otilde;es j&aacute; analisadas, com o intuito de dar efeito modificativo ao recurso.
+A parte recorrente alega que o Ac&oacute;rd&atilde;o vergastado foi omisso ao deixar de se pronunciar acerca da aus&ecirc;ncia de provas quanto &agrave; validade da assinatura da embargante, bem como que o caso dos autos se trata de fortuito interno e a n&atilde;o ocorr&ecirc;ncia de nenhuma excludente de responsabilidade, pisando-se pela exist&ecirc;ncia de omiss&atilde;o a alega&ccedil;&atilde;o de descumprimento dos requisitos dispostos na IN 138/2022.
+As mat&eacute;rias alegadas pela parte embargante versam acerca do m&eacute;rito da a&ccedil;&atilde;o de origem, n&atilde;o constituindo-se em omiss&otilde;es e contradi&ccedil;&otilde;es existentes no ac&oacute;rd&atilde;o de julgamento.
+Uma vez n&atilde;o verificada quaisquer v&iacute;cios pass&iacute;veis de serem sanados, os aclarat&oacute;rios devem ser rejeitados, nos termos do que estabelece o artigo 1.022, I e II, do C&oacute;digo de Processo Civil.   <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0870227-32.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Rescisão / Resolução
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									870227322024812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO   PROVIMENTO DO RECURSO DE APELAÇÃO DA EMBARGANTE – OMISSÃO E CONTRADIÇÃO – ALEGAÇÃO DE AUSÊNCIA DE ANÁLISE QUANTO À INEXISTÊNCIA DE BIOMETRIA – ALEGAÇÃO DE OCORRÊNCIA DE FORTUITO INTERNO – ANÁLISE ACERCA DA EXCLUDENTE DE RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – VÍCIOS NÃO IDENTIFICADOS – MERA REDISCUSSÃO DAS MATÉRIAS – RECURSO REJEITADO.
+Os embargos de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO   PROVIMENTO DO RECURSO DE APELAÇÃO DA EMBARGANTE – OMISSÃO E CONTRADIÇÃO – ALEGAÇÃO DE AUSÊNCIA DE ANÁLISE QUANTO À INEXISTÊNCIA DE BIOMETRIA – ALEGAÇÃO DE OCORRÊNCIA DE FORTUITO INTERNO – ANÁLISE ACERCA DA EXCLUDENTE DE RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – VÍCIOS NÃO IDENTIFICADOS – MERA REDISCUSSÃO DAS MATÉRIAS – RECURSO REJEITADO.
+Os embargos de declaração têm por escopo a supressão no acórdão de eventual contradição, obscuridade ou omissão, e não servem de instrumento para ensejar a rediscussão da matéria ou o simples reexame de questões já analisadas, com o intuito de dar efeito modificativo ao recurso.
+A parte recorrente alega que o Acórdão vergastado foi omisso ao deixar de se pronunciar acerca da ausência de provas quanto à validade da assinatura da embargante, bem como que o caso dos autos se trata de fortuito interno e a não ocorrência de nenhuma excludente de responsabilidade, pisando-se pela existência de omissão a alegação de descumprimento dos requisitos dispostos na IN 138/2022.
+As matérias alegadas pela parte embargante versam acerca do mérito da ação de origem, não constituindo-se em omissões e contradições existentes no acórdão de julgamento.
+Uma vez não verificada quaisquer vícios passíveis de serem sanados, os aclaratórios devem ser rejeitados, nos termos do que estabelece o artigo 1.022, I e II, do Código de Processo Civil.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>4&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878011" cdForo="0" >
+										0802926-02.2023.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878011" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878011);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878011" style="display: none;" >
+	<div id="textAreaDados_1878011" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O ANULAT&Oacute;RIA DE NEG&Oacute;CIO JUR&Iacute;DICO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CONTRATO DE EMPR&Eacute;STIMO DEVIDAMENTE FORMALIZADO PERANTE A INSTITUI&Ccedil;&Atilde;O FINANCEIRA APELANTE &ndash; AUTOR QUE RECEBEU O VALOR DO CONTRATO E UTILIZOU PARA PAGAMENTO DE BOLETO FALSO &ndash; AUS&Ecirc;NCIA DE ILICITUDE PRATICADA PELO BANCO &ndash; EXIST&Ecirc;NCIA DE PACTUA&Ccedil;&Atilde;O DISTINTA ENTRE O AUTOR E EMPRESA TERCEIRA &ndash; EXCLUDENTE DE RESPONSABILIDADE COMPROVADA &ndash; ART. 14, &sect;3&ordm;, II, DO CDC &ndash; FORTUITO EXTERNO &ndash; CULPA EXCLUSIVA DO CONSUMIDOR E/OU TERCEIRO &ndash; DECIS&Atilde;O MANTIDA &ndash; REDISCUSS&Atilde;O DA MAT&Eacute;RIA &ndash; PREQUESTIONAMENTO &ndash; DESNECESSIDADE DE MANIFESTA&Ccedil;&Atilde;O EXPRESSA &ndash; EMBARGOS REJEITADOS.
+A teor do disposto no art. 1022, do C&oacute;digo de Processo Civil, os embargos de declara&ccedil;&atilde;o t&ecirc;m por finalidade o aperfei&ccedil;oamento de pronunciamentos judiciais, afastando do decisum embargado eventuais v&iacute;cios, tais como obscuridade ou contradi&ccedil;&atilde;o ou, ainda, integrando-os por interm&eacute;dio da manifesta&ccedil;&atilde;o acerca de algum ponto ocasionalmente omisso, n&atilde;o se prestando, destarte, esta estreita via recursal, para alterar aquilo que restou decidido, salvo nos casos excepcionais em que, do saneamento de algum defeito, decorra l&oacute;gica e imediatamente uma mudan&ccedil;a substancial quanto &agrave; conclus&atilde;o anteriormente assentada acerca da controv&eacute;rsia posta &agrave; aprecia&ccedil;&atilde;o.
+Se o inconformismo do embargante prende-se a pontos isolados que foram elucidados no voto condutor e que serviram de lastro para fundamentar o ac&oacute;rd&atilde;o guerreado, tem-se claramente que o intuito &eacute; obter novo julgamento da quest&atilde;o versada, objetivo imposs&iacute;vel de se atingir atrav&eacute;s de embargos de declara&ccedil;&atilde;o, sob pena de se desvirtuar completamente a natureza do instrumento, dando azo &agrave; manipula&ccedil;&atilde;o de novo recurso de m&eacute;rito na mesma inst&acirc;ncia, o que a jurisprud&ecirc;ncia p&aacute;tria n&atilde;o admite.
+Em n&atilde;o sendo caso de nenhuma das hip&oacute;teses do art. 1.022, do C&oacute;digo de Processo Civil, rejeitam-se os embargos declarat&oacute;rios.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0802926-02.2023.8.12.0002,&nbsp; Dourados,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									802926022023812000250000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO ANULATÓRIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE EMPRÉSTIMO DEVIDAMENTE FORMALIZADO PERANTE A INSTITUIÇÃO FINANCEIRA APELANTE – AUTOR QUE RECEBEU O VALOR DO CONTRATO E UTILIZOU PARA PAGAMENTO DE BOLETO FALSO – AUSÊNCIA DE ILICITUDE PRATICADA PELO BANCO – EXISTÊNCIA DE PACTUAÇÃO DISTINTA ENTRE O AUTOR E EMPRESA TERCEIRA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO ANULATÓRIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE EMPRÉSTIMO DEVIDAMENTE FORMALIZADO PERANTE A INSTITUIÇÃO FINANCEIRA APELANTE – AUTOR QUE RECEBEU O VALOR DO CONTRATO E UTILIZOU PARA PAGAMENTO DE BOLETO FALSO – AUSÊNCIA DE ILICITUDE PRATICADA PELO BANCO – EXISTÊNCIA DE PACTUAÇÃO DISTINTA ENTRE O AUTOR E EMPRESA TERCEIRA – EXCLUDENTE DE RESPONSABILIDADE COMPROVADA – ART. 14, §3º, II, DO CDC – FORTUITO EXTERNO – CULPA EXCLUSIVA DO CONSUMIDOR E/OU TERCEIRO – DECISÃO MANTIDA – REDISCUSSÃO DA MATÉRIA – PREQUESTIONAMENTO – DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA – EMBARGOS REJEITADOS.
+A teor do disposto no art. 1022, do Código de Processo Civil, os embargos de declaração têm por finalidade o aperfeiçoamento de pronunciamentos judiciais, afastando do decisum embargado eventuais vícios, tais como obscuridade ou contradição ou, ainda, integrando-os por intermédio da manifestação acerca de algum ponto ocasionalmente omisso, não se prestando, destarte, esta estreita via recursal, para alterar aquilo que restou decidido, salvo nos casos excepcionais em que, do saneamento de algum defeito, decorra lógica e imediatamente uma mudança substancial quanto à conclusão anteriormente assentada acerca da controvérsia posta à apreciação.
+Se o inconformismo do embargante prende-se a pontos isolados que foram elucidados no voto condutor e que serviram de lastro para fundamentar o acórdão guerreado, tem-se claramente que o intuito é obter novo julgamento da questão versada, objetivo impossível de se atingir através de embargos de declaração, sob pena de se desvirtuar completamente a natureza do instrumento, dando azo à manipulação de novo recurso de mérito na mesma instância, o que a jurisprudência pátria não admite.
+Em não sendo caso de nenhuma das hipóteses do art. 1.022, do Código de Processo Civil, rejeitam-se os embargos declaratórios.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>5&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878013" cdForo="0" >
+										0814178-05.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878013" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878013);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878013" style="display: none;" >
+	<div id="textAreaDados_1878013" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O MONIT&Oacute;RIA &ndash; NOTA PROMISS&Oacute;RIA PRESCRITA &ndash; JUNTADA DE DOCUMENTOS EM SEDE RECURSAL &ndash; N&Atilde;O CONHECIMENTO &ndash; AUS&Ecirc;NCIA DE FATO NOVO OU FOR&Ccedil;A MAIOR &ndash; PRECLUS&Atilde;O (ARTS. 434 E 435 DO CPC) &ndash; M&Eacute;RITO &ndash; DISCUSS&Atilde;O DA CAUSA DEBENDI &ndash; POSSIBILIDADE &ndash; COMPROVA&Ccedil;&Atilde;O DE QUE O NEG&Oacute;CIO JUR&Iacute;DICO SUBJACENTE (COMPRA E VENDA DE SEMOVENTES) N&Atilde;O SE APERFEI&Ccedil;OOU &ndash; TRADI&Ccedil;&Atilde;O DO OBJETO A TERCEIRO COMPROVADA POR GUIAS DE TR&Acirc;NSITO ANIMAL (GTA) &ndash; INEXIGIBILIDADE DO T&Iacute;TULO &ndash; ALEGA&Ccedil;&Atilde;O DE ANALFABETISMO DO CREDOR E INAUTENTICIDADE DE DOCUMENTO &ndash; INOVA&Ccedil;&Atilde;O RECURSAL E PRECLUS&Atilde;O CONSUMATIVA &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO EM PARTE E, NA PARTE CONHECIDA, DESPROVIDO.
+I - A juntada de documentos em fase recursal &eacute; medida excepcional, admitida apenas para comprovar fatos novos ou se demonstrada a impossibilidade de apresenta&ccedil;&atilde;o oportuna por motivo de for&ccedil;a maior. Intelig&ecirc;ncia dos arts. 434 e 435 do CPC. Documenta&ccedil;&atilde;o que visa rediscutir fatos narrados desde o in&iacute;cio da lide n&atilde;o deve ser conhecida.
+II - As teses de que o credor original era analfabeto ou de que a declara&ccedil;&atilde;o por ele firmada seria inaut&ecirc;ntica n&atilde;o foram arguidas no momento oportuno (fase de instru&ccedil;&atilde;o), operando-se a preclus&atilde;o. A an&aacute;lise de tais mat&eacute;rias diretamente pelo Tribunal configuraria supress&atilde;o de inst&acirc;ncia e ofensa ao duplo grau de jurisdi&ccedil;&atilde;o.
+III - Em sede de A&ccedil;&atilde;o Monit&oacute;ria fundada em t&iacute;tulo prescrito, &eacute; admitida a discuss&atilde;o sobre a causa da d&iacute;vida. Demonstrado pelo devedor/embargante, por meio de prova documental dotada de f&eacute; p&uacute;blica (GTA e registros da SEFAZ), que os animais objeto da nota promiss&oacute;ria foram vendidos e entregues a terceiro na v&eacute;spera do vencimento do t&iacute;tulo, resta esvaziado o lastro do cr&eacute;dito.
+IV - A simples posse da c&aacute;rtula n&atilde;o autoriza a cobran&ccedil;a quando cabalmente comprovado o desfazimento ou a n&atilde;o concretiza&ccedil;&atilde;o do neg&oacute;cio jur&iacute;dico que lhe deu origem (causa debendi).
+V - Recurso conhecido em parte e, na parte conhecida, desprovido, com majora&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais em sede recursal (art. 85, &sect; 11, do CPC).  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0814178-05.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Duplicata
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO MONITÓRIA – NOTA PROMISSÓRIA PRESCRITA – JUNTADA DE DOCUMENTOS EM SEDE RECURSAL – NÃO CONHECIMENTO – AUSÊNCIA DE FATO NOVO OU FORÇA MAIOR – PRECLUSÃO (ARTS. 434 E 435 DO CPC) – MÉRITO – DISCUSSÃO DA CAUSA DEBENDI – POSSIBILIDADE – COMPROVAÇÃO DE QUE O NEGÓCIO JURÍDICO SUBJACENTE (COMPRA E VENDA DE SEMOVENTES) NÃO SE APERFEIÇOOU – TRADIÇÃO DO OBJETO A TERCEIRO COMPROVADA POR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO MONITÓRIA – NOTA PROMISSÓRIA PRESCRITA – JUNTADA DE DOCUMENTOS EM SEDE RECURSAL – NÃO CONHECIMENTO – AUSÊNCIA DE FATO NOVO OU FORÇA MAIOR – PRECLUSÃO (ARTS. 434 E 435 DO CPC) – MÉRITO – DISCUSSÃO DA CAUSA DEBENDI – POSSIBILIDADE – COMPROVAÇÃO DE QUE O NEGÓCIO JURÍDICO SUBJACENTE (COMPRA E VENDA DE SEMOVENTES) NÃO SE APERFEIÇOOU – TRADIÇÃO DO OBJETO A TERCEIRO COMPROVADA POR GUIAS DE TRÂNSITO ANIMAL (GTA) – INEXIGIBILIDADE DO TÍTULO – ALEGAÇÃO DE ANALFABETISMO DO CREDOR E INAUTENTICIDADE DE DOCUMENTO – INOVAÇÃO RECURSAL E PRECLUSÃO CONSUMATIVA – SENTENÇA MANTIDA – RECURSO CONHECIDO EM PARTE E, NA PARTE CONHECIDA, DESPROVIDO.
+I - A juntada de documentos em fase recursal é medida excepcional, admitida apenas para comprovar fatos novos ou se demonstrada a impossibilidade de apresentação oportuna por motivo de força maior. Inteligência dos arts. 434 e 435 do CPC. Documentação que visa rediscutir fatos narrados desde o início da lide não deve ser conhecida.
+II - As teses de que o credor original era analfabeto ou de que a declaração por ele firmada seria inautêntica não foram arguidas no momento oportuno (fase de instrução), operando-se a preclusão. A análise de tais matérias diretamente pelo Tribunal configuraria supressão de instância e ofensa ao duplo grau de jurisdição.
+III - Em sede de Ação Monitória fundada em título prescrito, é admitida a discussão sobre a causa da dívida. Demonstrado pelo devedor/embargante, por meio de prova documental dotada de fé pública (GTA e registros da SEFAZ), que os animais objeto da nota promissória foram vendidos e entregues a terceiro na véspera do vencimento do título, resta esvaziado o lastro do crédito.
+IV - A simples posse da cártula não autoriza a cobrança quando cabalmente comprovado o desfazimento ou a não concretização do negócio jurídico que lhe deu origem (causa debendi).
+V - Recurso conhecido em parte e, na parte conhecida, desprovido, com majoração dos honorários sucumbenciais em sede recursal (art. 85, § 11, do CPC).
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>6&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878039" cdForo="0" >
+										0831188-33.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878039" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878039);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878039" style="display: none;" >
+	<div id="textAreaDados_1878039" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O ORDIN&Aacute;RIA, DESCONTOS EM FOLHA DE PAGAMENTO, ABUSIVIDADE C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; EMPR&Eacute;STIMO CONSIGNADO &ndash; ASSINATURA FALSIFICADA &ndash; PROVA PERICIAL CONCLUSIVA &ndash; NULIDADE DOS CONTRATOS &ndash; RESTITUI&Ccedil;&Atilde;O EM DOBRO DEVIDA A PARTIR DE 29/03/2021 &ndash; AUS&Ecirc;NCIA DE PROVA DO ENGANO JUSTIFIC&Aacute;VEL &ndash; DANO MORAL &ndash; OCORR&Ecirc;NCIA &ndash; DESCONTOS ELEVADOS EM REMUNERA&Ccedil;&Atilde;O &ndash; APLICA&Ccedil;&Atilde;O DAS ALTERA&Ccedil;&Otilde;ES DA LEI N.&ordm; 14.905/2024  - SENTEN&Ccedil;A REFORMADA QUANTO AO &Iacute;NDICE APLICADO &Agrave;S RESTITUI&Ccedil;&Otilde;ES ANTERIORES &Agrave; LEI 14.905/2024 &ndash; RECURSO CONHECIDO E PROVIDO EM PARTE.
+A falsifica&ccedil;&atilde;o da assinatura no contrato de empr&eacute;stimo consignado, devidamente constatada por prova pericial grafot&eacute;cnica, inviabiliza a manifesta&ccedil;&atilde;o v&aacute;lida da vontade do consumidor e acarreta a nulidade absoluta do neg&oacute;cio jur&iacute;dico.
+Considerando que est&atilde;o presentes os requisitos do art. 42, par&aacute;grafo &uacute;nico, do CDC; que a parte fornecedora n&atilde;o logrou comprovar que seu engano foi justific&aacute;vel nos moldes aqui estabelecidos, ou seja, que tomou todas as cautelas devidas para que o fato n&atilde;o acontecesse; devida a restitui&ccedil;&atilde;o dos valores indevidamente descontados na forma dobrada.
+As especificidades do caso concreto, a saber, valor da remunera&ccedil;&atilde;o e dos descontos indevidos, implicam na conclus&atilde;o de ocorr&ecirc;ncia de les&atilde;o extrapatrimonial indeniz&aacute;vel.
+&nbsp;Em face do conjunto probat&oacute;rio do caso concreto, entendo que a quantia de R$ 5.000,00 (oito mil reais) se mostra suficiente, justa, razo&aacute;vel e adequada, atendendo &agrave; fun&ccedil;&atilde;o pedag&oacute;gica da condena&ccedil;&atilde;o.
+Impositiva a compensa&ccedil;&atilde;o entre o valor depositado em conta de titularidade da parte autora, devidamente atualizado, com o montante da condena&ccedil;&atilde;o, de modo a se evitar o enriquecimento il&iacute;cito da parte.
+Tratando-se o presente caso de responsabilidade extracontratual &ndash; quando n&atilde;o existe contrato &ndash;, o termo inicial dos juros de mora da condena&ccedil;&atilde;o por danos materiais e morais deve observar o evento danoso. Isto &eacute;, em rela&ccedil;&atilde;o &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, a contar de cada desconto indevido, e dos danos morais, da data do primeiro desconto indevido (quando o dano foi provocado).
+A t&iacute;tulo de corre&ccedil;&atilde;o monet&aacute;ria, o IPCA-E deve incidir desde a data de cada desconto, no que concerne &agrave; repara&ccedil;&atilde;o material e, a partir do arbitramento, quanto &agrave; repara&ccedil;&atilde;o moral.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0831188-33.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(72 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO ORDINÁRIA, DESCONTOS EM FOLHA DE PAGAMENTO, ABUSIVIDADE C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – ASSINATURA FALSIFICADA – PROVA PERICIAL CONCLUSIVA – NULIDADE DOS CONTRATOS – RESTITUIÇÃO EM DOBRO DEVIDA A PARTIR DE 29/03/2021 – AUSÊNCIA DE PROVA DO ENGANO JUSTIFICÁVEL – <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA – DESCONTOS ELEVADOS EM REMUNERAÇÃO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO ORDINÁRIA, DESCONTOS EM FOLHA DE PAGAMENTO, ABUSIVIDADE C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – ASSINATURA FALSIFICADA – PROVA PERICIAL CONCLUSIVA – NULIDADE DOS CONTRATOS – RESTITUIÇÃO EM DOBRO DEVIDA A PARTIR DE 29/03/2021 – AUSÊNCIA DE PROVA DO ENGANO JUSTIFICÁVEL – <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA – DESCONTOS ELEVADOS EM REMUNERAÇÃO – APLICAÇÃO DAS ALTERAÇÕES DA LEI N.º 14.905/2024  - SENTENÇA REFORMADA QUANTO AO ÍNDICE APLICADO ÀS RESTITUIÇÕES ANTERIORES À LEI 14.905/2024 – RECURSO CONHECIDO E PROVIDO EM PARTE.
+A falsificação da assinatura no contrato de empréstimo consignado, devidamente constatada por prova pericial grafotécnica, inviabiliza a manifestação válida da vontade do consumidor e acarreta a nulidade absoluta do negócio jurídico.
+Considerando que estão presentes os requisitos do art. 42, parágrafo único, do CDC; que a parte fornecedora não logrou comprovar que seu engano foi justificável nos moldes aqui estabelecidos, ou seja, que tomou todas as cautelas devidas para que o fato não acontecesse; devida a restituição dos valores indevidamente descontados na forma dobrada.
+As especificidades do caso concreto, a saber, valor da remuneração e dos descontos indevidos, implicam na conclusão de ocorrência de lesão extrapatrimonial indenizável.
+ Em face do conjunto probatório do caso concreto, entendo que a quantia de R$ 5.000,00 (oito mil reais) se mostra suficiente, justa, razoável e adequada, atendendo à função pedagógica da condenação.
+Impositiva a compensação entre o valor depositado em conta de titularidade da parte autora, devidamente atualizado, com o montante da condenação, de modo a se evitar o enriquecimento ilícito da parte.
+Tratando-se o presente caso de responsabilidade extracontratual – quando não existe contrato –, o termo inicial dos juros de mora da condenação por danos materiais e morais deve observar o evento danoso. Isto é, em relação à repetição do indébito, a contar de cada desconto indevido, e dos danos morais, da data do primeiro desconto indevido (quando o <em>dano</em> foi provocado).
+A título de correção monetária, o IPCA-E deve incidir desde a data de cada desconto, no que concerne à reparação material e, a partir do arbitramento, quanto à reparação <em>moral</em>.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>7&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878052" cdForo="0" >
+										0800560-55.2023.8.12.0045
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878052" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878052);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878052" style="display: none;" >
+	<div id="textAreaDados_1878052" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; ERRO NA IDENTIFICA&Ccedil;&Atilde;O DE PACIENTE EM UNIDADE HOSPITALAR &ndash; DECLARA&Ccedil;&Atilde;O INDEVIDA DE &Oacute;BITO &ndash; CESSA&Ccedil;&Atilde;O DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. RESPONSABILIDADE CIVIL DO ESTADO &ndash; CONFIGURADA. TEORIA DO RISCO ADMINISTRATIVO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; NEXO CAUSAL CONFIGURADO. DANO MORAL CARACTERIZADO &ndash; QUANTUM INDENIZAT&Oacute;RIO (R$20.000,00) &ndash; REVESTIDO DE RAZOABILIDADE E PROPORCIONALIDADE. PRETENS&Otilde;ES DE MAJORA&Ccedil;&Atilde;O (AUTOR) E MINORA&Ccedil;&Atilde;O (REQUERIDOS &ndash; REJEITADAS. SENTEN&Ccedil;A MANTIDA, RECURSOS DESPROVIDOS.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800560-55.2023.8.12.0045,&nbsp; Sidrol&acirc;ndia,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sidrolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ERRO NA IDENTIFICAÇÃO DE PACIENTE EM UNIDADE HOSPITALAR – DECLARAÇÃO INDEVIDA DE ÓBITO – CESSAÇÃO DE BENEFÍCIO PREVIDENCIÁRIO. RESPONSABILIDADE CIVIL DO ESTADO – CONFIGURADA. TEORIA DO RISCO ADMINISTRATIVO – FALHA NA PRESTAÇÃO DO SERVIÇO – NEXO CAUSAL CONFIGURADO. <em>DANO</em> <em>MORAL</em> CARACTERIZADO – QUANTUM INDENIZATÓRIO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ERRO NA IDENTIFICAÇÃO DE PACIENTE EM UNIDADE HOSPITALAR – DECLARAÇÃO INDEVIDA DE ÓBITO – CESSAÇÃO DE BENEFÍCIO PREVIDENCIÁRIO. RESPONSABILIDADE CIVIL DO ESTADO – CONFIGURADA. TEORIA DO RISCO ADMINISTRATIVO – FALHA NA PRESTAÇÃO DO SERVIÇO – NEXO CAUSAL CONFIGURADO. <em>DANO</em> <em>MORAL</em> CARACTERIZADO – QUANTUM INDENIZATÓRIO (R$20.000,00) – REVESTIDO DE RAZOABILIDADE E PROPORCIONALIDADE. PRETENSÕES DE MAJORAÇÃO (AUTOR) E MINORAÇÃO (REQUERIDOS – REJEITADAS. SENTENÇA MANTIDA, RECURSOS DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>8&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878059" cdForo="0" >
+										0800121-60.2020.8.12.0009
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878059" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878059);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878059" style="display: none;" >
+	<div id="textAreaDados_1878059" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE RESCIS&Atilde;O CONTRATUAL C/C INDENIZA&Ccedil;&Atilde;O. PRELIMINAR DE N&Atilde;O CONHECIMENTO PARCIAL DO RECURSO &ndash; AFASTADA. M&Eacute;RITO &ndash; SISTEMA FOTOVOLTAICO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; N&Atilde;O COMPROVA&Ccedil;&Atilde;O DE PERFORMANCE PROMETIDA &ndash; RESCIS&Atilde;O CONTRATUAL &ndash; RESTITUI&Ccedil;&Atilde;O DE VALORES &ndash; LUCROS CESSANTES &ndash; MANUTEN&Ccedil;&Atilde;O &ndash; PROVA PERICIAL N&Atilde;O REALIZADA POR IN&Eacute;RCIA DA R&Eacute; &ndash; INVERS&Atilde;O DO &Ocirc;NUS DA PROVA. DANOS MORAIS &ndash; PESSOA JUR&Iacute;DICA &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DE ABALO &Agrave; HONRA OBJETIVA &ndash; MERO INADIMPLEMENTO CONTRATUAL &ndash; INDENIZA&Ccedil;&Atilde;O INDEVIDA. RECURSO PARCIALMENTE PROVIDO.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800121-60.2020.8.12.0009,&nbsp; Costa Rica,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Costa Rica
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESCISÃO CONTRATUAL C/C INDENIZAÇÃO. PRELIMINAR DE NÃO CONHECIMENTO PARCIAL DO RECURSO – AFASTADA. MÉRITO – SISTEMA FOTOVOLTAICO – FALHA NA PRESTAÇÃO DO SERVIÇO – NÃO COMPROVAÇÃO DE PERFORMANCE PROMETIDA – RESCISÃO CONTRATUAL – RESTITUIÇÃO DE VALORES – LUCROS CESSANTES – MANUTENÇÃO – PROVA PERICIAL NÃO REALIZADA POR INÉRCIA DA RÉ – INVERSÃO DO ÔNUS DA PROVA. DANOS MORAIS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESCISÃO CONTRATUAL C/C INDENIZAÇÃO. PRELIMINAR DE NÃO CONHECIMENTO PARCIAL DO RECURSO – AFASTADA. MÉRITO – SISTEMA FOTOVOLTAICO – FALHA NA PRESTAÇÃO DO SERVIÇO – NÃO COMPROVAÇÃO DE PERFORMANCE PROMETIDA – RESCISÃO CONTRATUAL – RESTITUIÇÃO DE VALORES – LUCROS CESSANTES – MANUTENÇÃO – PROVA PERICIAL NÃO REALIZADA POR INÉRCIA DA RÉ – INVERSÃO DO ÔNUS DA PROVA. DANOS MORAIS – PESSOA JURÍDICA – AUSÊNCIA DE COMPROVAÇÃO DE ABALO À HONRA OBJETIVA – MERO INADIMPLEMENTO CONTRATUAL – INDENIZAÇÃO INDEVIDA. RECURSO PARCIALMENTE PROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>9&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878061" cdForo="0" >
+										1400892-06.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878061" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878061);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878061" style="display: none;" >
+	<div id="textAreaDados_1878061" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. AGRAVO DE INSTRUMENTO DA OPERADORA DE PLANO DE SA&Uacute;DE CONTRA DECIS&Atilde;O QUE REJEITOU A EXCE&Ccedil;&Atilde;O DE PR&Eacute;-EXECUTIVIDADE E DETERMINOU O PROSSEGUIMENTO DO CUMPRIMENTO DE SENTEN&Ccedil;A MOVIDO PELA AGRAVADA. DESCABIDA A REDU&Ccedil;&Atilde;O DOS ASTREINTES EM RAZ&Atilde;O DA DEMORA DESARAZOADA PARA O CUMPRIMENTO DA OBRIGA&Ccedil;&Atilde;O. RECURSO IMPROVIDO.
+I. Caso em exame
+1. Agravo de Instrumento contra decis&atilde;o que rejeitou a Exce&ccedil;&atilde;o de Pr&eacute;-Executividade e determinou o prosseguimento do Cumprimento de Senten&ccedil;a movido pela Agravada.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em an&aacute;lise diz respeito &agrave; possibilidade de redu&ccedil;&atilde;o da multa cominat&oacute;ria, com fundamento no artigo 537, &sect; 1&ordm; do C&oacute;digo de Processo Civil, bem como &agrave; contagem de prazo em dias &uacute;teis.
+III. Raz&otilde;es de decidir
+3. A possibilidade de alterar o valor da multa caso o juiz verifique que ela se tornou excessiva, conforme disposto no inciso I, &sect;1&ordm;, do art. 537 do CPC, trata-se de uma faculdade n&atilde;o exercida pelo magistrado de origem em raz&atilde;o da reiterada in&eacute;rcia da empresa Agravante em cumprir a obriga&ccedil;&atilde;o imposta, pois da concess&atilde;o liminar &agrave; autoriza&ccedil;&atilde;o para o procedimento transcorreu mais de um ano e meio, ou seja, n&atilde;o houve razoabilidade por parte da operadora para o atraso injustificado do cumprimento da obriga&ccedil;&atilde;o
+IV. Dispositivo e tese
+4. Agravo de Instrumento conhecido e improvido.
+
+Tese de julgamento:
+
+Dispositivo relevante citado: CPC, art. 537, &sect; 1&ordm;.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1400892-06.2026.8.12.0000,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Suplementar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. AÇÃO DE OBRIGAÇÃO DE FAZER. AGRAVO DE INSTRUMENTO DA OPERADORA DE PLANO DE SAÚDE CONTRA DECISÃO QUE REJEITOU A EXCEÇÃO DE PRÉ-EXECUTIVIDADE E DETERMINOU O PROSSEGUIMENTO DO CUMPRIMENTO DE SENTENÇA MOVIDO PELA AGRAVADA. DESCABIDA A REDUÇÃO DOS ASTREINTES EM RAZÃO DA DEMORA DESARAZOADA PARA O CUMPRIMENTO DA OBRIGAÇÃO. RECURSO IMPROVIDO.
+I. Caso em exame
+1. Agravo
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. AÇÃO DE OBRIGAÇÃO DE FAZER. AGRAVO DE INSTRUMENTO DA OPERADORA DE PLANO DE SAÚDE CONTRA DECISÃO QUE REJEITOU A EXCEÇÃO DE PRÉ-EXECUTIVIDADE E DETERMINOU O PROSSEGUIMENTO DO CUMPRIMENTO DE SENTENÇA MOVIDO PELA AGRAVADA. DESCABIDA A REDUÇÃO DOS ASTREINTES EM RAZÃO DA DEMORA DESARAZOADA PARA O CUMPRIMENTO DA OBRIGAÇÃO. RECURSO IMPROVIDO.
+I. Caso em exame
+1. Agravo de Instrumento contra decisão que rejeitou a Exceção de Pré-Executividade e determinou o prosseguimento do Cumprimento de Sentença movido pela Agravada.
+II. Questão em discussão
+2. A questão em análise diz respeito à possibilidade de redução da multa cominatória, com fundamento no artigo 537, § 1º do Código de Processo Civil, bem como à contagem de prazo em dias úteis.
+III. Razões de decidir
+3. A possibilidade de alterar o valor da multa caso o juiz verifique que ela se tornou excessiva, conforme disposto no inciso I, §1º, do art. 537 do CPC, trata-se de uma faculdade não exercida pelo magistrado de origem em razão da reiterada inércia da empresa Agravante em cumprir a obrigação imposta, pois da concessão liminar à autorização para o procedimento transcorreu mais de um ano e meio, ou seja, não houve razoabilidade por parte da operadora para o atraso injustificado do cumprimento da obrigação
+IV. Dispositivo e tese
+4. Agravo de Instrumento conhecido e improvido.
+
+Tese de julgamento:
+
+Dispositivo relevante citado: CPC, art. 537, § 1º.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>10&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878083" cdForo="0" >
+										0872565-76.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878083" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878083);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878083" style="display: none;" >
+	<div id="textAreaDados_1878083" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; TRANSPORTE A&Eacute;REO INTERNACIONAL &ndash; PRELIMINAR DE SOBRESTAMENTO (TEMA 1.417 STF) &ndash; HIP&Oacute;TESE N&Atilde;O CONFIGURADA - PRELIMINAR REJEITADA &ndash; EXTRAVIO TEMPOR&Aacute;RIO DE BAGAGEM &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; RESPONSABILIDADE OBJETIVA &ndash; DANO MORAL CONFIGURADO (IN RE IPSA) &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; DANOS MATERIAIS DEVIDOS &ndash; RESSARCIMENTO DE DESPESAS COM ITENS B&Aacute;SICOS E MALA DANIFICADA &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA &ndash; INCID&Ecirc;NCIA DA TAXA SELIC E DA LEI 14.905/2024 &ndash; RECURSO CONHECIDO E DESPROVIDO.
+I - A suspens&atilde;o nacional determinada pelo STF no Tema 1.417 restringe-se a processos que discutem fortuito externo ou for&ccedil;a maior (art. 256, &sect; 3&ordm;, do CBA). Hip&oacute;tese de extravio de bagagem em voo internacional que n&atilde;o se enquadra nas exce&ccedil;&otilde;es taxativas, permitindo o regular julgamento do feito.
+II - O transportador a&eacute;reo possui obriga&ccedil;&atilde;o de resultado, respondendo objetivamente pela cust&oacute;dia da bagagem. O extravio, ainda que tempor&aacute;rio, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o e gera dano moral pass&iacute;vel de repara&ccedil;&atilde;o, diante do tempo perdido e da ang&uacute;stia causada ao passageiro fora de seu domic&iacute;lio.
+III - &Eacute; devido o ressarcimento das despesas efetuadas com a compra de itens de higiene e vestu&aacute;rio essencial, bem como o valor da mala danificada, nos termos do art. 33 da Resolu&ccedil;&atilde;o n&ordm; 400 da ANAC, n&atilde;o subsistindo a tese de que a devolu&ccedil;&atilde;o posterior da bagagem afasta o preju&iacute;zo patrimonial imediato.
+IV - A indeniza&ccedil;&atilde;o deve ser fixada com observ&acirc;ncia aos princ&iacute;pios da razoabilidade e proporcionalidade. No caso concreto, o valor de R$ 10.000,00 revela-se razo&aacute;vel e proporcional para a situa&ccedil;&atilde;o suportada pelo consumidor.
+V - Consect&aacute;rios Legais: (Danos Morais) Corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA a partir do arbitramento (S&uacute;mula 362/STJ). Juros de mora pela Taxa Selic (deduzido o IPCA) a partir da cita&ccedil;&atilde;o. (Danos Materiais) Aplica&ccedil;&atilde;o exclusiva da Taxa Selic (juros e corre&ccedil;&atilde;o englobados) desde o desembolso at&eacute; 29/08/2024. A partir de 30/08/2024 (vig&ecirc;ncia da Lei 14.905/2024), incidir&aacute; corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA e juros de mora pela Taxa Selic (deduzido o IPCA).
+VI - Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0872565-76.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(49 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Irregularidade no atendimento
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – TRANSPORTE AÉREO INTERNACIONAL – PRELIMINAR DE SOBRESTAMENTO (TEMA 1.417 STF) – HIPÓTESE NÃO CONFIGURADA - PRELIMINAR REJEITADA – EXTRAVIO TEMPORÁRIO DE BAGAGEM – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> CONFIGURADO (IN RE IPSA) – QUANTUM INDENIZATÓRIO MANTIDO – DANOS MATERIAIS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – TRANSPORTE AÉREO INTERNACIONAL – PRELIMINAR DE SOBRESTAMENTO (TEMA 1.417 STF) – HIPÓTESE NÃO CONFIGURADA - PRELIMINAR REJEITADA – EXTRAVIO TEMPORÁRIO DE BAGAGEM – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> CONFIGURADO (IN RE IPSA) – QUANTUM INDENIZATÓRIO MANTIDO – DANOS MATERIAIS DEVIDOS – RESSARCIMENTO DE DESPESAS COM ITENS BÁSICOS E MALA DANIFICADA – ATUALIZAÇÃO MONETÁRIA – INCIDÊNCIA DA TAXA SELIC E DA LEI 14.905/2024 – RECURSO CONHECIDO E DESPROVIDO.
+I - A suspensão nacional determinada pelo STF no Tema 1.417 restringe-se a processos que discutem fortuito externo ou força maior (art. 256, § 3º, do CBA). Hipótese de extravio de bagagem em voo internacional que não se enquadra nas exceções taxativas, permitindo o regular julgamento do feito.
+II - O transportador aéreo possui obrigação de resultado, respondendo objetivamente pela custódia da bagagem. O extravio, ainda que temporário, configura falha na prestação do serviço e gera <em>dano</em> <em>moral</em> passível de reparação, diante do tempo perdido e da angústia causada ao passageiro fora de seu domicílio.
+III - É devido o ressarcimento das despesas efetuadas com a compra de itens de higiene e vestuário essencial, bem como o valor da mala danificada, nos termos do art. 33 da Resolução nº 400 da ANAC, não subsistindo a tese de que a devolução posterior da bagagem afasta o prejuízo patrimonial imediato.
+IV - A indenização deve ser fixada com observância aos princípios da razoabilidade e proporcionalidade. No caso concreto, o valor de R$ 10.000,00 revela-se razoável e proporcional para a situação suportada pelo consumidor.
+V - Consectários Legais: (Danos Morais) Correção monetária pelo IPCA a partir do arbitramento (Súmula 362/STJ). Juros de mora pela Taxa Selic (deduzido o IPCA) a partir da citação. (Danos Materiais) Aplicação exclusiva da Taxa Selic (juros e correção englobados) desde o desembolso até 29/08/2024. A partir de 30/08/2024 (vigência da Lei 14.905/2024), incidirá correção monetária pelo IPCA e juros de mora pela Taxa Selic (deduzido o IPCA).
+VI - Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>11&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878088" cdForo="0" >
+										0800814-77.2025.8.12.0006
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878088" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878088);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878088" style="display: none;" >
+	<div id="textAreaDados_1878088" class="mensagemSemFormatacao" >
+		PROCESSO CIVIL - EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; OMISS&Atilde;O  &ndash; CORRE&Ccedil;&Atilde;O DO V&Iacute;CIO SEM EFEITOS INFRINGENTES &ndash; EMBARGOS DE DECLARA&Ccedil;&Atilde;O ACOLHIDOS, SEM ATRIBUI&Ccedil;&Atilde;O DE EFEITO MODIFICATIVO.
+I. CASO EM EXAME
+1. Embargos de Declara&ccedil;&atilde;o opostos contra Ac&oacute;rd&atilde;o que negou provimento ao recurso de Apela&ccedil;&atilde;o interposto pelo embargante.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso a ocorr&ecirc;ncia de omiss&atilde;o no Ac&oacute;rd&atilde;o embargado.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Nos  termos do art. 1.022, do C&oacute;digo de Processo Civil/2015,  os  Embargos de Declara&ccedil;&atilde;o  &ndash;  recurso  de  natureza estrita  e   de  fundamenta&ccedil;&atilde;o  vinculada   &ndash;   s&atilde;o   cab&iacute;veis apenas para:  a) esclarecer  obscuridade;   b) eliminar   contradi&ccedil;&atilde;o;    c) suprir  omiss&atilde;o de ponto ou de quest&atilde;o sobre a qual devia se pronunciar o juiz de of&iacute;cio ou a requerimento,   e/ou    d) para  corrigir  eventual  erro  material.
+4. Omiss&atilde;o sanada, sem, contudo, atribui&ccedil;&atilde;o de efeitos infringentes aos aclarat&oacute;rios.
+IV. DISPOSITIVO
+5. Embargos  de Declara&ccedil;&atilde;o acolhidos, sem efeitos infringentes.           <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0800814-77.2025.8.12.0006,&nbsp; Camapu&atilde;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Camapuã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800814772025812000650000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>PROCESSO CIVIL - EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – OMISSÃO  – CORREÇÃO DO VÍCIO SEM EFEITOS INFRINGENTES – EMBARGOS DE DECLARAÇÃO ACOLHIDOS, SEM ATRIBUIÇÃO DE EFEITO MODIFICATIVO.
+I. CASO EM EXAME
+1. Embargos de Declaração opostos contra Acórdão que negou provimento ao recurso de Apelação interposto pelo embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>PROCESSO CIVIL - EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – OMISSÃO  – CORREÇÃO DO VÍCIO SEM EFEITOS INFRINGENTES – EMBARGOS DE DECLARAÇÃO ACOLHIDOS, SEM ATRIBUIÇÃO DE EFEITO MODIFICATIVO.
+I. CASO EM EXAME
+1. Embargos de Declaração opostos contra Acórdão que negou provimento ao recurso de Apelação interposto pelo embargante.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso a ocorrência de omissão no Acórdão embargado.
+III. RAZÕES DE DECIDIR
+3. Nos  termos do art. 1.022, do Código de Processo Civil/2015,  os  Embargos de Declaração  –  recurso  de  natureza estrita  e   de  fundamentação  vinculada   –   são   cabíveis apenas para:  a) esclarecer  obscuridade;   b) eliminar   contradição;    c) suprir  omissão de ponto ou de questão sobre a qual devia se pronunciar o juiz de ofício ou a requerimento,   e/ou    d) para  corrigir  eventual  erro  material.
+4. Omissão sanada, sem, contudo, atribuição de efeitos infringentes aos aclaratórios.
+IV. DISPOSITIVO
+5. Embargos  de Declaração acolhidos, sem efeitos infringentes.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>12&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878093" cdForo="0" >
+										0801068-88.2024.8.12.0037
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878093" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878093);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878093" style="display: none;" >
+	<div id="textAreaDados_1878093" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; SUPOSTA INSCRI&Ccedil;&Atilde;O INDEVIDA EM CADASTROS DE INADIMPLENTES &ndash; DOCUMENTO EXTRA&Iacute;DO DA PLATAFORMA &quot;ACERTA ESSENCIAL&quot; &ndash; AMBIENTE RESTRITO DE RENEGOCIA&Ccedil;&Atilde;O DE D&Iacute;VIDAS &ndash; AUS&Ecirc;NCIA DE PUBLICIDADE E DE RESTRI&Ccedil;&Atilde;O AO CR&Eacute;DITO NO MERCADO &ndash; DANO MORAL IN RE IPSA N&Atilde;O CONFIGURADO &ndash; RELA&Ccedil;&Atilde;O CONTRATUAL COMPROVADA PELA INSTITUI&Ccedil;&Atilde;O CREDORA &ndash; ALEGA&Ccedil;&Atilde;O DE FALTA DE NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA AFASTADA &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA &ndash; MAJORA&Ccedil;&Atilde;O DOS HONOR&Aacute;RIOS RECURSAIS &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A inser&ccedil;&atilde;o de dados do consumidor em plataformas de pontua&ccedil;&atilde;o de cr&eacute;dito ou de renegocia&ccedil;&atilde;o de d&iacute;vidas de acesso restrito (como o &quot;Acerta Essencial&quot; ou &quot;Serasa Limpa Nome&quot;) n&atilde;o se confunde com a negativa&ccedil;&atilde;o p&uacute;blica em cadastros de inadimplentes (SPC/SERASA).
+Inexistindo a publicidade do apontamento para o mercado financeiro e comercial, n&atilde;o h&aacute; restri&ccedil;&atilde;o de cr&eacute;dito apta a ensejar a presun&ccedil;&atilde;o de abalo extrapatrimonial (dano moral in re ipsa).
+Comprovada, por parte da institui&ccedil;&atilde;o requerida, a regularidade da contrata&ccedil;&atilde;o e a origem do d&eacute;bito, bem como a aus&ecirc;ncia de negativa&ccedil;&atilde;o p&uacute;blica, n&atilde;o prospera a tese de indeniza&ccedil;&atilde;o fulcrada na falta de notifica&ccedil;&atilde;o pr&eacute;via (art. 43, &sect; 2&ordm;, do CDC), porquanto incab&iacute;vel &agrave; esp&eacute;cie.
+Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801068-88.2024.8.12.0037,&nbsp; Itapor&atilde;,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Itaporã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – SUPOSTA INSCRIÇÃO INDEVIDA EM CADASTROS DE INADIMPLENTES – DOCUMENTO EXTRAÍDO DA PLATAFORMA "ACERTA ESSENCIAL" – AMBIENTE RESTRITO DE RENEGOCIAÇÃO DE DÍVIDAS – AUSÊNCIA DE PUBLICIDADE E DE RESTRIÇÃO AO CRÉDITO NO MERCADO – <em>DANO</em> <em>MORAL</em> IN RE IPSA NÃO CONFIGURADO – RELAÇÃO CONTRATUAL COMPROVADA PELA INSTITUIÇÃO CREDORA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – SUPOSTA INSCRIÇÃO INDEVIDA EM CADASTROS DE INADIMPLENTES – DOCUMENTO EXTRAÍDO DA PLATAFORMA "ACERTA ESSENCIAL" – AMBIENTE RESTRITO DE RENEGOCIAÇÃO DE DÍVIDAS – AUSÊNCIA DE PUBLICIDADE E DE RESTRIÇÃO AO CRÉDITO NO MERCADO – <em>DANO</em> <em>MORAL</em> IN RE IPSA NÃO CONFIGURADO – RELAÇÃO CONTRATUAL COMPROVADA PELA INSTITUIÇÃO CREDORA – ALEGAÇÃO DE FALTA DE NOTIFICAÇÃO PRÉVIA AFASTADA – SENTENÇA DE IMPROCEDÊNCIA MANTIDA – MAJORAÇÃO DOS HONORÁRIOS RECURSAIS – RECURSO CONHECIDO E DESPROVIDO.
+A inserção de dados do consumidor em plataformas de pontuação de crédito ou de renegociação de dívidas de acesso restrito (como o "Acerta Essencial" ou "Serasa Limpa Nome") não se confunde com a negativação pública em cadastros de inadimplentes (SPC/SERASA).
+Inexistindo a publicidade do apontamento para o mercado financeiro e comercial, não há restrição de crédito apta a ensejar a presunção de abalo extrapatrimonial (<em>dano</em> <em>moral</em> in re ipsa).
+Comprovada, por parte da instituição requerida, a regularidade da contratação e a origem do débito, bem como a ausência de negativação pública, não prospera a tese de indenização fulcrada na falta de notificação prévia (art. 43, § 2º, do CDC), porquanto incabível à espécie.
+Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>13&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878094" cdForo="0" >
+										0802271-27.2024.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878094" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878094);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878094" style="display: none;" >
+	<div id="textAreaDados_1878094" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; DESCONTOS INDEVIDOS EM CONTA CORRENTE &ndash; SERVI&Ccedil;O N&Atilde;O CONTRATADO &ndash; DANO MORAL CONFIGURADO &ndash; QUANTUM FIXADO EM R$ 3.000,00 &ndash; RAZOABILIDADE E PROPORCIONALIDADE &ndash; RECURSO CONHECIDO E PROVIDO  EM TERMOS.
+A responsabilidade das institui&ccedil;&otilde;es financeiras e empresas de servi&ccedil;os &eacute; objetiva, respondendo pelos danos causados por falhas na presta&ccedil;&atilde;o do servi&ccedil;o, salvo prova de culpa exclusiva do consumidor ou de terceiro, o que n&atilde;o ocorreu no caso.
+O desconto indevido de valores em conta corrente, decorrente de servi&ccedil;o n&atilde;o contratado, gera dano moral in re ipsa, especialmente quando envolve pessoa idosa e vulner&aacute;vel.
+Considerando a curta dura&ccedil;&atilde;o das cobran&ccedil;as indevidas e a extens&atilde;o do dano, fixa-se a indeniza&ccedil;&atilde;o em R$ 3.000,00 (tr&ecirc;s mil reais), valor que atende &agrave;s finalidades punitiva e pedag&oacute;gica, sem causar enriquecimento il&iacute;cito.
+Recurso conhecido e provido em termos. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802271-27.2024.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE – SERVIÇO NÃO CONTRATADO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM FIXADO EM R$ 3.000,00 – RAZOABILIDADE E PROPORCIONALIDADE – RECURSO CONHECIDO E PROVIDO  EM TERMOS.
+A responsabilidade das instituições financeiras e empresas de serviços é
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE – SERVIÇO NÃO CONTRATADO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM FIXADO EM R$ 3.000,00 – RAZOABILIDADE E PROPORCIONALIDADE – RECURSO CONHECIDO E PROVIDO  EM TERMOS.
+A responsabilidade das instituições financeiras e empresas de serviços é objetiva, respondendo pelos danos causados por falhas na prestação do serviço, salvo prova de culpa exclusiva do consumidor ou de terceiro, o que não ocorreu no caso.
+O desconto indevido de valores em conta corrente, decorrente de serviço não contratado, gera <em>dano</em> <em>moral</em> in re ipsa, especialmente quando envolve pessoa idosa e vulnerável.
+Considerando a curta duração das cobranças indevidas e a extensão do <em>dano</em>, fixa-se a indenização em R$ 3.000,00 (três mil reais), valor que atende às finalidades punitiva e pedagógica, sem causar enriquecimento ilícito.
+Recurso conhecido e provido em termos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>14&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878097" cdForo="0" >
+										0818119-31.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878097" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878097);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878097" style="display: none;" >
+	<div id="textAreaDados_1878097" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIGIBILIDADE DE D&Eacute;BITO C.C. RESTITUI&Ccedil;&Atilde;O DE IND&Eacute;BITO C.C. DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. DANOS MORAIS CONFIGURADOS.  REDISCUSS&Atilde;O DO M&Eacute;RITO. IMPOSSIBILIDADE. PREQUESTIONAMENTO. DESNECESSIDADE DE MANIFESTA&Ccedil;&Atilde;O EXPRESSA. EMBARGOS REJEITADOS.
+Os embargos de declara&ccedil;&atilde;o t&ecirc;m como escopo esclarecer senten&ccedil;as ou ac&oacute;rd&atilde;os que pade&ccedil;am de v&iacute;cios, como a obscuridade, omiss&atilde;o, contradi&ccedil;&atilde;o ou erro material.
+Assim, ainda que os aclarat&oacute;rios possuam natureza recursal, n&atilde;o t&ecirc;m cond&atilde;o de ser opostos com a inten&ccedil;&atilde;o de rediscutir o julgado, da mesma forma n&atilde;o se prestam &agrave; manifesta&ccedil;&atilde;o expressa sobre aplica&ccedil;&atilde;o ou viola&ccedil;&atilde;o de dispositivos legais ou constitucionais com a finalidade &uacute;nica de prequestionamento.
+Embargos rejeitados.
+  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0818119-31.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									818119312021812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C.C. RESTITUIÇÃO DE INDÉBITO C.C. DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. DANOS MORAIS CONFIGURADOS.  REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. PREQUESTIONAMENTO. DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA. EMBARGOS REJEITADOS.
+Os embargos de declaração têm como escopo esclarecer sentenças
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C.C. RESTITUIÇÃO DE INDÉBITO C.C. DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. DANOS MORAIS CONFIGURADOS.  REDISCUSSÃO DO MÉRITO. IMPOSSIBILIDADE. PREQUESTIONAMENTO. DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA. EMBARGOS REJEITADOS.
+Os embargos de declaração têm como escopo esclarecer sentenças ou acórdãos que padeçam de vícios, como a obscuridade, omissão, contradição ou erro material.
+Assim, ainda que os aclaratórios possuam natureza recursal, não têm condão de ser opostos com a intenção de rediscutir o julgado, da mesma forma não se prestam à manifestação expressa sobre aplicação ou violação de dispositivos legais ou constitucionais com a finalidade única de prequestionamento.
+Embargos rejeitados.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>15&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878102" cdForo="0" >
+										0857686-98.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878102" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878102);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878102" style="display: none;" >
+	<div id="textAreaDados_1878102" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO &ndash; SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. APELO DOS BANCOS &ndash; CORRE&Ccedil;&Atilde;O DO VALOR DA CAUSA &ndash; POSSIBILIDADE - ALEGA&Ccedil;&Atilde;O DE POSSIBILIDADE DE DESCONTOS DOS EMPR&Eacute;STIMOS CONSIGNADOS CONFORME CONTRATADOS &ndash; DESCONTOS QUE ULTRAPASSAM A MARGEM CONSIGN&Aacute;VEL S&Atilde;O INDEVIDOS DE ACORDO COM A LEI MUNICIPAL 13.870/2019. LIMITA&Ccedil;&Atilde;O EM 30% DOS RENDIMENTOS BRUTOS DO SERVIDOR &ndash; SENTEN&Ccedil;A ALTERADA APENAS NO VALOR DA CAUSA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO .  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0857686-98.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO – SENTENÇA DE PROCEDÊNCIA. APELO DOS BANCOS – CORREÇÃO DO VALOR DA CAUSA – POSSIBILIDADE - ALEGAÇÃO DE POSSIBILIDADE DE DESCONTOS DOS EMPRÉSTIMOS CONSIGNADOS CONFORME CONTRATADOS – DESCONTOS QUE ULTRAPASSAM A MARGEM CONSIGNÁVEL SÃO INDEVIDOS DE ACORDO COM A LEI MUNICIPAL 13.870/2019. LIMITAÇÃO EM 30% DOS RENDIMENTOS BRUTOS DO SERVIDOR – SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO – SENTENÇA DE PROCEDÊNCIA. APELO DOS BANCOS – CORREÇÃO DO VALOR DA CAUSA – POSSIBILIDADE - ALEGAÇÃO DE POSSIBILIDADE DE DESCONTOS DOS EMPRÉSTIMOS CONSIGNADOS CONFORME CONTRATADOS – DESCONTOS QUE ULTRAPASSAM A MARGEM CONSIGNÁVEL SÃO INDEVIDOS DE ACORDO COM A LEI MUNICIPAL 13.870/2019. LIMITAÇÃO EM 30% DOS RENDIMENTOS BRUTOS DO SERVIDOR – SENTENÇA ALTERADA APENAS NO VALOR DA CAUSA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO .
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>16&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878105" cdForo="0" >
+										0821021-98.2014.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878105" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878105);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878105" style="display: none;" >
+	<div id="textAreaDados_1878105" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. PROMESSA DE COMPRA E VENDA DE IM&Oacute;VEL. ATRASO NA ENTREGA DA OBRA. INOVA&Ccedil;&Atilde;O RECURSAL. N&Atilde;O CONHECIMENTO. RETIFICA&Ccedil;&Atilde;O DO TERMO FINAL DO PRAZO DE ENTREGA. DANOS MORAIS. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por adquirente de im&oacute;vel, menor representado por sua genitora, contra senten&ccedil;a que julgou parcialmente procedente a&ccedil;&atilde;o de revis&atilde;o contratual proposta em face de incorporadoras imobili&aacute;rias, em raz&atilde;o de atraso na entrega de unidade residencial adquirida mediante promessa de compra e venda.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. As quest&otilde;es submetidas a julgamento consistem em: i) verificar se houve inova&ccedil;&atilde;o recursal quanto aos pedidos de rescis&atilde;o contratual e restitui&ccedil;&atilde;o integral dos valores pagos; ii) definir o termo final do prazo contratual de entrega do im&oacute;vel, considerado o per&iacute;odo de toler&acirc;ncia; iii) analisar a possibilidade de majora&ccedil;&atilde;o da indeniza&ccedil;&atilde;o por danos morais fixada na senten&ccedil;a.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A pretens&atilde;o de rescis&atilde;o contratual com restitui&ccedil;&atilde;o integral dos valores pagos configura inova&ccedil;&atilde;o recursal, pois n&atilde;o foi deduzida na peti&ccedil;&atilde;o inicial nem objeto de aditamento ao longo da instru&ccedil;&atilde;o processual, sendo vedada sua aprecia&ccedil;&atilde;o em sede de apela&ccedil;&atilde;o, sob pena de viola&ccedil;&atilde;o aos princ&iacute;pios da adstri&ccedil;&atilde;o e da congru&ecirc;ncia (arts. 141 e 492 do CPC).
+4. Nos termos dos arts. 322 e 324 do CPC, a peti&ccedil;&atilde;o inicial delimita os pedidos que podem ser apreciados pelo Poder Judici&aacute;rio, sendo inadmiss&iacute;vel a formula&ccedil;&atilde;o de pretens&atilde;o in&eacute;dita em grau recursal, salvo hip&oacute;teses de mat&eacute;ria de ordem p&uacute;blica ou fatos supervenientes, o que n&atilde;o se verifica no caso.
+5. Quanto ao prazo de entrega do im&oacute;vel, o contrato estabeleceu como data de conclus&atilde;o o dia 30/06/2013, com toler&acirc;ncia contratual de 180 dias. Assim, o termo final correto corresponde a 27/12/2013, e n&atilde;o 27/01/2014, como constou na decis&atilde;o recorrida.
+6. Em rela&ccedil;&atilde;o aos danos morais, o valor de R$ 10.000,00 arbitrado na senten&ccedil;a mostra-se adequado e proporcional &agrave;s circunst&acirc;ncias do caso concreto, considerando que o im&oacute;vel foi adquirido em nome de menor para fins de investimento, inexistindo expectativa imediata de moradia pr&oacute;pria.
+7. Ademais, a aus&ecirc;ncia de demonstra&ccedil;&atilde;o de abalo psicol&oacute;gico relevante e a posterior disponibiliza&ccedil;&atilde;o do im&oacute;vel refor&ccedil;am a sufici&ecirc;ncia do valor fixado, que atende aos crit&eacute;rios de razoabilidade, proporcionalidade e car&aacute;ter pedag&oacute;gico da indeniza&ccedil;&atilde;o, sem ensejar enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+Preliminar acolhida para n&atilde;o conhecer das teses e pedidos relativos &agrave; rescis&atilde;o contratual e &agrave; restitui&ccedil;&atilde;o integral dos valores pagos, por inova&ccedil;&atilde;o recursal.
+Recurso parcialmente provido, apenas para retificar o termo final do prazo contratual de entrega do im&oacute;vel para 27/12/2013, mantida a senten&ccedil;a nos demais termos.
+Tese de julgamento:
+1. Configura inova&ccedil;&atilde;o recursal a formula&ccedil;&atilde;o, em sede de apela&ccedil;&atilde;o, de pedido de rescis&atilde;o contratual e restitui&ccedil;&atilde;o de valores n&atilde;o deduzido na peti&ccedil;&atilde;o inicial, sendo vedado ao tribunal apreciar pretens&otilde;es in&eacute;ditas n&atilde;o submetidas ao ju&iacute;zo de primeiro grau.
+2. Em contrato de promessa de compra e venda de im&oacute;vel com previs&atilde;o de toler&acirc;ncia de 180 dias para entrega da obra, o termo final do prazo contratual corresponde &agrave; soma do prazo originalmente pactuado com o per&iacute;odo de toler&acirc;ncia previsto no instrumento contratual.
+3. A indeniza&ccedil;&atilde;o por danos morais decorrente de atraso na entrega de im&oacute;vel deve observar os crit&eacute;rios de razoabilidade e proporcionalidade, podendo ser mantida quando o valor fixado n&atilde;o se revela manifestamente irris&oacute;rio nem desproporcional &agrave;s circunst&acirc;ncias do caso concreto.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0821021-98.2014.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. ATRASO NA ENTREGA DA OBRA. INOVAÇÃO RECURSAL. NÃO CONHECIMENTO. RETIFICAÇÃO DO TERMO FINAL DO PRAZO DE ENTREGA. DANOS MORAIS. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por adquirente de imóvel, menor representado por sua genitora, contra sentença que julgou parcialmente
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. ATRASO NA ENTREGA DA OBRA. INOVAÇÃO RECURSAL. NÃO CONHECIMENTO. RETIFICAÇÃO DO TERMO FINAL DO PRAZO DE ENTREGA. DANOS MORAIS. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por adquirente de imóvel, menor representado por sua genitora, contra sentença que julgou parcialmente procedente ação de revisão contratual proposta em face de incorporadoras imobiliárias, em razão de atraso na entrega de unidade residencial adquirida mediante promessa de compra e venda.
+II. QUESTÃO EM DISCUSSÃO
+2. As questões submetidas a julgamento consistem em: i) verificar se houve inovação recursal quanto aos pedidos de rescisão contratual e restituição integral dos valores pagos; ii) definir o termo final do prazo contratual de entrega do imóvel, considerado o período de tolerância; iii) analisar a possibilidade de majoração da indenização por danos morais fixada na sentença.
+III. RAZÕES DE DECIDIR
+3. A pretensão de rescisão contratual com restituição integral dos valores pagos configura inovação recursal, pois não foi deduzida na petição inicial nem objeto de aditamento ao longo da instrução processual, sendo vedada sua apreciação em sede de apelação, sob pena de violação aos princípios da adstrição e da congruência (arts. 141 e 492 do CPC).
+4. Nos termos dos arts. 322 e 324 do CPC, a petição inicial delimita os pedidos que podem ser apreciados pelo Poder Judiciário, sendo inadmissível a formulação de pretensão inédita em grau recursal, salvo hipóteses de matéria de ordem pública ou fatos supervenientes, o que não se verifica no caso.
+5. Quanto ao prazo de entrega do imóvel, o contrato estabeleceu como data de conclusão o dia 30/06/2013, com tolerância contratual de 180 dias. Assim, o termo final correto corresponde a 27/12/2013, e não 27/01/2014, como constou na decisão recorrida.
+6. Em relação aos danos morais, o valor de R$ 10.000,00 arbitrado na sentença mostra-se adequado e proporcional às circunstâncias do caso concreto, considerando que o imóvel foi adquirido em nome de menor para fins de investimento, inexistindo expectativa imediata de moradia própria.
+7. Ademais, a ausência de demonstração de abalo psicológico relevante e a posterior disponibilização do imóvel reforçam a suficiência do valor fixado, que atende aos critérios de razoabilidade, proporcionalidade e caráter pedagógico da indenização, sem ensejar enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+Preliminar acolhida para não conhecer das teses e pedidos relativos à rescisão contratual e à restituição integral dos valores pagos, por inovação recursal.
+Recurso parcialmente provido, apenas para retificar o termo final do prazo contratual de entrega do imóvel para 27/12/2013, mantida a sentença nos demais termos.
+Tese de julgamento:
+1. Configura inovação recursal a formulação, em sede de apelação, de pedido de rescisão contratual e restituição de valores não deduzido na petição inicial, sendo vedado ao tribunal apreciar pretensões inéditas não submetidas ao juízo de primeiro grau.
+2. Em contrato de promessa de compra e venda de imóvel com previsão de tolerância de 180 dias para entrega da obra, o termo final do prazo contratual corresponde à soma do prazo originalmente pactuado com o período de tolerância previsto no instrumento contratual.
+3. A indenização por danos morais decorrente de atraso na entrega de imóvel deve observar os critérios de razoabilidade e proporcionalidade, podendo ser mantida quando o valor fixado não se revela manifestamente irrisório nem desproporcional às circunstâncias do caso concreto.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>17&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878114" cdForo="0" >
+										0816774-25.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878114" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878114);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878114" style="display: none;" >
+	<div id="textAreaDados_1878114" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL E RECURSO ADESIVO EM  A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER/N&Atilde;O FAZER C C DANOS MORAIS &ndash; SENTEN&Ccedil;A DE PARCIAL PROCED&Ecirc;NCIA. PRELIMINAR DE OFENSA AO PRINC&Iacute;PIO DA DIALETICIDADE RECURSAL - REJEITADA. APELA&Ccedil;&Atilde;O DA CONSUMIDORA &ndash; PEDIDO PARA MAJORA&Ccedil;&Atilde;O DO VALOR FIXADO A T&Iacute;TULO DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS - INDEFERIDO - PRINC&Iacute;PIO DA RAZOABILIDADE E DA PROPORCIONALIDADE UTILIZADOS CORRETAMENTE PELO MAGISTRADO  &ndash; ENRIQUECIMENTO SEM CAUSA. RECURSO ADESIVO DE GAZIN - A&Ccedil;&Atilde;O EM QUE SE DISCUTE A OCORR&Ecirc;NCIA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O PELO FORNECEDOR - PRAZO DE ENTREGA N&Atilde;O CUMPRIDO &ndash; INTELIG&Ecirc;NCIA DO ART. 14 CDC &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO DE APELA&Ccedil;&Atilde;O E ADESIVO CONHECIDOS E DESPROVIDOS.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816774-25.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO EM  AÇÃO DE OBRIGAÇÃO DE FAZER/NÃO FAZER C C DANOS MORAIS – SENTENÇA DE PARCIAL PROCEDÊNCIA. PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE RECURSAL - REJEITADA. APELAÇÃO DA CONSUMIDORA – PEDIDO PARA MAJORAÇÃO DO VALOR FIXADO A TÍTULO DE INDENIZAÇÃO POR DANOS MORAIS - INDEFERIDO - PRINCÍPIO DA RAZOABILIDADE E DA PROPORCIONALIDADE UTILIZADOS CORRETAMENTE PELO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO EM  AÇÃO DE OBRIGAÇÃO DE FAZER/NÃO FAZER C C DANOS MORAIS – SENTENÇA DE PARCIAL PROCEDÊNCIA. PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE RECURSAL - REJEITADA. APELAÇÃO DA CONSUMIDORA – PEDIDO PARA MAJORAÇÃO DO VALOR FIXADO A TÍTULO DE INDENIZAÇÃO POR DANOS MORAIS - INDEFERIDO - PRINCÍPIO DA RAZOABILIDADE E DA PROPORCIONALIDADE UTILIZADOS CORRETAMENTE PELO MAGISTRADO  – ENRIQUECIMENTO SEM CAUSA. RECURSO ADESIVO DE GAZIN - AÇÃO EM QUE SE DISCUTE A OCORRÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO PELO FORNECEDOR - PRAZO DE ENTREGA NÃO CUMPRIDO – INTELIGÊNCIA DO ART. 14 CDC – SENTENÇA MANTIDA – RECURSO DE APELAÇÃO E ADESIVO CONHECIDOS E DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>18&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878127" cdForo="0" >
+										0801392-76.2023.8.12.0049
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878127" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878127);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878127" style="display: none;" >
+	<div id="textAreaDados_1878127" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA C/C A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O DE DANOS MATERIAL E MORAL &ndash; APELA&Ccedil;&Atilde;O DA CONSUMIDORA E DA EMPRESA PRESTADORA DE SERVI&Ccedil;O &ndash; M&Eacute;RITO &ndash; CONTRATO DE INSTALA&Ccedil;&Atilde;O DE GERADOR E C&Eacute;LULA FOTOVOLTAICA PARA GERA&Ccedil;&Atilde;O DE ENERGIA SOLAR &ndash; LEGITIMIDADE DA INSTITUI&Ccedil;&Atilde;O BANC&Aacute;RIA QUE FINANCIOU A COMPRA E INSTALA&Ccedil;&Atilde;O DO PRODUTO, POR SE TRATAR HIP&Oacute;TESE DE CONTRATOS COLIGADOS, NA FORMA DO ARTIGO 54-F, DO CDC &ndash; RESPONSABILIDADE SOLID&Aacute;RIA, CONFORME ARTIGO 7&ordm;, PAR&Aacute;GRAFO &Uacute;NICO, DO CDC &ndash; COROL&Aacute;RIO DA RESCIS&Atilde;O DO CONTRATO DE FORNECIMENTO DO PRODUTO &Eacute; A RESCIS&Atilde;O DO CONTRATO DE FINANCIAMENTO, POSTO QUE S&Atilde;O CORRELATOS E CODEPENDENTES &ndash; RESTITUI&Ccedil;&Atilde;O DOS VALORES PAGOS DEVE SE DAR NA FORMA DOBRADA, EIS QUE A PR&Oacute;PRIA EMPRESA CONFESSA QUE N&Atilde;O FORNECEU O PRODUTO NO PRAZO AVEN&Ccedil;ADO, N&Atilde;O TENDO SUSPENDIDO A COBRAN&Ccedil;A DOS VALORES &ndash; AUS&Ecirc;NCIA DE ENTREGA DO PRODUTO E DA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O CONTRATADO, QUE SEQUER ENTREGOU O GERADOR E OU AS C&Eacute;LULAS FOTOVOLTAICAS NA RESID&Ecirc;NCIA DA CONSUMIDORA, O QUE INDICA SITUA&Ccedil;&Atilde;O QUE EXTRAPOLOU OS LIMITES DO MERO INADIMPLEMENTO CONTRATUAL, E TAMB&Eacute;M DO MERO DISSABOR, CONFIGURANDO A EXIST&Ecirc;NCIA DE DANO DE ORDEM MORAL &ndash; APLICA&Ccedil;&Atilde;O DO DISPOSTO NO CDC, RELATIVAMENTE &Agrave; M&Aacute; PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; COMPROVADO O LIAME CAUSAL ENTRE A CONDUTA DO FORNECEDOR E O DANO MORAL AO CONSUMIDOR &ndash; INDENIZA&Ccedil;&Atilde;O ARBITRADA LEVANDO-SE EM CONTA OS PAR&Acirc;METROS DE RAZOABILIDADE E PROPORCIONALIDADE &ndash; ALEGADA MULTA CONTRATUAL E SERVI&Ccedil;OS COM TERCEIRO (ELETRICISTA) N&Atilde;O COMPROVADAS, PELO QUE O PEDIDO &Eacute; IMPROCEDENTE, NESTA PARTE &ndash; INDEFERIMENTO DA IMPUGNA&Ccedil;&Atilde;O &Agrave; GRATUIDADE DA JUSTI&Ccedil;A &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO DA EMPRESA PRESTADORA DE SERVI&Ccedil;O (APENAS COM RELA&Ccedil;&Atilde;O &Agrave; LEGITIMIDADE DO BANCO PARA RESPONDER AOS TERMOS DA A&Ccedil;&Atilde;O) PROVIDO &ndash; RECURSO DA CONSUMIDORA CONHECIDO E PARCIALMENTE PROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801392-76.2023.8.12.0049,&nbsp; Agua Clara,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(49 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Agua Clara
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA C/C AÇÃO DE REPARAÇÃO DE DANOS MATERIAL E <em>MORAL</em> – APELAÇÃO DA CONSUMIDORA E DA EMPRESA PRESTADORA DE SERVIÇO – MÉRITO – CONTRATO DE INSTALAÇÃO DE GERADOR E CÉLULA FOTOVOLTAICA PARA GERAÇÃO DE ENERGIA SOLAR – LEGITIMIDADE DA INSTITUIÇÃO BANCÁRIA QUE FINANCIOU A COMPRA E INSTALAÇÃO DO PRODUTO, POR SE TRATAR HIPÓTESE DE CONTRATOS COLIGADOS, NA FORMA DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA C/C AÇÃO DE REPARAÇÃO DE DANOS MATERIAL E <em>MORAL</em> – APELAÇÃO DA CONSUMIDORA E DA EMPRESA PRESTADORA DE SERVIÇO – MÉRITO – CONTRATO DE INSTALAÇÃO DE GERADOR E CÉLULA FOTOVOLTAICA PARA GERAÇÃO DE ENERGIA SOLAR – LEGITIMIDADE DA INSTITUIÇÃO BANCÁRIA QUE FINANCIOU A COMPRA E INSTALAÇÃO DO PRODUTO, POR SE TRATAR HIPÓTESE DE CONTRATOS COLIGADOS, NA FORMA DO ARTIGO 54-F, DO CDC – RESPONSABILIDADE SOLIDÁRIA, CONFORME ARTIGO 7º, PARÁGRAFO ÚNICO, DO CDC – COROLÁRIO DA RESCISÃO DO CONTRATO DE FORNECIMENTO DO PRODUTO É A RESCISÃO DO CONTRATO DE FINANCIAMENTO, POSTO QUE SÃO CORRELATOS E CODEPENDENTES – RESTITUIÇÃO DOS VALORES PAGOS DEVE SE DAR NA FORMA DOBRADA, EIS QUE A PRÓPRIA EMPRESA CONFESSA QUE NÃO FORNECEU O PRODUTO NO PRAZO AVENÇADO, NÃO TENDO SUSPENDIDO A COBRANÇA DOS VALORES – AUSÊNCIA DE ENTREGA DO PRODUTO E DA PRESTAÇÃO DO SERVIÇO CONTRATADO, QUE SEQUER ENTREGOU O GERADOR E OU AS CÉLULAS FOTOVOLTAICAS NA RESIDÊNCIA DA CONSUMIDORA, O QUE INDICA SITUAÇÃO QUE EXTRAPOLOU OS LIMITES DO MERO INADIMPLEMENTO CONTRATUAL, E TAMBÉM DO MERO DISSABOR, CONFIGURANDO A EXISTÊNCIA DE <em>DANO</em> DE ORDEM <em>MORAL</em> – APLICAÇÃO DO DISPOSTO NO CDC, RELATIVAMENTE À MÁ PRESTAÇÃO DO SERVIÇO – COMPROVADO O LIAME CAUSAL ENTRE A CONDUTA DO FORNECEDOR E O <em>DANO</em> <em>MORAL</em> AO CONSUMIDOR – INDENIZAÇÃO ARBITRADA LEVANDO-SE EM CONTA OS PARÂMETROS DE RAZOABILIDADE E PROPORCIONALIDADE – ALEGADA MULTA CONTRATUAL E SERVIÇOS COM TERCEIRO (ELETRICISTA) NÃO COMPROVADAS, PELO QUE O PEDIDO É IMPROCEDENTE, NESTA PARTE – INDEFERIMENTO DA IMPUGNAÇÃO À GRATUIDADE DA JUSTIÇA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO DA EMPRESA PRESTADORA DE SERVIÇO (APENAS COM RELAÇÃO À LEGITIMIDADE DO BANCO PARA RESPONDER AOS TERMOS DA AÇÃO) PROVIDO – RECURSO DA CONSUMIDORA CONHECIDO E PARCIALMENTE PROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>19&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878141" cdForo="0" >
+										0803485-38.2024.8.12.0029
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878141" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878141);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878141" style="display: none;" >
+	<div id="textAreaDados_1878141" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C DANOS MORAIS E MATERIAIS  &ndash;  PEDIDO DE JUSTI&Ccedil;A GRATUITA INDEFERIDO &ndash; DETERMINA&Ccedil;&Atilde;O DE RECOLHIMENTO DE PREPARO N&Atilde;O ATENDIDA &ndash;  DESER&Ccedil;&Atilde;O VERIFICADA  &ndash;  RECURSO N&Atilde;O CONHECIDO.
+Deixa-se de conhecer do recurso quando a parte apelante, diante do indeferimento do pedido de justi&ccedil;a gratuita e intima&ccedil;&atilde;o para recolher o preparo, deixa transcorrer o prazo in albis.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803485-38.2024.8.12.0029,&nbsp; Navira&iacute;,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Naviraí
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C DANOS MORAIS E MATERIAIS  –  PEDIDO DE JUSTIÇA GRATUITA INDEFERIDO – DETERMINAÇÃO DE RECOLHIMENTO DE PREPARO NÃO ATENDIDA –  DESERÇÃO VERIFICADA  –  RECURSO NÃO CONHECIDO.
+Deixa-se de conhecer do recurso quando a parte apelante, diante do indeferimento do pedido de justiça gratuita e intimação para recolher o preparo, deixa
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C DANOS MORAIS E MATERIAIS  –  PEDIDO DE JUSTIÇA GRATUITA INDEFERIDO – DETERMINAÇÃO DE RECOLHIMENTO DE PREPARO NÃO ATENDIDA –  DESERÇÃO VERIFICADA  –  RECURSO NÃO CONHECIDO.
+Deixa-se de conhecer do recurso quando a parte apelante, diante do indeferimento do pedido de justiça gratuita e intimação para recolher o preparo, deixa transcorrer o prazo in albis.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>20&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878143" cdForo="0" >
+										0800217-78.2025.8.12.0016
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878143" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878143);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878143" style="display: none;" >
+	<div id="textAreaDados_1878143" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIGIBILIDADE DE D&Eacute;BITO C/C ANULA&Ccedil;&Atilde;O DE CONTRATO, REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. INEXIST&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O. DESIST&Ecirc;NCIA DE PER&Iacute;CIA GRAFOT&Eacute;CNICA PELO BANCO. &Ocirc;NUS DA PROVA. RESTITUI&Ccedil;&Atilde;O SIMPLES. DANO MORAL CONFIGURADO. RECURSO DO BANCO DESPROVIDO. RECURSO DO AUTOR PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&otilde;es interpostas por Banco BMG S/A. e por Jose dos Santos Gomes contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito c/c anula&ccedil;&atilde;o de contrato, repeti&ccedil;&atilde;o de ind&eacute;bito e danos morais, julgou parcialmente procedentes os pedidos para: a) declarar inexistente a rela&ccedil;&atilde;o jur&iacute;dica relativa a contrato de cart&atilde;o de cr&eacute;dito consignado; b) determinar a restitui&ccedil;&atilde;o simples dos valores descontados do benef&iacute;cio previdenci&aacute;rio do autor, observada a prescri&ccedil;&atilde;o quinquenal; c) afastar o pedido de indeniza&ccedil;&atilde;o por danos morais.
+2. O banco sustenta a regularidade da contrata&ccedil;&atilde;o e a validade dos descontos, alegando assinatura do contrato e utiliza&ccedil;&atilde;o do cart&atilde;o pelo autor, bem como pugna pelo afastamento das condena&ccedil;&otilde;es ou compensa&ccedil;&atilde;o de valores.
+3. O autor requer a restitui&ccedil;&atilde;o em dobro dos valores descontados, indeniza&ccedil;&atilde;o por danos morais no valor de R$ 10.000,00 e majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. As controv&eacute;rsias consistem em definir: a) se houve comprova&ccedil;&atilde;o v&aacute;lida da contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado; b) se &eacute; devida a restitui&ccedil;&atilde;o em dobro dos valores descontados;  c) se os descontos indevidos em benef&iacute;cio previdenci&aacute;rio ensejam dano moral; d) se h&aacute; fundamento para majora&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais.
+III. RAZ&Otilde;ES DE DECIDIR
+5. Incide ao caso o C&oacute;digo de Defesa do Consumidor, nos termos dos arts. 2&ordm; e 3&ordm; do CDC, sendo aplic&aacute;vel a invers&atilde;o do &ocirc;nus da prova (art. 6&ordm;, VIII, do CDC).
+6. Impugnada a autenticidade da assinatura aposta no contrato, foi determinada a realiza&ccedil;&atilde;o de per&iacute;cia grafot&eacute;cnica, cujo &ocirc;nus financeiro foi atribu&iacute;do ao banco, nos termos do art. 373, II, do CPC e do art. 429, II, do CPC.
+7. A institui&ccedil;&atilde;o financeira, contudo, desistiu expressamente da prova pericial ap&oacute;s fixa&ccedil;&atilde;o dos honor&aacute;rios, operando-se a preclus&atilde;o quanto &agrave; demonstra&ccedil;&atilde;o da autenticidade da assinatura.
+8. A desist&ecirc;ncia da prova t&eacute;cnica impede a comprova&ccedil;&atilde;o da regularidade da contrata&ccedil;&atilde;o, impondo-se a presun&ccedil;&atilde;o de veracidade da alega&ccedil;&atilde;o de inexist&ecirc;ncia de v&iacute;nculo contratual.
+9. Demonstrada a aus&ecirc;ncia de contrata&ccedil;&atilde;o v&aacute;lida, os descontos realizados sobre benef&iacute;cio previdenci&aacute;rio revelam-se indevidos, legitimando a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito.
+10. Quanto &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, o Superior Tribunal de Justi&ccedil;a, ao julgar o EAREsp 600.663/RS (Tema 929), fixou entendimento de que a restitui&ccedil;&atilde;o em dobro prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC exige conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva.
+11. No caso concreto, embora reconhecida a inexist&ecirc;ncia da contrata&ccedil;&atilde;o, n&atilde;o h&aacute; elementos suficientes a demonstrar m&aacute;-f&eacute; ou conduta dolosa da institui&ccedil;&atilde;o financeira, sendo devida a restitui&ccedil;&atilde;o na forma simples.
+12. No tocante ao dano moral, os descontos indevidos incidentes sobre benef&iacute;cio previdenci&aacute;rio &ndash; verba de natureza alimentar &ndash; ultrapassam o mero aborrecimento, especialmente diante da vulnerabilidade do consumidor e da inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica v&aacute;lida.
+13. O preju&iacute;zo reiterado, com descontos mensais entre junho/2020 e fevereiro/2025, configura viola&ccedil;&atilde;o &agrave; dignidade da pessoa humana e enseja repara&ccedil;&atilde;o extrapatrimonial, nos termos do art. 186 do C&oacute;digo Civil.
+14. &Agrave; luz dos princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano, a capacidade econ&ocirc;mica das partes e o car&aacute;ter pedag&oacute;gico da medida, fixa-se a indeniza&ccedil;&atilde;o por danos morais em R$ 5.000,00.
+15. A corre&ccedil;&atilde;o monet&aacute;ria incide a partir do arbitramento (S&uacute;mula 362/STJ), pelo IPCA, nos termos do art. 389, par&aacute;grafo &uacute;nico, do C&oacute;digo Civil (Lei n&ordm; 14.905/2024), e os juros de mora fluem desde o evento danoso (S&uacute;mula 54/STJ), observada a taxa legal vigente.
+16. Quanto aos honor&aacute;rios advocat&iacute;cios, a verba fixada na origem (10% sobre o valor da causa) atende aos crit&eacute;rios do art. 85, &sect; 2&ordm;, do CPC, inexistindo fundamento para majora&ccedil;&atilde;o.
+IV. DISPOSITIVO E TESE
+17. Recurso do Banco BMG S/A. desprovido.
+18. Recurso de Jose dos Santos Gomes parcialmente provido, para condenar o r&eacute;u ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 5.000,00, mantidos os demais termos da senten&ccedil;a, com redimensionamento dos &ocirc;nus sucumbenciais (90% para o r&eacute;u e 10% para o autor, suspensa a exigibilidade quanto a este, nos termos do art. 98, &sect; 3&ordm;, do CPC).
+Tese de julgamento:
+19. Impugnada a autenticidade da assinatura em contrato banc&aacute;rio e determinada per&iacute;cia grafot&eacute;cnica, a desist&ecirc;ncia da prova pela institui&ccedil;&atilde;o financeira, a quem incumbia o &ocirc;nus probat&oacute;rio, implica presun&ccedil;&atilde;o de inexist&ecirc;ncia da contrata&ccedil;&atilde;o.
+20. A restitui&ccedil;&atilde;o em dobro prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC exige demonstra&ccedil;&atilde;o de conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva, n&atilde;o sendo cab&iacute;vel quando ausente comprova&ccedil;&atilde;o de m&aacute;-f&eacute; do fornecedor.
+21. Descontos indevidos incidentes sobre benef&iacute;cio previdenci&aacute;rio, verba de natureza alimentar, configuram dano moral indeniz&aacute;vel, por viola&ccedil;&atilde;o &agrave; dignidade do consumidor. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800217-78.2025.8.12.0016,&nbsp; Mundo Novo,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(55 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mundo Novo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C/C ANULAÇÃO DE CONTRATO, REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO. INEXISTÊNCIA DE CONTRATAÇÃO. DESISTÊNCIA DE PERÍCIA GRAFOTÉCNICA PELO BANCO. ÔNUS DA PROVA. RESTITUIÇÃO SIMPLES. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO DO BANCO DESPROVIDO. RECURSO DO AUTOR PARCIALMENTE PROVIDO.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C/C ANULAÇÃO DE CONTRATO, REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO. INEXISTÊNCIA DE CONTRATAÇÃO. DESISTÊNCIA DE PERÍCIA GRAFOTÉCNICA PELO BANCO. ÔNUS DA PROVA. RESTITUIÇÃO SIMPLES. <em>DANO</em> <em>MORAL</em> CONFIGURADO. RECURSO DO BANCO DESPROVIDO. RECURSO DO AUTOR PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelações interpostas por Banco BMG S/A. e por Jose dos Santos Gomes contra sentença que, em ação declaratória de inexistência de débito c/c anulação de contrato, repetição de indébito e danos morais, julgou parcialmente procedentes os pedidos para: a) declarar inexistente a relação jurídica relativa a contrato de cartão de crédito consignado; b) determinar a restituição simples dos valores descontados do benefício previdenciário do autor, observada a prescrição quinquenal; c) afastar o pedido de indenização por danos morais.
+2. O banco sustenta a regularidade da contratação e a validade dos descontos, alegando assinatura do contrato e utilização do cartão pelo autor, bem como pugna pelo afastamento das condenações ou compensação de valores.
+3. O autor requer a restituição em dobro dos valores descontados, indenização por danos morais no valor de R$ 10.000,00 e majoração dos honorários advocatícios.
+II. QUESTÃO EM DISCUSSÃO
+4. As controvérsias consistem em definir: a) se houve comprovação válida da contratação do cartão de crédito consignado; b) se é devida a restituição em dobro dos valores descontados;  c) se os descontos indevidos em benefício previdenciário ensejam <em>dano</em> <em>moral</em>; d) se há fundamento para majoração dos honorários sucumbenciais.
+III. RAZÕES DE DECIDIR
+5. Incide ao caso o Código de Defesa do Consumidor, nos termos dos arts. 2º e 3º do CDC, sendo aplicável a inversão do ônus da prova (art. 6º, VIII, do CDC).
+6. Impugnada a autenticidade da assinatura aposta no contrato, foi determinada a realização de perícia grafotécnica, cujo ônus financeiro foi atribuído ao banco, nos termos do art. 373, II, do CPC e do art. 429, II, do CPC.
+7. A instituição financeira, contudo, desistiu expressamente da prova pericial após fixação dos honorários, operando-se a preclusão quanto à demonstração da autenticidade da assinatura.
+8. A desistência da prova técnica impede a comprovação da regularidade da contratação, impondo-se a presunção de veracidade da alegação de inexistência de vínculo contratual.
+9. Demonstrada a ausência de contratação válida, os descontos realizados sobre benefício previdenciário revelam-se indevidos, legitimando a declaração de inexistência do débito.
+10. Quanto à repetição do indébito, o Superior Tribunal de Justiça, ao julgar o EAREsp 600.663/RS (Tema 929), fixou entendimento de que a restituição em dobro prevista no art. 42, parágrafo único, do CDC exige conduta contrária à boa-fé objetiva.
+11. No caso concreto, embora reconhecida a inexistência da contratação, não há elementos suficientes a demonstrar má-fé ou conduta dolosa da instituição financeira, sendo devida a restituição na forma simples.
+12. No tocante ao <em>dano</em> <em>moral</em>, os descontos indevidos incidentes sobre benefício previdenciário – verba de natureza alimentar – ultrapassam o mero aborrecimento, especialmente diante da vulnerabilidade do consumidor e da inexistência de relação jurídica válida.
+13. O prejuízo reiterado, com descontos mensais entre junho/2020 e fevereiro/2025, configura violação à dignidade da pessoa humana e enseja reparação extrapatrimonial, nos termos do art. 186 do Código Civil.
+14. À luz dos princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em>, a capacidade econômica das partes e o caráter pedagógico da medida, fixa-se a indenização por danos morais em R$ 5.000,00.
+15. A correção monetária incide a partir do arbitramento (Súmula 362/STJ), pelo IPCA, nos termos do art. 389, parágrafo único, do Código Civil (Lei nº 14.905/2024), e os juros de mora fluem desde o evento danoso (Súmula 54/STJ), observada a taxa legal vigente.
+16. Quanto aos honorários advocatícios, a verba fixada na origem (10% sobre o valor da causa) atende aos critérios do art. 85, § 2º, do CPC, inexistindo fundamento para majoração.
+IV. DISPOSITIVO E TESE
+17. Recurso do Banco BMG S/A. desprovido.
+18. Recurso de Jose dos Santos Gomes parcialmente provido, para condenar o réu ao pagamento de indenização por danos morais no valor de R$ 5.000,00, mantidos os demais termos da sentença, com redimensionamento dos ônus sucumbenciais (90% para o réu e 10% para o autor, suspensa a exigibilidade quanto a este, nos termos do art. 98, § 3º, do CPC).
+Tese de julgamento:
+19. Impugnada a autenticidade da assinatura em contrato bancário e determinada perícia grafotécnica, a desistência da prova pela instituição financeira, a quem incumbia o ônus probatório, implica presunção de inexistência da contratação.
+20. A restituição em dobro prevista no art. 42, parágrafo único, do CDC exige demonstração de conduta contrária à boa-fé objetiva, não sendo cabível quando ausente comprovação de má-fé do fornecedor.
+21. Descontos indevidos incidentes sobre benefício previdenciário, verba de natureza alimentar, configuram <em>dano</em> <em>moral</em> indenizável, por violação à dignidade do consumidor.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>21&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878146" cdForo="0" >
+										0034993-27.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878146" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878146);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878146" style="display: none;" >
+	<div id="textAreaDados_1878146" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C REPARA&Ccedil;&Atilde;O DE DANOS &ndash; ALEGADOS V&Iacute;CIOS DE OBRA EM EDIFICA&Ccedil;&Atilde;O &ndash; RECURSO DO CONSTRUTOR &ndash; PROVAS PERICIAL E TESTEMUNHAL PRODUZIDAS NOS AUTOS COMPROVAM A OCORR&Ecirc;NCIA DE V&Iacute;CIO DE CONSTRU&Ccedil;&Atilde;O, CONSUBSTANCIADO EM DEFEITO DE OBRA QUE OCASIONA O ALAGAMENTO DO IM&Oacute;VEL EM &Eacute;POCA DE CHUVA, O QUE FAZ EXSURGIR A RESPONSABILIDADE CIVIL DO CONSTRUTOR &ndash; EVIDENTE NEXO DE CAUSALIDADE ENTRE OS DANOS CONSTATADOS E A NEGLIG&Ecirc;NCIA NO MOMENTO DA CONSTRU&Ccedil;&Atilde;O DA EDIFICA&Ccedil;&Atilde;O &ndash; AUS&Ecirc;NCIA DE DEMONSTRA&Ccedil;&Atilde;O DE CULPA CONCORRENTE DO AUTOR, POR AMPLIA&Ccedil;&Atilde;O DO IM&Oacute;VEL, EIS QUE TAL OBRA RESPEITOU OS LIMITES DE ZONEAMENTO URBANO DA LEGISLA&Ccedil;&Atilde;O MUNICIPAL VIGENTE &Agrave; &Eacute;POCA DA AMPLIA&Ccedil;&Atilde;O &ndash; N&Atilde;O CONFIGURA&Ccedil;&Atilde;O DE ENRIQUECIMENTO IL&Iacute;CITO PELO ARBITRAMENTO DE INDENIZA&Ccedil;&Atilde;O A T&Iacute;TULO DE PERDAS E DANOS, EIS QUE CORRESPONDENTE AO VALOR DA RECONSTRU&Ccedil;&Atilde;O DE PARTE DO BEM, COM VISTAS A TORN&Aacute;-LO HABIT&Aacute;VEL, COM CORRE&Ccedil;&Atilde;O DO V&Iacute;CIO DE OBRA CONSTATADO &ndash; IMPUGNA&Ccedil;&Atilde;O AO VALOR DA INDENIZA&Ccedil;&Atilde;O QUE DEVE SER INDEFERIDO, EIS QUE TAL VALOR FOI ARBITRADO COM BASE EM DADOS T&Eacute;CNICOS CONSTANTES NO LAUDO PERICIAL DE ENGENHARIA CONFECCIONADO NOS AUTOS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0034993-27.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Vícios de Construção
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE DANOS – ALEGADOS VÍCIOS DE OBRA EM EDIFICAÇÃO – RECURSO DO CONSTRUTOR – PROVAS PERICIAL E TESTEMUNHAL PRODUZIDAS NOS AUTOS COMPROVAM A OCORRÊNCIA DE VÍCIO DE CONSTRUÇÃO, CONSUBSTANCIADO EM DEFEITO DE OBRA QUE OCASIONA O ALAGAMENTO DO IMÓVEL EM ÉPOCA DE CHUVA, O QUE FAZ EXSURGIR A RESPONSABILIDADE CIVIL DO CONSTRUTOR – EVIDENTE NEXO DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO DE DANOS – ALEGADOS VÍCIOS DE OBRA EM EDIFICAÇÃO – RECURSO DO CONSTRUTOR – PROVAS PERICIAL E TESTEMUNHAL PRODUZIDAS NOS AUTOS COMPROVAM A OCORRÊNCIA DE VÍCIO DE CONSTRUÇÃO, CONSUBSTANCIADO EM DEFEITO DE OBRA QUE OCASIONA O ALAGAMENTO DO IMÓVEL EM ÉPOCA DE CHUVA, O QUE FAZ EXSURGIR A RESPONSABILIDADE CIVIL DO CONSTRUTOR – EVIDENTE NEXO DE CAUSALIDADE ENTRE OS DANOS CONSTATADOS E A NEGLIGÊNCIA NO MOMENTO DA CONSTRUÇÃO DA EDIFICAÇÃO – AUSÊNCIA DE DEMONSTRAÇÃO DE CULPA CONCORRENTE DO AUTOR, POR AMPLIAÇÃO DO IMÓVEL, EIS QUE TAL OBRA RESPEITOU OS LIMITES DE ZONEAMENTO URBANO DA LEGISLAÇÃO MUNICIPAL VIGENTE À ÉPOCA DA AMPLIAÇÃO – NÃO CONFIGURAÇÃO DE ENRIQUECIMENTO ILÍCITO PELO ARBITRAMENTO DE INDENIZAÇÃO A TÍTULO DE PERDAS E DANOS, EIS QUE CORRESPONDENTE AO VALOR DA RECONSTRUÇÃO DE PARTE DO BEM, COM VISTAS A TORNÁ-LO HABITÁVEL, COM CORREÇÃO DO VÍCIO DE OBRA CONSTATADO – IMPUGNAÇÃO AO VALOR DA INDENIZAÇÃO QUE DEVE SER INDEFERIDO, EIS QUE TAL VALOR FOI ARBITRADO COM BASE EM DADOS TÉCNICOS CONSTANTES NO LAUDO PERICIAL DE ENGENHARIA CONFECCIONADO NOS AUTOS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>22&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878154" cdForo="0" >
+										0801158-47.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878154" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878154);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878154" style="display: none;" >
+	<div id="textAreaDados_1878154" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C.C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. RECURSO DO BANCO. LEGALIDADE DA ADES&Atilde;O AO SEGURO &ndash; N&Atilde;O COMPROVADA &ndash; BANCO N&Atilde;O SE DESINCUMBIU DO &Ocirc;NUS PROBAT&Oacute;RIO QUE LHE FOI ATRIBU&Iacute;DO DE COMPROVAR A AUTENTICIDADE DO CONTRATO DIGITAL. DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; MANTIDA &ndash; VIOLA&Ccedil;&Atilde;O &Agrave; BOA-F&Eacute; OBJETIVA. DANO MORAL &ndash; CONFIGURADO &ndash; MINORA&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO FIXADO &ndash; REJEITADA. RECURSO DO AUTOR. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; MAJORA&Ccedil;&Atilde;O PRETENDIDA PELO DEMANDANTE &ndash; REJEITADA. VALOR FIXADO ATENDE AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. RECURSO DO REQUERIDO E RECURSO DO AUTOR DESPROVIDOS. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801158-47.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. RECURSO DO BANCO. LEGALIDADE DA ADESÃO AO SEGURO – NÃO COMPROVADA – BANCO NÃO SE DESINCUMBIU DO ÔNUS PROBATÓRIO QUE LHE FOI ATRIBUÍDO DE COMPROVAR A AUTENTICIDADE DO CONTRATO DIGITAL. DEVOLUÇÃO EM DOBRO – MANTIDA – VIOLAÇÃO À BOA-FÉ OBJETIVA. <em>DANO</em> <em>MORAL</em> –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. RECURSO DO BANCO. LEGALIDADE DA ADESÃO AO SEGURO – NÃO COMPROVADA – BANCO NÃO SE DESINCUMBIU DO ÔNUS PROBATÓRIO QUE LHE FOI ATRIBUÍDO DE COMPROVAR A AUTENTICIDADE DO CONTRATO DIGITAL. DEVOLUÇÃO EM DOBRO – MANTIDA – VIOLAÇÃO À BOA-FÉ OBJETIVA. <em>DANO</em> <em>MORAL</em> – CONFIGURADO – MINORAÇÃO DO QUANTUM INDENIZATÓRIO FIXADO – REJEITADA. RECURSO DO AUTOR. INDENIZAÇÃO POR DANOS MORAIS – MAJORAÇÃO PRETENDIDA PELO DEMANDANTE – REJEITADA. VALOR FIXADO ATENDE AOS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE. RECURSO DO REQUERIDO E RECURSO DO AUTOR DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>23&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878160" cdForo="0" >
+										0802960-22.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878160" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878160);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878160" style="display: none;" >
+	<div id="textAreaDados_1878160" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE BUSCA E APREENS&Atilde;O &ndash; PRELIMINAR DE CERCEAMENTO DE DEFESA &ndash; PARTE QUE NEGA TER FIRMADO O CONTRATO &ndash; &Ocirc;NUS DA PROVA DA  REGULARIDADE DA CONTRATA&Ccedil;&Atilde;O QUE INCUMBE &Agrave; INSTITUI&Ccedil;&Atilde;O FINANCEIRA  - ART. 429, II DO CPC &ndash; AUS&Ecirc;NCIA DE OUTROS ELEMENTOS A PERMITIR A CONCLUS&Atilde;O PELA AUTENTICIDADE DA ASSINATURA &ndash; NECESSIDADE DE PRODU&Ccedil;&Atilde;O DE PROVA PERICIAL &ndash; TEMA N.&ordm; 1.061 DO STJ &ndash; RECURSO CONHECIDO E PROVIDO &ndash; SENTEN&Ccedil;A INSUBSISTENTE.
+Fato incontroverso que a rela&ccedil;&atilde;o jur&iacute;dica existente entre as partes tem natureza consumerista, impondo-se, pois, a aplica&ccedil;&atilde;o do C&oacute;digo de Defesa do Consumidor, em conson&acirc;ncia com a S&uacute;mula n&ordm; 297 do Egr&eacute;gio Superior Tribunal de Justi&ccedil;a (&quot;O C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras&quot;).
+A prova da regularidade da opera&ccedil;&atilde;o deve ser produzida pelo banco, fornecedor dos servi&ccedil;os, conforme disp&otilde;e o artigo 6&deg;, inciso VIII, do C&oacute;digo de Defesa do Consumidor, designadamente porque se afigura impratic&aacute;vel a produ&ccedil;&atilde;o de prova negativa por parte do r&eacute;u/consumidor.
+A parte recorrente argumenta ter sido v&iacute;tima de fraude contratual, refutando a contrata&ccedil;&atilde;o e negando a assinatura do contrato e a posse do bem. O ve&iacute;culo n&atilde;o foi apreendido em sua posse e, da an&aacute;lise das assinaturas apostas no contrato e, ainda, em documento pessoal da parte, n&atilde;o &eacute; poss&iacute;vel concluir, sem conhecimento t&eacute;cnico espec&iacute;fico, pela respectiva veracidade ou falsidade, dadas algumas incompatibilidades.
+Contestada a assinatura de documento particular, cessa sua f&eacute;, cabendo ao impugnado, isto &eacute;, &agrave; parte que produziu o documento e que sustenta a idoneidade da assinatura, o &ocirc;nus da prova de sua autenticidade, nos termos do artigo 429, inciso II do C&oacute;digo de Processo Civil. &Eacute; nesse sentido o Tema n.&ordm; 1.061 do STJ 'Na hip&oacute;tese em que o consumidor/autor impugnar a autenticidade da assinatura constante em contrato banc&aacute;rio juntado ao processo pela institui&ccedil;&atilde;o financeira, caber&aacute; a esta o &ocirc;nus de provar a sua autenticidade (CPC, arts. 6&ordm;, 368 e 429, II).'
+Diante da impugna&ccedil;&atilde;o quanto ao documento juntado, a aus&ecirc;ncia de outros elementos a permitir a conclus&atilde;o de regularidade da contrata&ccedil;&atilde;o (apreens&atilde;o do ve&iacute;culo na posse do contratante, benef&iacute;cio financeiro) e, ainda, a impossibilidade de aferi&ccedil;&atilde;o da veracidade da assinatura sem exame de grafot&eacute;cnico por especialista, &eacute; de se concluir que, no caso espec&iacute;fico, o indeferimento da prova pericial ensejou cerceamento de defesa. Senten&ccedil;a insubsistente, para retorno dos autos &agrave; origem e produ&ccedil;&atilde;o de prova pericial.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802960-22.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Alienação Fiduciária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE BUSCA E APREENSÃO – PRELIMINAR DE CERCEAMENTO DE DEFESA – PARTE QUE NEGA TER FIRMADO O CONTRATO – ÔNUS DA PROVA DA  REGULARIDADE DA CONTRATAÇÃO QUE INCUMBE À INSTITUIÇÃO FINANCEIRA  - ART. 429, II DO CPC – AUSÊNCIA DE OUTROS ELEMENTOS A PERMITIR A CONCLUSÃO PELA AUTENTICIDADE DA ASSINATURA – NECESSIDADE DE PRODUÇÃO DE PROVA PERICIAL – TEMA N.º 1.061 DO STJ – RECURSO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE BUSCA E APREENSÃO – PRELIMINAR DE CERCEAMENTO DE DEFESA – PARTE QUE NEGA TER FIRMADO O CONTRATO – ÔNUS DA PROVA DA  REGULARIDADE DA CONTRATAÇÃO QUE INCUMBE À INSTITUIÇÃO FINANCEIRA  - ART. 429, II DO CPC – AUSÊNCIA DE OUTROS ELEMENTOS A PERMITIR A CONCLUSÃO PELA AUTENTICIDADE DA ASSINATURA – NECESSIDADE DE PRODUÇÃO DE PROVA PERICIAL – TEMA N.º 1.061 DO STJ – RECURSO CONHECIDO E PROVIDO – SENTENÇA INSUBSISTENTE.
+Fato incontroverso que a relação jurídica existente entre as partes tem natureza consumerista, impondo-se, pois, a aplicação do Código de Defesa do Consumidor, em consonância com a Súmula nº 297 do Egrégio Superior Tribunal de Justiça ("O Código de Defesa do Consumidor é aplicável às instituições financeiras").
+A prova da regularidade da operação deve ser produzida pelo banco, fornecedor dos serviços, conforme dispõe o artigo 6°, inciso VIII, do Código de Defesa do Consumidor, designadamente porque se afigura impraticável a produção de prova negativa por parte do réu/consumidor.
+A parte recorrente argumenta ter sido vítima de fraude contratual, refutando a contratação e negando a assinatura do contrato e a posse do bem. O veículo não foi apreendido em sua posse e, da análise das assinaturas apostas no contrato e, ainda, em documento pessoal da parte, não é possível concluir, sem conhecimento técnico específico, pela respectiva veracidade ou falsidade, dadas algumas incompatibilidades.
+Contestada a assinatura de documento particular, cessa sua fé, cabendo ao impugnado, isto é, à parte que produziu o documento e que sustenta a idoneidade da assinatura, o ônus da prova de sua autenticidade, nos termos do artigo 429, inciso II do Código de Processo Civil. É nesse sentido o Tema n.º 1.061 do STJ 'Na hipótese em que o consumidor/autor impugnar a autenticidade da assinatura constante em contrato bancário juntado ao processo pela instituição financeira, caberá a esta o ônus de provar a sua autenticidade (CPC, arts. 6º, 368 e 429, II).'
+Diante da impugnação quanto ao documento juntado, a ausência de outros elementos a permitir a conclusão de regularidade da contratação (apreensão do veículo na posse do contratante, benefício financeiro) e, ainda, a impossibilidade de aferição da veracidade da assinatura sem exame de grafotécnico por especialista, é de se concluir que, no caso específico, o indeferimento da prova pericial ensejou cerceamento de defesa. Sentença insubsistente, para retorno dos autos à origem e produção de prova pericial.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>24&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878161" cdForo="0" >
+										0800409-11.2025.8.12.0016
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878161" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878161);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878161" style="display: none;" >
+	<div id="textAreaDados_1878161" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; REVISIONAL &ndash; FATURA DE ENERGIA &ndash; CONSUMO MUITO SUPERIOR &Agrave; M&Eacute;DIA DA UNIDADE CONSUMIDORA &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DA REGULARIDADE DA MEDI&Ccedil;&Atilde;O &ndash; COBRAN&Ccedil;A INDEVIDA -  PROTESTO INDEVIDO &ndash; DANO MORAL IN RE IPSA &ndash; MANUTEN&Ccedil;&Atilde;O DO VALOR DA COMPENSA&Ccedil;&Atilde;O.
+1. Aferido valor muito superior &agrave; m&eacute;dia de consumo mensal do consumidor e n&atilde;o tendo a concession&aacute;ria de energia el&eacute;trica comprovado a regularidade da medi&ccedil;&atilde;o, &eacute; indevida a cobran&ccedil;a do valor impugnado.
+2. O dano moral proveniente de&nbsp;protesto&nbsp;indevido&nbsp;&eacute; in re ipsa, ou seja, prescinde da prova do efetivo preju&iacute;zo.
+3. O valor fixado a t&iacute;tulo de compensa&ccedil;&atilde;o pelos danos morais &eacute; mantido quando observados, na senten&ccedil;a, os aspectos objetivos e subjetivos da demanda, em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recurso n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800409-11.2025.8.12.0016,&nbsp; Mundo Novo,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inexequibilidade do Título / Inexigibilidade da Obrigação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mundo Novo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – REVISIONAL – FATURA DE ENERGIA – CONSUMO MUITO SUPERIOR À MÉDIA DA UNIDADE CONSUMIDORA – AUSÊNCIA DE COMPROVAÇÃO DA REGULARIDADE DA MEDIÇÃO – COBRANÇA INDEVIDA -  PROTESTO INDEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR DA COMPENSAÇÃO.
+1. Aferido valor muito superior à média de consumo mensal do consumidor e não tendo a concessionária de energia
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – REVISIONAL – FATURA DE ENERGIA – CONSUMO MUITO SUPERIOR À MÉDIA DA UNIDADE CONSUMIDORA – AUSÊNCIA DE COMPROVAÇÃO DA REGULARIDADE DA MEDIÇÃO – COBRANÇA INDEVIDA -  PROTESTO INDEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR DA COMPENSAÇÃO.
+1. Aferido valor muito superior à média de consumo mensal do consumidor e não tendo a concessionária de energia elétrica comprovado a regularidade da medição, é indevida a cobrança do valor impugnado.
+2. O <em>dano</em> <em>moral</em> proveniente de protesto indevido é in re ipsa, ou seja, prescinde da prova do efetivo prejuízo.
+3. O valor fixado a título de compensação pelos danos morais é mantido quando observados, na sentença, os aspectos objetivos e subjetivos da demanda, em consonância com os princípios da razoabilidade e da proporcionalidade.
+Recurso não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>25&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878171" cdForo="0" >
+										0848287-11.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878171" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878171);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878171" style="display: none;" >
+	<div id="textAreaDados_1878171" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO BANC&Aacute;RIO &ndash; PRELIMINAR DE NULIDADE DA SENTEN&Ccedil;A POR DECIS&Atilde;O SURPRESA (ART. 10, CPC) E CERCEAMENTO DE DEFESA &ndash; AFASTADA &ndash; JULGAMENTO ANTECIPADO DA LIDE &ndash; POSSIBILIDADE &ndash; MAGISTRADO COMO DESTINAT&Aacute;RIO DA PROVA &ndash; M&Eacute;RITO &ndash; REVELIA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; PRESUN&Ccedil;&Atilde;O RELATIVA DE VERACIDADE &ndash; AN&Aacute;LISE DO CONTRATO E DAS TAXAS M&Eacute;DIAS DE MERCADO (BACEN) &ndash; ABUSIVIDADES N&Atilde;O CONFIGURADAS &ndash; JUROS REMUNERAT&Oacute;RIOS E CAPITALIZA&Ccedil;&Atilde;O EM CONFORMIDADE COM A JURISPRUD&Ecirc;NCIA DO STJ &ndash; DEVER DE INFORMA&Ccedil;&Atilde;O PRESERVADO &ndash; DANO MORAL E REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO INDEVIDOS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+I - O julgamento antecipado da lide n&atilde;o configura viola&ccedil;&atilde;o ao art. 10 do CPC ou cerceamento de defesa quando o acervo documental for suficiente para a forma&ccedil;&atilde;o do convencimento do magistrado. Sendo o juiz o destinat&aacute;rio da prova (art. 370, CPC), cabe a ele indeferir dilig&ecirc;ncias in&uacute;teis ou protelat&oacute;rias, especialmente quando a controv&eacute;rsia envolve mat&eacute;ria exclusivamente de direito ou pass&iacute;vel de prova documental (exame de encargos contratuais).
+II - A revelia n&atilde;o implica a proced&ecirc;ncia autom&aacute;tica dos pedidos, gerando apenas presun&ccedil;&atilde;o relativa de veracidade dos fatos narrados. Tal presun&ccedil;&atilde;o pode ser mitigada pelo livre convencimento do juiz diante das provas dos autos e da aplica&ccedil;&atilde;o do direito &agrave; esp&eacute;cie, especialmente em a&ccedil;&otilde;es revisionais onde o contrato permite o cotejo direto das cl&aacute;usulas com a legisla&ccedil;&atilde;o e a jurisprud&ecirc;ncia.
+III - Conforme entendimento do STJ, a estipula&ccedil;&atilde;o de juros acima de 12% ao ano n&atilde;o &eacute;, por si s&oacute;, abusiva, e a capitaliza&ccedil;&atilde;o mensal &eacute; permitida se expressamente pactuada (previs&atilde;o de taxa anual superior ao duod&eacute;cuplo da mensal). N&atilde;o demonstrada discrep&acirc;ncia substancial em rela&ccedil;&atilde;o &agrave; taxa m&eacute;dia de mercado divulgada pelo BACEN, mant&eacute;m-se a higidez das taxas contratadas.
+IV - Inexiste v&iacute;cio no dever de informa&ccedil;&atilde;o (art. 6&ordm;, III, CDC) quando as cl&aacute;usulas contratuais s&atilde;o claras e o instrumento foi disponibilizado &agrave; consumidora. Ausente a comprova&ccedil;&atilde;o de ato il&iacute;cito ou cobran&ccedil;a abusiva, n&atilde;o h&aacute; que se falar em repeti&ccedil;&atilde;o de ind&eacute;bito (dobro) ou indeniza&ccedil;&atilde;o por danos morais, configurando-se os descontos como regular exerc&iacute;cio de direito decorrente do pacto.
+V - Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0848287-11.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – PRELIMINAR DE NULIDADE DA SENTENÇA POR DECISÃO SURPRESA (ART. 10, CPC) E CERCEAMENTO DE DEFESA – AFASTADA – JULGAMENTO ANTECIPADO DA LIDE – POSSIBILIDADE – MAGISTRADO COMO DESTINATÁRIO DA PROVA – MÉRITO – REVELIA DA INSTITUIÇÃO FINANCEIRA – PRESUNÇÃO RELATIVA DE VERACIDADE – ANÁLISE DO CONTRATO E DAS TAXAS MÉDIAS DE MERCADO (BACEN) –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – PRELIMINAR DE NULIDADE DA SENTENÇA POR DECISÃO SURPRESA (ART. 10, CPC) E CERCEAMENTO DE DEFESA – AFASTADA – JULGAMENTO ANTECIPADO DA LIDE – POSSIBILIDADE – MAGISTRADO COMO DESTINATÁRIO DA PROVA – MÉRITO – REVELIA DA INSTITUIÇÃO FINANCEIRA – PRESUNÇÃO RELATIVA DE VERACIDADE – ANÁLISE DO CONTRATO E DAS TAXAS MÉDIAS DE MERCADO (BACEN) – ABUSIVIDADES NÃO CONFIGURADAS – JUROS REMUNERATÓRIOS E CAPITALIZAÇÃO EM CONFORMIDADE COM A JURISPRUDÊNCIA DO STJ – DEVER DE INFORMAÇÃO PRESERVADO – <em>DANO</em> <em>MORAL</em> E REPETIÇÃO DE INDÉBITO INDEVIDOS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+I - O julgamento antecipado da lide não configura violação ao art. 10 do CPC ou cerceamento de defesa quando o acervo documental for suficiente para a formação do convencimento do magistrado. Sendo o juiz o destinatário da prova (art. 370, CPC), cabe a ele indeferir diligências inúteis ou protelatórias, especialmente quando a controvérsia envolve matéria exclusivamente de direito ou passível de prova documental (exame de encargos contratuais).
+II - A revelia não implica a procedência automática dos pedidos, gerando apenas presunção relativa de veracidade dos fatos narrados. Tal presunção pode ser mitigada pelo livre convencimento do juiz diante das provas dos autos e da aplicação do direito à espécie, especialmente em ações revisionais onde o contrato permite o cotejo direto das cláusulas com a legislação e a jurisprudência.
+III - Conforme entendimento do STJ, a estipulação de juros acima de 12% ao ano não é, por si só, abusiva, e a capitalização mensal é permitida se expressamente pactuada (previsão de taxa anual superior ao duodécuplo da mensal). Não demonstrada discrepância substancial em relação à taxa média de mercado divulgada pelo BACEN, mantém-se a higidez das taxas contratadas.
+IV - Inexiste vício no dever de informação (art. 6º, III, CDC) quando as cláusulas contratuais são claras e o instrumento foi disponibilizado à consumidora. Ausente a comprovação de ato ilícito ou cobrança abusiva, não há que se falar em repetição de indébito (dobro) ou indenização por danos morais, configurando-se os descontos como regular exercício de direito decorrente do pacto.
+V - Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>26&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878172" cdForo="0" >
+										0818958-51.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878172" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878172);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878172" style="display: none;" >
+	<div id="textAreaDados_1878172" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. COBRAN&Ccedil;A DE FATURA DE ENERGIA EL&Eacute;TRICA. ALEGA&Ccedil;&Atilde;O DE CONSUMO EXCESSIVO. MEDIDOR SUBMETIDO &Agrave; VERIFICA&Ccedil;&Atilde;O T&Eacute;CNICA PELO INMETRO. LAUDO QUE ATESTA REGULARIDADE DO EQUIPAMENTO. AUS&Ecirc;NCIA DE PROVA DE IRREGULARIDADE NA MEDI&Ccedil;&Atilde;O OU NO FATURAMENTO. VARIA&Ccedil;&Atilde;O DE CONSUMO QUE, POR SI S&Oacute;, N&Atilde;O DEMONSTRA FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME: Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedentes os pedidos formulados em a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer cumulada com indeniza&ccedil;&atilde;o por danos morais proposta por consumidora em face de concession&aacute;ria de energia el&eacute;trica.
+A autora sustenta a ocorr&ecirc;ncia de cobran&ccedil;a abusiva em fatura de energia el&eacute;trica referente ao m&ecirc;s de abril de 2023, no valor de R$ 2.594,20, montante significativamente superior &agrave; m&eacute;dia hist&oacute;rica de consumo da unidade consumidora.
+A concession&aacute;ria defendeu a regularidade da cobran&ccedil;a e apresentou laudo t&eacute;cnico de verifica&ccedil;&atilde;o do medidor, realizado por &oacute;rg&atilde;o delegado do INMETRO, que concluiu pela inexist&ecirc;ncia de irregularidade no equipamento de medi&ccedil;&atilde;o.
+A senten&ccedil;a julgou improcedentes os pedidos de declara&ccedil;&atilde;o de inexigibilidade do d&eacute;bito, repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais, condenando a autora ao pagamento das custas e honor&aacute;rios advocat&iacute;cios, com exigibilidade suspensa em raz&atilde;o da gratuidade da justi&ccedil;a.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O: A quest&atilde;o em discuss&atilde;o consiste em verificar:
+a) se a cobran&ccedil;a da fatura de energia el&eacute;trica referente ao m&ecirc;s de abril de 2023 foi indevida em raz&atilde;o de suposta irregularidade no medidor ou no faturamento;
+b) se a discrep&acirc;ncia entre a fatura impugnada e a m&eacute;dia hist&oacute;rica de consumo &eacute; suficiente para caracterizar falha na presta&ccedil;&atilde;o do servi&ccedil;o;
+c) se est&atilde;o presentes os requisitos para repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR: A rela&ccedil;&atilde;o jur&iacute;dica estabelecida entre as partes &eacute; de consumo, aplicando-se as normas do C&oacute;digo de Defesa do Consumidor, que consagram a responsabilidade objetiva do fornecedor de servi&ccedil;os pelos danos decorrentes de defeitos na presta&ccedil;&atilde;o do servi&ccedil;o.
+Entretanto, a invers&atilde;o do &ocirc;nus da prova prevista na legisla&ccedil;&atilde;o consumerista n&atilde;o dispensa o consumidor da apresenta&ccedil;&atilde;o de elementos m&iacute;nimos capazes de evidenciar a plausibilidade de suas alega&ccedil;&otilde;es.
+No caso, embora a fatura impugnada apresente valor superior &agrave; m&eacute;dia hist&oacute;rica de consumo da unidade consumidora, tal circunst&acirc;ncia, isoladamente, n&atilde;o comprova irregularidade na medi&ccedil;&atilde;o ou na cobran&ccedil;a.
+A concession&aacute;ria demonstrou que o medidor foi submetido &agrave; verifica&ccedil;&atilde;o t&eacute;cnica por &oacute;rg&atilde;o delegado do INMETRO, cujo laudo concluiu pela regularidade do equipamento, documento que goza de presun&ccedil;&atilde;o de legitimidade e veracidade, nos termos da regulamenta&ccedil;&atilde;o da ANEEL.
+A parte autora n&atilde;o produziu prova apta a infirmar o resultado do exame realizado nem requereu a produ&ccedil;&atilde;o de per&iacute;cia judicial para questionar a conclus&atilde;o do &oacute;rg&atilde;o oficial.
+Ademais, varia&ccedil;&otilde;es de consumo podem decorrer de diversos fatores, como aumento no uso de equipamentos el&eacute;tricos, varia&ccedil;&atilde;o sazonal ou condi&ccedil;&otilde;es da instala&ccedil;&atilde;o interna da unidade consumidora, cuja manuten&ccedil;&atilde;o &eacute; de responsabilidade do usu&aacute;rio.
+Assim, n&atilde;o demonstrada irregularidade no funcionamento do medidor ou no faturamento realizado pela concession&aacute;ria, n&atilde;o se configura falha na presta&ccedil;&atilde;o do servi&ccedil;o nem ato il&iacute;cito capaz de ensejar repeti&ccedil;&atilde;o de ind&eacute;bito ou indeniza&ccedil;&atilde;o por danos morais.
+IV. DISPOSITIVO E TESE: Recurso conhecido e desprovido.
+Mantida integralmente a senten&ccedil;a que julgou improcedentes os pedidos iniciais.
+Honor&aacute;rios advocat&iacute;cios majorados de 10% para 15% sobre o valor da causa, nos termos do art. 85, &sect;11, do CPC, observada a suspens&atilde;o de exigibilidade em raz&atilde;o da gratuidade da justi&ccedil;a.
+Tese de julgamento: A discrep&acirc;ncia entre o valor de fatura de energia el&eacute;trica e a m&eacute;dia hist&oacute;rica de consumo da unidade consumidora, por si s&oacute;, n&atilde;o &eacute; suficiente para demonstrar irregularidade na medi&ccedil;&atilde;o ou cobran&ccedil;a.
+O laudo t&eacute;cnico de verifica&ccedil;&atilde;o do medidor realizado por &oacute;rg&atilde;o oficial delegado do INMETRO goza de presun&ccedil;&atilde;o de legitimidade e veracidade, sendo apto a comprovar a regularidade do equipamento quando n&atilde;o impugnado por prova t&eacute;cnica id&ocirc;nea.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0818958-51.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA DE FATURA DE ENERGIA ELÉTRICA. ALEGAÇÃO DE CONSUMO EXCESSIVO. MEDIDOR SUBMETIDO À VERIFICAÇÃO TÉCNICA PELO INMETRO. LAUDO QUE ATESTA REGULARIDADE DO EQUIPAMENTO. AUSÊNCIA DE PROVA DE IRREGULARIDADE NA MEDIÇÃO OU NO FATURAMENTO. VARIAÇÃO DE CONSUMO QUE, POR SI SÓ, NÃO DEMONSTRA FALHA NA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA DE FATURA DE ENERGIA ELÉTRICA. ALEGAÇÃO DE CONSUMO EXCESSIVO. MEDIDOR SUBMETIDO À VERIFICAÇÃO TÉCNICA PELO INMETRO. LAUDO QUE ATESTA REGULARIDADE DO EQUIPAMENTO. AUSÊNCIA DE PROVA DE IRREGULARIDADE NA MEDIÇÃO OU NO FATURAMENTO. VARIAÇÃO DE CONSUMO QUE, POR SI SÓ, NÃO DEMONSTRA FALHA NA PRESTAÇÃO DO SERVIÇO. SENTENÇA DE IMPROCEDÊNCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME: Apelação cível interposta contra sentença que julgou improcedentes os pedidos formulados em ação de obrigação de fazer cumulada com indenização por danos morais proposta por consumidora em face de concessionária de energia elétrica.
+A autora sustenta a ocorrência de cobrança abusiva em fatura de energia elétrica referente ao mês de abril de 2023, no valor de R$ 2.594,20, montante significativamente superior à média histórica de consumo da unidade consumidora.
+A concessionária defendeu a regularidade da cobrança e apresentou laudo técnico de verificação do medidor, realizado por órgão delegado do INMETRO, que concluiu pela inexistência de irregularidade no equipamento de medição.
+A sentença julgou improcedentes os pedidos de declaração de inexigibilidade do débito, repetição de indébito e indenização por danos morais, condenando a autora ao pagamento das custas e honorários advocatícios, com exigibilidade suspensa em razão da gratuidade da justiça.
+II. QUESTÃO EM DISCUSSÃO: A questão em discussão consiste em verificar:
+a) se a cobrança da fatura de energia elétrica referente ao mês de abril de 2023 foi indevida em razão de suposta irregularidade no medidor ou no faturamento;
+b) se a discrepância entre a fatura impugnada e a média histórica de consumo é suficiente para caracterizar falha na prestação do serviço;
+c) se estão presentes os requisitos para repetição de indébito e indenização por danos morais.
+III. RAZÕES DE DECIDIR: A relação jurídica estabelecida entre as partes é de consumo, aplicando-se as normas do Código de Defesa do Consumidor, que consagram a responsabilidade objetiva do fornecedor de serviços pelos danos decorrentes de defeitos na prestação do serviço.
+Entretanto, a inversão do ônus da prova prevista na legislação consumerista não dispensa o consumidor da apresentação de elementos mínimos capazes de evidenciar a plausibilidade de suas alegações.
+No caso, embora a fatura impugnada apresente valor superior à média histórica de consumo da unidade consumidora, tal circunstância, isoladamente, não comprova irregularidade na medição ou na cobrança.
+A concessionária demonstrou que o medidor foi submetido à verificação técnica por órgão delegado do INMETRO, cujo laudo concluiu pela regularidade do equipamento, documento que goza de presunção de legitimidade e veracidade, nos termos da regulamentação da ANEEL.
+A parte autora não produziu prova apta a infirmar o resultado do exame realizado nem requereu a produção de perícia judicial para questionar a conclusão do órgão oficial.
+Ademais, variações de consumo podem decorrer de diversos fatores, como aumento no uso de equipamentos elétricos, variação sazonal ou condições da instalação interna da unidade consumidora, cuja manutenção é de responsabilidade do usuário.
+Assim, não demonstrada irregularidade no funcionamento do medidor ou no faturamento realizado pela concessionária, não se configura falha na prestação do serviço nem ato ilícito capaz de ensejar repetição de indébito ou indenização por danos morais.
+IV. DISPOSITIVO E TESE: Recurso conhecido e desprovido.
+Mantida integralmente a sentença que julgou improcedentes os pedidos iniciais.
+Honorários advocatícios majorados de 10% para 15% sobre o valor da causa, nos termos do art. 85, §11, do CPC, observada a suspensão de exigibilidade em razão da gratuidade da justiça.
+Tese de julgamento: A discrepância entre o valor de fatura de energia elétrica e a média histórica de consumo da unidade consumidora, por si só, não é suficiente para demonstrar irregularidade na medição ou cobrança.
+O laudo técnico de verificação do medidor realizado por órgão oficial delegado do INMETRO goza de presunção de legitimidade e veracidade, sendo apto a comprovar a regularidade do equipamento quando não impugnado por prova técnica idônea.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>27&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878174" cdForo="0" >
+										0864377-94.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878174" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878174);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878174" style="display: none;" >
+	<div id="textAreaDados_1878174" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO - ILEGITIMIDADE PASSIVA - REJEI&Ccedil;&Atilde;O CONFIRMADA - DANO MORAL &ndash; OCORR&Ecirc;NCIA - DESCONTOS REALIZADOS EM CONTA-CORRENTE ONDE A PESSOA IDOSA RECEBE SEU BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO - QUANTIA RAZO&Aacute;VEL E PROPORCIONAL - RESTITUI&Ccedil;&Atilde;O EM DOBRO DO IND&Eacute;BITO - MANTIDA &ndash; RECURSO DA AUTORA, CONHECIDO E PROVIDO &ndash; APELO DO R&Eacute;U, CONHECIDO EM PARTE E DESPROVIDO.
+Na quantifica&ccedil;&atilde;o da indeniza&ccedil;&atilde;o por dano moral, deve o julgador, atendo-se &agrave;s espec&iacute;ficas condi&ccedil;&otilde;es do caso concreto, fixar o valor mais justo para o ressarcimento, lastreado nos princ&iacute;pios da razoabilidade e proporcionalidade. Nesse prop&oacute;sito, imp&otilde;e-se que sejam observadas as condi&ccedil;&otilde;es do ofensor, assim como a intensidade do sofrimento, o grau de reprova&ccedil;&atilde;o da atua&ccedil;&atilde;o do agente ativo da ilicitude, bem como a finalidade de impor ao executor o car&aacute;ter punitivo da condena&ccedil;&atilde;o para que n&atilde;o seja reincidente nessa conduta.
+Considerando que est&atilde;o presentes os requisitos do art. 42, par&aacute;grafo &uacute;nico, do CDC; que as partes fornecedoras n&atilde;o lograram comprovar engano justific&aacute;vel nos moldes aqui estabelecidos ou que tomaram todas as cautelas devidas para que o fato n&atilde;o acontecesse; e que n&atilde;o est&aacute; presente a hip&oacute;tese moduladora do  EAREsp n. 676.608/RS, nesse ponto, a senten&ccedil;a deve ser mantida.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0864377-94.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(83 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO - ILEGITIMIDADE PASSIVA - REJEIÇÃO CONFIRMADA - <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA - DESCONTOS REALIZADOS EM CONTA-CORRENTE ONDE A PESSOA IDOSA RECEBE SEU BENEFÍCIO PREVIDENCIÁRIO - QUANTIA RAZOÁVEL E PROPORCIONAL - RESTITUIÇÃO EM DOBRO DO INDÉBITO - MANTIDA – RECURSO DA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO - ILEGITIMIDADE PASSIVA - REJEIÇÃO CONFIRMADA - <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA - DESCONTOS REALIZADOS EM CONTA-CORRENTE ONDE A PESSOA IDOSA RECEBE SEU BENEFÍCIO PREVIDENCIÁRIO - QUANTIA RAZOÁVEL E PROPORCIONAL - RESTITUIÇÃO EM DOBRO DO INDÉBITO - MANTIDA – RECURSO DA AUTORA, CONHECIDO E PROVIDO – APELO DO RÉU, CONHECIDO EM PARTE E DESPROVIDO.
+Na quantificação da indenização por <em>dano</em> <em>moral</em>, deve o julgador, atendo-se às específicas condições do caso concreto, fixar o valor mais justo para o ressarcimento, lastreado nos princípios da razoabilidade e proporcionalidade. Nesse propósito, impõe-se que sejam observadas as condições do ofensor, assim como a intensidade do sofrimento, o grau de reprovação da atuação do agente ativo da ilicitude, bem como a finalidade de impor ao executor o caráter punitivo da condenação para que não seja reincidente nessa conduta.
+Considerando que estão presentes os requisitos do art. 42, parágrafo único, do CDC; que as partes fornecedoras não lograram comprovar engano justificável nos moldes aqui estabelecidos ou que tomaram todas as cautelas devidas para que o fato não acontecesse; e que não está presente a hipótese moduladora do  EAREsp n. 676.608/RS, nesse ponto, a sentença deve ser mantida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>28&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878175" cdForo="0" >
+										0801365-43.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878175" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878175);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878175" style="display: none;" >
+	<div id="textAreaDados_1878175" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E CONDENA&Ccedil;&Atilde;O EM DANOS MORAIS &ndash; CERCEAMENTO DE DEFESA N&Atilde;O EVIDENCIADO &ndash; INCID&Ecirc;NCIA DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; DESCONTOS REALIZADOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; VALIDADE DA CONTRATA&Ccedil;&Atilde;O N&Atilde;O DEMONSTRADA &ndash; AJUSTE COM DIVERG&Ecirc;NCIA QUANTO &Agrave; GEOLOCALIZA&Ccedil;&Atilde;O E N&Uacute;MERO DE TELEFONE UTILIZADO PARA ADES&Atilde;O - INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA ENTRE AS PARTES &ndash; DESCONTOS INDEVIDOS &ndash; DANO MORAL EXISTENTE E RESTITUI&Ccedil;&Atilde;O DAS QUANTIAS INDEVIDAMENTE DESCONTADAS &ndash; JUROS E CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA - RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO &ndash; RECURSO DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA CONHECIDO E N&Atilde;O PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produ&ccedil;&atilde;o de provas. E, portanto, n&atilde;o h&aacute; que se falar em cerceamento de defesa quando o julgador de primeira inst&acirc;ncia entendeu n&atilde;o ser necess&aacute;ria complementa&ccedil;&atilde;o probat&oacute;ria para o deslinde da causa, eis que as provas constantes nos autos s&atilde;o suficientes para o julgamento da demanda.
+O  C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave; rela&ccedil;&atilde;o jur&iacute;dica entabulada entre as partes, nos termos da S&uacute;mula 297, do STJ: &quot;O C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras.&quot;
+O recorrente n&atilde;o comprovou nos autos a exist&ecirc;ncia de&nbsp;contrato digital v&aacute;lido e regular a justificar os descontos reclamados pela parte autora, nos moldes do art. 373 do CPC. No caso dos autos, o ajuste colacionado foi firmado pela via digital, mas por meio de telefone de origem diversa do domic&iacute;lio da parte autora e sem apresenta&ccedil;&atilde;o de documentos pessoais. A diverg&ecirc;ncia &eacute; mais evidente quando se consulta a geolocaliza&ccedil;&atilde;o constante do contrato, donde se extrai que foi firmado na Avenida Senador Virg&iacute;lio T&aacute;vora, Fortaleza &ndash; Cear&aacute;, enquanto o endere&ccedil;o da parte autora, idosa, &eacute; em Campo Grande &ndash; MS.
+Os valores indevidamente descontados da parte autora devem ser restitu&iacute;dos em dobro, nos termos do art. 42 do CDC.
+No caso, os valores foram indevidamente debitados do benef&iacute;cio previdenci&aacute;rio da parte autora, pessoa idosa e pensionista do INSS &ndash;  situa&ccedil;&atilde;o que evidentemente foi de molde a caracterizar atentado &agrave; seguran&ccedil;a e tranquilidade financeiras da v&iacute;tima, privando-lhe de parcela de verba alimentar destinada a custear sua subsist&ecirc;ncia, de maneira que o dano moral indeniz&aacute;vel encontra-se suficientemente caracterizado.
+Tratando-se o caso de responsabilidade extracontratual &ndash; quando n&atilde;o existe contrato, o termo inicial dos juros de mora da condena&ccedil;&atilde;o por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido, enquanto a corre&ccedil;&atilde;o monet&aacute;ria, a data do arbitramento.
+Outrossim, deve ser aplicada a Taxa SELIC como crit&eacute;rio de transi&ccedil;&atilde;o e unifica&ccedil;&atilde;o, tanto na repara&ccedil;&atilde;o moral quanto material, a t&iacute;tulo de juros e corre&ccedil;&atilde;o monet&aacute;ria, at&eacute; o advento da Lei n&ordm; 14.905/24, a partir de quando a taxa Selic dever&aacute; incidir como &iacute;ndice de juros morat&oacute;rios com a dedu&ccedil;&atilde;o do &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria IPCA-IBGE, ou &iacute;ndice que vier a substitu&iacute;-lo, enquanto a corre&ccedil;&atilde;o monet&aacute;ria unicamente pelo IPCA, observados os termos iniciais j&aacute; fixados.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801365-43.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(88 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E CONDENAÇÃO EM DANOS MORAIS – CERCEAMENTO DE DEFESA NÃO EVIDENCIADO – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – DESCONTOS REALIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – VALIDADE DA CONTRATAÇÃO NÃO DEMONSTRADA – AJUSTE COM DIVERGÊNCIA QUANTO À GEOLOCALIZAÇÃO E NÚMERO DE TELEFONE UTILIZADO PARA ADESÃO -
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E CONDENAÇÃO EM DANOS MORAIS – CERCEAMENTO DE DEFESA NÃO EVIDENCIADO – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – DESCONTOS REALIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – VALIDADE DA CONTRATAÇÃO NÃO DEMONSTRADA – AJUSTE COM DIVERGÊNCIA QUANTO À GEOLOCALIZAÇÃO E NÚMERO DE TELEFONE UTILIZADO PARA ADESÃO - INEXISTÊNCIA DE RELAÇÃO JURÍDICA ENTRE AS PARTES – DESCONTOS INDEVIDOS – <em>DANO</em> <em>MORAL</em> EXISTENTE E RESTITUIÇÃO DAS QUANTIAS INDEVIDAMENTE DESCONTADAS – JUROS E CORREÇÃO MONETÁRIA - RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO – RECURSO DA INSTITUIÇÃO FINANCEIRA CONHECIDO E NÃO PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produção de provas. E, portanto, não há que se falar em cerceamento de defesa quando o julgador de primeira instância entendeu não ser necessária complementação probatória para o deslinde da causa, eis que as provas constantes nos autos são suficientes para o julgamento da demanda.
+O  Código de Defesa do Consumidor é aplicável à relação jurídica entabulada entre as partes, nos termos da Súmula 297, do STJ: "O Código de Defesa do Consumidor é aplicável às instituições financeiras."
+O recorrente não comprovou nos autos a existência de contrato digital válido e regular a justificar os descontos reclamados pela parte autora, nos moldes do art. 373 do CPC. No caso dos autos, o ajuste colacionado foi firmado pela via digital, mas por meio de telefone de origem diversa do domicílio da parte autora e sem apresentação de documentos pessoais. A divergência é mais evidente quando se consulta a geolocalização constante do contrato, donde se extrai que foi firmado na Avenida Senador Virgílio Távora, Fortaleza – Ceará, enquanto o endereço da parte autora, idosa, é em Campo Grande – MS.
+Os valores indevidamente descontados da parte autora devem ser restituídos em dobro, nos termos do art. 42 do CDC.
+No caso, os valores foram indevidamente debitados do benefício previdenciário da parte autora, pessoa idosa e pensionista do INSS –  situação que evidentemente foi de molde a caracterizar atentado à segurança e tranquilidade financeiras da vítima, privando-lhe de parcela de verba alimentar destinada a custear sua subsistência, de maneira que o <em>dano</em> <em>moral</em> indenizável encontra-se suficientemente caracterizado.
+Tratando-se o caso de responsabilidade extracontratual – quando não existe contrato, o termo inicial dos juros de mora da condenação por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido, enquanto a correção monetária, a data do arbitramento.
+Outrossim, deve ser aplicada a Taxa SELIC como critério de transição e unificação, tanto na reparação <em>moral</em> quanto material, a título de juros e correção monetária, até o advento da Lei nº 14.905/24, a partir de quando a taxa Selic deverá incidir como índice de juros moratórios com a dedução do índice de correção monetária IPCA-IBGE, ou índice que vier a substituí-lo, enquanto a correção monetária unicamente pelo IPCA, observados os termos iniciais já fixados.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>29&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878176" cdForo="0" >
+										0807056-09.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878176" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878176);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878176" style="display: none;" >
+	<div id="textAreaDados_1878176" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O &ndash; INDENIZAT&Oacute;RIA E COMPENSAT&Oacute;RIA &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; VIOLA&Ccedil;&Atilde;O DA INTEGRIDADE F&Iacute;SICA &ndash; DANO MORAL IN RE IPSA &ndash; MANUTEN&Ccedil;&Atilde;O DO VALOR.
+1. O dano moral &eacute; in re ipsa nas hip&oacute;teses em que ocorre viola&ccedil;&atilde;o da integridade f&iacute;sica decorrente de acidente de tr&acirc;nsito.
+2. O valor fixado a t&iacute;tulo de compensa&ccedil;&atilde;o por danos morais &eacute; mantido quando observados, na senten&ccedil;a, os aspectos objetivos e subjetivos da demanda, em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recursos n&atilde;o providos.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0807056-09.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INDENIZATÓRIA E COMPENSATÓRIA – ACIDENTE DE TRÂNSITO – VIOLAÇÃO DA INTEGRIDADE FÍSICA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR.
+1. O <em>dano</em> <em>moral</em> é in re ipsa nas hipóteses em que ocorre violação da integridade física decorrente de acidente de trânsito.
+2. O valor fixado a título de compensação por danos morais é mantido quando
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INDENIZATÓRIA E COMPENSATÓRIA – ACIDENTE DE TRÂNSITO – VIOLAÇÃO DA INTEGRIDADE FÍSICA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – MANUTENÇÃO DO VALOR.
+1. O <em>dano</em> <em>moral</em> é in re ipsa nas hipóteses em que ocorre violação da integridade física decorrente de acidente de trânsito.
+2. O valor fixado a título de compensação por danos morais é mantido quando observados, na sentença, os aspectos objetivos e subjetivos da demanda, em observância aos princípios da razoabilidade e da proporcionalidade.
+Recursos não providos.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>30&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878177" cdForo="0" >
+										0813568-66.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878177" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878177);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878177" style="display: none;" >
+	<div id="textAreaDados_1878177" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA - DANOS MORAIS DEVIDOS.
+O desconto indevido em benef&iacute;cio previdenci&aacute;rio do consumidor proveniente de contribui&ccedil;&atilde;o n&atilde;o contratada gera o dever de indenizar, independentemente da comprova&ccedil;&atilde;o do dano, por ser in re ipsa.
+Valor fixado em observ&acirc;ncia aos aspectos objetivos e subjetivos da demanda, em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recurso provido.
+
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0813568-66.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – CONTRATAÇÃO NÃO COMPROVADA - DANOS MORAIS DEVIDOS.
+O desconto indevido em benefício previdenciário do consumidor proveniente de contribuição não contratada gera o dever de indenizar, independentemente da comprovação do <em>dano</em>, por ser in re ipsa.
+Valor fixado em observância aos aspectos objetivos e subjetivos da demanda,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – CONTRATAÇÃO NÃO COMPROVADA - DANOS MORAIS DEVIDOS.
+O desconto indevido em benefício previdenciário do consumidor proveniente de contribuição não contratada gera o dever de indenizar, independentemente da comprovação do <em>dano</em>, por ser in re ipsa.
+Valor fixado em observância aos aspectos objetivos e subjetivos da demanda, em consonância com os princípios da razoabilidade e da proporcionalidade.
+Recurso provido.
+
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>31&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878182" cdForo="0" >
+										0828147-19.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878182" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878182);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878182" style="display: none;" >
+	<div id="textAreaDados_1878182" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR &ndash; RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; APONTAMENTO DE D&Iacute;VIDA NO SISTEMA DE INFORMA&Ccedil;&Otilde;ES DE CR&Eacute;DITO (SCR) OPERACIONALIZADO PELO BANCO CENTRAL DO BRASIL &ndash; ANOTA&Ccedil;&Atilde;O COM NATUREZA RESTRITIVA DE CR&Eacute;DITO &ndash; EXIG&Ecirc;NCIA DE PR&Eacute;VIA COMUNICA&Ccedil;&Atilde;O AO CONSUMIDOR DA REMESSA DE DADOS AO SCR &ndash; AUS&Ecirc;NCIA DE PROVA DA PR&Eacute;VIA COMUNICA&Ccedil;&Atilde;O ACERCA DO APONTAMENTO &ndash; ATO IL&Iacute;CITO CONFIGURADO  &ndash;  AUS&Ecirc;NCIA DE DANO MORAL &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Recurso de Apela&ccedil;&atilde;o interposto em face de senten&ccedil;a que julgou improcedentes os pedidos formulados em A&ccedil;&atilde;o de Obriga&ccedil;&atilde;o de Fazer c/c Danos Morais que tem por objeto o questionamento de apontamento de d&iacute;vida constante do Sistema de Informa&ccedil;&otilde;es do Cr&eacute;dito (SCR).
+II. HIP&Oacute;TESE EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a (in)validade do apontamento de d&iacute;vida no Sistema de Informa&ccedil;&otilde;es de Cr&eacute;dito (SCR); b) a ocorr&ecirc;ncia, ou n&atilde;o, de danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A Primeira Turma do STJ, no julgamento do REsp 1.626.547-RS, j&aacute; assentou o entendimento no sentido de que o BACEN &eacute; parte ileg&iacute;tima para figurar no polo passivo de demanda em que o consumidor questiona a falta de pr&eacute;via notifica&ccedil;&atilde;o em cadastro operacionalizado por tal autarquia federal, como &eacute; o caso do SCR. Preliminar de incompet&ecirc;ncia da Justi&ccedil;a Estadual rejeitada.
+4. O SCR &ndash; Sistema de Informa&ccedil;&otilde;es de Cr&eacute;ditos (SCR) &eacute; constitu&iacute;do por informa&ccedil;&otilde;es periodicamente remetidas ao Banco Central do Brasil acerca de opera&ccedil;&otilde;es de cr&eacute;dito firmadas por institui&ccedil;&otilde;es financeiras atuantes no pa&iacute;s, e tem por finalidade: (i) a consolida&ccedil;&atilde;o de informa&ccedil;&otilde;es ao BACEN para fins de monitoramento do cr&eacute;dito e exerc&iacute;cio de fiscaliza&ccedil;&atilde;o; e, (ii) propiciar o interc&acirc;mbio de informa&ccedil;&otilde;es entre institui&ccedil;&otilde;es financeiras e entre demais entidades, sobre o montante de responsabilidades de clientes em opera&ccedil;&otilde;es de cr&eacute;dito.
+5. Apesar da finalidade prec&iacute;pua de consolida&ccedil;&atilde;o de informa&ccedil;&otilde;es para fins de monitoramento e fiscaliza&ccedil;&atilde;o, o Superior Tribunal de Justi&ccedil;a j&aacute; ressaltou, no &acirc;mbito do REsp n&ordm; 1.626.547/RS, que, eventualmente, a t&iacute;tulo de efeito secund&aacute;rio, a inscri&ccedil;&atilde;o nos cadastros tamb&eacute;m tem o cond&atilde;o de controlar a inadimpl&ecirc;ncia em rela&ccedil;&atilde;o aos clientes de institui&ccedil;&otilde;es financeiras, o que tem o potencial de causar restri&ccedil;&atilde;o ao cr&eacute;dito, sendo que, at&eacute; mesmo por conta dessa potencialidade de restri&ccedil;&atilde;o ao cr&eacute;dito, o art. 13 da Resolu&ccedil;&atilde;o-CMN n&ordm; 5.037/2022 prev&ecirc; que &quot;As institui&ccedil;&otilde;es originadoras das opera&ccedil;&otilde;es de cr&eacute;dito ou que tenham adquirido tais opera&ccedil;&otilde;es de entidades n&atilde;o integrantes do Sistema Financeiro Nacional devem comunicar previamente ao cliente que os dados de suas respectivas opera&ccedil;&otilde;es ser&atilde;o registrados no SCR&quot;.
+6. A interpreta&ccedil;&atilde;o teleol&oacute;gica do art. 13, &sect;&sect; 2&ordm; e 3&ordm;, da Resolu&ccedil;&atilde;o-CMN n&ordm; 5.037/2022 indica que a comunica&ccedil;&atilde;o pr&eacute;via deve ser espec&iacute;fica, pessoal e realizada antes da remessa da informa&ccedil;&atilde;o ao SCR-BACEN; caso assim n&atilde;o fosse, n&atilde;o haveria raz&atilde;o para que se exigisse que a institui&ccedil;&atilde;o financeira mantenha a &quot;guarda da comunica&ccedil;&atilde;o de que trata este artigo, em meio f&iacute;sico ou eletr&ocirc;nico que permita comprovar a sua autenticidade&quot; (&sect; 3&ordm;).
+7. No caso, resta configurada a  pr&aacute;tica de ato il&iacute;cito pela r&eacute;, pois sua omiss&atilde;o na pr&eacute;via comunica&ccedil;&atilde;o da remessa de dados ao SCR atenta contra a transpar&ecirc;ncia, o equil&iacute;brio nas rela&ccedil;&otilde;es de consumo e o direito ao contradit&oacute;rio e ampla defesa.
+8. A simples aus&ecirc;ncia de notifica&ccedil;&atilde;o pr&eacute;via quanto &agrave; inclus&atilde;o no SCR, especialmente quando a d&iacute;vida &eacute; reconhecida pelo pr&oacute;prio devedor, n&atilde;o configura, por si s&oacute;, ato apto a ensejar indeniza&ccedil;&atilde;o por danos morais.
+9. A inser&ccedil;&atilde;o indevida  somada a exist&ecirc;ncia da d&iacute;vida importa em mero dissabor.
+
+IV. DISPOSITIVO
+11. Apela&ccedil;&atilde;o C&iacute;vel conhecida e parcialmente provida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0828147-19.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(66 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS – APONTAMENTO DE DÍVIDA NO SISTEMA DE INFORMAÇÕES DE CRÉDITO (SCR) OPERACIONALIZADO PELO BANCO CENTRAL DO BRASIL – ANOTAÇÃO COM NATUREZA RESTRITIVA DE CRÉDITO – EXIGÊNCIA DE PRÉVIA COMUNICAÇÃO AO CONSUMIDOR DA REMESSA DE DADOS AO SCR – AUSÊNCIA DE PROVA DA PRÉVIA COMUNICAÇÃO ACERCA DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS – APONTAMENTO DE DÍVIDA NO SISTEMA DE INFORMAÇÕES DE CRÉDITO (SCR) OPERACIONALIZADO PELO BANCO CENTRAL DO BRASIL – ANOTAÇÃO COM NATUREZA RESTRITIVA DE CRÉDITO – EXIGÊNCIA DE PRÉVIA COMUNICAÇÃO AO CONSUMIDOR DA REMESSA DE DADOS AO SCR – AUSÊNCIA DE PROVA DA PRÉVIA COMUNICAÇÃO ACERCA DO APONTAMENTO – ATO ILÍCITO CONFIGURADO  –  AUSÊNCIA DE <em>DANO</em> <em>MORAL</em> – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+
+I. CASO EM EXAME
+1. Recurso de Apelação interposto em face de sentença que julgou improcedentes os pedidos formulados em Ação de Obrigação de Fazer c/c Danos Morais que tem por objeto o questionamento de apontamento de dívida constante do Sistema de Informações do Crédito (SCR).
+II. HIPÓTESE EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a (in)validade do apontamento de dívida no Sistema de Informações de Crédito (SCR); b) a ocorrência, ou não, de danos morais.
+III. RAZÕES DE DECIDIR
+3. A Primeira Turma do STJ, no julgamento do REsp 1.626.547-RS, já assentou o entendimento no sentido de que o BACEN é parte ilegítima para figurar no polo passivo de demanda em que o consumidor questiona a falta de prévia notificação em cadastro operacionalizado por tal autarquia federal, como é o caso do SCR. Preliminar de incompetência da Justiça Estadual rejeitada.
+4. O SCR – Sistema de Informações de Créditos (SCR) é constituído por informações periodicamente remetidas ao Banco Central do Brasil acerca de operações de crédito firmadas por instituições financeiras atuantes no país, e tem por finalidade: (i) a consolidação de informações ao BACEN para fins de monitoramento do crédito e exercício de fiscalização; e, (ii) propiciar o intercâmbio de informações entre instituições financeiras e entre demais entidades, sobre o montante de responsabilidades de clientes em operações de crédito.
+5. Apesar da finalidade precípua de consolidação de informações para fins de monitoramento e fiscalização, o Superior Tribunal de Justiça já ressaltou, no âmbito do REsp nº 1.626.547/RS, que, eventualmente, a título de efeito secundário, a inscrição nos cadastros também tem o condão de controlar a inadimplência em relação aos clientes de instituições financeiras, o que tem o potencial de causar restrição ao crédito, sendo que, até mesmo por conta dessa potencialidade de restrição ao crédito, o art. 13 da Resolução-CMN nº 5.037/2022 prevê que "As instituições originadoras das operações de crédito ou que tenham adquirido tais operações de entidades não integrantes do Sistema Financeiro Nacional devem comunicar previamente ao cliente que os dados de suas respectivas operações serão registrados no SCR".
+6. A interpretação teleológica do art. 13, §§ 2º e 3º, da Resolução-CMN nº 5.037/2022 indica que a comunicação prévia deve ser específica, pessoal e realizada antes da remessa da informação ao SCR-BACEN; caso assim não fosse, não haveria razão para que se exigisse que a instituição financeira mantenha a "guarda da comunicação de que trata este artigo, em meio físico ou eletrônico que permita comprovar a sua autenticidade" (§ 3º).
+7. No caso, resta configurada a  prática de ato ilícito pela ré, pois sua omissão na prévia comunicação da remessa de dados ao SCR atenta contra a transparência, o equilíbrio nas relações de consumo e o direito ao contraditório e ampla defesa.
+8. A simples ausência de notificação prévia quanto à inclusão no SCR, especialmente quando a dívida é reconhecida pelo próprio devedor, não configura, por si só, ato apto a ensejar indenização por danos morais.
+9. A inserção indevida  somada a existência da dívida importa em mero dissabor.
+
+IV. DISPOSITIVO
+11. Apelação Cível conhecida e parcialmente provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>32&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878186" cdForo="0" >
+										0800629-90.2021.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878186" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878186);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878186" style="display: none;" >
+	<div id="textAreaDados_1878186" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL E RECURSO ADESIVO &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; EMPR&Eacute;STIMO CONSIGNADO N&Atilde;O CONTRATADO &ndash; DESCONTOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; S&Uacute;MULA 479 DO STJ &ndash; DANO MORAL CONFIGURADO IN RE IPSA &ndash; DESNECESSIDADE DE PROVA DO SOFRIMENTO &ndash; VIOLA&Ccedil;&Atilde;O DA ESFERA PATRIMONIAL E MORAL DE PESSOA IDOSA &ndash; VALOR DA INDENIZA&Ccedil;&Atilde;O &ndash; REDU&Ccedil;&Atilde;O PARA R$ 5.000,00 &ndash; OBSERV&Acirc;NCIA AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; JUROS DE MORA DESDE O EVENTO DANOSO (S&Uacute;MULA 54 STJ) &ndash; CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA A PARTIR DO ARBITRAMENTO (S&Uacute;MULA 362 STJ) &ndash; RECURSO ADESIVO DESPROVIDO &ndash; RECURSO DO BANCO PROVIDO EM PARTE.
+A fraude banc&aacute;ria que resulta em descontos indevidos em aposentadoria gera dano moral presumido (in re ipsa), dispensando a comprova&ccedil;&atilde;o de abalo psicol&oacute;gico severo, diante da natureza alimentar da verba e da vulnerabilidade do consumidor. A fixa&ccedil;&atilde;o do montante indenizat&oacute;rio deve pautar-se pelo crit&eacute;rio da modera&ccedil;&atilde;o, considerando a capacidade econ&ocirc;mica das partes e a extens&atilde;o do dano, sendo o valor de R$ 5.000,00 adequado para cumprir a fun&ccedil;&atilde;o punitiva e compensat&oacute;ria sem gerar enriquecimento il&iacute;cito. Em se tratando de responsabilidade extracontratual por ato il&iacute;cito, os juros morat&oacute;rios fluem a partir do evento danoso e a corre&ccedil;&atilde;o monet&aacute;ria desde a data do arbitramento. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800629-90.2021.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO NÃO CONTRATADO – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – SÚMULA 479 DO STJ – <em>DANO</em> <em>MORAL</em> CONFIGURADO IN RE IPSA – DESNECESSIDADE DE PROVA DO SOFRIMENTO – VIOLAÇÃO DA ESFERA PATRIMONIAL E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO NÃO CONTRATADO – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – SÚMULA 479 DO STJ – <em>DANO</em> <em>MORAL</em> CONFIGURADO IN RE IPSA – DESNECESSIDADE DE PROVA DO SOFRIMENTO – VIOLAÇÃO DA ESFERA PATRIMONIAL E <em>MORAL</em> DE PESSOA IDOSA – VALOR DA INDENIZAÇÃO – REDUÇÃO PARA R$ 5.000,00 – OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – JUROS DE MORA DESDE O EVENTO DANOSO (SÚMULA 54 STJ) – CORREÇÃO MONETÁRIA A PARTIR DO ARBITRAMENTO (SÚMULA 362 STJ) – RECURSO ADESIVO DESPROVIDO – RECURSO DO BANCO PROVIDO EM PARTE.
+A fraude bancária que resulta em descontos indevidos em aposentadoria gera <em>dano</em> <em>moral</em> presumido (in re ipsa), dispensando a comprovação de abalo psicológico severo, diante da natureza alimentar da verba e da vulnerabilidade do consumidor. A fixação do montante indenizatório deve pautar-se pelo critério da moderação, considerando a capacidade econômica das partes e a extensão do <em>dano</em>, sendo o valor de R$ 5.000,00 adequado para cumprir a função punitiva e compensatória sem gerar enriquecimento ilícito. Em se tratando de responsabilidade extracontratual por ato ilícito, os juros moratórios fluem a partir do evento danoso e a correção monetária desde a data do arbitramento.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>33&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878191" cdForo="0" >
+										0800137-44.2025.8.12.0007
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878191" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878191);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878191" style="display: none;" >
+	<div id="textAreaDados_1878191" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC) &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA &ndash; RECURSO DA PARTE AUTORA &ndash; PRETENS&Atilde;O DE CONVERS&Atilde;O DO NEG&Oacute;CIO JUR&Iacute;DICO EM CONTRATO DE M&Uacute;TUO COMUM &ndash; MAT&Eacute;RIA N&Atilde;O ARGUIDA NA PETI&Ccedil;&Atilde;O INICIAL &ndash; INOVA&Ccedil;&Atilde;O RECURSAL CONFIGURADA &ndash; SUPRESS&Atilde;O DE INST&Acirc;NCIA &ndash; VEDA&Ccedil;&Atilde;O PELO ORDENAMENTO JUR&Iacute;DICO &ndash; PRELIMINAR SUSCITADA DE OF&Iacute;CIO &ndash; RECURSO N&Atilde;O CONHECIDO.
+I - O efeito devolutivo da apela&ccedil;&atilde;o limita a aprecia&ccedil;&atilde;o do Tribunal &agrave;s quest&otilde;es que foram objeto de debate e decis&atilde;o no ju&iacute;zo de primeiro grau. &Eacute; vedado &agrave; parte inovar em sede recursal, formulando pedido ou causa de pedir n&atilde;o elencados na exordial, sob pena de viola&ccedil;&atilde;o ao princ&iacute;pio do duplo grau de jurisdi&ccedil;&atilde;o e de indevida supress&atilde;o de inst&acirc;ncia.
+II - Na peti&ccedil;&atilde;o inicial, a autora limitou-se a pleitear a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito e, subsidiariamente, a rescis&atilde;o contratual. Ao requerer, apenas em grau de recurso, a convers&atilde;o da modalidade contratual (de cart&atilde;o de cr&eacute;dito consignado para empr&eacute;stimo consignado t&iacute;pico) com base em erro substancial, a apelante extrapola os limites da lide fixados na inst&acirc;ncia origin&aacute;ria.
+III - Constatada a inova&ccedil;&atilde;o quanto ao objeto principal do recurso, imp&otilde;e-se o acolhimento da preliminar, suscitada de of&iacute;cio, para o n&atilde;o conhecimento do apelo.
+IV - Recurso n&atilde;o conhecido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800137-44.2025.8.12.0007,&nbsp; Cassil&acirc;ndia,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cassilândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – SENTENÇA DE IMPROCEDÊNCIA – RECURSO DA PARTE AUTORA – PRETENSÃO DE CONVERSÃO DO NEGÓCIO JURÍDICO EM CONTRATO DE MÚTUO COMUM – MATÉRIA NÃO ARGUIDA NA PETIÇÃO INICIAL – INOVAÇÃO RECURSAL CONFIGURADA – SUPRESSÃO DE INSTÂNCIA – VEDAÇÃO PELO ORDENAMENTO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – SENTENÇA DE IMPROCEDÊNCIA – RECURSO DA PARTE AUTORA – PRETENSÃO DE CONVERSÃO DO NEGÓCIO JURÍDICO EM CONTRATO DE MÚTUO COMUM – MATÉRIA NÃO ARGUIDA NA PETIÇÃO INICIAL – INOVAÇÃO RECURSAL CONFIGURADA – SUPRESSÃO DE INSTÂNCIA – VEDAÇÃO PELO ORDENAMENTO JURÍDICO – PRELIMINAR SUSCITADA DE OFÍCIO – RECURSO NÃO CONHECIDO.
+I - O efeito devolutivo da apelação limita a apreciação do Tribunal às questões que foram objeto de debate e decisão no juízo de primeiro grau. É vedado à parte inovar em sede recursal, formulando pedido ou causa de pedir não elencados na exordial, sob pena de violação ao princípio do duplo grau de jurisdição e de indevida supressão de instância.
+II - Na petição inicial, a autora limitou-se a pleitear a declaração de inexistência do débito e, subsidiariamente, a rescisão contratual. Ao requerer, apenas em grau de recurso, a conversão da modalidade contratual (de cartão de crédito consignado para empréstimo consignado típico) com base em erro substancial, a apelante extrapola os limites da lide fixados na instância originária.
+III - Constatada a inovação quanto ao objeto principal do recurso, impõe-se o acolhimento da preliminar, suscitada de ofício, para o não conhecimento do apelo.
+IV - Recurso não conhecido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>34&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878192" cdForo="0" >
+										0801944-27.2024.8.12.0010
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878192" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878192);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878192" style="display: none;" >
+	<div id="textAreaDados_1878192" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE ID&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO C/C DANOS MORAIS &ndash; INCID&Ecirc;NCIA DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; CONTRATO DE ADES&Atilde;O ASSOCIA&Ccedil;&Atilde;O  &ndash; AUS&Ecirc;NCIA DE ASSINATURA V&Aacute;LIDA &ndash; ASSINATURA SEM BIOMETRIA E SELF &ndash; GEOLOCALIZA&Ccedil;&Atilde;O INDICATIVA SOMENTE DA CIDADE EM QUE OCORREU O NEG&Oacute;CIO JUR&Iacute;DICO &ndash; CONTRATO NULO -  DANO MORAL EXISTENTE - RESTITUI&Ccedil;&Atilde;O DAS QUANTIAS INDEVIDAMENTE DESCONTADAS EM DOBRO &ndash; APLICA&Ccedil;&Atilde;O DO TEMA 1368 DO STJ - JUROS DE MORA E CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA PELA TAXA SELIC AT&Eacute; ENTRADA EM VIGOR DA LEI 14.905/2024 - RECURSO CONHECIDO E PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produ&ccedil;&atilde;o de provas. E, portanto, n&atilde;o h&aacute; que se falar em cerceamento de defesa quando magistrado entendeu pela desnecessidade de realiza&ccedil;&atilde;o de per&iacute;cia.
+Documento apresentado pelo banco n&atilde;o cont&eacute;m assinatura f&iacute;sica ou eletr&ocirc;nica v&aacute;lida da consumidora, indicando a geolocaliza&ccedil;&atilde;o somente a cidade de F&aacute;tima do Sul sem especificar endere&ccedil;o do consumidor ou da associa&ccedil;&atilde;o, bem como ausentes outros elementos comprobat&oacute;rios da regularidade da contrata&ccedil;&atilde;o tais como self, biometria e documentos pessoais da parte, sendo, portanto, nula a ades&atilde;o da consumidora &agrave; entidade associativa por aus&ecirc;ncia de assinatura v&aacute;lida.
+Em decorr&ecirc;ncia da nulidade da ades&atilde;o e autoriza&ccedil;&atilde;o de descontos, todas as parcelas debitadas do benef&iacute;cio da parte autora devem ser restitu&iacute;das com dobro, face a n&atilde;o demonstra&ccedil;&atilde;o de ocorr&ecirc;ncia de engano justific&aacute;vel do credor.
+No caso, os valores foram indevidamente debitados da aposentadoria do apelante, pessoa idosa e aposentada que percebe mensalmente 01 sal&aacute;rio m&iacute;nimo, situa&ccedil;&atilde;o que foi de molde a caracterizar atentado &agrave; tranquilidade financeira da consumidora, privando-lhe de parte de seus proventos que j&aacute; apresentam car&aacute;ter m&oacute;dico, de maneira que o dano moral indeniz&aacute;vel encontra-se suficientemente caracterizado, sendo fixado o valor de R$ 5.000,00 (cinco mil reais), observados os princ&iacute;pios da proporcionalidade e razoabilidade.
+Tratando-se o caso de responsabilidade extracontratual &ndash; quando n&atilde;o existe contrato -, os encargos ficam assim fixados conforme Tema 1368 do STJ: i) a indeniza&ccedil;&atilde;o por dano moral o termo inicial dos juros de mora da condena&ccedil;&atilde;o por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido (quando o dano foi provocado),  o qual dever&aacute; ser corrigido pela SELIC. Ap&oacute;s a data do in&iacute;cio da vig&ecirc;ncia da Lei n. 14.905/2024, a corre&ccedil;&atilde;o dever&aacute; ser feita pelo IPCA e os juros de mora indexados pela SELIC, deduzido o IPCA, consoante previs&atilde;o do artigo 406, do C&oacute;digo de Processo Civil,  ii) a repeti&ccedil;&atilde;o do ind&eacute;bito em dobro dever&aacute; ser corrigida e sofrer incid&ecirc;ncia de juros de mora desde o desconto indevido (S&uacute;mula 43 do STJ) unicamente pela taxa SELIC, at&eacute; entrada em vigor da Lei 14.905/2024 e, ap&oacute;s, ser corrigida monetariamente pelo IPCA e ter incid&ecirc;ncia de juros de mora da SELIC, deduzido o IPCA. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801944-27.2024.8.12.0010,&nbsp; F&aacute;tima do Sul,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(61 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fátima do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE IDÉBITO C/C REPETIÇÃO DE INDÉBITO C/C DANOS MORAIS – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – CONTRATO DE ADESÃO ASSOCIAÇÃO  – AUSÊNCIA DE ASSINATURA VÁLIDA – ASSINATURA SEM BIOMETRIA E SELF – GEOLOCALIZAÇÃO INDICATIVA SOMENTE DA CIDADE EM QUE OCORREU O NEGÓCIO JURÍDICO – CONTRATO NULO -  <em>DANO</em> <em>MORAL</em> EXISTENTE - RESTITUIÇÃO DAS QUANTIAS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE IDÉBITO C/C REPETIÇÃO DE INDÉBITO C/C DANOS MORAIS – INCIDÊNCIA DO CÓDIGO DE DEFESA DO CONSUMIDOR – CONTRATO DE ADESÃO ASSOCIAÇÃO  – AUSÊNCIA DE ASSINATURA VÁLIDA – ASSINATURA SEM BIOMETRIA E SELF – GEOLOCALIZAÇÃO INDICATIVA SOMENTE DA CIDADE EM QUE OCORREU O NEGÓCIO JURÍDICO – CONTRATO NULO -  <em>DANO</em> <em>MORAL</em> EXISTENTE - RESTITUIÇÃO DAS QUANTIAS INDEVIDAMENTE DESCONTADAS EM DOBRO – APLICAÇÃO DO TEMA 1368 DO STJ - JUROS DE MORA E CORREÇÃO MONETÁRIA PELA TAXA SELIC ATÉ ENTRADA EM VIGOR DA LEI 14.905/2024 - RECURSO CONHECIDO E PROVIDO.
+Compete ao magistrado, no intuito de formar o seu convencimento, decidir sobre a necessidade de produção de provas. E, portanto, não há que se falar em cerceamento de defesa quando magistrado entendeu pela desnecessidade de realização de perícia.
+Documento apresentado pelo banco não contém assinatura física ou eletrônica válida da consumidora, indicando a geolocalização somente a cidade de Fátima do Sul sem especificar endereço do consumidor ou da associação, bem como ausentes outros elementos comprobatórios da regularidade da contratação tais como self, biometria e documentos pessoais da parte, sendo, portanto, nula a adesão da consumidora à entidade associativa por ausência de assinatura válida.
+Em decorrência da nulidade da adesão e autorização de descontos, todas as parcelas debitadas do benefício da parte autora devem ser restituídas com dobro, face a não demonstração de ocorrência de engano justificável do credor.
+No caso, os valores foram indevidamente debitados da aposentadoria do apelante, pessoa idosa e aposentada que percebe mensalmente 01 salário mínimo, situação que foi de molde a caracterizar atentado à tranquilidade financeira da consumidora, privando-lhe de parte de seus proventos que já apresentam caráter módico, de maneira que o <em>dano</em> <em>moral</em> indenizável encontra-se suficientemente caracterizado, sendo fixado o valor de R$ 5.000,00 (cinco mil reais), observados os princípios da proporcionalidade e razoabilidade.
+Tratando-se o caso de responsabilidade extracontratual – quando não existe contrato -, os encargos ficam assim fixados conforme Tema 1368 do STJ: i) a indenização por <em>dano</em> <em>moral</em> o termo inicial dos juros de mora da condenação por danos morais deve observar o evento danoso, ou seja, da data do primeiro desconto indevido (quando o <em>dano</em> foi provocado),  o qual deverá ser corrigido pela SELIC. Após a data do início da vigência da Lei n. 14.905/2024, a correção deverá ser feita pelo IPCA e os juros de mora indexados pela SELIC, deduzido o IPCA, consoante previsão do artigo 406, do Código de Processo Civil,  ii) a repetição do indébito em dobro deverá ser corrigida e sofrer incidência de juros de mora desde o desconto indevido (Súmula 43 do STJ) unicamente pela taxa SELIC, até entrada em vigor da Lei 14.905/2024 e, após, ser corrigida monetariamente pelo IPCA e ter incidência de juros de mora da SELIC, deduzido o IPCA.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>35&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878198" cdForo="0" >
+										0800494-67.2025.8.12.0025
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878198" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878198);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878198" style="display: none;" >
+	<div id="textAreaDados_1878198" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; DEMANDA DE COBRAN&Ccedil;A DE SEGURO AGR&Iacute;COLA &ndash; CL&Aacute;USULA RESTRITIVA DE COBERTURA (PLANTIO EM &Aacute;REA DE PASTAGEM) &ndash; AUS&Ecirc;NCIA DE PROVA DE CI&Ecirc;NCIA INEQU&Iacute;VOCA DO SEGURADO &ndash; VIOLA&Ccedil;&Atilde;O AO DEVER DE INFORMA&Ccedil;&Atilde;O - REPARA&Ccedil;&Atilde;O POR DANOS MORAIS INDEVIDA.
+1.&Eacute; inopon&iacute;vel a cl&aacute;usula restritiva de direitos sem a demonstra&ccedil;&atilde;o de informa&ccedil;&atilde;o pr&eacute;via, clara e inequ&iacute;voca ao segurado no momento da contrata&ccedil;&atilde;o.
+2.Inexiste dano moral em decorr&ecirc;ncia de negativa de cobertura fundada em diverg&ecirc;ncia de interpreta&ccedil;&atilde;o contratual.
+Recurso parcialmente provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800494-67.2025.8.12.0025,&nbsp; Bandeirantes,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Bandeirantes
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DEMANDA DE COBRANÇA DE SEGURO AGRÍCOLA – CLÁUSULA RESTRITIVA DE COBERTURA (PLANTIO EM ÁREA DE PASTAGEM) – AUSÊNCIA DE PROVA DE CIÊNCIA INEQUÍVOCA DO SEGURADO – VIOLAÇÃO AO DEVER DE INFORMAÇÃO - REPARAÇÃO POR DANOS MORAIS INDEVIDA.
+1.É inoponível a cláusula restritiva de direitos sem a demonstração de informação prévia, clara e inequívoca ao segurado no momento da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DEMANDA DE COBRANÇA DE SEGURO AGRÍCOLA – CLÁUSULA RESTRITIVA DE COBERTURA (PLANTIO EM ÁREA DE PASTAGEM) – AUSÊNCIA DE PROVA DE CIÊNCIA INEQUÍVOCA DO SEGURADO – VIOLAÇÃO AO DEVER DE INFORMAÇÃO - REPARAÇÃO POR DANOS MORAIS INDEVIDA.
+1.É inoponível a cláusula restritiva de direitos sem a demonstração de informação prévia, clara e inequívoca ao segurado no momento da contratação.
+2.Inexiste <em>dano</em> <em>moral</em> em decorrência de negativa de cobertura fundada em divergência de interpretação contratual.
+Recurso parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>36&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878202" cdForo="0" >
+										0847743-57.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878202" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878202);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878202" style="display: none;" >
+	<div id="textAreaDados_1878202" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O &ndash; TRANSPORTE A&Eacute;REO INTERNACIONAL &ndash; AQUISI&Ccedil;&Atilde;O DE PASSAGENS EM CLASSE EXECUTIVA (PREMIUM BUSINESS) &ndash; PRE&Ccedil;O MANIFESTAMENTE IRRIS&Oacute;RIO &ndash; ERRO GROSSEIRO NA OFERTA &ndash; INAPLICABILIDADE DO ARTIGO 30 DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR - AUS&Ecirc;NCIA  DE FALHA NA PRESTA&Ccedil;&Atilde;O DE SERVI&Ccedil;O &ndash; RESTITUI&Ccedil;&Atilde;O DO VALOR PAGO DEVIDA.
+1. O artigo 30 do C&oacute;digo de Defesa do Consumidor prev&ecirc; a vincula&ccedil;&atilde;o da oferta ao fornecedor, integrando o contrato. Contudo, essa regra n&atilde;o &eacute; absoluta, sendo afastada quando h&aacute; erro grosseiro e evidente, capaz de excluir a leg&iacute;tima expectativa do consumidor quanto ao cumprimento da oferta.
+2. Ausente falha na presta&ccedil;&atilde;o do servi&ccedil;o, inexiste o dever de indenizar.
+3. Diante da altera&ccedil;&atilde;o da categoria sem concord&acirc;ncia da parte autora, devido a retorno das partes ao status quo ante, com a restitui&ccedil;&atilde;o do valor pago.
+Recurso das r&eacute;s provido e dos autores n&atilde;o provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0847743-57.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – TRANSPORTE AÉREO INTERNACIONAL – AQUISIÇÃO DE PASSAGENS EM CLASSE EXECUTIVA (PREMIUM BUSINESS) – PREÇO MANIFESTAMENTE IRRISÓRIO – ERRO GROSSEIRO NA OFERTA – INAPLICABILIDADE DO ARTIGO 30 DO CÓDIGO DE DEFESA DO CONSUMIDOR - AUSÊNCIA  DE FALHA NA PRESTAÇÃO DE SERVIÇO – RESTITUIÇÃO DO VALOR PAGO DEVIDA.
+1. O artigo 30 do Código de Defesa do Consumidor prevê a vinculação da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – TRANSPORTE AÉREO INTERNACIONAL – AQUISIÇÃO DE PASSAGENS EM CLASSE EXECUTIVA (PREMIUM BUSINESS) – PREÇO MANIFESTAMENTE IRRISÓRIO – ERRO GROSSEIRO NA OFERTA – INAPLICABILIDADE DO ARTIGO 30 DO CÓDIGO DE DEFESA DO CONSUMIDOR - AUSÊNCIA  DE FALHA NA PRESTAÇÃO DE SERVIÇO – RESTITUIÇÃO DO VALOR PAGO DEVIDA.
+1. O artigo 30 do Código de Defesa do Consumidor prevê a vinculação da oferta ao fornecedor, integrando o contrato. Contudo, essa regra não é absoluta, sendo afastada quando há erro grosseiro e evidente, capaz de excluir a legítima expectativa do consumidor quanto ao cumprimento da oferta.
+2. Ausente falha na prestação do serviço, inexiste o dever de indenizar.
+3. Diante da alteração da categoria sem concordância da parte autora, devido a retorno das partes ao status quo ante, com a restituição do valor pago.
+Recurso das rés provido e dos autores não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>37&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878212" cdForo="0" >
+										0810442-05.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878212" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878212);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878212" style="display: none;" >
+	<div id="textAreaDados_1878212" class="mensagemSemFormatacao" >
+		RECURSOS DE APELA&Ccedil;&Atilde;O &ndash; INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA, REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E COMPENSA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; DESCONTOS INDEVIDOS EM CONTA CORRENTE&ndash; RESPONSABILIDADE DA INSTITUI&Ccedil;&Atilde;O BANC&Aacute;RIA &ndash; RESTITUI&Ccedil;&Atilde;O &ndash; DANO MORAL &ndash; VALOR MANTIDO.
+1. A responsabilidade do banco &eacute; caracterizada quando ocorrem   descontos em conta corrente do autor sem autoriza&ccedil;&atilde;o expressa.
+2. Considerando que a parte r&eacute; n&atilde;o comprovou a exist&ecirc;ncia de contrato de seguro, &eacute; necess&aacute;rio o retorno das partes ao status quo ante, com a restitui&ccedil;&atilde;o do valor descontado.
+3. O valor fixado a t&iacute;tulo de compensa&ccedil;&atilde;o pelos danos morais &eacute; mantido quando observados, na senten&ccedil;a, os aspectos objetivos e subjetivos da demanda, em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recursos n&atilde;o providos. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0810442-05.2025.8.12.0002,&nbsp; Dourados,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Vilson Bertelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Descontos dos benefícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Vilson Bertelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INEXISTÊNCIA DE RELAÇÃO JURÍDICA, REPETIÇÃO DE INDÉBITO E COMPENSAÇÃO POR DANOS MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE– RESPONSABILIDADE DA INSTITUIÇÃO BANCÁRIA – RESTITUIÇÃO – <em>DANO</em> <em>MORAL</em> – VALOR MANTIDO.
+1. A responsabilidade do banco é caracterizada quando ocorrem   descontos em conta corrente do autor sem autorização expressa.
+2. Considerando
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSOS DE APELAÇÃO – INEXISTÊNCIA DE RELAÇÃO JURÍDICA, REPETIÇÃO DE INDÉBITO E COMPENSAÇÃO POR DANOS MORAIS – DESCONTOS INDEVIDOS EM CONTA CORRENTE– RESPONSABILIDADE DA INSTITUIÇÃO BANCÁRIA – RESTITUIÇÃO – <em>DANO</em> <em>MORAL</em> – VALOR MANTIDO.
+1. A responsabilidade do banco é caracterizada quando ocorrem   descontos em conta corrente do autor sem autorização expressa.
+2. Considerando que a parte ré não comprovou a existência de contrato de seguro, é necessário o retorno das partes ao status quo ante, com a restituição do valor descontado.
+3. O valor fixado a título de compensação pelos danos morais é mantido quando observados, na sentença, os aspectos objetivos e subjetivos da demanda, em consonância com os princípios da razoabilidade e da proporcionalidade.
+Recursos não providos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>38&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878216" cdForo="0" >
+										0806882-44.2024.8.12.0017
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878216" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878216);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878216" style="display: none;" >
+	<div id="textAreaDados_1878216" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. MAJORA&Ccedil;&Atilde;O DO DANO MORAL. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Trata-se de apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica cumulada com repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais, julgou parcialmente procedentes os pedidos.
+2. O ju&iacute;zo de origem declarou a inexist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, determinou a restitui&ccedil;&atilde;o em dobro dos valores indevidamente descontados e fixou indeniza&ccedil;&atilde;o por danos morais em R$ 3.000,00, al&eacute;m de honor&aacute;rios advocat&iacute;cios.
+3. O apelante insurge-se exclusivamente quanto ao valor da indeniza&ccedil;&atilde;o moral, pleiteando sua majora&ccedil;&atilde;o, bem como a eleva&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. A controv&eacute;rsia recursal cinge-se a:
+a) verificar a adequa&ccedil;&atilde;o do quantum indenizat&oacute;rio fixado a t&iacute;tulo de danos morais decorrentes de descontos indevidos em benef&iacute;cio previdenci&aacute;rio;
+b) definir o crit&eacute;rio de fixa&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios sucumbenciais.
+III. RAZ&Otilde;ES DE DECIDIR
+5. Restou incontroversa a inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica entre as partes e a ilicitude dos descontos realizados, configurando ato il&iacute;cito nos termos dos arts. 186 e 927 do C&oacute;digo Civil.
+6. Os descontos indevidos em benef&iacute;cio previdenci&aacute;rio, de natureza alimentar, configuram dano moral in re ipsa, dispensando prova do preju&iacute;zo extrapatrimonial.
+7. O valor da indeniza&ccedil;&atilde;o deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, atendendo &agrave;s fun&ccedil;&otilde;es compensat&oacute;ria e pedag&oacute;gica, considerando:
+a) a vulnerabilidade econ&ocirc;mica do autor, aposentado por incapacidade;
+b) a natureza alimentar do benef&iacute;cio atingido;
+c) a reitera&ccedil;&atilde;o dos descontos por per&iacute;odo prolongado (quase um ano);
+d) a gravidade da conduta il&iacute;cita.
+8. O montante fixado na origem (R$ 3.000,00) revela-se insuficiente, sendo adequada sua majora&ccedil;&atilde;o para R$ 5.000,00.
+9. Quanto aos honor&aacute;rios advocat&iacute;cios, inaplic&aacute;vel a fixa&ccedil;&atilde;o por equidade (art. 85, &sect;8&ordm;, do CPC) quando h&aacute; condena&ccedil;&atilde;o mensur&aacute;vel, devendo prevalecer o crit&eacute;rio percentual previsto no &sect;2&ordm; do mesmo dispositivo.
+10. Assim, mostra-se adequada a fixa&ccedil;&atilde;o dos honor&aacute;rios em 20% sobre o valor da condena&ccedil;&atilde;o, em aten&ccedil;&atilde;o aos crit&eacute;rios legais.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e parcialmente provido.
+Tese de julgamento:
+12. Os descontos indevidos em benef&iacute;cio previdenci&aacute;rio, sobretudo de natureza alimentar, configuram dano moral in re ipsa, sendo devida a indeniza&ccedil;&atilde;o independentemente de prova do preju&iacute;zo.
+13. O quantum indenizat&oacute;rio por danos morais deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano, a condi&ccedil;&atilde;o da v&iacute;tima e o car&aacute;ter pedag&oacute;gico da medida, admitindo-se majora&ccedil;&atilde;o quando o valor fixado se mostrar insuficiente.
+14. Havendo condena&ccedil;&atilde;o com valor mensur&aacute;vel, os honor&aacute;rios advocat&iacute;cios devem ser fixados com base no percentual previsto no art. 85, &sect;2&ordm;, do CPC, sendo excepcional a fixa&ccedil;&atilde;o por equidade. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806882-44.2024.8.12.0017,&nbsp; Nova Andradina,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Nova Andradina
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. MAJORAÇÃO DO <em>DANO</em> <em>MORAL</em>. HONORÁRIOS ADVOCATÍCIOS. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Trata-se de apelação cível interposta contra sentença que, em ação declaratória de inexistência
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. MAJORAÇÃO DO <em>DANO</em> <em>MORAL</em>. HONORÁRIOS ADVOCATÍCIOS. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+1. Trata-se de apelação cível interposta contra sentença que, em ação declaratória de inexistência de relação jurídica cumulada com repetição de indébito e indenização por danos morais, julgou parcialmente procedentes os pedidos.
+2. O juízo de origem declarou a inexistência da relação jurídica, determinou a restituição em dobro dos valores indevidamente descontados e fixou indenização por danos morais em R$ 3.000,00, além de honorários advocatícios.
+3. O apelante insurge-se exclusivamente quanto ao valor da indenização <em>moral</em>, pleiteando sua majoração, bem como a elevação dos honorários sucumbenciais.
+II. QUESTÃO EM DISCUSSÃO
+4. A controvérsia recursal cinge-se a:
+a) verificar a adequação do quantum indenizatório fixado a título de danos morais decorrentes de descontos indevidos em benefício previdenciário;
+b) definir o critério de fixação dos honorários advocatícios sucumbenciais.
+III. RAZÕES DE DECIDIR
+5. Restou incontroversa a inexistência de relação jurídica entre as partes e a ilicitude dos descontos realizados, configurando ato ilícito nos termos dos arts. 186 e 927 do Código Civil.
+6. Os descontos indevidos em benefício previdenciário, de natureza alimentar, configuram <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo extrapatrimonial.
+7. O valor da indenização deve observar os princípios da razoabilidade e proporcionalidade, atendendo às funções compensatória e pedagógica, considerando:
+a) a vulnerabilidade econômica do autor, aposentado por incapacidade;
+b) a natureza alimentar do benefício atingido;
+c) a reiteração dos descontos por período prolongado (quase um ano);
+d) a gravidade da conduta ilícita.
+8. O montante fixado na origem (R$ 3.000,00) revela-se insuficiente, sendo adequada sua majoração para R$ 5.000,00.
+9. Quanto aos honorários advocatícios, inaplicável a fixação por equidade (art. 85, §8º, do CPC) quando há condenação mensurável, devendo prevalecer o critério percentual previsto no §2º do mesmo dispositivo.
+10. Assim, mostra-se adequada a fixação dos honorários em 20% sobre o valor da condenação, em atenção aos critérios legais.
+IV. DISPOSITIVO E TESE
+11. Recurso conhecido e parcialmente provido.
+Tese de julgamento:
+12. Os descontos indevidos em benefício previdenciário, sobretudo de natureza alimentar, configuram <em>dano</em> <em>moral</em> in re ipsa, sendo devida a indenização independentemente de prova do prejuízo.
+13. O quantum indenizatório por danos morais deve observar os princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em>, a condição da vítima e o caráter pedagógico da medida, admitindo-se majoração quando o valor fixado se mostrar insuficiente.
+14. Havendo condenação com valor mensurável, os honorários advocatícios devem ser fixados com base no percentual previsto no art. 85, §2º, do CPC, sendo excepcional a fixação por equidade.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>39&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878219" cdForo="0" >
+										0803592-35.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878219" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878219);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878219" style="display: none;" >
+	<div id="textAreaDados_1878219" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE NEG&Oacute;CIO JUR&Iacute;DICO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC). ALEGA&Ccedil;&Atilde;O DE V&Iacute;CIO DE CONSENTIMENTO. AUS&Ecirc;NCIA DE PROVA. CONTRATA&Ccedil;&Atilde;O V&Aacute;LIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por Roberto Ramai da Costa contra senten&ccedil;a que julgou improcedentes os pedidos em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de neg&oacute;cio jur&iacute;dico cumulada com repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais, ajuizada em face de Banco Bmg S/A.
+2. O autor sustenta que pretendia contratar empr&eacute;stimo consignado simples, mas aderiu a cart&atilde;o de cr&eacute;dito consignado (RMC), alegando v&iacute;cio de consentimento, falha no dever de informa&ccedil;&atilde;o e cobran&ccedil;a abusiva decorrente de d&iacute;vida de natureza rotativa.
+3. Requer a nulidade do contrato ou sua convers&atilde;o em m&uacute;tuo consignado, restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+4. A controv&eacute;rsia consiste em verificar:
+a) se houve v&iacute;cio de consentimento na contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado (RMC);
+b) se houve falha no dever de informa&ccedil;&atilde;o capaz de invalidar o neg&oacute;cio jur&iacute;dico;
+c) se s&atilde;o devidos restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+5. Preliminares rejeitadas. N&atilde;o configurada ofensa ao princ&iacute;pio da dialeticidade, uma vez que as raz&otilde;es recursais enfrentam os fundamentos da senten&ccedil;a. Inocorr&ecirc;ncia de prescri&ccedil;&atilde;o e decad&ecirc;ncia, por se tratar de rela&ccedil;&atilde;o de trato sucessivo, cujo prazo conta-se do &uacute;ltimo desconto.
+6. A rela&ccedil;&atilde;o jur&iacute;dica &eacute; de consumo, sendo aplic&aacute;vel o C&oacute;digo de Defesa do Consumidor, conforme S&uacute;mula 297 do STJ.
+7. A institui&ccedil;&atilde;o financeira comprovou a regular contrata&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito consignado, mediante termo de ades&atilde;o assinado e demonstra&ccedil;&atilde;o de disponibiliza&ccedil;&atilde;o do cr&eacute;dito ao consumidor.
+8. Inexistente prova de v&iacute;cio de consentimento (erro, dolo ou coa&ccedil;&atilde;o), incumbindo ao autor o &ocirc;nus probat&oacute;rio, nos termos do art. 373, I, do CPC.
+9. O mero alegado desconhecimento das caracter&iacute;sticas do contrato n&atilde;o &eacute; suficiente para invalidar o neg&oacute;cio jur&iacute;dico, especialmente quando as condi&ccedil;&otilde;es contratuais constam expressamente no instrumento firmado.
+10. A utiliza&ccedil;&atilde;o do cr&eacute;dito e a aus&ecirc;ncia de prova de irregularidade afastam a alega&ccedil;&atilde;o de falha no dever de informa&ccedil;&atilde;o.
+11. A modalidade de cart&atilde;o de cr&eacute;dito consignado (RMC) &eacute; l&iacute;cita e regulamentada, sendo v&aacute;lida a cobran&ccedil;a do pagamento m&iacute;nimo da fatura mediante desconto em folha.
+12. Ausente ilegalidade na contrata&ccedil;&atilde;o, inexiste fundamento para repeti&ccedil;&atilde;o de ind&eacute;bito ou indeniza&ccedil;&atilde;o por danos morais.
+IV. DISPOSITIVO E TESE
+13. Recurso desprovido.
+Tese de julgamento:
+14. A contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado (RMC) &eacute; v&aacute;lida quando comprovada por termo de ades&atilde;o assinado e disponibiliza&ccedil;&atilde;o do cr&eacute;dito, inexistindo nulidade sem prova de v&iacute;cio de consentimento.
+15. O &ocirc;nus de demonstrar erro substancial ou falha no dever de informa&ccedil;&atilde;o incumbe ao consumidor, n&atilde;o sendo suficiente a alega&ccedil;&atilde;o gen&eacute;rica de desconhecimento da modalidade contratada.
+16. A natureza rotativa do cr&eacute;dito consignado, com desconto do valor m&iacute;nimo da fatura, n&atilde;o configura abusividade quando expressamente prevista no contrato.
+17. Inexistindo irregularidade na contrata&ccedil;&atilde;o, s&atilde;o indevidos a repeti&ccedil;&atilde;o de ind&eacute;bito e o dano moral. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803592-35.2025.8.12.0001,&nbsp; Terenos,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Terenos
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO (RMC). ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO. AUSÊNCIA DE PROVA. CONTRATAÇÃO VÁLIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por Roberto Ramai da Costa contra sentença que julgou improcedentes os
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO (RMC). ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO. AUSÊNCIA DE PROVA. CONTRATAÇÃO VÁLIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por Roberto Ramai da Costa contra sentença que julgou improcedentes os pedidos em ação declaratória de inexistência de negócio jurídico cumulada com repetição de indébito e indenização por danos morais, ajuizada em face de Banco Bmg S/A.
+2. O autor sustenta que pretendia contratar empréstimo consignado simples, mas aderiu a cartão de crédito consignado (RMC), alegando vício de consentimento, falha no dever de informação e cobrança abusiva decorrente de dívida de natureza rotativa.
+3. Requer a nulidade do contrato ou sua conversão em mútuo consignado, restituição de valores e indenização por danos morais.
+II. QUESTÃO EM DISCUSSÃO
+4. A controvérsia consiste em verificar:
+a) se houve vício de consentimento na contratação do cartão de crédito consignado (RMC);
+b) se houve falha no dever de informação capaz de invalidar o negócio jurídico;
+c) se são devidos restituição de valores e indenização por danos morais.
+III. RAZÕES DE DECIDIR
+5. Preliminares rejeitadas. Não configurada ofensa ao princípio da dialeticidade, uma vez que as razões recursais enfrentam os fundamentos da sentença. Inocorrência de prescrição e decadência, por se tratar de relação de trato sucessivo, cujo prazo conta-se do último desconto.
+6. A relação jurídica é de consumo, sendo aplicável o Código de Defesa do Consumidor, conforme Súmula 297 do STJ.
+7. A instituição financeira comprovou a regular contratação do cartão de crédito consignado, mediante termo de adesão assinado e demonstração de disponibilização do crédito ao consumidor.
+8. Inexistente prova de vício de consentimento (erro, dolo ou coação), incumbindo ao autor o ônus probatório, nos termos do art. 373, I, do CPC.
+9. O mero alegado desconhecimento das características do contrato não é suficiente para invalidar o negócio jurídico, especialmente quando as condições contratuais constam expressamente no instrumento firmado.
+10. A utilização do crédito e a ausência de prova de irregularidade afastam a alegação de falha no dever de informação.
+11. A modalidade de cartão de crédito consignado (RMC) é lícita e regulamentada, sendo válida a cobrança do pagamento mínimo da fatura mediante desconto em folha.
+12. Ausente ilegalidade na contratação, inexiste fundamento para repetição de indébito ou indenização por danos morais.
+IV. DISPOSITIVO E TESE
+13. Recurso desprovido.
+Tese de julgamento:
+14. A contratação de cartão de crédito consignado (RMC) é válida quando comprovada por termo de adesão assinado e disponibilização do crédito, inexistindo nulidade sem prova de vício de consentimento.
+15. O ônus de demonstrar erro substancial ou falha no dever de informação incumbe ao consumidor, não sendo suficiente a alegação genérica de desconhecimento da modalidade contratada.
+16. A natureza rotativa do crédito consignado, com desconto do valor mínimo da fatura, não configura abusividade quando expressamente prevista no contrato.
+17. Inexistindo irregularidade na contratação, são indevidos a repetição de indébito e o <em>dano</em> <em>moral</em>.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>40&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878224" cdForo="0" >
+										0861350-40.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878224" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878224);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878224" style="display: none;" >
+	<div id="textAreaDados_1878224" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; DIREITO CIVIL &ndash; A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO BANC&Aacute;RIO &ndash; LITIG&Acirc;NCIA PREDAT&Oacute;RIA N&Atilde;O CONFIGURADA &ndash; CERCEAMENTO DE DEFESA AFASTADO &ndash; JUROS REMUNERAT&Oacute;RIOS &ndash; TAXA M&Eacute;DIA DE MERCADO &ndash; ABUSIVIDADE CONSTATADA &ndash; RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Trata-se de apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou procedentes os pedidos formulados pela parte autora em a&ccedil;&atilde;o revisional, para limitar os juros remunerat&oacute;rios &agrave; taxa m&eacute;dia de mercado e descaracterizar eventual mora.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) Verifica-se a discuss&atilde;o sobre: i) ocorr&ecirc;ncia de cerceamento de defesa por indeferimento de provas; ii) alega&ccedil;&atilde;o de litig&acirc;ncia predat&oacute;ria por ajuizamento reiterado de a&ccedil;&otilde;es semelhantes; iii) possibilidade de revis&atilde;o das cl&aacute;usulas contratuais, notadamente quanto &agrave; abusividade das taxas de juros remunerat&oacute;rios pactuadas acima da taxa m&eacute;dia de mercado.
+III. RAZ&Otilde;ES DE DECIDIR
+3) Quanto &agrave; preliminar de litig&acirc;ncia predat&oacute;ria, inexistem provas concretas de ajuizamento massivo e padronizado de a&ccedil;&otilde;es pela mesma patrona em preju&iacute;zo da parte recorrente, raz&atilde;o pela qual foi afastada.
+4) Rejeita-se tamb&eacute;m a alega&ccedil;&atilde;o de cerceamento de defesa, haja vista que a mat&eacute;ria em an&aacute;lise &eacute; predominantemente de direito e os documentos j&aacute; constantes nos autos s&atilde;o suficientes &agrave; forma&ccedil;&atilde;o do convencimento do ju&iacute;zo, dispensando a produ&ccedil;&atilde;o de outras provas, inclusive pericial.
+5) No m&eacute;rito, resta evidenciada a abusividade das taxas de juros remunerat&oacute;rios pactuadas, por serem significativamente superiores &agrave; taxa m&eacute;dia de mercado divulgada pelo Banco Central para contratos similares &agrave; &eacute;poca da contrata&ccedil;&atilde;o.
+6) A revis&atilde;o das taxas contratadas se ampara em jurisprud&ecirc;ncia consolidada do STJ, especialmente no julgamento do REsp 1.061.530/RS, que admite a revis&atilde;o excepcional de juros quando comprovada a abusividade no caso concreto, sobretudo em rela&ccedil;&otilde;es de consumo.
+7)Diante da constata&ccedil;&atilde;o de abusividade, correta a limita&ccedil;&atilde;o dos juros &agrave; taxa m&eacute;dia de mercado e consequente descaracteriza&ccedil;&atilde;o da mora, conforme entendimento do STJ no Tema 28.
+IV. DISPOSITIVO E TESE
+8) Recurso desprovido.
+Tese de julgamento:
+9) A simples alega&ccedil;&atilde;o de ajuizamento reiterado de demandas contra a mesma institui&ccedil;&atilde;o financeira, sem provas concretas, n&atilde;o configura litig&acirc;ncia predat&oacute;ria.
+10) N&atilde;o h&aacute; cerceamento de defesa quando a prova requerida se mostra desnecess&aacute;ria e a mat&eacute;ria em julgamento &eacute; eminentemente de direito, sendo leg&iacute;tima a forma&ccedil;&atilde;o do convencimento judicial com base nas provas documentais constantes dos autos.
+11) &Eacute; abusiva a cobran&ccedil;a de juros remunerat&oacute;rios em patamar significativamente superior &agrave; taxa m&eacute;dia de mercado divulgada pelo Banco Central, sendo leg&iacute;tima sua limita&ccedil;&atilde;o, com fundamento nos princ&iacute;pios da boa-f&eacute; objetiva e da fun&ccedil;&atilde;o social do contrato.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0861350-40.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DIREITO CIVIL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – LITIGÂNCIA PREDATÓRIA NÃO CONFIGURADA – CERCEAMENTO DE DEFESA AFASTADO – JUROS REMUNERATÓRIOS – TAXA MÉDIA DE MERCADO – ABUSIVIDADE CONSTATADA – RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Trata-se de apelação cível interposta contra sentença que julgou procedentes os pedidos formulados pela parte autora em ação revisional,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – DIREITO CIVIL – AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – LITIGÂNCIA PREDATÓRIA NÃO CONFIGURADA – CERCEAMENTO DE DEFESA AFASTADO – JUROS REMUNERATÓRIOS – TAXA MÉDIA DE MERCADO – ABUSIVIDADE CONSTATADA – RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Trata-se de apelação cível interposta contra sentença que julgou procedentes os pedidos formulados pela parte autora em ação revisional, para limitar os juros remuneratórios à taxa média de mercado e descaracterizar eventual mora.
+II. QUESTÃO EM DISCUSSÃO
+2) Verifica-se a discussão sobre: i) ocorrência de cerceamento de defesa por indeferimento de provas; ii) alegação de litigância predatória por ajuizamento reiterado de ações semelhantes; iii) possibilidade de revisão das cláusulas contratuais, notadamente quanto à abusividade das taxas de juros remuneratórios pactuadas acima da taxa média de mercado.
+III. RAZÕES DE DECIDIR
+3) Quanto à preliminar de litigância predatória, inexistem provas concretas de ajuizamento massivo e padronizado de ações pela mesma patrona em prejuízo da parte recorrente, razão pela qual foi afastada.
+4) Rejeita-se também a alegação de cerceamento de defesa, haja vista que a matéria em análise é predominantemente de direito e os documentos já constantes nos autos são suficientes à formação do convencimento do juízo, dispensando a produção de outras provas, inclusive pericial.
+5) No mérito, resta evidenciada a abusividade das taxas de juros remuneratórios pactuadas, por serem significativamente superiores à taxa média de mercado divulgada pelo Banco Central para contratos similares à época da contratação.
+6) A revisão das taxas contratadas se ampara em jurisprudência consolidada do STJ, especialmente no julgamento do REsp 1.061.530/RS, que admite a revisão excepcional de juros quando comprovada a abusividade no caso concreto, sobretudo em relações de consumo.
+7)Diante da constatação de abusividade, correta a limitação dos juros à taxa média de mercado e consequente descaracterização da mora, conforme entendimento do STJ no Tema 28.
+IV. DISPOSITIVO E TESE
+8) Recurso desprovido.
+Tese de julgamento:
+9) A simples alegação de ajuizamento reiterado de demandas contra a mesma instituição financeira, sem provas concretas, não configura litigância predatória.
+10) Não há cerceamento de defesa quando a prova requerida se mostra desnecessária e a matéria em julgamento é eminentemente de direito, sendo legítima a formação do convencimento judicial com base nas provas documentais constantes dos autos.
+11) É abusiva a cobrança de juros remuneratórios em patamar significativamente superior à taxa média de mercado divulgada pelo Banco Central, sendo legítima sua limitação, com fundamento nos princípios da boa-fé objetiva e da função social do contrato.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>41&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878227" cdForo="0" >
+										0801548-20.2024.8.12.0020
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878227" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878227);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878227" style="display: none;" >
+	<div id="textAreaDados_1878227" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS. PRELIMINAR DE ILEGITIMIDADE PASSIVA ACOLHIDA NA ORIGEM. BANCO RESPONS&Aacute;VEL PELA GEST&Atilde;O E SEGURAN&Ccedil;A DA CONTA CORRENTE. DESCONTOS INDEVIDOS REALIZADOS SEM AUTORIZA&Ccedil;&Atilde;O DA CORRENTISTA. RESPONSABILIDADE OBJETIVA. CDC. AUS&Ecirc;NCIA DE APRECIA&Ccedil;&Atilde;O DAS DEMAIS PRELIMINARES SUSCITADAS NA CONTESTA&Ccedil;&Atilde;O. CAUSA N&Atilde;O MADURA PARA JULGAMENTO DIRETO. ANULA&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por Julia Gen&eacute;sia Garcia contra senten&ccedil;a que acolheu a preliminar de ilegitimidade passiva do Banco Bradesco S/A e extinguiu o feito sem resolu&ccedil;&atilde;o de m&eacute;rito, nos termos do art. 485, VI, do C&oacute;digo de Processo Civil, condenando a autora ao pagamento das custas processuais e honor&aacute;rios advocat&iacute;cios, com exigibilidade suspensa em raz&atilde;o da gratuidade da justi&ccedil;a.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o central consiste em definir se o Banco Bradesco S/A det&eacute;m legitimidade passiva para figurar no polo passivo de a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito cumulada com indeniza&ccedil;&atilde;o por danos materiais e morais, em raz&atilde;o de descontos realizados em conta corrente de sua titularidade sem autoriza&ccedil;&atilde;o expressa da correntista.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O banco que administra conta corrente e efetua descontos em favor de terceiro sem verificar a regularidade da autoriza&ccedil;&atilde;o do correntista responde objetivamente pelos danos causados, nos termos do art. 14 do C&oacute;digo de Defesa do Consumidor e da S&uacute;mula 479 do Superior Tribunal de Justi&ccedil;a, que estabelece a responsabilidade objetiva das institui&ccedil;&otilde;es financeiras pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no &acirc;mbito de opera&ccedil;&otilde;es banc&aacute;rias.
+4. A mera intermedia&ccedil;&atilde;o operacional n&atilde;o afasta a legitimidade passiva da institui&ccedil;&atilde;o financeira quando inexiste nos autos prova de autoriza&ccedil;&atilde;o expressa do correntista para a realiza&ccedil;&atilde;o dos descontos, &ocirc;nus que incumbia ao banco, especialmente diante da invers&atilde;o do &ocirc;nus da prova reconhecida na pr&oacute;pria senten&ccedil;a recorrida.
+5. A extin&ccedil;&atilde;o prematura do feito em rela&ccedil;&atilde;o ao Banco Bradesco S/A, sem aprecia&ccedil;&atilde;o das demais preliminares suscitadas na contesta&ccedil;&atilde;o &ndash;  falta de interesse de agir, in&eacute;pcia da inicial, impugna&ccedil;&atilde;o &agrave; justi&ccedil;a gratuita, prescri&ccedil;&atilde;o e decad&ecirc;ncia &ndash; , impede o julgamento imediato do m&eacute;rito pelo Tribunal, pois a causa n&atilde;o se encontra madura para tanto, impondo-se a anula&ccedil;&atilde;o da senten&ccedil;a para que o ju&iacute;zo de origem aprecie todas as quest&otilde;es preliminares e, se for o caso, prossiga no exame do m&eacute;rito.
+IV. DISPOSITIVO
+Recurso provido para anular a senten&ccedil;a.
+Tese de julgamento:
+1. A institui&ccedil;&atilde;o financeira que administra conta corrente e efetua descontos em favor de terceiro, sem verificar a regular autoriza&ccedil;&atilde;o do titular, possui legitimidade passiva em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito, respondendo objetivamente pelos danos causados, nos termos do art. 14 do CDC e da S&uacute;mula 479 do STJ.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801548-20.2024.8.12.0020,&nbsp; Rio Brilhante,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Vitor Luis de Oliveira Guibo, j: 16/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Vitor Luis de Oliveira Guibo
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Brilhante
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS. PRELIMINAR DE ILEGITIMIDADE PASSIVA ACOLHIDA NA ORIGEM. BANCO RESPONSÁVEL PELA GESTÃO E SEGURANÇA DA CONTA CORRENTE. DESCONTOS INDEVIDOS REALIZADOS SEM AUTORIZAÇÃO DA CORRENTISTA. RESPONSABILIDADE OBJETIVA. CDC. AUSÊNCIA DE APRECIAÇÃO DAS DEMAIS PRELIMINARES SUSCITADAS NA CONTESTAÇÃO. CAUSA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS. PRELIMINAR DE ILEGITIMIDADE PASSIVA ACOLHIDA NA ORIGEM. BANCO RESPONSÁVEL PELA GESTÃO E SEGURANÇA DA CONTA CORRENTE. DESCONTOS INDEVIDOS REALIZADOS SEM AUTORIZAÇÃO DA CORRENTISTA. RESPONSABILIDADE OBJETIVA. CDC. AUSÊNCIA DE APRECIAÇÃO DAS DEMAIS PRELIMINARES SUSCITADAS NA CONTESTAÇÃO. CAUSA NÃO MADURA PARA JULGAMENTO DIRETO. ANULAÇÃO DA SENTENÇA. RECURSO PROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta por Julia Genésia Garcia contra sentença que acolheu a preliminar de ilegitimidade passiva do Banco Bradesco S/A e extinguiu o feito sem resolução de mérito, nos termos do art. 485, VI, do Código de Processo Civil, condenando a autora ao pagamento das custas processuais e honorários advocatícios, com exigibilidade suspensa em razão da gratuidade da justiça.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão central consiste em definir se o Banco Bradesco S/A detém legitimidade passiva para figurar no polo passivo de ação declaratória de inexistência de débito cumulada com indenização por danos materiais e morais, em razão de descontos realizados em conta corrente de sua titularidade sem autorização expressa da correntista.
+III. RAZÕES DE DECIDIR
+3. O banco que administra conta corrente e efetua descontos em favor de terceiro sem verificar a regularidade da autorização do correntista responde objetivamente pelos danos causados, nos termos do art. 14 do Código de Defesa do Consumidor e da Súmula 479 do Superior Tribunal de Justiça, que estabelece a responsabilidade objetiva das instituições financeiras pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no âmbito de operações bancárias.
+4. A mera intermediação operacional não afasta a legitimidade passiva da instituição financeira quando inexiste nos autos prova de autorização expressa do correntista para a realização dos descontos, ônus que incumbia ao banco, especialmente diante da inversão do ônus da prova reconhecida na própria sentença recorrida.
+5. A extinção prematura do feito em relação ao Banco Bradesco S/A, sem apreciação das demais preliminares suscitadas na contestação –  falta de interesse de agir, inépcia da inicial, impugnação à justiça gratuita, prescrição e decadência – , impede o julgamento imediato do mérito pelo Tribunal, pois a causa não se encontra madura para tanto, impondo-se a anulação da sentença para que o juízo de origem aprecie todas as questões preliminares e, se for o caso, prossiga no exame do mérito.
+IV. DISPOSITIVO
+Recurso provido para anular a sentença.
+Tese de julgamento:
+1. A instituição financeira que administra conta corrente e efetua descontos em favor de terceiro, sem verificar a regular autorização do titular, possui legitimidade passiva em ação declaratória de inexistência de débito, respondendo objetivamente pelos danos causados, nos termos do art. 14 do CDC e da Súmula 479 do STJ.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>42&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878307" cdForo="0" >
+										0806969-79.2023.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878307" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878307);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878307" style="display: none;" >
+	<div id="textAreaDados_1878307" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O DE DANOS MORAIS E EST&Eacute;TICOS &ndash; RECURSOS INTERPOSTOS PELAS EMPRESAS REQUERIDAS &ndash; CONCESSION&Aacute;RIA E PRESTADORA DE SERVI&Ccedil;OS P&Uacute;BLICOS &ndash;&nbsp;ACIDENTE&nbsp;DE TR&Acirc;NSITO COM MOTOCICLISTA &ndash;&nbsp; FIO SOLTO NA VIA P&Uacute;BLICA &ndash;  HIP&Oacute;TESE DE RESPONSABILIDADE OBJETIVA, PELA TEORIA DO RISCO ADMINISTRATIVO &ndash; NEXO CAUSAL DEMONSTRADO &ndash; CULPA DE TERCEIRO N&Atilde;O DEMONSTRADA &ndash; ALEGADA PROPRIEDADE E RESPONSABILIDADE DE OUTRA EMPRESA PELO FIO N&Atilde;O COMPROVADA &ndash; DANO MORAL CONFIGURADO &ndash; DANO EST&Eacute;TICO COMPROVADO. PEDIDO DE REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO &ndash; N&Atilde;O ACOLHIDO &ndash; ATENDIMENTO AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; SENTEN&Ccedil;A MANTIDA. RECURSOS DESPROVIDOS. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806969-79.2023.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE REPARAÇÃO DE DANOS MORAIS E ESTÉTICOS – RECURSOS INTERPOSTOS PELAS EMPRESAS REQUERIDAS – CONCESSIONÁRIA E PRESTADORA DE SERVIÇOS PÚBLICOS – ACIDENTE DE TRÂNSITO COM MOTOCICLISTA –  FIO SOLTO NA VIA PÚBLICA –  HIPÓTESE DE RESPONSABILIDADE OBJETIVA, PELA TEORIA DO RISCO ADMINISTRATIVO – NEXO CAUSAL DEMONSTRADO – CULPA DE TERCEIRO NÃO DEMONSTRADA – ALEGADA PROPRIEDADE E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE REPARAÇÃO DE DANOS MORAIS E ESTÉTICOS – RECURSOS INTERPOSTOS PELAS EMPRESAS REQUERIDAS – CONCESSIONÁRIA E PRESTADORA DE SERVIÇOS PÚBLICOS – ACIDENTE DE TRÂNSITO COM MOTOCICLISTA –  FIO SOLTO NA VIA PÚBLICA –  HIPÓTESE DE RESPONSABILIDADE OBJETIVA, PELA TEORIA DO RISCO ADMINISTRATIVO – NEXO CAUSAL DEMONSTRADO – CULPA DE TERCEIRO NÃO DEMONSTRADA – ALEGADA PROPRIEDADE E RESPONSABILIDADE DE OUTRA EMPRESA PELO FIO NÃO COMPROVADA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – <em>DANO</em> ESTÉTICO COMPROVADO. PEDIDO DE REDUÇÃO DO QUANTUM INDENIZATÓRIO – NÃO ACOLHIDO – ATENDIMENTO AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA MANTIDA. RECURSOS DESPROVIDOS.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>43&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878356" cdForo="0" >
+										0806491-86.2024.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878356" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878356);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878356" style="display: none;" >
+	<div id="textAreaDados_1878356" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; ACORDO CELEBRADO COM UM DOS R&Eacute;US (INSTITUI&Ccedil;&Atilde;O FINANCEIRA) &ndash; SOLIDARIEDADE PASSIVA CONFIGURADA &ndash; ART. 7&ordm;, PAR&Aacute;GRAFO &Uacute;NICO, E ART. 25, &sect; 1&ordm;, AMBOS DO CDC &ndash; EXTENS&Atilde;O DOS EFEITOS DA TRANSA&Ccedil;&Atilde;O AO CODEVEDOR &ndash; ART. 844, &sect; 3&ordm;, DO C&Oacute;DIGO CIVIL &ndash; QUITA&Ccedil;&Atilde;O INTEGRAL DO OBJETO DA LIDE &ndash; EXTIN&Ccedil;&Atilde;O DA OBRIGA&Ccedil;&Atilde;O QUANTO A TODOS OS DEVEDORES &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A responsabilidade entre os integrantes da cadeia de fornecimento de servi&ccedil;os (banco e entidade conveniada) &eacute; solid&aacute;ria, nos termos do C&oacute;digo de Defesa do Consumidor.
+A transa&ccedil;&atilde;o celebrada entre o credor e um dos devedores solid&aacute;rios extingue a d&iacute;vida em rela&ccedil;&atilde;o aos demais co-devedores, salvo se houver ressalva expressa, o que n&atilde;o ocorreu no caso em tela.
+Uma vez quitado o valor acordado para dar fim &agrave; lide que discutia a inexist&ecirc;ncia do d&eacute;bito e o dano moral, a obriga&ccedil;&atilde;o est&aacute; satisfeita, n&atilde;o subsistindo interesse processual no prosseguimento do feito contra o corr&eacute;u.
+Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806491-86.2024.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – ACORDO CELEBRADO COM UM DOS RÉUS (INSTITUIÇÃO FINANCEIRA) – SOLIDARIEDADE PASSIVA CONFIGURADA – ART. 7º, PARÁGRAFO ÚNICO, E ART. 25, § 1º, AMBOS DO CDC – EXTENSÃO DOS EFEITOS DA TRANSAÇÃO AO CODEVEDOR – ART. 844, § 3º, DO CÓDIGO CIVIL – QUITAÇÃO INTEGRAL DO OBJETO DA LIDE – EXTINÇÃO DA OBRIGAÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – ACORDO CELEBRADO COM UM DOS RÉUS (INSTITUIÇÃO FINANCEIRA) – SOLIDARIEDADE PASSIVA CONFIGURADA – ART. 7º, PARÁGRAFO ÚNICO, E ART. 25, § 1º, AMBOS DO CDC – EXTENSÃO DOS EFEITOS DA TRANSAÇÃO AO CODEVEDOR – ART. 844, § 3º, DO CÓDIGO CIVIL – QUITAÇÃO INTEGRAL DO OBJETO DA LIDE – EXTINÇÃO DA OBRIGAÇÃO QUANTO A TODOS OS DEVEDORES – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+A responsabilidade entre os integrantes da cadeia de fornecimento de serviços (banco e entidade conveniada) é solidária, nos termos do Código de Defesa do Consumidor.
+A transação celebrada entre o credor e um dos devedores solidários extingue a dívida em relação aos demais co-devedores, salvo se houver ressalva expressa, o que não ocorreu no caso em tela.
+Uma vez quitado o valor acordado para dar fim à lide que discutia a inexistência do débito e o <em>dano</em> <em>moral</em>, a obrigação está satisfeita, não subsistindo interesse processual no prosseguimento do feito contra o corréu.
+Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>44&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878364" cdForo="0" >
+										0828473-76.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878364" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878364);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878364" style="display: none;" >
+	<div id="textAreaDados_1878364" class="mensagemSemFormatacao" >
+		EMENTA - APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZAT&Oacute;RIA &ndash; MOTORISTA DE APLICATIVO E PLATAFORMA DE TECNOLOGIA &ndash; DESCREDENCIAMENTO DE CONTA &ndash; LOCALIZA&Ccedil;&Atilde;O DE APONTAMENTO CRIMINAL ANTIGO COM TRANSA&Ccedil;&Atilde;O PENAL &ndash; IRRELEV&Acirc;NCIA PARA A SEARA CIVIL &ndash; LIBERDADE CONTRATUAL E AUTONOMIA DA VONTADE &ndash; EXERC&Iacute;CIO REGULAR DE DIREITO DA EMPRESA &ndash; VIOLA&Ccedil;&Atilde;O AOS TERMOS DE USO E &Agrave; POL&Iacute;TICA DE SEGURAN&Ccedil;A &ndash; IL&Iacute;CITO CIVIL N&Atilde;O CONFIGURADO &ndash; DANOS MORAIS E LUCROS CESSANTES INDEVIDOS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A rela&ccedil;&atilde;o havida entre os motoristas parceiros e as plataformas de aplicativos de transporte possui natureza civil, regendo-se pelos princ&iacute;pios da liberdade contratual e da autonomia da vontade (art. 421 do CC).
+Conquanto o cumprimento de transa&ccedil;&atilde;o penal obste a gera&ccedil;&atilde;o de maus antecedentes na esfera criminal, tal fato n&atilde;o retira da empresa privada o direito de rescindir a parceria, especialmente quando as diretrizes internas de seguran&ccedil;a &ndash;  previamente aceitas pelo usu&aacute;rio por meio dos Termos de Uso &ndash;  estabelecem a aus&ecirc;ncia de apontamentos criminais como requisito para a manuten&ccedil;&atilde;o do cadastro.
+O descredenciamento de motorista que deixa de preencher os requisitos de seguran&ccedil;a da plataforma configura exerc&iacute;cio regular de direito (art. 188, I, do CC), recha&ccedil;ando a configura&ccedil;&atilde;o de ato il&iacute;cito e, por consequ&ecirc;ncia, o dever de indenizar a t&iacute;tulo de lucros cessantes ou danos morais.
+Recurso conhecido e desprovido. Senten&ccedil;a mantida. Honor&aacute;rios recursais majorados, com exigibilidade suspensa.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0828473-76.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMENTA - APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZATÓRIA – MOTORISTA DE APLICATIVO E PLATAFORMA DE TECNOLOGIA – DESCREDENCIAMENTO DE CONTA – LOCALIZAÇÃO DE APONTAMENTO CRIMINAL ANTIGO COM TRANSAÇÃO PENAL – IRRELEVÂNCIA PARA A SEARA CIVIL – LIBERDADE CONTRATUAL E AUTONOMIA DA VONTADE – EXERCÍCIO REGULAR DE DIREITO DA EMPRESA – VIOLAÇÃO AOS TERMOS DE USO E À POLÍTICA DE SEGURANÇA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMENTA - APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZATÓRIA – MOTORISTA DE APLICATIVO E PLATAFORMA DE TECNOLOGIA – DESCREDENCIAMENTO DE CONTA – LOCALIZAÇÃO DE APONTAMENTO CRIMINAL ANTIGO COM TRANSAÇÃO PENAL – IRRELEVÂNCIA PARA A SEARA CIVIL – LIBERDADE CONTRATUAL E AUTONOMIA DA VONTADE – EXERCÍCIO REGULAR DE DIREITO DA EMPRESA – VIOLAÇÃO AOS TERMOS DE USO E À POLÍTICA DE SEGURANÇA – ILÍCITO CIVIL NÃO CONFIGURADO – DANOS MORAIS E LUCROS CESSANTES INDEVIDOS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+A relação havida entre os motoristas parceiros e as plataformas de aplicativos de transporte possui natureza civil, regendo-se pelos princípios da liberdade contratual e da autonomia da vontade (art. 421 do CC).
+Conquanto o cumprimento de transação penal obste a geração de maus antecedentes na esfera criminal, tal fato não retira da empresa privada o direito de rescindir a parceria, especialmente quando as diretrizes internas de segurança –  previamente aceitas pelo usuário por meio dos Termos de Uso –  estabelecem a ausência de apontamentos criminais como requisito para a manutenção do cadastro.
+O descredenciamento de motorista que deixa de preencher os requisitos de segurança da plataforma configura exercício regular de direito (art. 188, I, do CC), rechaçando a configuração de ato ilícito e, por consequência, o dever de indenizar a título de lucros cessantes ou danos morais.
+Recurso conhecido e desprovido. Sentença mantida. Honorários recursais majorados, com exigibilidade suspensa.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>45&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878371" cdForo="0" >
+										0806053-74.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878371" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878371);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878371" style="display: none;" >
+	<div id="textAreaDados_1878371" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; DESCONTOS N&Atilde;O AUTORIZADOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; INEXIST&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O RECONHECIDA NA ORIGEM &ndash; DANO MORAL CONFIGURADO &ndash; PRIVA&Ccedil;&Atilde;O DE VERBA DE NATUREZA ALIMENTAR &ndash; DANO IN RE IPSA &ndash; QUANTUM INDENIZAT&Oacute;RIO FIXADO EM R$ 5.000,00 &ndash; OBSERV&Acirc;NCIA AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; JUROS DE MORA &ndash; RESPONSABILIDADE EXTRACONTRATUAL &ndash; TERMO INICIAL A PARTIR DO EVENTO DANOSO &ndash; INTELIG&Ecirc;NCIA DA S&Uacute;MULA 54 DO SUPERIOR TRIBUNAL DE JUSTI&Ccedil;A &ndash; REDISTRIBUI&Ccedil;&Atilde;O DO &Ocirc;NUS DE SUCUMB&Ecirc;NCIA &ndash; RECURSO CONHECIDO E PROVIDO EM TERMOS.
+A realiza&ccedil;&atilde;o de descontos n&atilde;o autorizados em benef&iacute;cio previdenci&aacute;rio, verba de ineg&aacute;vel car&aacute;ter alimentar essencial &agrave; subsist&ecirc;ncia, extrapola o mero aborrecimento cotidiano e configura dano moral presumido (in re ipsa), ensejando o dever de indenizar.
+Na fixa&ccedil;&atilde;o do quantum indenizat&oacute;rio, deve o magistrado observar os princ&iacute;pios da razoabilidade e da proporcionalidade, atendendo &agrave; dupla finalidade da condena&ccedil;&atilde;o (compensat&oacute;ria e pedag&oacute;gica), sem propiciar o enriquecimento sem causa da v&iacute;tima. O valor de R$ 5.000,00 (cinco mil reais) revela-se adequado &agrave;s circunst&acirc;ncias do caso e aos precedentes da C&acirc;mara.
+Tratando-se de responsabilidade extracontratual decorrente de fraude ou inexist&ecirc;ncia de contrata&ccedil;&atilde;o, os juros de mora incidentes sobre a indeniza&ccedil;&atilde;o por danos morais fluem a partir do evento danoso (data do primeiro desconto indevido), nos moldes da S&uacute;mula 54 do Superior Tribunal de Justi&ccedil;a.
+Recurso conhecido e provido em termos. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806053-74.2025.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – DESCONTOS NÃO AUTORIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – INEXISTÊNCIA DE CONTRATAÇÃO RECONHECIDA NA ORIGEM – <em>DANO</em> <em>MORAL</em> CONFIGURADO – PRIVAÇÃO DE VERBA DE NATUREZA ALIMENTAR – <em>DANO</em> IN RE IPSA – QUANTUM INDENIZATÓRIO FIXADO EM R$ 5.000,00 –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – DESCONTOS NÃO AUTORIZADOS EM BENEFÍCIO PREVIDENCIÁRIO – INEXISTÊNCIA DE CONTRATAÇÃO RECONHECIDA NA ORIGEM – <em>DANO</em> <em>MORAL</em> CONFIGURADO – PRIVAÇÃO DE VERBA DE NATUREZA ALIMENTAR – <em>DANO</em> IN RE IPSA – QUANTUM INDENIZATÓRIO FIXADO EM R$ 5.000,00 – OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – JUROS DE MORA – RESPONSABILIDADE EXTRACONTRATUAL – TERMO INICIAL A PARTIR DO EVENTO DANOSO – INTELIGÊNCIA DA SÚMULA 54 DO SUPERIOR TRIBUNAL DE JUSTIÇA – REDISTRIBUIÇÃO DO ÔNUS DE SUCUMBÊNCIA – RECURSO CONHECIDO E PROVIDO EM TERMOS.
+A realização de descontos não autorizados em benefício previdenciário, verba de inegável caráter alimentar essencial à subsistência, extrapola o mero aborrecimento cotidiano e configura <em>dano</em> <em>moral</em> presumido (in re ipsa), ensejando o dever de indenizar.
+Na fixação do quantum indenizatório, deve o magistrado observar os princípios da razoabilidade e da proporcionalidade, atendendo à dupla finalidade da condenação (compensatória e pedagógica), sem propiciar o enriquecimento sem causa da vítima. O valor de R$ 5.000,00 (cinco mil reais) revela-se adequado às circunstâncias do caso e aos precedentes da Câmara.
+Tratando-se de responsabilidade extracontratual decorrente de fraude ou inexistência de contratação, os juros de mora incidentes sobre a indenização por danos morais fluem a partir do evento danoso (data do primeiro desconto indevido), nos moldes da Súmula 54 do Superior Tribunal de Justiça.
+Recurso conhecido e provido em termos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>46&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878382" cdForo="0" >
+										0801982-24.2024.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878382" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878382);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878382" style="display: none;" >
+	<div id="textAreaDados_1878382" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE NEG&Oacute;CIO JUR&Iacute;DICO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; PEDIDO DE MAJORA&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO &ndash; IMPOSSIBILIDADE &ndash; VALOR ARBITRADO EM CONSON&Acirc;NCIA COM OS PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE &ndash; MAJORA&Ccedil;&Atilde;O DOS HONOR&Aacute;RIOS SUCUMBENCIAIS OU FIXA&Ccedil;&Atilde;O POR EQUIDADE &ndash; DESCABIMENTO &ndash; APLICA&Ccedil;&Atilde;O DO TEMA 1.076 DO STJ E DO ART. 85, &sect; 2&ordm;, DO CPC &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+O valor da indeniza&ccedil;&atilde;o por danos morais deve ser fixado com modera&ccedil;&atilde;o, em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e da proporcionalidade, servindo para compensar a v&iacute;tima pelo abalo sofrido e punir o ofensor, sem importar em enriquecimento sem causa. A quantia de R$ 4.000,00 revela-se adequada e suficiente para as peculiaridades do caso.
+Havendo condena&ccedil;&atilde;o mensur&aacute;vel em dinheiro, os honor&aacute;rios advocat&iacute;cios devem ser fixados entre 10% e 20% sobre esse valor, conforme o art. 85, &sect; 2&ordm;, do CPC, sendo vedada a fixa&ccedil;&atilde;o por aprecia&ccedil;&atilde;o equitativa, em estrita observ&acirc;ncia ao Tema Repetitivo n&ordm; 1.076 do Superior Tribunal de Justi&ccedil;a. O percentual de 15% fixado na origem remunera adequadamente o trabalho desenvolvido.
+Tratando-se de recurso integralmente desprovido, imp&otilde;e-se a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios, por for&ccedil;a do disposto no &sect; 11 do art. 85 do CPC.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801982-24.2024.8.12.0015,&nbsp; Miranda,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – PEDIDO DE MAJORAÇÃO DO QUANTUM INDENIZATÓRIO – IMPOSSIBILIDADE – VALOR ARBITRADO EM CONSONÂNCIA COM OS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE – MAJORAÇÃO DOS HONORÁRIOS SUCUMBENCIAIS OU FIXAÇÃO POR EQUIDADE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE NEGÓCIO JURÍDICO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – PEDIDO DE MAJORAÇÃO DO QUANTUM INDENIZATÓRIO – IMPOSSIBILIDADE – VALOR ARBITRADO EM CONSONÂNCIA COM OS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE – MAJORAÇÃO DOS HONORÁRIOS SUCUMBENCIAIS OU FIXAÇÃO POR EQUIDADE – DESCABIMENTO – APLICAÇÃO DO TEMA 1.076 DO STJ E DO ART. 85, § 2º, DO CPC – RECURSO CONHECIDO E NÃO PROVIDO.
+O valor da indenização por danos morais deve ser fixado com moderação, em observância aos princípios da razoabilidade e da proporcionalidade, servindo para compensar a vítima pelo abalo sofrido e punir o ofensor, sem importar em enriquecimento sem causa. A quantia de R$ 4.000,00 revela-se adequada e suficiente para as peculiaridades do caso.
+Havendo condenação mensurável em dinheiro, os honorários advocatícios devem ser fixados entre 10% e 20% sobre esse valor, conforme o art. 85, § 2º, do CPC, sendo vedada a fixação por apreciação equitativa, em estrita observância ao Tema Repetitivo nº 1.076 do Superior Tribunal de Justiça. O percentual de 15% fixado na origem remunera adequadamente o trabalho desenvolvido.
+Tratando-se de recurso integralmente desprovido, impõe-se a majoração dos honorários advocatícios, por força do disposto no § 11 do art. 85 do CPC.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>47&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878383" cdForo="0" >
+										0850718-18.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878383" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878383);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878383" style="display: none;" >
+	<div id="textAreaDados_1878383" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL (RMC) C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E RESTITUI&Ccedil;&Atilde;O DE VALORES &ndash; CONTRATA&Ccedil;&Atilde;O V&Aacute;LIDA &ndash; AUS&Ecirc;NCIA DE V&Iacute;CIO DE CONSENTIMENTO &ndash; INFORMA&Ccedil;&Otilde;ES CLARAS NO INSTRUMENTO CONTRATUAL &ndash; SAQUE DO LIMITE DE CR&Eacute;DITO &ndash; OPERA&Ccedil;&Atilde;O REGULAR E INERENTE &Agrave; MODALIDADE &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA &ndash; HONOR&Aacute;RIOS RECURSAIS FIXADOS &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+&Eacute; l&iacute;cita e v&aacute;lida a contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito com reserva de margem consign&aacute;vel (RMC) quando o instrumento assinado pelo consumidor disp&otilde;e de forma expressa sobre a modalidade do cr&eacute;dito, a autoriza&ccedil;&atilde;o para desconto do m&iacute;nimo da fatura e a incid&ecirc;ncia de juros rotativos.
+A realiza&ccedil;&atilde;o de saque do limite de cr&eacute;dito disponibilizado no cart&atilde;o, com a correspondente transfer&ecirc;ncia do numer&aacute;rio para a conta banc&aacute;ria do consumidor, constitui opera&ccedil;&atilde;o regular e prevista para esta esp&eacute;cie de pacto, n&atilde;o configurando, de forma isolada, abusividade ou induzimento a erro. Inexistindo prova de v&iacute;cio de consentimento e n&atilde;o demonstrada qualquer falha na presta&ccedil;&atilde;o do servi&ccedil;o pela institui&ccedil;&atilde;o financeira, a manuten&ccedil;&atilde;o da senten&ccedil;a que julgou improcedentes os pedidos iniciais &eacute; medida que se imp&otilde;e.
+Desprovido integralmente o recurso, &eacute; devida a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios de sucumb&ecirc;ncia, conforme a regra do artigo 85, &sect; 11, do C&oacute;digo de Processo Civil.
+Recurso conhecido e n&atilde;o provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0850718-18.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC) C/C INDENIZAÇÃO POR DANOS MORAIS E RESTITUIÇÃO DE VALORES – CONTRATAÇÃO VÁLIDA – AUSÊNCIA DE VÍCIO DE CONSENTIMENTO – INFORMAÇÕES CLARAS NO INSTRUMENTO CONTRATUAL – SAQUE DO LIMITE DE CRÉDITO – OPERAÇÃO REGULAR E INERENTE À MODALIDADE – SENTENÇA DE IMPROCEDÊNCIA MANTIDA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC) C/C INDENIZAÇÃO POR DANOS MORAIS E RESTITUIÇÃO DE VALORES – CONTRATAÇÃO VÁLIDA – AUSÊNCIA DE VÍCIO DE CONSENTIMENTO – INFORMAÇÕES CLARAS NO INSTRUMENTO CONTRATUAL – SAQUE DO LIMITE DE CRÉDITO – OPERAÇÃO REGULAR E INERENTE À MODALIDADE – SENTENÇA DE IMPROCEDÊNCIA MANTIDA – HONORÁRIOS RECURSAIS FIXADOS – RECURSO CONHECIDO E NÃO PROVIDO.
+É lícita e válida a contratação de cartão de crédito com reserva de margem consignável (RMC) quando o instrumento assinado pelo consumidor dispõe de forma expressa sobre a modalidade do crédito, a autorização para desconto do mínimo da fatura e a incidência de juros rotativos.
+A realização de saque do limite de crédito disponibilizado no cartão, com a correspondente transferência do numerário para a conta bancária do consumidor, constitui operação regular e prevista para esta espécie de pacto, não configurando, de forma isolada, abusividade ou induzimento a erro. Inexistindo prova de vício de consentimento e não demonstrada qualquer falha na prestação do serviço pela instituição financeira, a manutenção da sentença que julgou improcedentes os pedidos iniciais é medida que se impõe.
+Desprovido integralmente o recurso, é devida a majoração dos honorários advocatícios de sucumbência, conforme a regra do artigo 85, § 11, do Código de Processo Civil.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>48&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878387" cdForo="0" >
+										1402247-51.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878387" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878387);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878387" style="display: none;" >
+	<div id="textAreaDados_1878387" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; TUTELA DE URG&Ecirc;NCIA &ndash; CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC) &ndash; PEDIDO DE CANCELAMENTO DO CART&Atilde;O E SUSPENS&Atilde;O DOS DESCONTOS EM FOLHA DE PAGAMENTO &ndash; DIREITO POTESTATIVO DO CONSUMIDOR DE RESCINDIR O SERVI&Ccedil;O DE CR&Eacute;DITO &ndash; CANCELAMENTO DO PL&Aacute;STICO DEVIDO &ndash; SUSPENS&Atilde;O DOS DESCONTOS MENSAIS &ndash; IMPOSSIBILIDADE &ndash; MANUTEN&Ccedil;&Atilde;O AT&Eacute; A QUITA&Ccedil;&Atilde;O DE EVENTUAL SALDO DEVEDOR PREEXISTENTE &ndash; DECIS&Atilde;O PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O consumidor possui o direito potestativo de postular o cancelamento de cart&atilde;o de cr&eacute;dito a qualquer tempo, a fim de evitar a cobran&ccedil;a de novos encargos e anuidades atrelados &agrave; mera disponibiliza&ccedil;&atilde;o do servi&ccedil;o, restando preenchidos os requisitos do art. 300 do CPC neste aspecto. O cancelamento do cart&atilde;o de cr&eacute;dito n&atilde;o extingue a d&iacute;vida contra&iacute;da em momento anterior &agrave; rescis&atilde;o. Inexistindo prova inequ&iacute;voca da quita&ccedil;&atilde;o integral do d&eacute;bito, revela-se invi&aacute;vel a suspens&atilde;o imediata dos descontos efetuados na folha de pagamento da parte agravante, devendo as consigna&ccedil;&otilde;es serem mantidas para a amortiza&ccedil;&atilde;o do saldo devedor at&eacute; o seu integral adimplemento.
+Recurso conhecido e parcialmente provido.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1402247-51.2026.8.12.0000,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C OBRIGAÇÃO DE FAZER – TUTELA DE URGÊNCIA – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – PEDIDO DE CANCELAMENTO DO CARTÃO E SUSPENSÃO DOS DESCONTOS EM FOLHA DE PAGAMENTO – DIREITO POTESTATIVO DO CONSUMIDOR DE RESCINDIR O SERVIÇO DE CRÉDITO – CANCELAMENTO DO PLÁSTICO DEVIDO – SUSPENSÃO DOS DESCONTOS MENSAIS – IMPOSSIBILIDADE –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C OBRIGAÇÃO DE FAZER – TUTELA DE URGÊNCIA – CARTÃO DE CRÉDITO CONSIGNADO (RMC) – PEDIDO DE CANCELAMENTO DO CARTÃO E SUSPENSÃO DOS DESCONTOS EM FOLHA DE PAGAMENTO – DIREITO POTESTATIVO DO CONSUMIDOR DE RESCINDIR O SERVIÇO DE CRÉDITO – CANCELAMENTO DO PLÁSTICO DEVIDO – SUSPENSÃO DOS DESCONTOS MENSAIS – IMPOSSIBILIDADE – MANUTENÇÃO ATÉ A QUITAÇÃO DE EVENTUAL SALDO DEVEDOR PREEXISTENTE – DECISÃO PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O consumidor possui o direito potestativo de postular o cancelamento de cartão de crédito a qualquer tempo, a fim de evitar a cobrança de novos encargos e anuidades atrelados à mera disponibilização do serviço, restando preenchidos os requisitos do art. 300 do CPC neste aspecto. O cancelamento do cartão de crédito não extingue a dívida contraída em momento anterior à rescisão. Inexistindo prova inequívoca da quitação integral do débito, revela-se inviável a suspensão imediata dos descontos efetuados na folha de pagamento da parte agravante, devendo as consignações serem mantidas para a amortização do saldo devedor até o seu integral adimplemento.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>49&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878407" cdForo="0" >
+										0823803-97.2022.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878407" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878407);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878407" style="display: none;" >
+	<div id="textAreaDados_1878407" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSOS DE APELA&Ccedil;&Atilde;O E RECURSO ADESIVO. COBRAN&Ccedil;A VEXAT&Oacute;RIA POR LIGA&Ccedil;&Otilde;ES EXCESSIVAS AP&Oacute;S DECLARA&Ccedil;&Atilde;O DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO. RECURSOS DESPROVIDOS.
+CASO EM EXAME
+Recursos de apela&ccedil;&atilde;o interpostos por Banco Votorantim S/A e, adesivamente, por Geovano de O. contra senten&ccedil;a que julgou procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, em raz&atilde;o de cobran&ccedil;as indevidas e reiteradas, inclusive no local de trabalho do autor, fixando indeniza&ccedil;&atilde;o em R$ 10.000,00, com crit&eacute;rios de corre&ccedil;&atilde;o monet&aacute;ria e juros, e definindo honor&aacute;rios.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) saber se a conduta de cobran&ccedil;a, com liga&ccedil;&otilde;es excessivas e reiteradas, inclusive ao local de trabalho do consumidor, ap&oacute;s reconhecimento judicial da inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica, configura dano moral indeniz&aacute;vel, &agrave; luz do CDC e da responsabilidade objetiva do fornecedor; e (ii) saber se o quantum indenizat&oacute;rio de R$ 10.000,00 e os crit&eacute;rios de atualiza&ccedil;&atilde;o (inclusive com aplica&ccedil;&atilde;o da SELIC nos termos definidos na senten&ccedil;a em raz&atilde;o de legisla&ccedil;&atilde;o superveniente) devem ser alterados, bem como se &eacute; cab&iacute;vel a majora&ccedil;&atilde;o do dano moral e dos honor&aacute;rios no recurso adesivo.
+RAZ&Otilde;ES DE DECIDIR
+Manteve-se a senten&ccedil;a quanto &agrave; responsabilidade do banco e ao dever de indenizar, porque a controv&eacute;rsia &eacute; regida pelo CDC (CDC, art. 3&ordm;, &sect; 2&ordm;; S&uacute;mula n&ordm; 297 do STJ) e a responsabilidade do fornecedor &eacute; objetiva (CDC, art. 14). Reconheceram-se hipossufici&ecirc;ncia e verossimilhan&ccedil;a, autorizando a invers&atilde;o do &ocirc;nus da prova (CDC, art. 6&ordm;, VIII), sem que o r&eacute;u demonstrasse excludente. A prova testemunhal descreveu liga&ccedil;&otilde;es reiteradas e cobran&ccedil;a indevida de d&iacute;vida j&aacute; declarada inexistente, inclusive no local de trabalho, com exposi&ccedil;&atilde;o do autor e impacto no v&iacute;nculo empregat&iacute;cio. A situa&ccedil;&atilde;o excede mero aborrecimento e configura dano moral, com amparo em CF/1988, art. 5&ordm;, incs. V e X, CC, art. 186, e CDC, art. 6&ordm;, VI, conforme precedentes citados no voto (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 29/04/2025, p. 05/05/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0805745-24.2024.8.12.0018, Rel. Des&ordf; Jaceguara Dantas da Silva, 5&ordf; C&acirc;mara C&iacute;vel, j. 26/03/2025, p. 28/03/2025).
+Rejeitou-se a pretens&atilde;o de redu&ccedil;&atilde;o do quantum, porque o valor de R$ 10.000,00 foi considerado proporcional &agrave; gravidade da cobran&ccedil;a indevida e reiterada, especialmente no ambiente de trabalho, e adequado &agrave;s fun&ccedil;&otilde;es compensat&oacute;ria, preventiva e punitiva da repara&ccedil;&atilde;o, sem ensejar enriquecimento sem causa e com preserva&ccedil;&atilde;o do car&aacute;ter pedag&oacute;gico.
+Manteve-se a disciplina de corre&ccedil;&atilde;o monet&aacute;ria e juros, porque a senten&ccedil;a j&aacute; aplicou a legisla&ccedil;&atilde;o superveniente (Lei n&ordm; 000), estabelecendo, a partir de 28/08/2024, corre&ccedil;&atilde;o pelo IPCA/IBGE e juros pela SELIC, deduzido o &iacute;ndice de atualiza&ccedil;&atilde;o, al&eacute;m de fixar, at&eacute; 27/08/2024, corre&ccedil;&atilde;o pelo IPCA e juros de 1% ao m&ecirc;s, com refer&ecirc;ncia a CC, art. 406, CTN, art. 161, &sect; 1&ordm;, e CC, art. 389, p.u.
+Negou-se provimento ao recurso adesivo do autor, porque o colegiado considerou adequado o montante de R$ 10.000,00 fixado a t&iacute;tulo de danos morais e n&atilde;o acolheu a majora&ccedil;&atilde;o pretendida, inclusive quanto aos honor&aacute;rios, conforme conclus&atilde;o expressa do voto.
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o do Banco Votorantim S/A conhecido e desprovido. Recurso adesivo de Geovano de Oliveira. conhecido e desprovido.
+Dispositivos relevantes citados: CDC, art. 3&ordm;, &sect; 2&ordm;; CDC, art. 6&ordm;, incs. VI e VIII; CDC, art. 14; CF/1988, art. 5&ordm;, incs. V e X; CC, art. 186; CC, art. 389, p.u.; CC, art. 406; CTN, art. 161, &sect; 1&ordm;; e CPC, art. 373, I.
+Jurisprud&ecirc;ncia relevante citada: STJ, S&uacute;mula n&ordm; 297; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 29/04/2025, p. 05/05/2025; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0805745-24.2024.8.12.0018, Rel. Des&ordf; Jaceguara Dantas da Silva, 5&ordf; C&acirc;mara C&iacute;vel, j. 26/03/2025, p. 28/03/2025. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0823803-97.2022.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(17 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSOS DE APELAÇÃO E RECURSO ADESIVO. COBRANÇA VEXATÓRIA POR LIGAÇÕES EXCESSIVAS APÓS DECLARAÇÃO DE INEXISTÊNCIA DE DÉBITO. RECURSOS DESPROVIDOS.
+CASO EM EXAME
+Recursos de apelação interpostos por Banco Votorantim S/A e, adesivamente, por Geovano de O. contra sentença que julgou procedente ação de indenização por danos morais, em razão de cobranças
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSOS DE APELAÇÃO E RECURSO ADESIVO. COBRANÇA VEXATÓRIA POR LIGAÇÕES EXCESSIVAS APÓS DECLARAÇÃO DE INEXISTÊNCIA DE DÉBITO. RECURSOS DESPROVIDOS.
+CASO EM EXAME
+Recursos de apelação interpostos por Banco Votorantim S/A e, adesivamente, por Geovano de O. contra sentença que julgou procedente ação de indenização por danos morais, em razão de cobranças indevidas e reiteradas, inclusive no local de trabalho do autor, fixando indenização em R$ 10.000,00, com critérios de correção monetária e juros, e definindo honorários.
+QUESTÃO EM DISCUSSÃO
+Há duas questões em discussão: (i) saber se a conduta de cobrança, com ligações excessivas e reiteradas, inclusive ao local de trabalho do consumidor, após reconhecimento judicial da inexistência de relação jurídica, configura <em>dano</em> <em>moral</em> indenizável, à luz do CDC e da responsabilidade objetiva do fornecedor; e (ii) saber se o quantum indenizatório de R$ 10.000,00 e os critérios de atualização (inclusive com aplicação da SELIC nos termos definidos na sentença em razão de legislação superveniente) devem ser alterados, bem como se é cabível a majoração do <em>dano</em> <em>moral</em> e dos honorários no recurso adesivo.
+RAZÕES DE DECIDIR
+Manteve-se a sentença quanto à responsabilidade do banco e ao dever de indenizar, porque a controvérsia é regida pelo CDC (CDC, art. 3º, § 2º; Súmula nº 297 do STJ) e a responsabilidade do fornecedor é objetiva (CDC, art. 14). Reconheceram-se hipossuficiência e verossimilhança, autorizando a inversão do ônus da prova (CDC, art. 6º, VIII), sem que o réu demonstrasse excludente. A prova testemunhal descreveu ligações reiteradas e cobrança indevida de dívida já declarada inexistente, inclusive no local de trabalho, com exposição do autor e impacto no vínculo empregatício. A situação excede mero aborrecimento e configura <em>dano</em> <em>moral</em>, com amparo em CF/1988, art. 5º, incs. V e X, CC, art. 186, e CDC, art. 6º, VI, conforme precedentes citados no voto (TJMS, Apelação Cível n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 29/04/2025, p. 05/05/2025; TJMS, Apelação Cível n. 0805745-24.2024.8.12.0018, Rel. Desª Jaceguara Dantas da Silva, 5ª Câmara Cível, j. 26/03/2025, p. 28/03/2025).
+Rejeitou-se a pretensão de redução do quantum, porque o valor de R$ 10.000,00 foi considerado proporcional à gravidade da cobrança indevida e reiterada, especialmente no ambiente de trabalho, e adequado às funções compensatória, preventiva e punitiva da reparação, sem ensejar enriquecimento sem causa e com preservação do caráter pedagógico.
+Manteve-se a disciplina de correção monetária e juros, porque a sentença já aplicou a legislação superveniente (Lei nº 000), estabelecendo, a partir de 28/08/2024, correção pelo IPCA/IBGE e juros pela SELIC, deduzido o índice de atualização, além de fixar, até 27/08/2024, correção pelo IPCA e juros de 1% ao mês, com referência a CC, art. 406, CTN, art. 161, § 1º, e CC, art. 389, p.u.
+Negou-se provimento ao recurso adesivo do autor, porque o colegiado considerou adequado o montante de R$ 10.000,00 fixado a título de danos morais e não acolheu a majoração pretendida, inclusive quanto aos honorários, conforme conclusão expressa do voto.
+DISPOSITIVO
+Recurso de apelação do Banco Votorantim S/A conhecido e desprovido. Recurso adesivo de Geovano de Oliveira. conhecido e desprovido.
+Dispositivos relevantes citados: CDC, art. 3º, § 2º; CDC, art. 6º, incs. VI e VIII; CDC, art. 14; CF/1988, art. 5º, incs. V e X; CC, art. 186; CC, art. 389, p.u.; CC, art. 406; CTN, art. 161, § 1º; e CPC, art. 373, I.
+Jurisprudência relevante citada: STJ, Súmula nº 297; TJMS, Apelação Cível n. 0823846-34.2022.8.12.0001, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 29/04/2025, p. 05/05/2025; e TJMS, Apelação Cível n. 0805745-24.2024.8.12.0018, Rel. Desª Jaceguara Dantas da Silva, 5ª Câmara Cível, j. 26/03/2025, p. 28/03/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>50&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878409" cdForo="0" >
+										0832601-76.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878409" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878409);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878409" style="display: none;" >
+	<div id="textAreaDados_1878409" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSO DE APELA&Ccedil;&Atilde;O. A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. PAGAMENTO DE BOLETO/PIX FRAUDULENTO EM SUPOSTO SITE DE CONCESSION&Aacute;RIA DE ENERGIA EL&Eacute;TRICA. RESPONSABILIDADE OBJETIVA E EXCLUDENTE POR CULPA EXCLUSIVA DE TERCEIRO. SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.
+CASO EM EXAME
+Recurso de apela&ccedil;&atilde;o interposto por Z.A.S. e J.A. contra senten&ccedil;a que julgou improcedentes pedidos de restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais, em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos materiais e morais fundada em pagamento fraudulento de faturas de energia el&eacute;trica.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em saber se o pagamento de faturas por meio de PIX/boletos gerados em ambiente digital, com benefici&aacute;rio diverso da concession&aacute;ria, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o apta a caracterizar fortuito interno e a gerar dever de restitui&ccedil;&atilde;o e indeniza&ccedil;&atilde;o, ou se h&aacute; excludente de responsabilidade por fato de terceiro e aus&ecirc;ncia de nexo causal, nos termos do art. 14, &sect; 3&ordm;, II, do CDC.
+RAZ&Otilde;ES DE DECIDIR
+Reconheceu-se a rela&ccedil;&atilde;o de consumo (CDC, arts. 2&ordm; e 3&ordm;) e a responsabilidade objetiva do fornecedor (CDC, art. 14). Assentou-se, contudo, que essa responsabilidade pode ser afastada quando configurada excludente legal (CDC, art. 14, &sect; 3&ordm;).
+Afastou-se a responsabilidade da concession&aacute;ria e manteve-se a improced&ecirc;ncia, porque os comprovantes indicaram benefici&aacute;rios distintos da r&eacute; (X55 e Autentica Pag Ltda.), sem prova segura de acesso ao site oficial para emiss&atilde;o de boleto. Concluiu-se pela aus&ecirc;ncia de nexo causal e pela configura&ccedil;&atilde;o de excludente de responsabilidade (CDC, art. 14, &sect; 3&ordm;, II), pois a fraude foi praticada por terceiro e os autores n&atilde;o demonstraram cautela m&iacute;nima. Aplicaram-se, como refor&ccedil;o, precedentes do pr&oacute;prio Tribunal em casos de pagamento de boleto fraudulento (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801316-17.2024.8.12.0017, Rel. Des&ordf; E.R.B., 4&ordf; C&acirc;mara C&iacute;vel, j. 26.11.2025, p. 27.11.2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 09.05.2025, p. 12.05.2025).
+Fixaram-se honor&aacute;rios recursais em 2% sobre o valor da causa, a serem somados aos honor&aacute;rios fixados na origem. Suspendeu-se a exigibilidade na forma do CPC, art. 98, &sect; 3&ordm;.
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o conhecido e desprovido.
+Dispositivos relevantes citados: CDC, arts. 2&ordm;, 3&ordm; e 14, &sect; 3&ordm;, II; e CPC, art. 98, &sect; 3&ordm;.
+Jurisprud&ecirc;ncia relevante citada: TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801316-17.2024.8.12.0017, Rel. Des&ordf; E.R.B., 4&ordf; C&acirc;mara C&iacute;vel, j. 26.11.2025, p. 27.11.2025; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2&ordf; C&acirc;mara C&iacute;vel, j. 09.05.2025, p. 12.05.2025  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0832601-76.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSO DE APELAÇÃO. AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – SENTENÇA DE IMPROCEDÊNCIA. PAGAMENTO DE BOLETO/PIX FRAUDULENTO EM SUPOSTO SITE DE CONCESSIONÁRIA DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E EXCLUDENTE POR CULPA EXCLUSIVA DE TERCEIRO. SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Z.A.S. e
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. RECURSO DE APELAÇÃO. AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – SENTENÇA DE IMPROCEDÊNCIA. PAGAMENTO DE BOLETO/PIX FRAUDULENTO EM SUPOSTO SITE DE CONCESSIONÁRIA DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E EXCLUDENTE POR CULPA EXCLUSIVA DE TERCEIRO. SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Z.A.S. e J.A. contra sentença que julgou improcedentes pedidos de restituição de valores e indenização por danos morais, em ação de indenização por danos materiais e morais fundada em pagamento fraudulento de faturas de energia elétrica.
+QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em saber se o pagamento de faturas por meio de PIX/boletos gerados em ambiente digital, com beneficiário diverso da concessionária, configura falha na prestação do serviço apta a caracterizar fortuito interno e a gerar dever de restituição e indenização, ou se há excludente de responsabilidade por fato de terceiro e ausência de nexo causal, nos termos do art. 14, § 3º, II, do CDC.
+RAZÕES DE DECIDIR
+Reconheceu-se a relação de consumo (CDC, arts. 2º e 3º) e a responsabilidade objetiva do fornecedor (CDC, art. 14). Assentou-se, contudo, que essa responsabilidade pode ser afastada quando configurada excludente legal (CDC, art. 14, § 3º).
+Afastou-se a responsabilidade da concessionária e manteve-se a improcedência, porque os comprovantes indicaram beneficiários distintos da ré (X55 e Autentica Pag Ltda.), sem prova segura de acesso ao site oficial para emissão de boleto. Concluiu-se pela ausência de nexo causal e pela configuração de excludente de responsabilidade (CDC, art. 14, § 3º, II), pois a fraude foi praticada por terceiro e os autores não demonstraram cautela mínima. Aplicaram-se, como reforço, precedentes do próprio Tribunal em casos de pagamento de boleto fraudulento (TJMS, Apelação Cível n. 0801316-17.2024.8.12.0017, Rel. Desª E.R.B., 4ª Câmara Cível, j. 26.11.2025, p. 27.11.2025; TJMS, Apelação Cível n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 09.05.2025, p. 12.05.2025).
+Fixaram-se honorários recursais em 2% sobre o valor da causa, a serem somados aos honorários fixados na origem. Suspendeu-se a exigibilidade na forma do CPC, art. 98, § 3º.
+DISPOSITIVO
+Recurso de apelação conhecido e desprovido.
+Dispositivos relevantes citados: CDC, arts. 2º, 3º e 14, § 3º, II; e CPC, art. 98, § 3º.
+Jurisprudência relevante citada: TJMS, Apelação Cível n. 0801316-17.2024.8.12.0017, Rel. Desª E.R.B., 4ª Câmara Cível, j. 26.11.2025, p. 27.11.2025; e TJMS, Apelação Cível n. 0800115-26.2024.8.12.0005, Rel. Juiz V.L.O.G., 2ª Câmara Cível, j. 09.05.2025, p. 12.05.2025
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>51&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878413" cdForo="0" >
+										0824187-89.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878413" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878413);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878413" style="display: none;" >
+	<div id="textAreaDados_1878413" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O &ndash; TRANSPORTE A&Eacute;REO &ndash; 	SENTEN&Ccedil;A DE PARCIAL PROCED&Ecirc;NCIA. TRANSPORTE A&Eacute;REO -  OVERBOOKING &ndash; RESPONSABILIDADE OBJETIVA &ndash; DANO MORAL CONFIGURADO &ndash; VALOR FIXADO PREENCHE OS REQUISITOS DA RAZOABILIDADE E PROPORCIONALIDADE.  SENTEN&Ccedil;A DEVIDAMENTE FUNDAMENTADA, RAZ&Atilde;O PORQUE DEVE SER MANTIDA. RECURSO CONHECIDO E DESPROVIDO. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0824187-89.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1878413" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO – TRANSPORTE AÉREO – 	SENTENÇA DE PARCIAL PROCEDÊNCIA. TRANSPORTE AÉREO -  OVERBOOKING – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – VALOR FIXADO PREENCHE OS REQUISITOS DA RAZOABILIDADE E PROPORCIONALIDADE.  SENTENÇA DEVIDAMENTE FUNDAMENTADA, RAZÃO PORQUE DEVE SER MANTIDA. RECURSO CONHECIDO E DESPROVIDO.
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>52&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878420" cdForo="0" >
+										0837422-89.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878420" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878420);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878420" style="display: none;" >
+	<div id="textAreaDados_1878420" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. PLANO DE SA&Uacute;DE. LEGITIMIDADE UNIMED CAMPO GRANDE CONFIRMADA. NEGATIVA DE COBERTURA DE PROCEDIMENTO CIR&Uacute;RGICO INDEVIDA. INDENIZA&Ccedil;&Atilde;O CAB&Iacute;VEL. QUANTUM RAZO&Aacute;VEL. SENTEN&Ccedil;A MANTIDA. RECURSO CONHECIDO E DESPROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0837422-89.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1878420" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												APELAÇÃO CÍVEL. AÇÃO DE OBRIGAÇÃO DE FAZER. PLANO DE SAÚDE. LEGITIMIDADE UNIMED CAMPO GRANDE CONFIRMADA. NEGATIVA DE COBERTURA DE PROCEDIMENTO CIRÚRGICO INDEVIDA. INDENIZAÇÃO CABÍVEL. QUANTUM RAZOÁVEL. SENTENÇA MANTIDA. RECURSO CONHECIDO E DESPROVIDO.
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>53&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878422" cdForo="0" >
+										0829907-03.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878422" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878422);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878422" style="display: none;" >
+	<div id="textAreaDados_1878422" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E DIREITO CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. COBRAN&Ccedil;A E RESTRI&Ccedil;&Atilde;O CREDIT&Iacute;CIA POR D&Eacute;BITO INEXIG&Iacute;VEL. RECURSO DESPROVIDO.
+CASO EM EXAME
+Apela&ccedil;&atilde;o interposta por Cristiane Bentos da Silva contra senten&ccedil;a que julgou parcialmente procedentes os pedidos em a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais ajuizada em face de Energisa Mato Grosso do Sul-Distribuidora de Energia S.A., para declarar a inexigibilidade de d&eacute;bitos vinculados ao CPF da autora, determinar a exclus&atilde;o de protesto e restri&ccedil;&otilde;es credit&iacute;cias, impor a viabiliza&ccedil;&atilde;o de cadastro e presta&ccedil;&atilde;o do servi&ccedil;o de energia el&eacute;trica em novo endere&ccedil;o sem condicionamento ao pagamento dos valores tidos por inexig&iacute;veis, condenar ao pagamento de indeniza&ccedil;&atilde;o por dano moral em R$ 5.000,00, e julgar improcedente a repeti&ccedil;&atilde;o de ind&eacute;bito por aus&ecirc;ncia de prova de pagamento.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em saber se o valor fixado a t&iacute;tulo de indeniza&ccedil;&atilde;o por dano moral (R$ 5.000,00) deve ser majorado para R$ 10.000,00, &agrave; luz das fun&ccedil;&otilde;es compensat&oacute;ria e punitivo-pedag&oacute;gica da responsabilidade civil e dos crit&eacute;rios de razoabilidade e proporcionalidade.
+RAZ&Otilde;ES DE DECIDIR
+Negou-se provimento ao recurso, mantendo-se a indeniza&ccedil;&atilde;o por dano moral em R$ 5.000,00, porque a fun&ccedil;&atilde;o compensat&oacute;ria deve orientar primordialmente o arbitramento, e o montante fixado foi considerado razo&aacute;vel e proporcional &agrave;s circunst&acirc;ncias do caso e compat&iacute;vel com os par&acirc;metros adotados pela C&acirc;mara. Considerou-se, ainda, a dupla fun&ccedil;&atilde;o da repara&ccedil;&atilde;o extrapatrimonial (compensat&oacute;ria e inibit&oacute;ria), sem identifica&ccedil;&atilde;o de fundamento concreto para majora&ccedil;&atilde;o, em conformidade com precedentes apontados no voto (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4&ordf; C&acirc;mara C&iacute;vel, j. 23/02/2026, p. 24/02/2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1&ordf; C&acirc;mara C&iacute;vel, j. 23/09/2025, p. 24/09/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3&ordf; C&acirc;mara C&iacute;vel, j. 31/07/2025, p. 04/08/2025).
+DISPOSITIVO
+Apela&ccedil;&atilde;o conhecida e desprovida.
+Dispositivos relevantes citados: CPC, art. 487, inc. I; CC, art. 406, &sect; 1&ordm;; CPC, art. 373, inc. II; CF/1988, art. 5&ordm;, V e X; CC, art. 944; e CPC, arts. 489, &sect; 1&ordm;, e 1.022.
+Jurisprud&ecirc;ncia relevante citada: TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4&ordf; C&acirc;mara C&iacute;vel, j. 23/02/2026, p. 24/02/2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1&ordf; C&acirc;mara C&iacute;vel, j. 23/09/2025, p. 24/09/2025; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3&ordf; C&acirc;mara C&iacute;vel, j. 31/07/2025, p. 04/08/2025. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0829907-03.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. APELAÇÃO CÍVEL. INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA E RESTRIÇÃO CREDITÍCIA POR DÉBITO INEXIGÍVEL. RECURSO DESPROVIDO.
+CASO EM EXAME
+Apelação interposta por Cristiane Bentos da Silva contra sentença que julgou parcialmente procedentes os pedidos em ação de indenização por danos morais ajuizada em face de Energisa Mato Grosso do Sul-Distribuidora de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E DIREITO CIVIL. APELAÇÃO CÍVEL. INDENIZAÇÃO POR DANOS MORAIS. COBRANÇA E RESTRIÇÃO CREDITÍCIA POR DÉBITO INEXIGÍVEL. RECURSO DESPROVIDO.
+CASO EM EXAME
+Apelação interposta por Cristiane Bentos da Silva contra sentença que julgou parcialmente procedentes os pedidos em ação de indenização por danos morais ajuizada em face de Energisa Mato Grosso do Sul-Distribuidora de Energia S.A., para declarar a inexigibilidade de débitos vinculados ao CPF da autora, determinar a exclusão de protesto e restrições creditícias, impor a viabilização de cadastro e prestação do serviço de energia elétrica em novo endereço sem condicionamento ao pagamento dos valores tidos por inexigíveis, condenar ao pagamento de indenização por <em>dano</em> <em>moral</em> em R$ 5.000,00, e julgar improcedente a repetição de indébito por ausência de prova de pagamento.
+QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em saber se o valor fixado a título de indenização por <em>dano</em> <em>moral</em> (R$ 5.000,00) deve ser majorado para R$ 10.000,00, à luz das funções compensatória e punitivo-pedagógica da responsabilidade civil e dos critérios de razoabilidade e proporcionalidade.
+RAZÕES DE DECIDIR
+Negou-se provimento ao recurso, mantendo-se a indenização por <em>dano</em> <em>moral</em> em R$ 5.000,00, porque a função compensatória deve orientar primordialmente o arbitramento, e o montante fixado foi considerado razoável e proporcional às circunstâncias do caso e compatível com os parâmetros adotados pela Câmara. Considerou-se, ainda, a dupla função da reparação extrapatrimonial (compensatória e inibitória), sem identificação de fundamento concreto para majoração, em conformidade com precedentes apontados no voto (TJMS, Apelação Cível n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4ª Câmara Cível, j. 23/02/2026, p. 24/02/2026; TJMS, Apelação Cível n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1ª Câmara Cível, j. 23/09/2025, p. 24/09/2025; TJMS, Apelação Cível n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3ª Câmara Cível, j. 31/07/2025, p. 04/08/2025).
+DISPOSITIVO
+Apelação conhecida e desprovida.
+Dispositivos relevantes citados: CPC, art. 487, inc. I; CC, art. 406, § 1º; CPC, art. 373, inc. II; CF/1988, art. 5º, V e X; CC, art. 944; e CPC, arts. 489, § 1º, e 1.022.
+Jurisprudência relevante citada: TJMS, Apelação Cível n. 0801748-66.2024.8.12.0007, Rel. Juiz W.M.S., 4ª Câmara Cível, j. 23/02/2026, p. 24/02/2026; TJMS, Apelação Cível n. 0802806-87.2024.8.12.0045, Rel. Des. A.B.P., 1ª Câmara Cível, j. 23/09/2025, p. 24/09/2025; e TJMS, Apelação Cível n. 0801128-16.2023.8.12.0031, Rel. Des. P.A.O., 3ª Câmara Cível, j. 31/07/2025, p. 04/08/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>54&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878432" cdForo="0" >
+										0802234-97.2024.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878432" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878432);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878432" style="display: none;" >
+	<div id="textAreaDados_1878432" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANO MORAL JULGADA IMPROCEDENTE &ndash; RECURSO DA CONSUMIDORA &ndash; M&Eacute;RITO &ndash; ELEMENTOS TRAZIDOS PELA INSTITUI&Ccedil;&Atilde;O FINANCEIRA, TAIS COMO C&Oacute;PIA DE CONTRATO COM IDENTIFICA&Ccedil;&Atilde;O BIOM&Eacute;TRICA (FACIAL), QUE CUMPRE OS REQUISITOS LEGAIS, COMPROVAM A CONTRATA&Ccedil;&Atilde;O DO CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL (RMC), BEM COMO DO EMPR&Eacute;STIMO CONSIGNADO ORIUNDO DE TAL CONTRATO &ndash; IMPROCED&Ecirc;NCIA DOS PEDIDOS DE NULIDADE DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA, RESTITUI&Ccedil;&Atilde;O DE VALORES EM DOBRO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802234-97.2024.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em> JULGADA IMPROCEDENTE – RECURSO DA CONSUMIDORA – MÉRITO – ELEMENTOS TRAZIDOS PELA INSTITUIÇÃO FINANCEIRA, TAIS COMO CÓPIA DE CONTRATO COM IDENTIFICAÇÃO BIOMÉTRICA (FACIAL), QUE CUMPRE OS REQUISITOS LEGAIS, COMPROVAM A CONTRATAÇÃO DO CARTÃO DE CRÉDITO COM RESERVA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em> JULGADA IMPROCEDENTE – RECURSO DA CONSUMIDORA – MÉRITO – ELEMENTOS TRAZIDOS PELA INSTITUIÇÃO FINANCEIRA, TAIS COMO CÓPIA DE CONTRATO COM IDENTIFICAÇÃO BIOMÉTRICA (FACIAL), QUE CUMPRE OS REQUISITOS LEGAIS, COMPROVAM A CONTRATAÇÃO DO CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC), BEM COMO DO EMPRÉSTIMO CONSIGNADO ORIUNDO DE TAL CONTRATO – IMPROCEDÊNCIA DOS PEDIDOS DE NULIDADE DE RELAÇÃO JURÍDICA, RESTITUIÇÃO DE VALORES EM DOBRO E INDENIZAÇÃO POR DANOS MORAIS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>55&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878433" cdForo="0" >
+										0803016-39.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878433" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878433);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878433" style="display: none;" >
+	<div id="textAreaDados_1878433" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DIREITO DO CONSUMIDOR. RECURSO DE APELA&Ccedil;&Atilde;O. INTERRUP&Ccedil;&Atilde;O NO FORNECIMENTO DE ENERGIA EL&Eacute;TRICA. RESPONSABILIDADE OBJETIVA E DANO MORAL IN RE IPSA. REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO PARCIALMENTE PROVIDO.
+CASO EM EXAME
+Recurso de apela&ccedil;&atilde;o interposto por Energisa Mato Grosso do Sul - Distribuidora de Energia S.A. contra senten&ccedil;a que julgou procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, condenando a concession&aacute;ria ao pagamento de R$ 20.000,00, com corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA a partir da senten&ccedil;a e juros morat&oacute;rios desde a cita&ccedil;&atilde;o.
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) saber se a interrup&ccedil;&atilde;o do fornecimento de energia el&eacute;trica por dois dias, com alega&ccedil;&atilde;o de evento clim&aacute;tico, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o e enseja dano moral indeniz&aacute;vel; e (ii) saber se o valor fixado a t&iacute;tulo de dano moral (R$ 20.000,00) deve ser mantido ou reduzido.
+RAZ&Otilde;ES DE DECIDIR
+Rejeitou-se a tese de caso fortuito/for&ccedil;a maior e de aus&ecirc;ncia de nexo causal. Reconheceu-se a responsabilidade objetiva da concession&aacute;ria (CF/1988, art. 37, &sect; 6&ordm;) em rela&ccedil;&atilde;o de consumo (CDC, arts. 2&ordm; e 3&ordm;), com dever de presta&ccedil;&atilde;o cont&iacute;nua e adequada do servi&ccedil;o p&uacute;blico essencial (CDC, art. 22, p.u.). Embora evento clim&aacute;tico possa justificar a interrup&ccedil;&atilde;o inicial, a demora de dois dias para restabelecimento n&atilde;o foi adequadamente justificada, sobretudo diante do prazo do art. 362 da Resolu&ccedil;&atilde;o ANEEL n&ordm; 1.000/2021. Configurou-se falha do servi&ccedil;o (CDC, art. 14) e dano moral in re ipsa, conforme precedentes citados do TJMS e do STJ.
+Afastou-se a necessidade de prova espec&iacute;fica do abalo, pois o dano moral foi considerado presumido (in re ipsa) diante da falha na presta&ccedil;&atilde;o de servi&ccedil;o p&uacute;blico essencial e da priva&ccedil;&atilde;o ileg&iacute;tima da energia el&eacute;trica, com fundamento no CDC, art. 6&ordm;, VI, e nos precedentes citados do STJ e do TJMS.
+Acolheu-se o pedido de redu&ccedil;&atilde;o do quantum. Consideraram-se as circunst&acirc;ncias do caso (demora de dois dias), a condi&ccedil;&atilde;o econ&ocirc;mica das partes e a fun&ccedil;&atilde;o pedag&oacute;gica da indeniza&ccedil;&atilde;o. Concluiu-se que R$ 20.000,00 era excessivo e se reduziu a indeniza&ccedil;&atilde;o para R$ 5.000,00, em conson&acirc;ncia com precedentes do TJMS (TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0855487-69.2024.8.12.0001, 1&ordf; C&acirc;mara C&iacute;vel, Rel. Ju&iacute;za D.B.D., j. 20/02/2026, p. 23/02/2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n.0838408-14.2023.8.12.0001, 2&ordf; C&acirc;mara C&iacute;vel, Rel. Juiz V.L.O.G., j. 26/02/2026, p. 03/03/2026).
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o parcialmente provido, para reduzir a indeniza&ccedil;&atilde;o por danos morais para R$ 5.000,00 (cinco mil reais).
+Dispositivos relevantes citados: CF/1988, art. 37, &sect; 6&ordm;; CPC, art. 487, inc. I; CC, art. 389, p.u.; CC, art. 406, &sect; 1&ordm;; CDC, arts. 2&ordm; e 3&ordm;; CDC, art. 6&ordm;, inc. VI; CDC, art. 14; CDC, art. 22, p.u.; e Resolu&ccedil;&atilde;o Normativa ANEEL n&ordm; 1.000/2021, art. 362.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no AREsp 166.040/RJ, Rel. Min. R.A., 4&ordf; Turma, j. 14.08.2012, DJe 31.08.2012; STJ, AgInt no AREsp 1.933.139/RJ, Rel. Min. R.A., 4&ordf; Turma, j. 13.12.2021, DJe 17.12.2021; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802848-11.2023.8.12.0001, 5&ordf; C&acirc;mara C&iacute;vel, Rel. Des. A.R., j. 09.02.2026, p. 10.02.2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0806680-64.2024.8.12.0018, 2&ordf; C&acirc;mara C&iacute;vel, Rel. Des&ordf; S.R.S. R. Artioli, j. 30.01.2026, p. 03.02.2026; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0855487-69.2024.8.12.0001, 1&ordf; C&acirc;mara C&iacute;vel, Rel. Ju&iacute;za D.B.D., j. 20.02.2026, p. 23.02.2026; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0838408-14.2023.8.12.0001, 2&ordf; C&acirc;mara C&iacute;vel, Rel. Juiz V.L.O.G., j. 26.02.2026, p. 03.03.2026. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803016-39.2025.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(35 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. RECURSO DE APELAÇÃO. INTERRUPÇÃO NO FORNECIMENTO DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E <em>DANO</em> <em>MORAL</em> IN RE IPSA. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Energisa Mato Grosso do Sul - Distribuidora de Energia S.A. contra sentença que julgou procedente ação de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DIREITO DO CONSUMIDOR. RECURSO DE APELAÇÃO. INTERRUPÇÃO NO FORNECIMENTO DE ENERGIA ELÉTRICA. RESPONSABILIDADE OBJETIVA E <em>DANO</em> <em>MORAL</em> IN RE IPSA. REDUÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO PARCIALMENTE PROVIDO.
+CASO EM EXAME
+Recurso de apelação interposto por Energisa Mato Grosso do Sul - Distribuidora de Energia S.A. contra sentença que julgou procedente ação de indenização por danos morais, condenando a concessionária ao pagamento de R$ 20.000,00, com correção monetária pelo IPCA a partir da sentença e juros moratórios desde a citação.
+QUESTÃO EM DISCUSSÃO
+Há duas questões em discussão: (i) saber se a interrupção do fornecimento de energia elétrica por dois dias, com alegação de evento climático, configura falha na prestação do serviço e enseja <em>dano</em> <em>moral</em> indenizável; e (ii) saber se o valor fixado a título de <em>dano</em> <em>moral</em> (R$ 20.000,00) deve ser mantido ou reduzido.
+RAZÕES DE DECIDIR
+Rejeitou-se a tese de caso fortuito/força maior e de ausência de nexo causal. Reconheceu-se a responsabilidade objetiva da concessionária (CF/1988, art. 37, § 6º) em relação de consumo (CDC, arts. 2º e 3º), com dever de prestação contínua e adequada do serviço público essencial (CDC, art. 22, p.u.). Embora evento climático possa justificar a interrupção inicial, a demora de dois dias para restabelecimento não foi adequadamente justificada, sobretudo diante do prazo do art. 362 da Resolução ANEEL nº 1.000/2021. Configurou-se falha do serviço (CDC, art. 14) e <em>dano</em> <em>moral</em> in re ipsa, conforme precedentes citados do TJMS e do STJ.
+Afastou-se a necessidade de prova específica do abalo, pois o <em>dano</em> <em>moral</em> foi considerado presumido (in re ipsa) diante da falha na prestação de serviço público essencial e da privação ilegítima da energia elétrica, com fundamento no CDC, art. 6º, VI, e nos precedentes citados do STJ e do TJMS.
+Acolheu-se o pedido de redução do quantum. Consideraram-se as circunstâncias do caso (demora de dois dias), a condição econômica das partes e a função pedagógica da indenização. Concluiu-se que R$ 20.000,00 era excessivo e se reduziu a indenização para R$ 5.000,00, em consonância com precedentes do TJMS (TJMS, Apelação Cível n. 0855487-69.2024.8.12.0001, 1ª Câmara Cível, Rel. Juíza D.B.D., j. 20/02/2026, p. 23/02/2026; TJMS, Apelação Cível n.0838408-14.2023.8.12.0001, 2ª Câmara Cível, Rel. Juiz V.L.O.G., j. 26/02/2026, p. 03/03/2026).
+DISPOSITIVO
+Recurso de apelação parcialmente provido, para reduzir a indenização por danos morais para R$ 5.000,00 (cinco mil reais).
+Dispositivos relevantes citados: CF/1988, art. 37, § 6º; CPC, art. 487, inc. I; CC, art. 389, p.u.; CC, art. 406, § 1º; CDC, arts. 2º e 3º; CDC, art. 6º, inc. VI; CDC, art. 14; CDC, art. 22, p.u.; e Resolução Normativa ANEEL nº 1.000/2021, art. 362.
+Jurisprudência relevante citada: STJ, AgRg no AREsp 166.040/RJ, Rel. Min. R.A., 4ª Turma, j. 14.08.2012, DJe 31.08.2012; STJ, AgInt no AREsp 1.933.139/RJ, Rel. Min. R.A., 4ª Turma, j. 13.12.2021, DJe 17.12.2021; TJMS, Apelação Cível n. 0802848-11.2023.8.12.0001, 5ª Câmara Cível, Rel. Des. A.R., j. 09.02.2026, p. 10.02.2026; TJMS, Apelação Cível n. 0806680-64.2024.8.12.0018, 2ª Câmara Cível, Rel. Desª S.R.S. R. Artioli, j. 30.01.2026, p. 03.02.2026; TJMS, Apelação Cível n. 0855487-69.2024.8.12.0001, 1ª Câmara Cível, Rel. Juíza D.B.D., j. 20.02.2026, p. 23.02.2026; e TJMS, Apelação Cível n. 0838408-14.2023.8.12.0001, 2ª Câmara Cível, Rel. Juiz V.L.O.G., j. 26.02.2026, p. 03.03.2026.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>56&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878437" cdForo="0" >
+										0805917-77.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878437" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878437);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878437" style="display: none;" >
+	<div id="textAreaDados_1878437" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS C C PEDIDO DE TUTELA PROVIS&Oacute;RIA DE URG&Ecirc;NCIA. SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. APELO DO BANCO REQUERIDO: ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE RESPONSABILIDADE CIVIL &ndash; IMPOSSIBILIDADE &ndash; APLICA&Ccedil;&Atilde;O DA S&Uacute;MULA 479/STJ &ndash; AUS&Ecirc;NCIA DO DEVER DE CUIDADO NA ABERTURA DE CONTA DE SEUS CLIENTES &ndash; PERMISS&Atilde;O DE ABERTURA DE CONTA, POR TERCEIROS, COM DOCUMENTOS FALSOS &ndash; RECURSO CONHECIDO E DESPROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0805917-77.2025.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C C INDENIZAÇÃO POR DANOS MORAIS C C PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA. SENTENÇA DE PROCEDÊNCIA. APELO DO BANCO REQUERIDO: ALEGAÇÃO DE AUSÊNCIA DE RESPONSABILIDADE CIVIL – IMPOSSIBILIDADE – APLICAÇÃO DA SÚMULA 479/STJ – AUSÊNCIA DO DEVER DE CUIDADO NA ABERTURA DE CONTA DE SEUS CLIENTES – PERMISSÃO DE ABERTURA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO EM AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C C INDENIZAÇÃO POR DANOS MORAIS C C PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA. SENTENÇA DE PROCEDÊNCIA. APELO DO BANCO REQUERIDO: ALEGAÇÃO DE AUSÊNCIA DE RESPONSABILIDADE CIVIL – IMPOSSIBILIDADE – APLICAÇÃO DA SÚMULA 479/STJ – AUSÊNCIA DO DEVER DE CUIDADO NA ABERTURA DE CONTA DE SEUS CLIENTES – PERMISSÃO DE ABERTURA DE CONTA, POR TERCEIROS, COM DOCUMENTOS FALSOS – RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>57&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878438" cdForo="0" >
+										0816423-57.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878438" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878438);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878438" style="display: none;" >
+	<div id="textAreaDados_1878438" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O A T&Iacute;TULO DE DANO MORAL, EST&Eacute;TICO E MATERIAL &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA. ACIDENTE DE TR&Acirc;NSITO &ndash; CRUZAMENTO SEM SINALIZA&Ccedil;&Atilde;O &ndash; INCID&Ecirc;NCIA DO ART. 29, INCISO III, &quot;C&quot;, DO CTB &ndash; AUS&Ecirc;NCIA DE RESPONSABILIDADE DO R&Eacute;U. A SINALIZA&Ccedil;&Atilde;O NAS VIAS, ANOS DEPOIS DA OCORR&Ecirc;NCIA DO ACIDENTE, N&Atilde;O COMPROVAM CULPA DA PARTE REQUERIDA. SENTEN&Ccedil;A MANTIDA. RECURSO CONHECIDO E DESPROVIDO. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816423-57.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE INDENIZAÇÃO A TÍTULO DE <em>DANO</em> <em>MORAL</em>, ESTÉTICO E MATERIAL – SENTENÇA DE IMPROCEDÊNCIA. ACIDENTE DE TRÂNSITO – CRUZAMENTO SEM SINALIZAÇÃO – INCIDÊNCIA DO ART. 29, INCISO III, "C", DO CTB – AUSÊNCIA DE RESPONSABILIDADE DO RÉU. A SINALIZAÇÃO NAS VIAS, ANOS DEPOIS DA OCORRÊNCIA DO ACIDENTE, NÃO COMPROVAM CULPA DA PARTE REQUERIDA. SENTENÇA MANTIDA. RECURSO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE INDENIZAÇÃO A TÍTULO DE <em>DANO</em> <em>MORAL</em>, ESTÉTICO E MATERIAL – SENTENÇA DE IMPROCEDÊNCIA. ACIDENTE DE TRÂNSITO – CRUZAMENTO SEM SINALIZAÇÃO – INCIDÊNCIA DO ART. 29, INCISO III, "C", DO CTB – AUSÊNCIA DE RESPONSABILIDADE DO RÉU. A SINALIZAÇÃO NAS VIAS, ANOS DEPOIS DA OCORRÊNCIA DO ACIDENTE, NÃO COMPROVAM CULPA DA PARTE REQUERIDA. SENTENÇA MANTIDA. RECURSO CONHECIDO E DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>58&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878439" cdForo="0" >
+										0800540-44.2025.8.12.0029
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878439" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878439);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878439" style="display: none;" >
+	<div id="textAreaDados_1878439" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E TUTELA DE URG&Ecirc;NCIA &ndash;&nbsp;CONCESSION&Aacute;RIA DE SERVI&Ccedil;O P&Uacute;BLICO &ndash;&nbsp; SANEAMENTO B&Aacute;SICO &ndash;&nbsp;INTERRUP&Ccedil;&Atilde;O DO&nbsp;FORNECIMENTO DE &Aacute;GUA&nbsp;POT&Aacute;VEL &ndash; &nbsp;C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash;&nbsp; RESPONSABILIDADE&nbsp;CIVIL OBJETIVA DO FORNECEDOR&nbsp;&ndash;&nbsp;DANO MORAL&nbsp;CONFIGURADO&nbsp; &ndash;&nbsp; VALOR MANTIDO &ndash;&nbsp;RAZOABILIDADE E PROPORCIONALIDADE &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+A rela&ccedil;&atilde;o havida entre concession&aacute;ria de servi&ccedil;o p&uacute;blico e o usu&aacute;rio final, para fornecimento de servi&ccedil;os p&uacute;blicos essenciais, a exemplo da &aacute;gua pot&aacute;vel, &eacute; regulada pelo C&oacute;digo de Defesa do Consumidor.
+Nos casos de danos oriundos de produtos ou servi&ccedil;os de consumo deve ser afastada a aplica&ccedil;&atilde;o do C&oacute;digo Civil, prevalecendo o regime especial do C&oacute;digo de Defesa do Consumidor. &Eacute; excepcional&iacute;ssima a aplica&ccedil;&atilde;o do C&oacute;digo Civil e desde que n&atilde;o contrarie o sistema e a principiologia do C&oacute;digo de Defesa do Consumidor.
+Apesar das reiteradas situa&ccedil;&otilde;es que trouxeram um desconforto significativo ao consumidor, compartilho da conclus&atilde;o da senten&ccedil;a, no sentido de que o valor de R$5.000,00 &eacute; suficiente para compensar os danos causados ao apelante, notadamente porque n&atilde;o h&aacute; prova nos autos de que o atendimento da empresa fornecedora de &aacute;gua foi negligente ou at&eacute; mesmo que esta n&atilde;o realizou os servi&ccedil;os requeridos, n&atilde;o havendo pedido administrativo comprovado deste &uacute;ltimo para que fosse realizada a implanta&ccedil;&atilde;o do encanamento de forma subterr&acirc;nea.
+Recurso conhecido e n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800540-44.2025.8.12.0029,&nbsp; Navira&iacute;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(43 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Naviraí
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS E TUTELA DE URGÊNCIA – CONCESSIONÁRIA DE SERVIÇO PÚBLICO –  SANEAMENTO BÁSICO – INTERRUPÇÃO DO FORNECIMENTO DE ÁGUA POTÁVEL –  CÓDIGO DE DEFESA DO CONSUMIDOR –  RESPONSABILIDADE CIVIL OBJETIVA DO FORNECEDOR – <em>DANO</em> <em>MORAL</em> CONFIGURADO  –  VALOR MANTIDO – RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA MANTIDA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS E TUTELA DE URGÊNCIA – CONCESSIONÁRIA DE SERVIÇO PÚBLICO –  SANEAMENTO BÁSICO – INTERRUPÇÃO DO FORNECIMENTO DE ÁGUA POTÁVEL –  CÓDIGO DE DEFESA DO CONSUMIDOR –  RESPONSABILIDADE CIVIL OBJETIVA DO FORNECEDOR – <em>DANO</em> <em>MORAL</em> CONFIGURADO  –  VALOR MANTIDO – RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA MANTIDA – RECURSO CONHECIDO E NÃO PROVIDO.
+A relação havida entre concessionária de serviço público e o usuário final, para fornecimento de serviços públicos essenciais, a exemplo da água potável, é regulada pelo Código de Defesa do Consumidor.
+Nos casos de danos oriundos de produtos ou serviços de consumo deve ser afastada a aplicação do Código Civil, prevalecendo o regime especial do Código de Defesa do Consumidor. É excepcionalíssima a aplicação do Código Civil e desde que não contrarie o sistema e a principiologia do Código de Defesa do Consumidor.
+Apesar das reiteradas situações que trouxeram um desconforto significativo ao consumidor, compartilho da conclusão da sentença, no sentido de que o valor de R$5.000,00 é suficiente para compensar os danos causados ao apelante, notadamente porque não há prova nos autos de que o atendimento da empresa fornecedora de água foi negligente ou até mesmo que esta não realizou os serviços requeridos, não havendo pedido administrativo comprovado deste último para que fosse realizada a implantação do encanamento de forma subterrânea.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>59&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878444" cdForo="0" >
+										0803090-95.2024.8.12.0045
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878444" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878444);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878444" style="display: none;" >
+	<div id="textAreaDados_1878444" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; DUPLICATAS MERCANTIS &ndash; CESS&Atilde;O DE CR&Eacute;DITO &ndash; AUS&Ecirc;NCIA DE NOTIFICA&Ccedil;&Atilde;O DO DEVEDOR (ART. 290, CC) &ndash; PAGAMENTO EFETUADO AO CREDOR PRIMITIVO (CEDENTE) &ndash; VALIDADE (ART. 292, CC) &ndash; PROTESTO POSTERIOR PELO BANCO (CESSION&Aacute;RIO) &ndash; ATO IL&Iacute;CITO CONFIGURADO &ndash; RESPONSABILIDADE SOLID&Aacute;RIA ENTRE CEDENTE E CESSION&Aacute;RIO &ndash; TEORIA DO RISCO DO EMPREENDIMENTO &ndash; DANO MORAL IN RE IPSA &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A cess&atilde;o de cr&eacute;dito apenas &eacute; eficaz em rela&ccedil;&atilde;o ao devedor quando este &eacute; formalmente notificado, nos termos do art. 290 do C&oacute;digo Civil. &Agrave; m&iacute;ngua de prova da notifica&ccedil;&atilde;o pr&eacute;via, &eacute; v&aacute;lido e eficaz o pagamento realizado pelo devedor ao credor primitivo (art. 292, CC), extinguindo-se a obriga&ccedil;&atilde;o.
+O protesto de t&iacute;tulos cujos valores j&aacute; haviam sido quitados perante a empresa cedente configura ato il&iacute;cito, ensejando o dever de indenizar.
+A responsabilidade entre a empresa cedente (que recebeu o pagamento e n&atilde;o informou imediatamente o banco) e a institui&ccedil;&atilde;o financeira cession&aacute;ria (que levou os t&iacute;tulos a protesto sem conferir a persist&ecirc;ncia do cr&eacute;dito) &eacute; solid&aacute;ria, pois ambas as condutas concorreram para o evento danoso (art. 942, CC).
+O dano moral decorrente de protesto indevido de t&iacute;tulo &eacute; in re ipsa, prescindindo de prova do preju&iacute;zo efetivo.
+O valor indenizat&oacute;rio de R$ 10.000,00 (dez mil reais) atende aos princ&iacute;pios da razoabilidade e proporcionalidade, bem como ao car&aacute;ter pedag&oacute;gico da medida.
+Senten&ccedil;a mantida. Recurso desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803090-95.2024.8.12.0045,&nbsp; Sidrol&acirc;ndia,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Sustação de Protesto
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sidrolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – DUPLICATAS MERCANTIS – CESSÃO DE CRÉDITO – AUSÊNCIA DE NOTIFICAÇÃO DO DEVEDOR (ART. 290, CC) – PAGAMENTO EFETUADO AO CREDOR PRIMITIVO (CEDENTE) – VALIDADE (ART. 292, CC) – PROTESTO POSTERIOR PELO BANCO (CESSIONÁRIO) – ATO ILÍCITO CONFIGURADO – RESPONSABILIDADE SOLIDÁRIA ENTRE CEDENTE E CESSIONÁRIO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – DUPLICATAS MERCANTIS – CESSÃO DE CRÉDITO – AUSÊNCIA DE NOTIFICAÇÃO DO DEVEDOR (ART. 290, CC) – PAGAMENTO EFETUADO AO CREDOR PRIMITIVO (CEDENTE) – VALIDADE (ART. 292, CC) – PROTESTO POSTERIOR PELO BANCO (CESSIONÁRIO) – ATO ILÍCITO CONFIGURADO – RESPONSABILIDADE SOLIDÁRIA ENTRE CEDENTE E CESSIONÁRIO – TEORIA DO RISCO DO EMPREENDIMENTO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – QUANTUM INDENIZATÓRIO MANTIDO – RECURSO CONHECIDO E DESPROVIDO.
+A cessão de crédito apenas é eficaz em relação ao devedor quando este é formalmente notificado, nos termos do art. 290 do Código Civil. À míngua de prova da notificação prévia, é válido e eficaz o pagamento realizado pelo devedor ao credor primitivo (art. 292, CC), extinguindo-se a obrigação.
+O protesto de títulos cujos valores já haviam sido quitados perante a empresa cedente configura ato ilícito, ensejando o dever de indenizar.
+A responsabilidade entre a empresa cedente (que recebeu o pagamento e não informou imediatamente o banco) e a instituição financeira cessionária (que levou os títulos a protesto sem conferir a persistência do crédito) é solidária, pois ambas as condutas concorreram para o evento danoso (art. 942, CC).
+O <em>dano</em> <em>moral</em> decorrente de protesto indevido de título é in re ipsa, prescindindo de prova do prejuízo efetivo.
+O valor indenizatório de R$ 10.000,00 (dez mil reais) atende aos princípios da razoabilidade e proporcionalidade, bem como ao caráter pedagógico da medida.
+Sentença mantida. Recurso desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>60&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878449" cdForo="0" >
+										0802044-57.2021.8.12.0019
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878449" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878449);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878449" style="display: none;" >
+	<div id="textAreaDados_1878449" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE/INEXIGIBILIDADE DE DESCONTO EM FOLHA DE PAGAMENTO CUMULADA COM REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; PRELIMINAR &ndash; JUNTADA EXTEMPOR&Acirc;NEA DE DOCUMENTOS &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; N&Atilde;O COMPROVADA &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; APLICA&Ccedil;&Atilde;O DA MODULA&Ccedil;&Atilde;O DOS EFEITOS DO EARESP N. 676.608/RS &ndash; DESCONTOS ANTERIORES A 30.3.2021 &ndash;  DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash;  DESCONTOS A PARTIR  30.3.2021 &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; ALTERADOS &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO. RECURSO DA PARTE R&Eacute; CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+A rela&ccedil;&atilde;o jur&iacute;dica vincula os sujeitos de direito em decorr&ecirc;ncia dos fatos jur&iacute;dicos suficientemente comprovados, que s&atilde;o a causa da instaura&ccedil;&atilde;o, da modifica&ccedil;&atilde;o ou da extin&ccedil;&atilde;o de obriga&ccedil;&otilde;es. Especificamente no contrato de m&uacute;tuo ou de empr&eacute;stimo, a tradi&ccedil;&atilde;o da coisa mutuada &eacute; suficiente para se concluir pela exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, cujos efeitos devem operar regulamente, nos termos do art. 586 do C&oacute;digo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que, nos termos art. 42, par&aacute;grafo &uacute;nico, da Lei n&ordm; 8.078/1990 (C&oacute;digo de Defesa do Consumidor), a restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe da natureza do elemento volitivo do fornecedor que realizou a cobran&ccedil;a indevida, revelando-se cab&iacute;vel quando a referida cobran&ccedil;a consubstanciar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva. N&atilde;o obstante, houve modula&ccedil;&atilde;o dos efeitos, impondo a aplica&ccedil;&atilde;o dessa tese a partir de 30.3.2021, data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o dos Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, e unicamente para as cobran&ccedil;as indevidas em contratos de consumo que n&atilde;o envolvam presta&ccedil;&atilde;o de servi&ccedil;os p&uacute;blicos pelo Estado ou por concession&aacute;rias, as quais apenas ser&atilde;o atingidas pelo novo entendimento quando pagas ap&oacute;s a data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a, nos julgamentos dos Recursos Especiais n&ordm; 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixa&ccedil;&atilde;o dos honor&aacute;rios por aprecia&ccedil;&atilde;o equitativa n&atilde;o &eacute; permitida quando os valores da condena&ccedil;&atilde;o ou da causa, ou o proveito econ&ocirc;mico da demanda, forem elevados. &Eacute; obrigat&oacute;ria, nesses casos, a observ&acirc;ncia dos percentuais previstos nos par&aacute;grafos 2&ordm; ou 3&ordm; do artigo 85 do C&oacute;digo de Processo Civil (CPC) &ndash; a depender da presen&ccedil;a da Fazenda P&uacute;blica na lide &ndash;, os quais ser&atilde;o subsequentemente calculados sobre o valor: (a) da condena&ccedil;&atilde;o; ou (b) do proveito econ&ocirc;mico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honor&aacute;rios por equidade quando, havendo ou n&atilde;o condena&ccedil;&atilde;o: (a) o proveito econ&ocirc;mico obtido pelo vencedor for inestim&aacute;vel ou irris&oacute;rio; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso da parte autora conhecido e provido. Recurso da parte r&eacute; conhecido e provido parcialmente. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802044-57.2021.8.12.0019,&nbsp; Ponta Por&atilde;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Ponta Porã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE/INEXIGIBILIDADE DE DESCONTO EM FOLHA DE PAGAMENTO CUMULADA COM REPETIÇÃO DE INDÉBITO E DANOS MORAIS – PRELIMINAR – JUNTADA EXTEMPORÂNEA DE DOCUMENTOS – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE/INEXIGIBILIDADE DE DESCONTO EM FOLHA DE PAGAMENTO CUMULADA COM REPETIÇÃO DE INDÉBITO E DANOS MORAIS – PRELIMINAR – JUNTADA EXTEMPORÂNEA DE DOCUMENTOS – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – HONORÁRIOS ADVOCATÍCIOS – ALTERADOS – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO. RECURSO DA PARTE RÉ CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+A relação jurídica vincula os sujeitos de direito em decorrência dos fatos jurídicos suficientemente comprovados, que são a causa da instauração, da modificação ou da extinção de obrigações. Especificamente no contrato de mútuo ou de empréstimo, a tradição da coisa mutuada é suficiente para se concluir pela existência da relação jurídica, cujos efeitos devem operar regulamente, nos termos do art. 586 do Código Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que, nos termos art. 42, parágrafo único, da Lei nº 8.078/1990 (Código de Defesa do Consumidor), a restituição em dobro do indébito independe da natureza do elemento volitivo do fornecedor que realizou a cobrança indevida, revelando-se cabível quando a referida cobrança consubstanciar conduta contrária à boa-fé objetiva. Não obstante, houve modulação dos efeitos, impondo a aplicação dessa tese a partir de 30.3.2021, data da publicação do acórdão dos Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, e unicamente para as cobranças indevidas em contratos de consumo que não envolvam prestação de serviços públicos pelo Estado ou por concessionárias, as quais apenas serão atingidas pelo novo entendimento quando pagas após a data da publicação do acórdão (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça, nos julgamentos dos Recursos Especiais nº 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixação dos honorários por apreciação equitativa não é permitida quando os valores da condenação ou da causa, ou o proveito econômico da demanda, forem elevados. É obrigatória, nesses casos, a observância dos percentuais previstos nos parágrafos 2º ou 3º do artigo 85 do Código de Processo Civil (CPC) – a depender da presença da Fazenda Pública na lide –, os quais serão subsequentemente calculados sobre o valor: (a) da condenação; ou (b) do proveito econômico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honorários por equidade quando, havendo ou não condenação: (a) o proveito econômico obtido pelo vencedor for inestimável ou irrisório; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso da parte autora conhecido e provido. Recurso da parte ré conhecido e provido parcialmente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>61&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878451" cdForo="0" >
+										0819344-81.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878451" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878451);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878451" style="display: none;" >
+	<div id="textAreaDados_1878451" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C REPARA&Ccedil;&Atilde;O &ndash; CONCESSION&Aacute;RIA DE SERVI&Ccedil;O P&Uacute;BLICO &ndash; PRETENS&Atilde;O DE RECONHECIMENTO DE IRREGULARIDADE NO REGISTRO DE CONSUMO DE ENERGIA EL&Eacute;TRICA &ndash; RESPONSABILIDADE OBJETIVA &ndash; D&Eacute;BITO DECLARADO INEXISTENTE &ndash; REVIS&Atilde;O DO FATURAMENTO &ndash; DANO MORAL IN RE IPSA &ndash; CONFIGURADO &ndash; INDENIZA&Ccedil;&Atilde;O FIXADA &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+As concession&aacute;rias de servi&ccedil;o p&uacute;blico est&atilde;o sujeitas &agrave; responsabilidade objetiva pelos danos causados a terceiros, conforme o art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal. Nesse sentido, o Supremo Tribunal Federal, no julgamento do Recurso Extraordin&aacute;rio n&ordm; 591.874, com repercuss&atilde;o geral reconhecida, fixou a seguinte tese (Tema n&ordm; 130): &quot;A responsabilidade civil das pessoas jur&iacute;dicas de direito privado prestadoras de servi&ccedil;o p&uacute;blico &eacute; objetiva relativamente a terceiros usu&aacute;rios e n&atilde;o usu&aacute;rios do servi&ccedil;o, segundo decorre do art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal&quot;.
+Tratando-se de hip&oacute;tese de responsabilidade objetiva e de invers&atilde;o legal do &ocirc;nus da prova (arts. 6&ordm;, VIII, CDC e art. 37, &sect; 6&ordm;, CF), competia &agrave; concession&aacute;ria fornecedora de energia el&eacute;trica comprovar a exist&ecirc;ncia de fato impeditivo, modificativo ou extintivo do direito do autor (art. 373, II, CPC) em raz&atilde;o da culpa exclusiva do consumidor ou de terceiro ou da inexist&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o (art. 14, &sect; 3&ordm;, CDC) &ndash; isto &eacute;, regularidade da medi&ccedil;&atilde;o da energia el&eacute;trica, regularidade da medi&ccedil;&atilde;o do consumo de energia el&eacute;trica, bem como normalidade do consumo na unidade consumidora, &ocirc;nus dos quais n&atilde;o se desincumbiu.
+Havendo irregularidade no faturamento da unidade consumidora e cobran&ccedil;a indevida &ndash; o que constitui falha na presta&ccedil;&atilde;o de servi&ccedil;o p&uacute;blico essencial &ndash; o dano moral configura-se in re ipsa. Observando-se as condi&ccedil;&otilde;es econ&ocirc;micas das partes, a extens&atilde;o do dano e o abalo ps&iacute;quico e emocional causados ao Apelante, conclui-se que a indeniza&ccedil;&atilde;o por dano moral deve ser fixada em R$5.000,00, uma vez que atende ao cen&aacute;rio dos autos e aos crit&eacute;rios de razoabilidade e proporcionalidade exigidos para que se compense adequadamente a v&iacute;tima, bem como o car&aacute;ter preventivo e pedag&oacute;gico da medida.
+Recurso conhecido e parcialmente provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0819344-81.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(54 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO – CONCESSIONÁRIA DE SERVIÇO PÚBLICO – PRETENSÃO DE RECONHECIMENTO DE IRREGULARIDADE NO REGISTRO DE CONSUMO DE ENERGIA ELÉTRICA – RESPONSABILIDADE OBJETIVA – DÉBITO DECLARADO INEXISTENTE – REVISÃO DO FATURAMENTO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – CONFIGURADO – INDENIZAÇÃO FIXADA – SENTENÇA REFORMADA – RECURSO CONHECIDO E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPARAÇÃO – CONCESSIONÁRIA DE SERVIÇO PÚBLICO – PRETENSÃO DE RECONHECIMENTO DE IRREGULARIDADE NO REGISTRO DE CONSUMO DE ENERGIA ELÉTRICA – RESPONSABILIDADE OBJETIVA – DÉBITO DECLARADO INEXISTENTE – REVISÃO DO FATURAMENTO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – CONFIGURADO – INDENIZAÇÃO FIXADA – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+As concessionárias de serviço público estão sujeitas à responsabilidade objetiva pelos danos causados a terceiros, conforme o art. 37, § 6º, da Constituição Federal. Nesse sentido, o Supremo Tribunal Federal, no julgamento do Recurso Extraordinário nº 591.874, com repercussão geral reconhecida, fixou a seguinte tese (Tema nº 130): "A responsabilidade civil das pessoas jurídicas de direito privado prestadoras de serviço público é objetiva relativamente a terceiros usuários e não usuários do serviço, segundo decorre do art. 37, § 6º, da Constituição Federal".
+Tratando-se de hipótese de responsabilidade objetiva e de inversão legal do ônus da prova (arts. 6º, VIII, CDC e art. 37, § 6º, CF), competia à concessionária fornecedora de energia elétrica comprovar a existência de fato impeditivo, modificativo ou extintivo do direito do autor (art. 373, II, CPC) em razão da culpa exclusiva do consumidor ou de terceiro ou da inexistência de falha na prestação do serviço (art. 14, § 3º, CDC) – isto é, regularidade da medição da energia elétrica, regularidade da medição do consumo de energia elétrica, bem como normalidade do consumo na unidade consumidora, ônus dos quais não se desincumbiu.
+Havendo irregularidade no faturamento da unidade consumidora e cobrança indevida – o que constitui falha na prestação de serviço público essencial – o <em>dano</em> <em>moral</em> configura-se in re ipsa. Observando-se as condições econômicas das partes, a extensão do <em>dano</em> e o abalo psíquico e emocional causados ao Apelante, conclui-se que a indenização por <em>dano</em> <em>moral</em> deve ser fixada em R$5.000,00, uma vez que atende ao cenário dos autos e aos critérios de razoabilidade e proporcionalidade exigidos para que se compense adequadamente a vítima, bem como o caráter preventivo e pedagógico da medida.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>62&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878458" cdForo="0" >
+										0831263-72.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878458" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878458);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878458" style="display: none;" >
+	<div id="textAreaDados_1878458" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; INVAS&Atilde;O DE VIA PREFERENCIAL &ndash; CULPA EXCLUSIVA DO R&Eacute;U &ndash; AUS&Ecirc;NCIA DE CNH DA V&Iacute;TIMA &ndash; IRRELEV&Acirc;NCIA &ndash; PENS&Atilde;O VITAL&Iacute;CIA &ndash; REDU&Ccedil;&Atilde;O DA CAPACIDADE LABORATIVA &ndash; ADEQUA&Ccedil;&Atilde;O DO PERCENTUAL &ndash; DANOS MORAIS E EST&Eacute;TICOS &ndash; MANUTEN&Ccedil;&Atilde;O DO QUANTUM &ndash; SEGURO DPVAT &ndash; IMPOSSIBILIDADE DE COMPENSA&Ccedil;&Atilde;O COM DANOS MORAIS E EST&Eacute;TICOS &ndash; RECURSOS PARCIALMENTE PROVIDOS.
+
+CASO EM EXAME
+
+Apela&ccedil;&otilde;es c&iacute;veis interpostas por v&iacute;tima e r&eacute;u em a&ccedil;&atilde;o indenizat&oacute;ria decorrente de acidente de tr&acirc;nsito, na qual reconhecida a responsabilidade do requerido por colis&atilde;o em cruzamento com desrespeito &agrave; sinaliza&ccedil;&atilde;o de &quot;pare&quot;, com condena&ccedil;&atilde;o ao pagamento de pens&atilde;o vital&iacute;cia, danos morais e danos est&eacute;ticos, al&eacute;m de dedu&ccedil;&atilde;o de valores recebidos a t&iacute;tulo de seguro DPVAT.
+
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+(i) Verifica&ccedil;&atilde;o da responsabilidade pelo acidente e eventual culpa exclusiva ou concorrente da v&iacute;tima;
+(ii) Cabimento e quantum da pens&atilde;o vital&iacute;cia em raz&atilde;o de incapacidade parcial permanente;
+(iii) Adequa&ccedil;&atilde;o dos valores fixados a t&iacute;tulo de danos morais e est&eacute;ticos;
+(iv) Possibilidade de dedu&ccedil;&atilde;o do seguro DPVAT das indeniza&ccedil;&otilde;es por danos morais e est&eacute;ticos.
+
+RAZ&Otilde;ES DE DECIDIR
+Responsabilidade civil: Comprovado que o r&eacute;u avan&ccedil;ou sinaliza&ccedil;&atilde;o obrigat&oacute;ria e invadiu via preferencial, configurando culpa exclusiva pelo acidente. Alega&ccedil;&otilde;es de excesso de velocidade n&atilde;o comprovadas. A aus&ecirc;ncia de habilita&ccedil;&atilde;o da v&iacute;tima constitui mera infra&ccedil;&atilde;o administrativa, sem relev&acirc;ncia causal para o sinistro.
+Pens&atilde;o vital&iacute;cia: Demonstrada incapacidade parcial e permanente (perda funcional de 75% do p&eacute; direito), &eacute; devida pens&atilde;o nos termos do art. 950 do C&oacute;digo Civil. Ajuste do percentual para 15% do sal&aacute;rio m&iacute;nimo, proporcional &agrave; deprecia&ccedil;&atilde;o da capacidade laborativa.
+Danos morais: Evidente o abalo decorrente das graves les&otilde;es, cirurgias e limita&ccedil;&otilde;es permanentes. Valor de R$ 30.000,00 mantido por atender aos princ&iacute;pios da razoabilidade e proporcionalidade.
+Danos est&eacute;ticos: Comprovada altera&ccedil;&atilde;o morfol&oacute;gica permanente (cicatrizes e deformidade funcional), sendo cab&iacute;vel indeniza&ccedil;&atilde;o aut&ocirc;noma cumul&aacute;vel com danos morais. Quantum de R$ 15.000,00 mantido.
+Seguro DPVAT: A dedu&ccedil;&atilde;o prevista na S&uacute;mula 246 do STJ n&atilde;o se aplica automaticamente &agrave;s verbas de natureza extrapatrimonial. Invi&aacute;vel compensa&ccedil;&atilde;o com danos morais e est&eacute;ticos, por aus&ecirc;ncia de identidade de natureza e finalidade com o seguro obrigat&oacute;rio.
+DISPOSITIVO
+Recurso da autora: parcialmente provido para afastar a dedu&ccedil;&atilde;o do seguro DPVAT das indeniza&ccedil;&otilde;es por danos morais e est&eacute;ticos.
+Recurso do r&eacute;u: parcialmente provido para reduzir a pens&atilde;o vital&iacute;cia ao percentual de 15% do sal&aacute;rio m&iacute;nimo vigente, mantidos os demais termos da senten&ccedil;a.
+TESE
+A aus&ecirc;ncia de habilita&ccedil;&atilde;o da v&iacute;tima, por si s&oacute;, n&atilde;o configura culpa pelo acidente de tr&acirc;nsito, se n&atilde;o demonstrado nexo causal com o evento danoso.
+A pens&atilde;o vital&iacute;cia deve ser fixada proporcionalmente &agrave; redu&ccedil;&atilde;o da capacidade laborativa, ainda que parcial e permanente (art. 950 do CC).
+&Eacute; poss&iacute;vel a cumula&ccedil;&atilde;o de danos morais e est&eacute;ticos (S&uacute;mula 387 do STJ).
+O seguro DPVAT n&atilde;o pode ser compensado com indeniza&ccedil;&otilde;es por danos morais e est&eacute;ticos, por aus&ecirc;ncia de identidade de natureza jur&iacute;dica.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0831263-72.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(62 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – INVASÃO DE VIA PREFERENCIAL – CULPA EXCLUSIVA DO RÉU – AUSÊNCIA DE CNH DA VÍTIMA – IRRELEVÂNCIA – PENSÃO VITALÍCIA – REDUÇÃO DA CAPACIDADE LABORATIVA – ADEQUAÇÃO DO PERCENTUAL – DANOS MORAIS E ESTÉTICOS – MANUTENÇÃO DO QUANTUM – SEGURO DPVAT – IMPOSSIBILIDADE DE COMPENSAÇÃO COM DANOS MORAIS E ESTÉTICOS – RECURSOS PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – INVASÃO DE VIA PREFERENCIAL – CULPA EXCLUSIVA DO RÉU – AUSÊNCIA DE CNH DA VÍTIMA – IRRELEVÂNCIA – PENSÃO VITALÍCIA – REDUÇÃO DA CAPACIDADE LABORATIVA – ADEQUAÇÃO DO PERCENTUAL – DANOS MORAIS E ESTÉTICOS – MANUTENÇÃO DO QUANTUM – SEGURO DPVAT – IMPOSSIBILIDADE DE COMPENSAÇÃO COM DANOS MORAIS E ESTÉTICOS – RECURSOS PARCIALMENTE PROVIDOS.
+
+CASO EM EXAME
+
+Apelações cíveis interpostas por vítima e réu em ação indenizatória decorrente de acidente de trânsito, na qual reconhecida a responsabilidade do requerido por colisão em cruzamento com desrespeito à sinalização de "pare", com condenação ao pagamento de pensão vitalícia, danos morais e danos estéticos, além de dedução de valores recebidos a título de seguro DPVAT.
+
+QUESTÃO EM DISCUSSÃO
+
+(i) Verificação da responsabilidade pelo acidente e eventual culpa exclusiva ou concorrente da vítima;
+(ii) Cabimento e quantum da pensão vitalícia em razão de incapacidade parcial permanente;
+(iii) Adequação dos valores fixados a título de danos morais e estéticos;
+(iv) Possibilidade de dedução do seguro DPVAT das indenizações por danos morais e estéticos.
+
+RAZÕES DE DECIDIR
+Responsabilidade civil: Comprovado que o réu avançou sinalização obrigatória e invadiu via preferencial, configurando culpa exclusiva pelo acidente. Alegações de excesso de velocidade não comprovadas. A ausência de habilitação da vítima constitui mera infração administrativa, sem relevância causal para o sinistro.
+Pensão vitalícia: Demonstrada incapacidade parcial e permanente (perda funcional de 75% do pé direito), é devida pensão nos termos do art. 950 do Código Civil. Ajuste do percentual para 15% do salário mínimo, proporcional à depreciação da capacidade laborativa.
+Danos morais: Evidente o abalo decorrente das graves lesões, cirurgias e limitações permanentes. Valor de R$ 30.000,00 mantido por atender aos princípios da razoabilidade e proporcionalidade.
+Danos estéticos: Comprovada alteração morfológica permanente (cicatrizes e deformidade funcional), sendo cabível indenização autônoma cumulável com danos morais. Quantum de R$ 15.000,00 mantido.
+Seguro DPVAT: A dedução prevista na Súmula 246 do STJ não se aplica automaticamente às verbas de natureza extrapatrimonial. Inviável compensação com danos morais e estéticos, por ausência de identidade de natureza e finalidade com o seguro obrigatório.
+DISPOSITIVO
+Recurso da autora: parcialmente provido para afastar a dedução do seguro DPVAT das indenizações por danos morais e estéticos.
+Recurso do réu: parcialmente provido para reduzir a pensão vitalícia ao percentual de 15% do salário mínimo vigente, mantidos os demais termos da sentença.
+TESE
+A ausência de habilitação da vítima, por si só, não configura culpa pelo acidente de trânsito, se não demonstrado nexo causal com o evento danoso.
+A pensão vitalícia deve ser fixada proporcionalmente à redução da capacidade laborativa, ainda que parcial e permanente (art. 950 do CC).
+É possível a cumulação de danos morais e estéticos (Súmula 387 do STJ).
+O seguro DPVAT não pode ser compensado com indenizações por danos morais e estéticos, por ausência de identidade de natureza jurídica.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>63&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1878461" cdForo="0" >
+										0841036-44.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1878461" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1878461);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1878461" style="display: none;" >
+	<div id="textAreaDados_1878461" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash;  A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; ABORDAGEM EM SUPERMERCADO POR FUNCION&Aacute;RIO &Agrave; CLIENTE &ndash; ACUSA&Ccedil;&Atilde;O DE FURTO &ndash; DANO MORAL DEMONSTRADO &ndash; VALOR MANTIDO &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+O Enunciado n&ordm; 445 da V Jornada de Direito Civil disp&otilde;e que: &quot;O dano moral indeniz&aacute;vel n&atilde;o pressup&otilde;e necessariamente a verifica&ccedil;&atilde;o de sentimentos humanos desagrad&aacute;veis como dor ou sofrimento&quot;.
+Na indeniza&ccedil;&atilde;o por danos morais, o magistrado deve agir com equidade, analisando: a) a extens&atilde;o do dano; b) as condi&ccedil;&otilde;es socioecon&ocirc;micas e culturais dos envolvidos; c) as condi&ccedil;&otilde;es psicol&oacute;gicas das partes; d) o grau de culpa do agente, de terceiro ou da v&iacute;tima (TARTUCE, Fl&aacute;vio. Manual de Direito Civil: volume &uacute;nico. 12. ed. Rio de Janeiro: Forense; M&eacute;todo, 2022, p. 509).
+O caso concreto trata-se de abordagem por funcion&aacute;rio de supermercado &agrave; cliente, acusando-a de furto, sem discri&ccedil;&atilde;o ou cuidado no procedimento, bem como sem quaisquer suspeitas a fundamentar o ato realizado, causando constrangimento ao cliente, raz&atilde;o pela qual a indeniza&ccedil;&atilde;o pelos danos morais deve ser mantida, assim como o valor fixado, porquanto observada a finalidade compensat&oacute;ria do instituto e os princ&iacute;pios da razoabilidade e proporcionalidade.
+Recurso conhecido e n&atilde;o provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0841036-44.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 17/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(53 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									17/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ABORDAGEM EM SUPERMERCADO POR FUNCIONÁRIO À CLIENTE – ACUSAÇÃO DE FURTO – <em>DANO</em> <em>MORAL</em> DEMONSTRADO – VALOR MANTIDO – RECURSO CONHECIDO E NÃO PROVIDO.
+O Enunciado nº 445 da V Jornada de Direito Civil dispõe que: "O <em>dano</em> <em>moral</em> indenizável não pressupõe necessariamente a verificação de sentimentos humanos
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – ABORDAGEM EM SUPERMERCADO POR FUNCIONÁRIO À CLIENTE – ACUSAÇÃO DE FURTO – <em>DANO</em> <em>MORAL</em> DEMONSTRADO – VALOR MANTIDO – RECURSO CONHECIDO E NÃO PROVIDO.
+O Enunciado nº 445 da V Jornada de Direito Civil dispõe que: "O <em>dano</em> <em>moral</em> indenizável não pressupõe necessariamente a verificação de sentimentos humanos desagradáveis como dor ou sofrimento".
+Na indenização por danos morais, o magistrado deve agir com equidade, analisando: a) a extensão do <em>dano</em>; b) as condições socioeconômicas e culturais dos envolvidos; c) as condições psicológicas das partes; d) o grau de culpa do agente, de terceiro ou da vítima (TARTUCE, Flávio. Manual de Direito Civil: volume único. 12. ed. Rio de Janeiro: Forense; Método, 2022, p. 509).
+O caso concreto trata-se de abordagem por funcionário de supermercado à cliente, acusando-a de furto, sem discrição ou cuidado no procedimento, bem como sem quaisquer suspeitas a fundamentar o ato realizado, causando constrangimento ao cliente, razão pela qual a indenização pelos danos morais deve ser mantida, assim como o valor fixado, porquanto observada a finalidade compensatória do instituto e os princípios da razoabilidade e proporcionalidade.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>64&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877112" cdForo="0" >
+										0800231-77.2021.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877112" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877112);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877112" style="display: none;" >
+	<div id="textAreaDados_1877112" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O REPARAT&Oacute;RIA DE DANOS &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; MOTOTAXISTA QUE PERDE O CONTROLE DA MOTOCICLETA - DANO MORAL  &ndash; VERIFICADO &ndash; QUANTUM INDENIZAT&Oacute;RIO REDUZIDO &ndash; DANOS MATERIAIS N&Atilde;O COMPROVADOS - LUCROS CESSANTES DEVIDOS - COMPENSA&Ccedil;&Atilde;O COM OS VALORES RECEBIDOS A T&Iacute;TULO DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO - IMPOSSIBILIDADE - NATUREZAS DISTINTAS - RECURSOS CONHECIDOS E PARCIALMENTE PROVIDOS.
+A fixa&ccedil;&atilde;o do quantum do dano moral deve ficar ao prudente arb&iacute;trio do julgador, devendo ser fixado de maneira equitativa, levando-se em considera&ccedil;&atilde;o as circunst&acirc;ncias do caso concreto e as condi&ccedil;&otilde;es socioecon&ocirc;micas das partes, n&atilde;o podendo ser irris&oacute;rio, de maneira que nada represente para o ofensor, nem exorbitante, de modo a provocar o enriquecimento il&iacute;cito por parte da v&iacute;tima. Valor reduzido pelas condi&ccedil;&otilde;es do ofensor.
+Inexiste veda&ccedil;&atilde;o &agrave; cumula&ccedil;&atilde;o de pens&atilde;o previdenci&aacute;ria com a pens&atilde;o mensal decorrente de ato il&iacute;cito, porquanto verbas de natureza distintas.
+&Eacute; dever da parte autora comprovar os danos materiais sofridos, o que n&atilde;o ocorreu nos autos, na forma do art. 373, I do CPC.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800231-77.2021.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO REPARATÓRIA DE DANOS – ACIDENTE DE TRÂNSITO – MOTOTAXISTA QUE PERDE O CONTROLE DA MOTOCICLETA - <em>DANO</em> <em>MORAL</em>  – VERIFICADO – QUANTUM INDENIZATÓRIO REDUZIDO – DANOS MATERIAIS NÃO COMPROVADOS - LUCROS CESSANTES DEVIDOS - COMPENSAÇÃO COM OS VALORES RECEBIDOS A TÍTULO DE BENEFÍCIO PREVIDENCIÁRIO - IMPOSSIBILIDADE - NATUREZAS DISTINTAS - RECURSOS CONHECIDOS E PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO REPARATÓRIA DE DANOS – ACIDENTE DE TRÂNSITO – MOTOTAXISTA QUE PERDE O CONTROLE DA MOTOCICLETA - <em>DANO</em> <em>MORAL</em>  – VERIFICADO – QUANTUM INDENIZATÓRIO REDUZIDO – DANOS MATERIAIS NÃO COMPROVADOS - LUCROS CESSANTES DEVIDOS - COMPENSAÇÃO COM OS VALORES RECEBIDOS A TÍTULO DE BENEFÍCIO PREVIDENCIÁRIO - IMPOSSIBILIDADE - NATUREZAS DISTINTAS - RECURSOS CONHECIDOS E PARCIALMENTE PROVIDOS.
+A fixação do quantum do <em>dano</em> <em>moral</em> deve ficar ao prudente arbítrio do julgador, devendo ser fixado de maneira equitativa, levando-se em consideração as circunstâncias do caso concreto e as condições socioeconômicas das partes, não podendo ser irrisório, de maneira que nada represente para o ofensor, nem exorbitante, de modo a provocar o enriquecimento ilícito por parte da vítima. Valor reduzido pelas condições do ofensor.
+Inexiste vedação à cumulação de pensão previdenciária com a pensão mensal decorrente de ato ilícito, porquanto verbas de natureza distintas.
+É dever da parte autora comprovar os danos materiais sofridos, o que não ocorreu nos autos, na forma do art. 373, I do CPC.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>65&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877119" cdForo="0" >
+										0800417-59.2023.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877119" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877119);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877119" style="display: none;" >
+	<div id="textAreaDados_1877119" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANO MATERIAL E MORAL &ndash; ACIDENTE DE TR&Acirc;NSITO - AUS&Ecirc;NCIA DE PROVA DE CULPA DO R&Eacute;U - CULPA&nbsp;EXCLUSIVA&nbsp;DA&nbsp;V&Iacute;TIMA&nbsp;CONFIGURADA - DEVER DE INDENIZAR AFASTADO &ndash; A&Ccedil;&Atilde;O IMPROCEDENTE &ndash; RECURSO DESPROVIDO.
+N&atilde;o tendo a autora obtido &ecirc;xito em demonstrar a culpa do demandado e, por outro norte, tendo o apelado demonstrado a culpa exclusiva da v&iacute;tima, conclui-se pela aus&ecirc;ncia dos requisitos ensejadores da responsabilidade civil aplicada ao caso.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800417-59.2023.8.12.0015,&nbsp; Miranda,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO DE INDENIZAÇÃO POR <em>DANO</em> MATERIAL E <em>MORAL</em> – ACIDENTE DE TRÂNSITO - AUSÊNCIA DE PROVA DE CULPA DO RÉU - CULPA EXCLUSIVA DA VÍTIMA CONFIGURADA - DEVER DE INDENIZAR AFASTADO – AÇÃO IMPROCEDENTE – RECURSO DESPROVIDO.
+Não tendo a autora obtido êxito em demonstrar a culpa do demandado e, por outro norte, tendo o apelado demonstrado a culpa exclusiva da vítima, conclui-se pela
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO DE INDENIZAÇÃO POR <em>DANO</em> MATERIAL E <em>MORAL</em> – ACIDENTE DE TRÂNSITO - AUSÊNCIA DE PROVA DE CULPA DO RÉU - CULPA EXCLUSIVA DA VÍTIMA CONFIGURADA - DEVER DE INDENIZAR AFASTADO – AÇÃO IMPROCEDENTE – RECURSO DESPROVIDO.
+Não tendo a autora obtido êxito em demonstrar a culpa do demandado e, por outro norte, tendo o apelado demonstrado a culpa exclusiva da vítima, conclui-se pela ausência dos requisitos ensejadores da responsabilidade civil aplicada ao caso.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>66&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877148" cdForo="0" >
+										0808139-29.2023.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877148" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877148);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877148" style="display: none;" >
+	<div id="textAreaDados_1877148" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE CONHECIMENTO &ndash; PRELIMINAR DE OFENSA AO PRINC&Iacute;PIO DA DIALETICIDADE, REJEITADA &ndash; PRELIMINAR DE INOVA&Ccedil;&Atilde;O RECURSAL, ACOLHIDA EM PARTE &ndash; M&Eacute;RITO &ndash;  SISTEMA DE PAGAMENTO POR CART&Atilde;O DE CR&Eacute;DITO &ndash; TRANSA&Ccedil;&Otilde;ES REALIZADAS POR LINK DE PAGAMENTO &ndash; POSTERIOR CONTESTA&Ccedil;&Atilde;O PELO TITULAR DO CART&Atilde;O (CHARGEBACK) &ndash; ESTORNO DOS VALORES &ndash; RESPONSABILIDADE DA CREDENCIADORA &ndash; APLICA&Ccedil;&Atilde;O DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; TEORIA FINALISTA MITIGADA &ndash; RESPONSABILIDADE OBJETIVA &ndash; RISCO DA ATIVIDADE &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; CL&Aacute;USULA CONTRATUAL QUE TRANSFERE O RISCO AO ESTABELECIMENTO COMERCIAL &ndash; ABUSIVIDADE &ndash; DANO MATERIAL &ndash; DEVER DE INDENIZAR &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO EM PARTE; NA PARTE CONHECIDA, DESPROVIDO.
+I - Se a parte combate os principais fundamentos da senten&ccedil;a, n&atilde;o h&aacute; espa&ccedil;o para discutir ofensa ao princ&iacute;pio da&nbsp;dialeticidade. Preliminar rejeitada.
+II - N&atilde;o se conhece da alega&ccedil;&atilde;o de inexist&ecirc;ncia de dano material por aus&ecirc;ncia de prova de entrega dos produtos, por configurar inova&ccedil;&atilde;o recursal, vedada pelo art. 1.014, CPC, uma vez que referida mat&eacute;ria n&atilde;o foi suscitada na contesta&ccedil;&atilde;o, tampouco analisada pelo ju&iacute;zo de origem.
+III - Aplica-se o C&oacute;digo de Defesa do Consumidor &agrave; rela&ccedil;&atilde;o jur&iacute;dica estabelecida entre credenciadora de cart&otilde;es e estabelecimento comercial, quando evidenciada a vulnerabilidade t&eacute;cnica deste, nos termos da teoria finalista mitigada.
+IV - A credenciadora de cart&atilde;o de cr&eacute;dito responde objetivamente pelos danos decorrentes de falha na presta&ccedil;&atilde;o do servi&ccedil;o, nos termos do art. 14, CDC, por se tratar de atividade que implica risco inerente.
+V - A autoriza&ccedil;&atilde;o pr&eacute;via das transa&ccedil;&otilde;es pela plataforma de pagamento gera leg&iacute;tima expectativa de validade e seguran&ccedil;a da opera&ccedil;&atilde;o, n&atilde;o sendo poss&iacute;vel transferir ao estabelecimento comercial os preju&iacute;zos decorrentes de posterior contesta&ccedil;&atilde;o pelo titular do cart&atilde;o (chargeback). Ademais, a demora na solu&ccedil;&atilde;o evidencia a falha na presta&ccedil;&atilde;o do servi&ccedil;o. Senten&ccedil;a mantida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0808139-29.2023.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE CONHECIMENTO – PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE, REJEITADA – PRELIMINAR DE INOVAÇÃO RECURSAL, ACOLHIDA EM PARTE – MÉRITO –  SISTEMA DE PAGAMENTO POR CARTÃO DE CRÉDITO – TRANSAÇÕES REALIZADAS POR LINK DE PAGAMENTO – POSTERIOR CONTESTAÇÃO PELO TITULAR DO CARTÃO (CHARGEBACK) – ESTORNO DOS VALORES – RESPONSABILIDADE DA CREDENCIADORA – APLICAÇÃO DO CÓDIGO DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE CONHECIMENTO – PRELIMINAR DE OFENSA AO PRINCÍPIO DA DIALETICIDADE, REJEITADA – PRELIMINAR DE INOVAÇÃO RECURSAL, ACOLHIDA EM PARTE – MÉRITO –  SISTEMA DE PAGAMENTO POR CARTÃO DE CRÉDITO – TRANSAÇÕES REALIZADAS POR LINK DE PAGAMENTO – POSTERIOR CONTESTAÇÃO PELO TITULAR DO CARTÃO (CHARGEBACK) – ESTORNO DOS VALORES – RESPONSABILIDADE DA CREDENCIADORA – APLICAÇÃO DO CÓDIGO DE DEFESA DO CONSUMIDOR – TEORIA FINALISTA MITIGADA – RESPONSABILIDADE OBJETIVA – RISCO DA ATIVIDADE – FALHA NA PRESTAÇÃO DO SERVIÇO – CLÁUSULA CONTRATUAL QUE TRANSFERE O RISCO AO ESTABELECIMENTO COMERCIAL – ABUSIVIDADE – <em>DANO</em> MATERIAL – DEVER DE INDENIZAR – SENTENÇA MANTIDA – RECURSO CONHECIDO EM PARTE; NA PARTE CONHECIDA, DESPROVIDO.
+I - Se a parte combate os principais fundamentos da sentença, não há espaço para discutir ofensa ao princípio da dialeticidade. Preliminar rejeitada.
+II - Não se conhece da alegação de inexistência de <em>dano</em> material por ausência de prova de entrega dos produtos, por configurar inovação recursal, vedada pelo art. 1.014, CPC, uma vez que referida matéria não foi suscitada na contestação, tampouco analisada pelo juízo de origem.
+III - Aplica-se o Código de Defesa do Consumidor à relação jurídica estabelecida entre credenciadora de cartões e estabelecimento comercial, quando evidenciada a vulnerabilidade técnica deste, nos termos da teoria finalista mitigada.
+IV - A credenciadora de cartão de crédito responde objetivamente pelos danos decorrentes de falha na prestação do serviço, nos termos do art. 14, CDC, por se tratar de atividade que implica risco inerente.
+V - A autorização prévia das transações pela plataforma de pagamento gera legítima expectativa de validade e segurança da operação, não sendo possível transferir ao estabelecimento comercial os prejuízos decorrentes de posterior contestação pelo titular do cartão (chargeback). Ademais, a demora na solução evidencia a falha na prestação do serviço. Sentença mantida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>67&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877155" cdForo="0" >
+										0800841-63.2025.8.12.0005
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877155" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877155);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877155" style="display: none;" >
+	<div id="textAreaDados_1877155" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; ALEGA&Ccedil;&Atilde;O DE V&Iacute;CIO NO AC&Oacute;RD&Atilde;O &ndash; OMISS&Atilde;O NA AN&Aacute;LISE DO PEDIDO DE RESTITUI&Ccedil;&Atilde;O SIMPLES DE VALORES &ndash; V&Iacute;CIO EXISTENTE &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO EM DOBRO &ndash; DEVIDA  A PARTIR DE 30/03/2021&ndash; MODULA&Ccedil;&Atilde;O DE EFEITOS NO EARESP N. 676.608/RS PELO STJ &ndash; REPETI&Ccedil;&Atilde;O SIMPLES EM RELA&Ccedil;&Atilde;O AO PER&Iacute;ODO ANTERIOR (25/02/2019 at&eacute; 30/03/2021) &ndash; EMBARGOS ACOLHIDOS.
+Acolhem-se os embargos de declara&ccedil;&atilde;o, se verificada qualquer das hip&oacute;teses previstas no artigo 1.022 do C&oacute;digo de Processo Civil, que no caso restou configurada a omiss&atilde;o, pela n&atilde;o an&aacute;lise do pedido de restitui&ccedil;&atilde;o simples de valores.
+O STJ definiu que a interpreta&ccedil;&atilde;o do art. 42 do CDC deve ser feita &agrave; luz dos princ&iacute;pios da vulnerabilidade e da boa-f&eacute; objetiva, mandamentos centrais da prote&ccedil;&atilde;o ao consumidor, de modo que a restitui&ccedil;&atilde;o simples somente ser&aacute; admitida quando o fornecedor de produtos ou servi&ccedil;os comprovar a ocorr&ecirc;ncia de engano justific&aacute;vel para a cobran&ccedil;a indevida.
+Conforme modula&ccedil;&atilde;o dos efeitos da decis&atilde;o proferida pelo STJ, no julgamento do EAREsp n. 676.608/RS, a altera&ccedil;&atilde;o do entendimento somente ser&aacute; aplicada para os descontos indevidos ocorridos a partir da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (30/03/2021). No caso, os descontos que ocorreram a partir de 30/03/2021  &eacute; aplic&aacute;vel a restitui&ccedil;&atilde;o em dobro. No que tange os valores cobrados indevidamente do per&iacute;odo anterior a 30/03/2021 dever&atilde;o ser restitu&iacute;dos de forma simples.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0800841-63.2025.8.12.0005,&nbsp; Aquidauana,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aquidauana
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800841632025812000550000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – ALEGAÇÃO DE VÍCIO NO ACÓRDÃO – OMISSÃO NA ANÁLISE DO PEDIDO DE RESTITUIÇÃO SIMPLES DE VALORES – VÍCIO EXISTENTE – REPETIÇÃO DE INDÉBITO EM DOBRO – DEVIDA  A PARTIR DE 30/03/2021– MODULAÇÃO DE EFEITOS NO EARESP N. 676.608/RS PELO STJ – REPETIÇÃO SIMPLES EM RELAÇÃO AO PERÍODO ANTERIOR (25/02/2019 até 30/03/2021) – EMBARGOS ACOLHIDOS.
+Acolhem-se os
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – ALEGAÇÃO DE VÍCIO NO ACÓRDÃO – OMISSÃO NA ANÁLISE DO PEDIDO DE RESTITUIÇÃO SIMPLES DE VALORES – VÍCIO EXISTENTE – REPETIÇÃO DE INDÉBITO EM DOBRO – DEVIDA  A PARTIR DE 30/03/2021– MODULAÇÃO DE EFEITOS NO EARESP N. 676.608/RS PELO STJ – REPETIÇÃO SIMPLES EM RELAÇÃO AO PERÍODO ANTERIOR (25/02/2019 até 30/03/2021) – EMBARGOS ACOLHIDOS.
+Acolhem-se os embargos de declaração, se verificada qualquer das hipóteses previstas no artigo 1.022 do Código de Processo Civil, que no caso restou configurada a omissão, pela não análise do pedido de restituição simples de valores.
+O STJ definiu que a interpretação do art. 42 do CDC deve ser feita à luz dos princípios da vulnerabilidade e da boa-fé objetiva, mandamentos centrais da proteção ao consumidor, de modo que a restituição simples somente será admitida quando o fornecedor de produtos ou serviços comprovar a ocorrência de engano justificável para a cobrança indevida.
+Conforme modulação dos efeitos da decisão proferida pelo STJ, no julgamento do EAREsp n. 676.608/RS, a alteração do entendimento somente será aplicada para os descontos indevidos ocorridos a partir da publicação do acórdão (30/03/2021). No caso, os descontos que ocorreram a partir de 30/03/2021  é aplicável a restituição em dobro. No que tange os valores cobrados indevidamente do período anterior a 30/03/2021 deverão ser restituídos de forma simples.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>68&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877161" cdForo="0" >
+										1421692-89.2025.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877161" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877161);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877161" style="display: none;" >
+	<div id="textAreaDados_1877161" class="mensagemSemFormatacao" >
+		AGRAVO INTERNO EM AGRAVO DE INSTRUMENTO &ndash; OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; PLANO DE SA&Uacute;DE &ndash; TRATAMENTO MULTIDISCIPLINAR PARA TRANSTORNO DO ESPECTRO AUTISTA &ndash; TUTELA DE URG&Ecirc;NCIA PARCIALMENTE DEFERIDA &ndash; COBERTURA DE EQUOTERAPIA E TERAPIA ABA EM LOCALIDADE DA BENEFICI&Aacute;RIA &ndash; NECESSIDADE TERAP&Ecirc;UTICA E IMPRESCINDIBILIDADE DO TRATAMENTO &ndash; PRECEDENTES DO STJ &ndash; AUS&Ecirc;NCIA DE ARGUMENTOS NOVOS APTOS A INFIRMAR A DECIS&Atilde;O AGRAVADA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+No presente Agravo Interno, a Agravante apenas reitera os fundamentos anteriormente apresentados e insuficientes para afastar a probabilidade do direito e o perigo de dano j&aacute; reconhecidos, raz&atilde;o pela qual devem ser igualmente mantidas as raz&otilde;es de decidir da decis&atilde;o monocr&aacute;tica, o que n&atilde;o constitui viola&ccedil;&atilde;o ao disposto no &sect; 3&ordm; do artigo 1.021 do CPC.
+No Tema Repetitivo n&ordm; 1306, o STJ fixou a tese de que &quot;A reprodu&ccedil;&atilde;o dos fundamentos da decis&atilde;o agravada como raz&otilde;es de decidir para negar provimento ao agravo interno, na hip&oacute;tese do &sect;3&ordm; do artigo 1.021 do CPC, &eacute; admitida quando a parte deixa de apresentar argumento novo e relevante a ser apreciado pelo colegiado&quot;.
+No caso, os elementos f&aacute;ticos e jur&iacute;dicos apresentados pela parte Requerente/Agravada se mostram aptos a preencher os requisitos da tutela de urg&ecirc;ncia para a concess&atilde;o da equoterapia e da terapia ABA na localidade da benefici&aacute;ria, dada a especificidade do tratamento de TEA em infante, a jurisprud&ecirc;ncia consolidada do STJ e a inviabilidade de deslocamento. Logo, n&atilde;o h&aacute; falar em reforma da decis&atilde;o agravada.
+Recurso conhecido e desprovido.
+ <br><br>(<b>TJMS</b>. Agravo Interno C&iacute;vel n. 1421692-89.2025.8.12.0000,&nbsp; Sidrol&acirc;ndia,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sidrolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO INTERNO EM AGRAVO DE INSTRUMENTO – OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – TRATAMENTO MULTIDISCIPLINAR PARA TRANSTORNO DO ESPECTRO AUTISTA – TUTELA DE URGÊNCIA PARCIALMENTE DEFERIDA – COBERTURA DE EQUOTERAPIA E TERAPIA ABA EM LOCALIDADE DA BENEFICIÁRIA – NECESSIDADE TERAPÊUTICA E IMPRESCINDIBILIDADE DO TRATAMENTO – PRECEDENTES DO STJ – AUSÊNCIA DE ARGUMENTOS NOVOS APTOS A INFIRMAR A DECISÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO INTERNO EM AGRAVO DE INSTRUMENTO – OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – TRATAMENTO MULTIDISCIPLINAR PARA TRANSTORNO DO ESPECTRO AUTISTA – TUTELA DE URGÊNCIA PARCIALMENTE DEFERIDA – COBERTURA DE EQUOTERAPIA E TERAPIA ABA EM LOCALIDADE DA BENEFICIÁRIA – NECESSIDADE TERAPÊUTICA E IMPRESCINDIBILIDADE DO TRATAMENTO – PRECEDENTES DO STJ – AUSÊNCIA DE ARGUMENTOS NOVOS APTOS A INFIRMAR A DECISÃO AGRAVADA – RECURSO CONHECIDO E DESPROVIDO.
+No presente Agravo Interno, a Agravante apenas reitera os fundamentos anteriormente apresentados e insuficientes para afastar a probabilidade do direito e o perigo de <em>dano</em> já reconhecidos, razão pela qual devem ser igualmente mantidas as razões de decidir da decisão monocrática, o que não constitui violação ao disposto no § 3º do artigo 1.021 do CPC.
+No Tema Repetitivo nº 1306, o STJ fixou a tese de que "A reprodução dos fundamentos da decisão agravada como razões de decidir para negar provimento ao agravo interno, na hipótese do §3º do artigo 1.021 do CPC, é admitida quando a parte deixa de apresentar argumento novo e relevante a ser apreciado pelo colegiado".
+No caso, os elementos fáticos e jurídicos apresentados pela parte Requerente/Agravada se mostram aptos a preencher os requisitos da tutela de urgência para a concessão da equoterapia e da terapia ABA na localidade da beneficiária, dada a especificidade do tratamento de TEA em infante, a jurisprudência consolidada do STJ e a inviabilidade de deslocamento. Logo, não há falar em reforma da decisão agravada.
+Recurso conhecido e desprovido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>69&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877186" cdForo="0" >
+										0817163-46.2020.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877186" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877186);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877186" style="display: none;" >
+	<div id="textAreaDados_1877186" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; INEXIST&Ecirc;NCIA DOS V&Iacute;CIOS PREVISTOS NO ARTIGO 1.022, DO CPC &ndash; PREQUESTIONAMENTO &ndash; EMBARGOS DECLARAT&Oacute;RIOS REJEITADOS.
+Nos termos do artigo 1.022, do CPC/2015, cabem embargos de declara&ccedil;&atilde;o para esclarecer obscuridade, eliminar contradi&ccedil;&atilde;o ou suprir omiss&atilde;o de ponto ou quest&atilde;o sobre o qual devia se pronunciar o juiz de of&iacute;cio ou a requerimento, ou corrigir erro material.   <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0817163-46.2020.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									817163462020812000250001
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – INEXISTÊNCIA DOS VÍCIOS PREVISTOS NO ARTIGO 1.022, DO CPC – PREQUESTIONAMENTO – EMBARGOS DECLARATÓRIOS REJEITADOS.
+Nos termos do artigo 1.022, do CPC/2015, cabem embargos de declaração para esclarecer obscuridade, eliminar contradição ou suprir omissão de ponto ou questão sobre o qual devia se pronunciar o juiz de ofício ou
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – INEXISTÊNCIA DOS VÍCIOS PREVISTOS NO ARTIGO 1.022, DO CPC – PREQUESTIONAMENTO – EMBARGOS DECLARATÓRIOS REJEITADOS.
+Nos termos do artigo 1.022, do CPC/2015, cabem embargos de declaração para esclarecer obscuridade, eliminar contradição ou suprir omissão de ponto ou questão sobre o qual devia se pronunciar o juiz de ofício ou a requerimento, ou corrigir erro material.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>70&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877203" cdForo="0" >
+										1421885-07.2025.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877203" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877203);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877203" style="display: none;" >
+	<div id="textAreaDados_1877203" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DE NULIDADE DE DECIS&Atilde;O ADMINISTRATIVA C/C PEDIDO LIMINAR DE URG&Ecirc;NCIA PARA INSCRI&Ccedil;&Atilde;O DE CHAPA EM CAR&Aacute;TER SUBJUDICE - CONDOM&Iacute;NIO &ndash; ELEI&Ccedil;&Atilde;O DE S&Iacute;NDICO &ndash; TUTELA DE URG&Ecirc;NCIA DEFERIDA NA ORIGEM PARA SUSPENDER A POSSE DOS ELEITOS &ndash; PRELIMINARES DE FALTA DE CONDI&Ccedil;&Atilde;O DA A&Ccedil;&Atilde;O E AUS&Ecirc;NCIA DE CAUSA DE PEDIR &ndash; REJEITADAS &ndash; M&Eacute;RITO &ndash; INTERVEN&Ccedil;&Atilde;O JUDICIAL EM QUEST&Otilde;ES INTERNA CORPORIS &ndash; EXCEPCIONALIDADE &ndash; SOBERANIA DA ASSEMBLEIA GERAL &ndash; ART. 1.355 DO C&Oacute;DIGO CIVIL &ndash; AUS&Ecirc;NCIA DE PROBABILIDADE DO DIREITO &ndash; PERICULUM IN MORA INVERSO CONFIGURADO &ndash; DECIS&Atilde;O REFORMADA &ndash; RECURSO CONHECIDO E PROVIDO.
+I - A propositura de a&ccedil;&atilde;o anulat&oacute;ria pela atual s&iacute;ndica, em nome pr&oacute;prio (pessoa f&iacute;sica), para tutelar o direito individual de ter sua candidatura registrada no pleito eleitoral n&atilde;o configura confus&atilde;o entre as partes, tampouco h&aacute; falar em aus&ecirc;ncia de causa de pedir quando a inicial descreve de forma clara os fatos e os fundamentos jur&iacute;dicos da suposta nulidade.
+II - As delibera&ccedil;&otilde;es tomadas em assembleia condominial s&atilde;o soberanas e possuem for&ccedil;a cogente, nos termos do art. 1.355 do C&oacute;digo Civil, de modo que a interven&ccedil;&atilde;o do Poder Judici&aacute;rio em quest&otilde;es interna corporis deve ser excepcional, limitando-se a casos de flagrante ilegalidade ou inobserv&acirc;ncia da conven&ccedil;&atilde;o e do edital.
+III - O indeferimento de candidatura pela comiss&atilde;o eleitoral com base em regras objetivas do edital, de intempestividade do registro e de an&aacute;lise de idoneidade curricular, demanda dila&ccedil;&atilde;o probat&oacute;ria sob o crivo do contradit&oacute;rio, n&atilde;o evidenciando, em cogni&ccedil;&atilde;o sum&aacute;ria, a probabilidade do direito apta a suspender os efeitos de pleito eleitoral em que a chapa vencedora obteve a maioria absoluta dos votos dos presentes.
+IV - A manuten&ccedil;&atilde;o de tutela de urg&ecirc;ncia que suspende a posse de chapa democraticamente eleita e imp&otilde;e a continuidade de gest&atilde;o cujo mandato se encerrou configura evidente periculum in mora inverso, gerando grave instabilidade administrativa, financeira e inseguran&ccedil;a jur&iacute;dica para a coletividade condominial.
+V - Decis&atilde;o reformada. Recurso conhecido e provido.
+  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1421885-07.2025.8.12.0000,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Assembléia
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DE NULIDADE DE DECISÃO ADMINISTRATIVA C/C PEDIDO LIMINAR DE URGÊNCIA PARA INSCRIÇÃO DE CHAPA EM CARÁTER SUBJUDICE - CONDOMÍNIO – ELEIÇÃO DE SÍNDICO – TUTELA DE URGÊNCIA DEFERIDA NA ORIGEM PARA SUSPENDER A POSSE DOS ELEITOS – PRELIMINARES DE FALTA DE CONDIÇÃO DA AÇÃO E AUSÊNCIA DE CAUSA DE PEDIR – REJEITADAS – MÉRITO – INTERVENÇÃO JUDICIAL EM QUESTÕES INTERNA CORPORIS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DE NULIDADE DE DECISÃO ADMINISTRATIVA C/C PEDIDO LIMINAR DE URGÊNCIA PARA INSCRIÇÃO DE CHAPA EM CARÁTER SUBJUDICE - CONDOMÍNIO – ELEIÇÃO DE SÍNDICO – TUTELA DE URGÊNCIA DEFERIDA NA ORIGEM PARA SUSPENDER A POSSE DOS ELEITOS – PRELIMINARES DE FALTA DE CONDIÇÃO DA AÇÃO E AUSÊNCIA DE CAUSA DE PEDIR – REJEITADAS – MÉRITO – INTERVENÇÃO JUDICIAL EM QUESTÕES INTERNA CORPORIS – EXCEPCIONALIDADE – SOBERANIA DA ASSEMBLEIA GERAL – ART. 1.355 DO CÓDIGO CIVIL – AUSÊNCIA DE PROBABILIDADE DO DIREITO – PERICULUM IN MORA INVERSO CONFIGURADO – DECISÃO REFORMADA – RECURSO CONHECIDO E PROVIDO.
+I - A propositura de ação anulatória pela atual síndica, em nome próprio (pessoa física), para tutelar o direito individual de ter sua candidatura registrada no pleito eleitoral não configura confusão entre as partes, tampouco há falar em ausência de causa de pedir quando a inicial descreve de forma clara os fatos e os fundamentos jurídicos da suposta nulidade.
+II - As deliberações tomadas em assembleia condominial são soberanas e possuem força cogente, nos termos do art. 1.355 do Código Civil, de modo que a intervenção do Poder Judiciário em questões interna corporis deve ser excepcional, limitando-se a casos de flagrante ilegalidade ou inobservância da convenção e do edital.
+III - O indeferimento de candidatura pela comissão eleitoral com base em regras objetivas do edital, de intempestividade do registro e de análise de idoneidade curricular, demanda dilação probatória sob o crivo do contraditório, não evidenciando, em cognição sumária, a probabilidade do direito apta a suspender os efeitos de pleito eleitoral em que a chapa vencedora obteve a maioria absoluta dos votos dos presentes.
+IV - A manutenção de tutela de urgência que suspende a posse de chapa democraticamente eleita e impõe a continuidade de gestão cujo mandato se encerrou configura evidente periculum in mora inverso, gerando grave instabilidade administrativa, financeira e insegurança jurídica para a coletividade condominial.
+V - Decisão reformada. Recurso conhecido e provido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>71&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877225" cdForo="0" >
+										0931297-50.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877225" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877225);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877225" style="display: none;" >
+	<div id="textAreaDados_1877225" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL &ndash; APELA&Ccedil;&Atilde;O CRIMINAL DEFENSIVA &ndash; LES&Atilde;O CORPORAL GRAVE &ndash; DOSIMETRIA DA PENA &ndash; CIRCUNST&Acirc;NCIAS JUDICIAIS &ndash; FRA&Ccedil;&Atilde;O EXCESSIVA &ndash; ADEQUA&Ccedil;&Atilde;O DA FRA&Ccedil;&Atilde;O RELATIVA &Agrave; CONFISS&Atilde;O ESPONT&Acirc;NEA &ndash; INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; MANUTEN&Ccedil;&Atilde;O &ndash;  RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1) Recurso de Apela&ccedil;&atilde;o Criminal interposto contra Senten&ccedil;a que condenou o R&eacute;u pela pr&aacute;tica do crime de les&atilde;o corporal grave (art. 129, &sect; 1&ordm;, incisos I e II, do C&oacute;digo Penal), com reconhecimento da atenuante da confiss&atilde;o espont&acirc;nea, fixando pena privativa de liberdade e valor m&iacute;nimo de indeniza&ccedil;&atilde;o por danos morais em favor da v&iacute;tima.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (2.1) definir se a exaspera&ccedil;&atilde;o da pena-base observou crit&eacute;rio proporcional ao n&uacute;mero de circunst&acirc;ncias judiciais negativadas; (2.2) estabelecer se a fra&ccedil;&atilde;o aplicada &agrave; atenuante da confiss&atilde;o espont&acirc;nea deve ser majorada; e (2.3) determinar se &eacute; cab&iacute;vel a fixa&ccedil;&atilde;o e manuten&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima por danos morais na senten&ccedil;a penal condenat&oacute;ria.
+III. RAZ&Otilde;ES DE DECIDIR
+3)  O C&oacute;digo Penal n&atilde;o estabelece crit&eacute;rios objetivos para a fixa&ccedil;&atilde;o da pena-base, mas a jurisprud&ecirc;ncia do STJ adota, como par&acirc;metro, a fra&ccedil;&atilde;o de 1/8 sobre o intervalo entre as penas m&iacute;nima e m&aacute;xima cominadas ao tipo para cada circunst&acirc;ncia judicial negativada, por possu&iacute;rem id&ecirc;ntico grau de import&acirc;ncia (art. 59 do CP).
+4) O Ju&iacute;zo de origem negativou tr&ecirc;s circunst&acirc;ncias judiciais (motivo torpe, circunst&acirc;ncias do crime e consequ&ecirc;ncias do delito), mas exasperou a pena-base em patamar superior ao correspondente &agrave; fra&ccedil;&atilde;o de 1/8 para cada vetor, impondo aumento desproporcional.
+5) A readequa&ccedil;&atilde;o da pena-base com a incid&ecirc;ncia de 1/8 sobre o intervalo legal para cada circunst&acirc;ncia desfavor&aacute;vel conduz &agrave; fixa&ccedil;&atilde;o da pena-base em 2 anos e 6 meses de reclus&atilde;o.
+6) A confiss&atilde;o espont&acirc;nea, ainda que parcial, configura atenuante (art. 65, III, &quot;d&quot;, do CP), sendo cab&iacute;vel sua valora&ccedil;&atilde;o na segunda fase da dosimetria.
+7) A jurisprud&ecirc;ncia do STJ e do STF adota, como par&acirc;metro ordin&aacute;rio para agravantes e atenuantes, a fra&ccedil;&atilde;o de 1/6, admitindo-se percentual diverso desde que fundamentado e proporcional ao caso concreto.
+8) Considerando que o R&eacute;u confessou apenas parcialmente os fatos e que a autoria foi corroborada por prova testemunhal e pela palavra da v&iacute;tima, revela-se adequado fixar a redu&ccedil;&atilde;o em 1/7, em observ&acirc;ncia aos princ&iacute;pios da proporcionalidade e da individualiza&ccedil;&atilde;o da pena.
+9) O art. 387, IV, do CPP imp&otilde;e ao Juiz o dever de fixar valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos causados pela infra&ccedil;&atilde;o, abrangendo danos morais.
+10) A exist&ecirc;ncia de pedido expresso na den&uacute;ncia e a comprova&ccedil;&atilde;o da pr&aacute;tica delitiva autorizam a fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima, sendo o dano moral, na hip&oacute;tese de viol&ecirc;ncia com efetivo perigo de vida e incapacidade por mais de 30 dias, evidente diante da gravidade da conduta.
+11) O valor de R$ 5.000,00 mostra-se proporcional &agrave;s circunst&acirc;ncias do caso, &agrave; extens&atilde;o do dano e ao car&aacute;ter pedag&oacute;gico da medida, n&atilde;o configurando enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+12) Em parte com o parecer, Recurso parcialmente provido.
+Tese de julgamento:
+a) Na aus&ecirc;ncia de crit&eacute;rio legal espec&iacute;fico, aplica-se a fra&ccedil;&atilde;o de 1/8 sobre o intervalo entre as penas m&iacute;nima e m&aacute;xima do tipo penal para cada circunst&acirc;ncia judicial negativada, salvo fundamenta&ccedil;&atilde;o concreta que justifique patamar diverso.
+b) A atenuante da confiss&atilde;o espont&acirc;nea admite redu&ccedil;&atilde;o em fra&ccedil;&atilde;o diversa de 1/6, desde que o percentual fixado observe a proporcionalidade e a relev&acirc;ncia da colabora&ccedil;&atilde;o do R&eacute;u.
+c) &Eacute; cab&iacute;vel a fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o de danos morais na senten&ccedil;a penal condenat&oacute;ria, nos termos do art. 387, IV, do CPP, desde que haja pedido expresso e elementos suficientes nos autos.
+Dispositivos relevantes citados: CP, arts. 59, 65, III, &quot;d&quot;, e 68; CP, art. 129, &sect; 1&ordm;, I e II; CPP, art. 387, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, HC 367.917/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 14.02.2017; STJ, HC 381.179/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 16.02.2017; STJ, REsp 1.819.504/MS, Rel. Min. Laurita Vaz, Sexta Turma, j. 10.09.2019. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0931297-50.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. L&uacute;cio R. da Silveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Grave
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Lúcio R. da Silveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL – APELAÇÃO CRIMINAL DEFENSIVA – LESÃO CORPORAL GRAVE – DOSIMETRIA DA PENA – CIRCUNSTÂNCIAS JUDICIAIS – FRAÇÃO EXCESSIVA – ADEQUAÇÃO DA FRAÇÃO RELATIVA À CONFISSÃO ESPONTÂNEA – INDENIZAÇÃO POR DANOS MORAIS – MANUTENÇÃO –  RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1) Recurso de Apelação Criminal interposto contra Sentença que condenou o Réu pela prática do
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL – APELAÇÃO CRIMINAL DEFENSIVA – LESÃO CORPORAL GRAVE – DOSIMETRIA DA PENA – CIRCUNSTÂNCIAS JUDICIAIS – FRAÇÃO EXCESSIVA – ADEQUAÇÃO DA FRAÇÃO RELATIVA À CONFISSÃO ESPONTÂNEA – INDENIZAÇÃO POR DANOS MORAIS – MANUTENÇÃO –  RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1) Recurso de Apelação Criminal interposto contra Sentença que condenou o Réu pela prática do crime de lesão corporal grave (art. 129, § 1º, incisos I e II, do Código Penal), com reconhecimento da atenuante da confissão espontânea, fixando pena privativa de liberdade e valor mínimo de indenização por danos morais em favor da vítima.
+II. QUESTÃO EM DISCUSSÃO
+2) Há três questões em discussão: (2.1) definir se a exasperação da pena-base observou critério proporcional ao número de circunstâncias judiciais negativadas; (2.2) estabelecer se a fração aplicada à atenuante da confissão espontânea deve ser majorada; e (2.3) determinar se é cabível a fixação e manutenção de indenização mínima por danos morais na sentença penal condenatória.
+III. RAZÕES DE DECIDIR
+3)  O Código Penal não estabelece critérios objetivos para a fixação da pena-base, mas a jurisprudência do STJ adota, como parâmetro, a fração de 1/8 sobre o intervalo entre as penas mínima e máxima cominadas ao tipo para cada circunstância judicial negativada, por possuírem idêntico grau de importância (art. 59 do CP).
+4) O Juízo de origem negativou três circunstâncias judiciais (motivo torpe, circunstâncias do crime e consequências do delito), mas exasperou a pena-base em patamar superior ao correspondente à fração de 1/8 para cada vetor, impondo aumento desproporcional.
+5) A readequação da pena-base com a incidência de 1/8 sobre o intervalo legal para cada circunstância desfavorável conduz à fixação da pena-base em 2 anos e 6 meses de reclusão.
+6) A confissão espontânea, ainda que parcial, configura atenuante (art. 65, III, "d", do CP), sendo cabível sua valoração na segunda fase da dosimetria.
+7) A jurisprudência do STJ e do STF adota, como parâmetro ordinário para agravantes e atenuantes, a fração de 1/6, admitindo-se percentual diverso desde que fundamentado e proporcional ao caso concreto.
+8) Considerando que o Réu confessou apenas parcialmente os fatos e que a autoria foi corroborada por prova testemunhal e pela palavra da vítima, revela-se adequado fixar a redução em 1/7, em observância aos princípios da proporcionalidade e da individualização da pena.
+9) O art. 387, IV, do CPP impõe ao Juiz o dever de fixar valor mínimo para reparação dos danos causados pela infração, abrangendo danos morais.
+10) A existência de pedido expresso na denúncia e a comprovação da prática delitiva autorizam a fixação de indenização mínima, sendo o <em>dano</em> <em>moral</em>, na hipótese de violência com efetivo perigo de vida e incapacidade por mais de 30 dias, evidente diante da gravidade da conduta.
+11) O valor de R$ 5.000,00 mostra-se proporcional às circunstâncias do caso, à extensão do <em>dano</em> e ao caráter pedagógico da medida, não configurando enriquecimento sem causa.
+IV. DISPOSITIVO E TESE
+12) Em parte com o parecer, Recurso parcialmente provido.
+Tese de julgamento:
+a) Na ausência de critério legal específico, aplica-se a fração de 1/8 sobre o intervalo entre as penas mínima e máxima do tipo penal para cada circunstância judicial negativada, salvo fundamentação concreta que justifique patamar diverso.
+b) A atenuante da confissão espontânea admite redução em fração diversa de 1/6, desde que o percentual fixado observe a proporcionalidade e a relevância da colaboração do Réu.
+c) É cabível a fixação de valor mínimo para reparação de danos morais na sentença penal condenatória, nos termos do art. 387, IV, do CPP, desde que haja pedido expresso e elementos suficientes nos autos.
+Dispositivos relevantes citados: CP, arts. 59, 65, III, "d", e 68; CP, art. 129, § 1º, I e II; CPP, art. 387, IV.
+Jurisprudência relevante citada: STJ, HC 367.917/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 14.02.2017; STJ, HC 381.179/SP, Rel. Min. Ribeiro Dantas, Quinta Turma, j. 16.02.2017; STJ, REsp 1.819.504/MS, Rel. Min. Laurita Vaz, Sexta Turma, j. 10.09.2019.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>72&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877235" cdForo="0" >
+										0800797-14.2025.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877235" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877235);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877235" style="display: none;" >
+	<div id="textAreaDados_1877235" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O DE DANOS MATERIAIS E MORAIS C C OBRIGA&Ccedil;&Atilde;O DE FAZER COM PEDIDO DE TUTELA PROVIS&Oacute;RIA DE URG&Ecirc;NCIA.  DIREITO DO CONSUMIDOR E DIREITO PROCESSUAL CIVIL. SENTEN&Ccedil;A QUE INDEFERE INICIAL.  INDEFERIMENTO DA PETI&Ccedil;&Atilde;O INICIAL POR EXIG&Ecirc;NCIA DE PROVA PR&Eacute;VIA DE CONTRATA&Ccedil;&Atilde;O SUPOSTAMENTE FRAUDULENTA. SENTEN&Ccedil;A ANULADA. RECURSO PROVIDO.
+CASO EM EXAME.
+Recurso de apela&ccedil;&atilde;o interposto contra senten&ccedil;a que indeferiu a peti&ccedil;&atilde;o inicial em a&ccedil;&atilde;o de repara&ccedil;&atilde;o de danos materiais e morais c/c obriga&ccedil;&atilde;o de fazer e pedido de tutela, fundada em alega&ccedil;&atilde;o de financiamento de ve&iacute;culo realizado de forma fraudulenta em nome do autor.
+ QUEST&Atilde;O EM DISCUSS&Atilde;O
+A quest&atilde;o em discuss&atilde;o consiste em saber se &eacute; poss&iacute;vel indeferir a peti&ccedil;&atilde;o inicial e condicionar o regular processamento da demanda &agrave; apresenta&ccedil;&atilde;o, pelo consumidor, de contrato de compra, venda e financiamento, em hip&oacute;tese de alega&ccedil;&atilde;o de inexist&ecirc;ncia de contrata&ccedil;&atilde;o por suposta fraude, &agrave; luz do CPC e do CDC.
+RAZ&Otilde;ES DE DECIDIR
+Deu-se provimento ao recurso para anular a senten&ccedil;a e afastar o indeferimento da inicial, porque a peti&ccedil;&atilde;o inicial preenchia os requisitos dos arts. 319 e 320 do CPC e o indeferimento &eacute; excepcional e restrito &agrave;s hip&oacute;teses do art. 330 do CPC. O ju&iacute;zo de origem condicionou o prosseguimento &agrave; prova pr&eacute;via do fato constitutivo, confundindo aus&ecirc;ncia de documento indispens&aacute;vel com insufici&ecirc;ncia probat&oacute;ria, o que s&oacute; pode ser avaliado ap&oacute;s contradit&oacute;rio e instru&ccedil;&atilde;o. Considerou-se, ainda, que o autor alegou fato negativo (inexist&ecirc;ncia de contrata&ccedil;&atilde;o) em contexto de poss&iacute;vel fraude, o que torna irrazo&aacute;vel exigir a juntada do contrato, sobretudo em rela&ccedil;&atilde;o de consumo, na qual se admite a invers&atilde;o do &ocirc;nus da prova (CDC, art. 6&ordm;, VIII). O voto tamb&eacute;m assentou que condicionar o andamento da a&ccedil;&atilde;o &agrave; pr&eacute;via comprova&ccedil;&atilde;o viola a inafastabilidade da jurisdi&ccedil;&atilde;o (CF/1988, art. 5&ordm;, XXXV) e citou precedentes do TJMS sobre cerceamento de defesa e necessidade de oportunizar prova, inclusive com refer&ecirc;ncia ao CPC, art. 370 (TJMS. Apela&ccedil;&atilde;o C&iacute;vel n. 0810514-66.2024.8.12.0021, 1&ordf; C&acirc;mara C&iacute;vel, Rel. Des. M.C.R., j. 26/02/2026, p. 02/03/2026).
+
+
+
+DISPOSITIVO
+Recurso de apela&ccedil;&atilde;o conhecido e provido para anular a senten&ccedil;a, afastar o indeferimento da peti&ccedil;&atilde;o inicial e determinar o regular prosseguimento do feito, com intima&ccedil;&atilde;o da requerida para contestar, nos termos do art. 331, &sect; 2&ordm;, do CPC.
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;, XXXV; CPC, arts. 319 e 320; CPC, art.330; CPC, art. 331, &sect; 2&ordm;; CPC, art. 370; CDC, art. 6&ordm;, VIII; CPC, art. 373, II; e CPC, art. 85, &sect; 11.
+Jurisprud&ecirc;ncia relevante citada: TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0810514-66.2024.8.12.0021, Rel. Des. M.C.R., 1&ordf; C&acirc;mara C&iacute;vel, j. 26.02.2026, p. 02.03.2026; e TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0804923-83.2024.8.12.0002, Rel. Des&ordf; E.R.B., 4&ordf; C&acirc;mara C&iacute;vel, j. 25.02.2026, p. 27.02.2026.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800797-14.2025.8.12.0015,&nbsp; Miranda,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE REPARAÇÃO DE DANOS MATERIAIS E MORAIS C C OBRIGAÇÃO DE FAZER COM PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA.  DIREITO DO CONSUMIDOR E DIREITO PROCESSUAL CIVIL. SENTENÇA QUE INDEFERE INICIAL.  INDEFERIMENTO DA PETIÇÃO INICIAL POR EXIGÊNCIA DE PROVA PRÉVIA DE CONTRATAÇÃO SUPOSTAMENTE FRAUDULENTA. SENTENÇA ANULADA. RECURSO PROVIDO.
+CASO EM EXAME.
+Recurso de apelação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL EM AÇÃO DE REPARAÇÃO DE DANOS MATERIAIS E MORAIS C C OBRIGAÇÃO DE FAZER COM PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA.  DIREITO DO CONSUMIDOR E DIREITO PROCESSUAL CIVIL. SENTENÇA QUE INDEFERE INICIAL.  INDEFERIMENTO DA PETIÇÃO INICIAL POR EXIGÊNCIA DE PROVA PRÉVIA DE CONTRATAÇÃO SUPOSTAMENTE FRAUDULENTA. SENTENÇA ANULADA. RECURSO PROVIDO.
+CASO EM EXAME.
+Recurso de apelação interposto contra sentença que indeferiu a petição inicial em ação de reparação de danos materiais e morais c/c obrigação de fazer e pedido de tutela, fundada em alegação de financiamento de veículo realizado de forma fraudulenta em nome do autor.
+ QUESTÃO EM DISCUSSÃO
+A questão em discussão consiste em saber se é possível indeferir a petição inicial e condicionar o regular processamento da demanda à apresentação, pelo consumidor, de contrato de compra, venda e financiamento, em hipótese de alegação de inexistência de contratação por suposta fraude, à luz do CPC e do CDC.
+RAZÕES DE DECIDIR
+Deu-se provimento ao recurso para anular a sentença e afastar o indeferimento da inicial, porque a petição inicial preenchia os requisitos dos arts. 319 e 320 do CPC e o indeferimento é excepcional e restrito às hipóteses do art. 330 do CPC. O juízo de origem condicionou o prosseguimento à prova prévia do fato constitutivo, confundindo ausência de documento indispensável com insuficiência probatória, o que só pode ser avaliado após contraditório e instrução. Considerou-se, ainda, que o autor alegou fato negativo (inexistência de contratação) em contexto de possível fraude, o que torna irrazoável exigir a juntada do contrato, sobretudo em relação de consumo, na qual se admite a inversão do ônus da prova (CDC, art. 6º, VIII). O voto também assentou que condicionar o andamento da ação à prévia comprovação viola a inafastabilidade da jurisdição (CF/1988, art. 5º, XXXV) e citou precedentes do TJMS sobre cerceamento de defesa e necessidade de oportunizar prova, inclusive com referência ao CPC, art. 370 (TJMS. Apelação Cível n. 0810514-66.2024.8.12.0021, 1ª Câmara Cível, Rel. Des. M.C.R., j. 26/02/2026, p. 02/03/2026).
+
+
+
+DISPOSITIVO
+Recurso de apelação conhecido e provido para anular a sentença, afastar o indeferimento da petição inicial e determinar o regular prosseguimento do feito, com intimação da requerida para contestar, nos termos do art. 331, § 2º, do CPC.
+Dispositivos relevantes citados: CF/1988, art. 5º, XXXV; CPC, arts. 319 e 320; CPC, art.330; CPC, art. 331, § 2º; CPC, art. 370; CDC, art. 6º, VIII; CPC, art. 373, II; e CPC, art. 85, § 11.
+Jurisprudência relevante citada: TJMS, Apelação Cível n. 0810514-66.2024.8.12.0021, Rel. Des. M.C.R., 1ª Câmara Cível, j. 26.02.2026, p. 02.03.2026; e TJMS, Apelação Cível n. 0804923-83.2024.8.12.0002, Rel. Desª E.R.B., 4ª Câmara Cível, j. 25.02.2026, p. 27.02.2026.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>73&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877239" cdForo="0" >
+										0803245-24.2020.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877239" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877239);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877239" style="display: none;" >
+	<div id="textAreaDados_1877239" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash;  RESPONSABILIDADE CIVIL OBJETIVA &ndash; CONCESSION&Aacute;RIA DE SERVI&Ccedil;OS P&Uacute;BLICOS &ndash; ESTA&Ccedil;&Atilde;O DE TRATAMENTO DE ESGOTO (ETE) &ndash; EMISS&Atilde;O DE GASES DECORRENTES DA OPERA&Ccedil;&Atilde;O &ndash; MAU CHEIRO PROVENIENTE DO EMPREENDIMENTO &ndash; LAUDO PERICIAL &ndash; VEDA&Ccedil;&Atilde;O PREC&Aacute;RIA E CORTINA ARB&Oacute;REA INSUFICIENTE &ndash; OCUPA&Ccedil;&Atilde;O RESIDENCIAL POSTERIOR &Agrave; INSTALA&Ccedil;&Atilde;O DA ETE &ndash; INDIFERENTE &ndash; DIREITO CONSTITUCIONAL &Agrave; MORADIA ADEQUADA, SA&Uacute;DE E MEIO AMBIENTE &ndash; RACISMO AMBIENTAL &ndash; PROTOCOLO POR PERSPECTIVA RACIAL &ndash; DANOS MORAIS CONFIGURADOS &ndash; RECURSO CONHECIDO E PROVIDO.
+Cinge-se a controv&eacute;rsia em definir se a Requerente/Apelante det&eacute;m o direito &agrave; fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais decorrentes de supostos odores provenientes de Esta&ccedil;&atilde;o de Tratamento de Esgoto operacionalizado pela Requerida/Apelada na cidade de Parana&iacute;ba/MS.
+Os fatos narrados nos autos devem ser analisados sob a &oacute;tica da responsabilidade objetiva, conforme o disposto no art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal, &agrave; luz da Teoria do Risco Administrativo em que a obriga&ccedil;&atilde;o de indenizar existe ainda que a conduta n&atilde;o seja culposa, na medida em que o polo passivo &eacute; ocupado por concession&aacute;ria de servi&ccedil;os p&uacute;blicos.
+N&atilde;o h&aacute; controv&eacute;rsia sobre a exist&ecirc;ncia da Esta&ccedil;&atilde;o de Tratamento de Esgoto em local pr&oacute;ximo &agrave; resid&ecirc;ncia da parte autora, sendo que, de acordo com a prova pericial, a despeito do mau cheiro pr&oacute;prio da atividade desenvolvida, h&aacute; falhas na veda&ccedil;&atilde;o das tampas de um dos reatores e na &quot;cortina arb&oacute;rea&quot;, as quais, se em pleno funcionamento, poderiam mitigar o forte odor percebido pelos moradores da regi&atilde;o.
+A par do direito &agrave; sa&uacute;de e meio ambiente equilibrado, a parte autora det&eacute;m direito &agrave; moradia (art. 6&ordm; da CF), que n&atilde;o se limita &agrave; exist&ecirc;ncia de um teto, mas ao padr&atilde;o de vida adequado dentro desse local de habita&ccedil;&atilde;o cont&iacute;nua, conforme reconhecido no cen&aacute;rio internacional pelo Protocolo Internacional dos Direitos Econ&ocirc;micos, Sociais e Culturais e no Coment&aacute;rio Geral n&ordm; 04, do PIDESC.
+Indiferente o fato de a parte autora ter passado a residir no local ap&oacute;s a instala&ccedil;&atilde;o da ETE, pois n&atilde;o h&aacute; uma simples &quot;op&ccedil;&atilde;o&quot; de residir num local perif&eacute;rico, mas a jun&ccedil;&atilde;o de fatores sociais que fazem com que a popula&ccedil;&atilde;o de baixa renda seja deslocada para &aacute;reas urbanas desprovidas de recursos.
+Obstar o direito &agrave; repara&ccedil;&atilde;o &eacute; refor&ccedil;ar um cen&aacute;rio de racismo ambiental, consistente no agravamento da situa&ccedil;&atilde;o de vida das pessoas carentes que vivem em locais perif&eacute;ricos e sofrem, de maneira mais acentuada, com eventos da natureza por for&ccedil;a do desenvolvimento e a explora&ccedil;&atilde;o de atividades empresariais (Resolu&ccedil;&atilde;o n&ordm; 598/2024, do CNJ, que instituiu o &quot;Protocolo para Julgamento com Perspectiva Racial do CNJ&quot;).
+O dano moral caracteriza-se pela les&atilde;o aos direitos de personalidade, pertencentes a uma esfera extrapatrimonial do indiv&iacute;duo e, no caso, n&atilde;o houve simples aborrecimento, pois a presen&ccedil;a constante de odor pela regi&atilde;o n&atilde;o pode ser compreendido como indiferente, mas como causador de les&atilde;o em decorr&ecirc;ncia da viola&ccedil;&atilde;o &agrave; integridade f&iacute;sica e psicol&oacute;gica da moradora.
+Quanto ao valor da indeniza&ccedil;&atilde;o, destaca-se que n&atilde;o existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercuss&atilde;o dos fatos, estabelecer a indeniza&ccedil;&atilde;o que venha ressarcir a parte lesada (car&aacute;ter indenizat&oacute;rio) e que tamb&eacute;m iniba a reitera&ccedil;&atilde;o de condutas an&aacute;logas (aspecto pedag&oacute;gico).
+Diante desses par&acirc;metros, mostra-se adequada a fixa&ccedil;&atilde;o de R$ 4.000,00 (quatro mil reais), levando em considera&ccedil;&atilde;o tamb&eacute;m o n&uacute;mero de pessoas que buscam id&ecirc;ntica repara&ccedil;&atilde;o.
+Recurso conhecido e provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803245-24.2020.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA –  RESPONSABILIDADE CIVIL OBJETIVA – CONCESSIONÁRIA DE SERVIÇOS PÚBLICOS – ESTAÇÃO DE TRATAMENTO DE ESGOTO (ETE) – EMISSÃO DE GASES DECORRENTES DA OPERAÇÃO – MAU CHEIRO PROVENIENTE DO EMPREENDIMENTO – LAUDO PERICIAL – VEDAÇÃO PRECÁRIA E CORTINA ARBÓREA INSUFICIENTE – OCUPAÇÃO RESIDENCIAL POSTERIOR À INSTALAÇÃO DA ETE – INDIFERENTE – DIREITO CONSTITUCIONAL À
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA –  RESPONSABILIDADE CIVIL OBJETIVA – CONCESSIONÁRIA DE SERVIÇOS PÚBLICOS – ESTAÇÃO DE TRATAMENTO DE ESGOTO (ETE) – EMISSÃO DE GASES DECORRENTES DA OPERAÇÃO – MAU CHEIRO PROVENIENTE DO EMPREENDIMENTO – LAUDO PERICIAL – VEDAÇÃO PRECÁRIA E CORTINA ARBÓREA INSUFICIENTE – OCUPAÇÃO RESIDENCIAL POSTERIOR À INSTALAÇÃO DA ETE – INDIFERENTE – DIREITO CONSTITUCIONAL À MORADIA ADEQUADA, SAÚDE E MEIO AMBIENTE – RACISMO AMBIENTAL – PROTOCOLO POR PERSPECTIVA RACIAL – DANOS MORAIS CONFIGURADOS – RECURSO CONHECIDO E PROVIDO.
+Cinge-se a controvérsia em definir se a Requerente/Apelante detém o direito à fixação de indenização por danos morais decorrentes de supostos odores provenientes de Estação de Tratamento de Esgoto operacionalizado pela Requerida/Apelada na cidade de Paranaíba/MS.
+Os fatos narrados nos autos devem ser analisados sob a ótica da responsabilidade objetiva, conforme o disposto no art. 37, § 6º, da Constituição Federal, à luz da Teoria do Risco Administrativo em que a obrigação de indenizar existe ainda que a conduta não seja culposa, na medida em que o polo passivo é ocupado por concessionária de serviços públicos.
+Não há controvérsia sobre a existência da Estação de Tratamento de Esgoto em local próximo à residência da parte autora, sendo que, de acordo com a prova pericial, a despeito do mau cheiro próprio da atividade desenvolvida, há falhas na vedação das tampas de um dos reatores e na "cortina arbórea", as quais, se em pleno funcionamento, poderiam mitigar o forte odor percebido pelos moradores da região.
+A par do direito à saúde e meio ambiente equilibrado, a parte autora detém direito à moradia (art. 6º da CF), que não se limita à existência de um teto, mas ao padrão de vida adequado dentro desse local de habitação contínua, conforme reconhecido no cenário internacional pelo Protocolo Internacional dos Direitos Econômicos, Sociais e Culturais e no Comentário Geral nº 04, do PIDESC.
+Indiferente o fato de a parte autora ter passado a residir no local após a instalação da ETE, pois não há uma simples "opção" de residir num local periférico, mas a junção de fatores sociais que fazem com que a população de baixa renda seja deslocada para áreas urbanas desprovidas de recursos.
+Obstar o direito à reparação é reforçar um cenário de racismo ambiental, consistente no agravamento da situação de vida das pessoas carentes que vivem em locais periféricos e sofrem, de maneira mais acentuada, com eventos da natureza por força do desenvolvimento e a exploração de atividades empresariais (Resolução nº 598/2024, do CNJ, que instituiu o "Protocolo para Julgamento com Perspectiva Racial do CNJ").
+O <em>dano</em> <em>moral</em> caracteriza-se pela lesão aos direitos de personalidade, pertencentes a uma esfera extrapatrimonial do indivíduo e, no caso, não houve simples aborrecimento, pois a presença constante de odor pela região não pode ser compreendido como indiferente, mas como causador de lesão em decorrência da violação à integridade física e psicológica da moradora.
+Quanto ao valor da indenização, destaca-se que não existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercussão dos fatos, estabelecer a indenização que venha ressarcir a parte lesada (caráter indenizatório) e que também iniba a reiteração de condutas análogas (aspecto pedagógico).
+Diante desses parâmetros, mostra-se adequada a fixação de R$ 4.000,00 (quatro mil reais), levando em consideração também o número de pessoas que buscam idêntica reparação.
+Recurso conhecido e provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>74&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877248" cdForo="0" >
+										0811321-49.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877248" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877248);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877248" style="display: none;" >
+	<div id="textAreaDados_1877248" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER CUMULADA COM INDENIZAT&Oacute;RIA &ndash; CONTA DO APLICATIVO INSTAGRAM HACKEADA POR CRIMINOSO &ndash; AUS&Ecirc;NCIA DE ATO IL&Iacute;CITO DA R&Eacute; &ndash; DANO MORAL N&Atilde;O CONFIGURADO &ndash; MANTIDA A OBRIGA&Ccedil;&Atilde;O DE FAZER DE EXCLUS&Atilde;O DA CONTA &ndash; SUCUMB&Ecirc;NCIA REC&Iacute;PROCA &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A an&aacute;lise dos autos demonstra que o dano alegado pelo autor foi praticado por terceiro, um criminoso que invadiu e tomou conta do seu perfil no Instagram, sendo que a plataforma digital possui ferramentas pr&oacute;prias para a recupera&ccedil;&atilde;o do perfil e, no caso, n&atilde;o comprovado que o autor seguiu os protocolos necess&aacute;rios para a retomada ou exclus&atilde;o da sua conta.
+Logo, n&atilde;o se pode dizer que houve a pr&aacute;tica de ato il&iacute;cito pela r&eacute;, que n&atilde;o foi devidamente informada na seara administrativa sobre o infort&uacute;nio sofrido pelo autor, a fim de que pudesse providenciar a r&aacute;pida solu&ccedil;&atilde;o do problema. Nesse contexto, tem-se que n&atilde;o configurada a responsabilidade civil da r&eacute;-apelante pelo dano suportado pelo autor, pois n&atilde;o praticou ato il&iacute;cito, o que afasta o dever de indenizar.
+Manuten&ccedil;&atilde;o da obriga&ccedil;&atilde;o de fazer de cancelamento da conta.
+A sucumb&ecirc;ncia deve ser distribu&iacute;da igualmente entre as partes, ante a exist&ecirc;ncia de sucumb&ecirc;ncia rec&iacute;proca, nos termos do artigo 86, do CPC. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0811321-49.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – CONTA DO APLICATIVO INSTAGRAM HACKEADA POR CRIMINOSO – AUSÊNCIA DE ATO ILÍCITO DA RÉ – <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO – MANTIDA A OBRIGAÇÃO DE FAZER DE EXCLUSÃO DA CONTA – SUCUMBÊNCIA RECÍPROCA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A análise dos autos demonstra que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – CONTA DO APLICATIVO INSTAGRAM HACKEADA POR CRIMINOSO – AUSÊNCIA DE ATO ILÍCITO DA RÉ – <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO – MANTIDA A OBRIGAÇÃO DE FAZER DE EXCLUSÃO DA CONTA – SUCUMBÊNCIA RECÍPROCA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A análise dos autos demonstra que o <em>dano</em> alegado pelo autor foi praticado por terceiro, um criminoso que invadiu e tomou conta do seu perfil no Instagram, sendo que a plataforma digital possui ferramentas próprias para a recuperação do perfil e, no caso, não comprovado que o autor seguiu os protocolos necessários para a retomada ou exclusão da sua conta.
+Logo, não se pode dizer que houve a prática de ato ilícito pela ré, que não foi devidamente informada na seara administrativa sobre o infortúnio sofrido pelo autor, a fim de que pudesse providenciar a rápida solução do problema. Nesse contexto, tem-se que não configurada a responsabilidade civil da ré-apelante pelo <em>dano</em> suportado pelo autor, pois não praticou ato ilícito, o que afasta o dever de indenizar.
+Manutenção da obrigação de fazer de cancelamento da conta.
+A sucumbência deve ser distribuída igualmente entre as partes, ante a existência de sucumbência recíproca, nos termos do artigo 86, do CPC.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>75&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877280" cdForo="0" >
+										0800922-23.2023.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877280" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877280);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877280" style="display: none;" >
+	<div id="textAreaDados_1877280" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash; RESPONSABILIDADE CIVIL OBJETIVA. RECURSO DO REQUERIDO &ndash; DONO DOS ANIMAIS &ndash; ATAQUE DE C&Atilde;ES A ANIMAL DE ESTIMA&Ccedil;&Atilde;O &ndash; NEXO DE CAUSALIDADE EVIDENTE ENTRE O ACIDENTE E MORTE DO FELINO &ndash;  ROMPIMENTO DO NEXO CAUSAL N&Atilde;O DEMONSTRADO &ndash; EXCLUDENTE  DE RESPONSABILIDADE CIVIL N&Atilde;O COMPROVADO. ALEGADA FOR&Ccedil;A MAIOR &ndash; N&Atilde;O EVIDENCIADA. EVENTO PREVIS&Iacute;VEL. PENA DE CONFESSO &ndash; SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.
+
+EMENTA &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash; RESPONSABILIDADE CIVIL OBJETIVA. RECURSO AUTORAL &ndash; PEDIDO DE MAJORA&Ccedil;&Atilde;O &ndash; ART. 936 CC &ndash; ARBITRAMENTO EM CONSON&Acirc;NCIA COM OS PRINC&Iacute;PIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE &ndash; QUANTUM INDENIZAT&Oacute;RIO ADEQUADO E JUSTO &ndash; SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800922-23.2023.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – RESPONSABILIDADE CIVIL OBJETIVA. RECURSO DO REQUERIDO – DONO DOS ANIMAIS – ATAQUE DE CÃES A ANIMAL DE ESTIMAÇÃO – NEXO DE CAUSALIDADE EVIDENTE ENTRE O ACIDENTE E MORTE DO FELINO –  ROMPIMENTO DO NEXO CAUSAL NÃO DEMONSTRADO – EXCLUDENTE  DE RESPONSABILIDADE CIVIL NÃO COMPROVADO. ALEGADA FORÇA MAIOR – NÃO EVIDENCIADA. EVENTO PREVISÍVEL. PENA DE CONFESSO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – RESPONSABILIDADE CIVIL OBJETIVA. RECURSO DO REQUERIDO – DONO DOS ANIMAIS – ATAQUE DE CÃES A ANIMAL DE ESTIMAÇÃO – NEXO DE CAUSALIDADE EVIDENTE ENTRE O ACIDENTE E MORTE DO FELINO –  ROMPIMENTO DO NEXO CAUSAL NÃO DEMONSTRADO – EXCLUDENTE  DE RESPONSABILIDADE CIVIL NÃO COMPROVADO. ALEGADA FORÇA MAIOR – NÃO EVIDENCIADA. EVENTO PREVISÍVEL. PENA DE CONFESSO – SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+
+EMENTA – APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – RESPONSABILIDADE CIVIL OBJETIVA. RECURSO AUTORAL – PEDIDO DE MAJORAÇÃO – ART. 936 CC – ARBITRAMENTO EM CONSONÂNCIA COM OS PRINCÍPIOS DA RAZOABILIDADE E DA PROPORCIONALIDADE – QUANTUM INDENIZATÓRIO ADEQUADO E JUSTO – SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>76&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877292" cdForo="0" >
+										0900161-39.2023.8.12.0011
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877292" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877292);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877292" style="display: none;" >
+	<div id="textAreaDados_1877292" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. FURTO QUALIFICADO (ROMPIMENTO DE OBST&Aacute;CULO E ESCALADA). RECEPTA&Ccedil;&Atilde;O DOLOSA. NULIDADE POR REVELIA. INOCORR&Ecirc;NCIA. PROVA SUFICIENTE. LAUDO PERICIAL INCONCLUSIVO. AFASTAMENTO DAS QUALIFICADORAS. DESCLASSIFICA&Ccedil;&Atilde;O PARA FURTO SIMPLES MAJORADO PELO REPOUSO NOTURNO. INDENIZA&Ccedil;&Atilde;O M&Iacute;NIMA. AUS&Ecirc;NCIA DE INSTRU&Ccedil;&Atilde;O ESPEC&Iacute;FICA. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a que condenou um dos r&eacute;us como incurso no art. 155, &sect; 4&ordm;, I e II, do C&oacute;digo Penal, e outro r&eacute;u como incurso no art. 180, caput, do C&oacute;digo Penal.
+Em grau recursal, a defesa apresentou as seguintes teses: a) nulidade por cerceamento de defesa (revelia indevida); b) absolvi&ccedil;&atilde;o por insufici&ecirc;ncia probat&oacute;ria; c) afastamento das qualificadoras; d) desclassifica&ccedil;&atilde;o da recepta&ccedil;&atilde;o para modalidade culposa; e) exclus&atilde;o da indeniza&ccedil;&atilde;o fixada.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+As controv&eacute;rsias consistem em definir: a) se houve nulidade processual pela decreta&ccedil;&atilde;o da revelia; b) se a prova produzida &eacute; suficiente para a condena&ccedil;&atilde;o; c) se restaram comprovadas as qualificadoras do rompimento de obst&aacute;culo e da escalada; d) se a conduta configura recepta&ccedil;&atilde;o dolosa ou culposa; e) se &eacute; v&aacute;lida a fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima sem instru&ccedil;&atilde;o espec&iacute;fica.
+III. RAZ&Otilde;ES DE DECIDIR
+Preliminar de nulidade: A revelia foi decretada ap&oacute;s intima&ccedil;&atilde;o pessoal do acusado em audi&ecirc;ncia, nos termos do art. 367 do C&oacute;digo de Processo Penal. A aus&ecirc;ncia injustificada do r&eacute;u, regularmente cientificado, autoriza a decreta&ccedil;&atilde;o da revelia, inexistindo cerceamento de defesa, sobretudo porque a defesa t&eacute;cnica permaneceu atuante e n&atilde;o houve demonstra&ccedil;&atilde;o de preju&iacute;zo. Preliminar rejeitada.
+Autoria e materialidade do furto: A condena&ccedil;&atilde;o n&atilde;o se baseou exclusivamente em reconhecimento informal. Ainda que se considere a orienta&ccedil;&atilde;o firmada pelo Superior Tribunal de Justi&ccedil;a no HC 598.886/SC quanto &agrave; invalidade do reconhecimento realizado em desacordo com o art. 226 do CPP, h&aacute; nos autos conjunto probat&oacute;rio aut&ocirc;nomo e harm&ocirc;nico: a) confiss&atilde;o extrajudicial detalhada; b) apreens&atilde;o dos bens na resid&ecirc;ncia do corr&eacute;u; c) depoimentos judiciais dos policiais e da v&iacute;tima. A confiss&atilde;o extrajudicial foi corroborada por provas judicializadas, n&atilde;o havendo not&iacute;cia de coa&ccedil;&atilde;o. Mantida a condena&ccedil;&atilde;o.
+Afastamento das qualificadoras: O art. 158 do CPP exige exame pericial quando a infra&ccedil;&atilde;o deixa vest&iacute;gios. O laudo pericial indireto concluiu ser imposs&iacute;vel atestar o rompimento da cerca el&eacute;trica ou a ocorr&ecirc;ncia de escalada. N&atilde;o se trata de desaparecimento de vest&iacute;gios (art. 167 do CPP), mas de laudo inconclusivo. Diante da d&uacute;vida t&eacute;cnica, aplica-se o princ&iacute;pio do in dubio pro reo. Afastadas as qualificadoras dos incisos I e II do &sect; 4&ordm; do art. 155 do C&oacute;digo Penal.
+Recepta&ccedil;&atilde;o &ndash; modalidade dolosa: As circunst&acirc;ncias da aquisi&ccedil;&atilde;o evidenciam ci&ecirc;ncia da proced&ecirc;ncia criminosa. Invi&aacute;vel a desclassifica&ccedil;&atilde;o para recepta&ccedil;&atilde;o culposa (art. 180, &sect; 3&ordm;, do CP). Mantida a condena&ccedil;&atilde;o pelo art. 180, caput, do C&oacute;digo Penal.
+Indeniza&ccedil;&atilde;o m&iacute;nima: O art. 387, IV, do CPP exige pedido expresso e instru&ccedil;&atilde;o probat&oacute;ria que permita contradit&oacute;rio quanto ao quantum debeatur. Embora conste pedido gen&eacute;rico na den&uacute;ncia, n&atilde;o houve instru&ccedil;&atilde;o espec&iacute;fica quanto ao valor do preju&iacute;zo remanescente. Os bens foram apreendidos e n&atilde;o houve debate t&eacute;cnico sobre eventual dano material residual. &Agrave; luz da jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a, a fixa&ccedil;&atilde;o do valor m&iacute;nimo sem adequada instru&ccedil;&atilde;o viola o contradit&oacute;rio. Afastada a indeniza&ccedil;&atilde;o, sem preju&iacute;zo da discuss&atilde;o na seara c&iacute;vel.
+IV. DISPOSITIVO E TESE
+Recurso parcialmente provido.
+Tese de julgamento:
+A decreta&ccedil;&atilde;o da revelia do r&eacute;u regularmente intimado em audi&ecirc;ncia n&atilde;o configura cerceamento de defesa.
+A condena&ccedil;&atilde;o pode subsistir ainda que desconsiderado eventual reconhecimento irregular, quando fundada em conjunto probat&oacute;rio aut&ocirc;nomo e judicializado, incluindo confiss&atilde;o extrajudicial corroborada por outras provas.
+Laudo pericial inconclusivo quanto &agrave; ocorr&ecirc;ncia de rompimento de obst&aacute;culo e escalada impede o reconhecimento das qualificadoras, impondo-se sua exclus&atilde;o com fundamento no princ&iacute;pio do in dubio pro reo.
+Configura recepta&ccedil;&atilde;o dolosa a aquisi&ccedil;&atilde;o de bens em circunst&acirc;ncias que evidenciem ci&ecirc;ncia da origem criminosa, sendo invi&aacute;vel a desclassifica&ccedil;&atilde;o para modalidade culposa quando demonstrado o dolo.
+A fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o de danos materiais exige pedido expresso e instru&ccedil;&atilde;o probat&oacute;ria espec&iacute;fica quanto ao montante, sob pena de viola&ccedil;&atilde;o ao contradit&oacute;rio.
+Dispositivos relevantes citados: C&oacute;digo Penal, arts. 155, &sect; 1&ordm; e &sect; 4&ordm;, I e II; 180, caput e &sect; 3&ordm;; 59; C&oacute;digo de Processo Penal, arts. 155, 158, 167, 226, 367 e 387, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, HC 598.886/SC, Rel. Min. Rog&eacute;rio Schietti Cruz, Sexta Turma, DJe 18.12.2020; STJ, AgRg no HC 872.909/PR, Rel. Min. Jesu&iacute;no Rissato (Des. Conv.), Sexta Turma, DJe 27.5.2024; STJ, AgRg no REsp 2.142.318/DF, Rel. Min. Rog&eacute;rio Schietti Cruz, Sexta Turma, DJe 4.9.2024; STJ, AgRg no AREsp 2.068.728/MG, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, DJe 13.5.2022; STJ, AgRg no REsp 2.011.839/TO, Sexta Turma, DJe 15.12.2022. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0900161-39.2023.8.12.0011,&nbsp; Coxim,&nbsp; 1&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des&ordf; Elizabete Anache, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Desª Elizabete Anache
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Coxim
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO (ROMPIMENTO DE OBSTÁCULO E ESCALADA). RECEPTAÇÃO DOLOSA. NULIDADE POR REVELIA. INOCORRÊNCIA. PROVA SUFICIENTE. LAUDO PERICIAL INCONCLUSIVO. AFASTAMENTO DAS QUALIFICADORAS. DESCLASSIFICAÇÃO PARA FURTO SIMPLES MAJORADO PELO REPOUSO NOTURNO. INDENIZAÇÃO MÍNIMA. AUSÊNCIA DE INSTRUÇÃO ESPECÍFICA. PARCIAL PROVIMENTO.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. FURTO QUALIFICADO (ROMPIMENTO DE OBSTÁCULO E ESCALADA). RECEPTAÇÃO DOLOSA. NULIDADE POR REVELIA. INOCORRÊNCIA. PROVA SUFICIENTE. LAUDO PERICIAL INCONCLUSIVO. AFASTAMENTO DAS QUALIFICADORAS. DESCLASSIFICAÇÃO PARA FURTO SIMPLES MAJORADO PELO REPOUSO NOTURNO. INDENIZAÇÃO MÍNIMA. AUSÊNCIA DE INSTRUÇÃO ESPECÍFICA. PARCIAL PROVIMENTO.
+I. CASO EM EXAME
+Apelação criminal interposta contra sentença que condenou um dos réus como incurso no art. 155, § 4º, I e II, do Código Penal, e outro réu como incurso no art. 180, caput, do Código Penal.
+Em grau recursal, a defesa apresentou as seguintes teses: a) nulidade por cerceamento de defesa (revelia indevida); b) absolvição por insuficiência probatória; c) afastamento das qualificadoras; d) desclassificação da receptação para modalidade culposa; e) exclusão da indenização fixada.
+II. QUESTÃO EM DISCUSSÃO
+As controvérsias consistem em definir: a) se houve nulidade processual pela decretação da revelia; b) se a prova produzida é suficiente para a condenação; c) se restaram comprovadas as qualificadoras do rompimento de obstáculo e da escalada; d) se a conduta configura receptação dolosa ou culposa; e) se é válida a fixação de indenização mínima sem instrução específica.
+III. RAZÕES DE DECIDIR
+Preliminar de nulidade: A revelia foi decretada após intimação pessoal do acusado em audiência, nos termos do art. 367 do Código de Processo Penal. A ausência injustificada do réu, regularmente cientificado, autoriza a decretação da revelia, inexistindo cerceamento de defesa, sobretudo porque a defesa técnica permaneceu atuante e não houve demonstração de prejuízo. Preliminar rejeitada.
+Autoria e materialidade do furto: A condenação não se baseou exclusivamente em reconhecimento informal. Ainda que se considere a orientação firmada pelo Superior Tribunal de Justiça no HC 598.886/SC quanto à invalidade do reconhecimento realizado em desacordo com o art. 226 do CPP, há nos autos conjunto probatório autônomo e harmônico: a) confissão extrajudicial detalhada; b) apreensão dos bens na residência do corréu; c) depoimentos judiciais dos policiais e da vítima. A confissão extrajudicial foi corroborada por provas judicializadas, não havendo notícia de coação. Mantida a condenação.
+Afastamento das qualificadoras: O art. 158 do CPP exige exame pericial quando a infração deixa vestígios. O laudo pericial indireto concluiu ser impossível atestar o rompimento da cerca elétrica ou a ocorrência de escalada. Não se trata de desaparecimento de vestígios (art. 167 do CPP), mas de laudo inconclusivo. Diante da dúvida técnica, aplica-se o princípio do in dubio pro reo. Afastadas as qualificadoras dos incisos I e II do § 4º do art. 155 do Código Penal.
+Receptação – modalidade dolosa: As circunstâncias da aquisição evidenciam ciência da procedência criminosa. Inviável a desclassificação para receptação culposa (art. 180, § 3º, do CP). Mantida a condenação pelo art. 180, caput, do Código Penal.
+Indenização mínima: O art. 387, IV, do CPP exige pedido expresso e instrução probatória que permita contraditório quanto ao quantum debeatur. Embora conste pedido genérico na denúncia, não houve instrução específica quanto ao valor do prejuízo remanescente. Os bens foram apreendidos e não houve debate técnico sobre eventual <em>dano</em> material residual. À luz da jurisprudência do Superior Tribunal de Justiça, a fixação do valor mínimo sem adequada instrução viola o contraditório. Afastada a indenização, sem prejuízo da discussão na seara cível.
+IV. DISPOSITIVO E TESE
+Recurso parcialmente provido.
+Tese de julgamento:
+A decretação da revelia do réu regularmente intimado em audiência não configura cerceamento de defesa.
+A condenação pode subsistir ainda que desconsiderado eventual reconhecimento irregular, quando fundada em conjunto probatório autônomo e judicializado, incluindo confissão extrajudicial corroborada por outras provas.
+Laudo pericial inconclusivo quanto à ocorrência de rompimento de obstáculo e escalada impede o reconhecimento das qualificadoras, impondo-se sua exclusão com fundamento no princípio do in dubio pro reo.
+Configura receptação dolosa a aquisição de bens em circunstâncias que evidenciem ciência da origem criminosa, sendo inviável a desclassificação para modalidade culposa quando demonstrado o dolo.
+A fixação de valor mínimo para reparação de danos materiais exige pedido expresso e instrução probatória específica quanto ao montante, sob pena de violação ao contraditório.
+Dispositivos relevantes citados: Código Penal, arts. 155, § 1º e § 4º, I e II; 180, caput e § 3º; 59; Código de Processo Penal, arts. 155, 158, 167, 226, 367 e 387, IV.
+Jurisprudência relevante citada: STJ, HC 598.886/SC, Rel. Min. Rogério Schietti Cruz, Sexta Turma, DJe 18.12.2020; STJ, AgRg no HC 872.909/PR, Rel. Min. Jesuíno Rissato (Des. Conv.), Sexta Turma, DJe 27.5.2024; STJ, AgRg no REsp 2.142.318/DF, Rel. Min. Rogério Schietti Cruz, Sexta Turma, DJe 4.9.2024; STJ, AgRg no AREsp 2.068.728/MG, Rel. Min. Reynaldo Soares da Fonseca, Quinta Turma, DJe 13.5.2022; STJ, AgRg no REsp 2.011.839/TO, Sexta Turma, DJe 15.12.2022.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>77&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877304" cdForo="0" >
+										1402580-03.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877304" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877304);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877304" style="display: none;" >
+	<div id="textAreaDados_1877304" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. AGRAVO INTERNO EM MANDADO DE SEGURAN&Ccedil;A CRIMINAL. SEQUESTRO DE BEM IM&Oacute;VEL. ALEGA&Ccedil;&Atilde;O DE BOA-F&Eacute; DE TERCEIRO ADQUIRENTE. NECESSIDADE DE DILA&Ccedil;&Atilde;O PROBAT&Oacute;RIA. INADEQUA&Ccedil;&Atilde;O DA VIA MANDAMENTAL. AUS&Ecirc;NCIA DE DIREITO L&Iacute;QUIDO E CERTO. MANUTEN&Ccedil;&Atilde;O DA DECIS&Atilde;O. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Agravo Interno interposto contra decis&atilde;o monocr&aacute;tica que, em Mandado de Seguran&ccedil;a Criminal, indeferiu pedido liminar destinado &agrave; suspens&atilde;o do sequestro incidente sobre im&oacute;vel adquirido pela impetrante, bem como &agrave; retomada da posse direta e continuidade de obras, sob o fundamento de inadequa&ccedil;&atilde;o da via eleita diante da necessidade de dila&ccedil;&atilde;o probat&oacute;ria.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se est&atilde;o presentes os requisitos para concess&atilde;o de liminar em mandado de seguran&ccedil;a, notadamente a demonstra&ccedil;&atilde;o de direito l&iacute;quido e certo; (ii) estabelecer se a controv&eacute;rsia acerca da boa-f&eacute; da adquirente e da origem l&iacute;cita do bem pode ser apreciada na via mandamental, sem necessidade de dila&ccedil;&atilde;o probat&oacute;ria.
+III. RAZ&Otilde;ES DE DECIDIR
+3) A concess&atilde;o de liminar em mandado de seguran&ccedil;a exige a presen&ccedil;a concomitante do fumus boni iuris e do periculum in mora, nos termos do art. 7&ordm;, III, da Lei n&ordm; 12.016/2009.
+4) A controv&eacute;rsia envolve elementos f&aacute;ticos relevantes, como a cronologia da aquisi&ccedil;&atilde;o, a eventual vincula&ccedil;&atilde;o do bem aos fatos delitivos e a alegada boa-f&eacute; da adquirente, os quais demandam dila&ccedil;&atilde;o probat&oacute;ria incompat&iacute;vel com a via mandamental.
+5) A exist&ecirc;ncia de embargos de terceiro em tr&acirc;mite na origem evidencia a adequa&ccedil;&atilde;o de via pr&oacute;pria para a an&aacute;lise aprofundada da mat&eacute;ria f&aacute;tica e probat&oacute;ria.
+6) A presen&ccedil;a de terceiro interessado e de impugna&ccedil;&atilde;o quanto &agrave; licitude da aquisi&ccedil;&atilde;o refor&ccedil;a a necessidade de preserva&ccedil;&atilde;o do contradit&oacute;rio e da ampla defesa.
+7) N&atilde;o se verifica, de plano, direito l&iacute;quido e certo apto a justificar o levantamento imediato da constri&ccedil;&atilde;o, nem ilegalidade manifesta ou teratologia na decis&atilde;o impugnada.
+8) A possibilidade de substitui&ccedil;&atilde;o da constri&ccedil;&atilde;o por cau&ccedil;&atilde;o, prevista no art. 131 do CPP, n&atilde;o foi apreciada definitivamente na origem, de modo que a interven&ccedil;&atilde;o do Tribunal implicaria supress&atilde;o de inst&acirc;ncia.
+IV. DISPOSITIVO E TESE
+9) Recurso desprovido.
+Tese de julgamento:
+1. A concess&atilde;o de liminar em mandado de seguran&ccedil;a exige demonstra&ccedil;&atilde;o inequ&iacute;voca de direito l&iacute;quido e certo, n&atilde;o sendo admitida quando a controv&eacute;rsia demanda dila&ccedil;&atilde;o probat&oacute;ria.
+2. A discuss&atilde;o sobre boa-f&eacute; de terceiro adquirente e origem de bem sequestrado deve ser realizada em via pr&oacute;pria, como embargos de terceiro, e n&atilde;o em mandado de seguran&ccedil;a.
+3. A aus&ecirc;ncia de ilegalidade manifesta ou teratologia na decis&atilde;o impugnada impede a concess&atilde;o de medida liminar na via mandamental.
+Dispositivos relevantes citados: Lei n&ordm; 12.016/2009, art. 7&ordm;, III; CPP, art. 131.
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) Magistrados(as) do(a) 1&ordf; Se&ccedil;&atilde;o Criminal do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade e contra o parecer, negaram provimento ao agravo interno, nos termos do voto do Relator.  <br><br>(<b>TJMS</b>. Agravo Interno Criminal n. 1402580-03.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 1&ordf; Se&ccedil;&atilde;o Criminal, Relator (a):&nbsp; Des. L&uacute;cio R. da Silveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Criminal / Liminar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Lúcio R. da Silveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Seção Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. AGRAVO INTERNO EM MANDADO DE SEGURANÇA CRIMINAL. SEQUESTRO DE BEM IMÓVEL. ALEGAÇÃO DE BOA-FÉ DE TERCEIRO ADQUIRENTE. NECESSIDADE DE DILAÇÃO PROBATÓRIA. INADEQUAÇÃO DA VIA MANDAMENTAL. AUSÊNCIA DE DIREITO LÍQUIDO E CERTO. MANUTENÇÃO DA DECISÃO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Agravo Interno interposto contra decisão monocrática que, em Mandado de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. AGRAVO INTERNO EM MANDADO DE SEGURANÇA CRIMINAL. SEQUESTRO DE BEM IMÓVEL. ALEGAÇÃO DE BOA-FÉ DE TERCEIRO ADQUIRENTE. NECESSIDADE DE DILAÇÃO PROBATÓRIA. INADEQUAÇÃO DA VIA MANDAMENTAL. AUSÊNCIA DE DIREITO LÍQUIDO E CERTO. MANUTENÇÃO DA DECISÃO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Agravo Interno interposto contra decisão monocrática que, em Mandado de Segurança Criminal, indeferiu pedido liminar destinado à suspensão do sequestro incidente sobre imóvel adquirido pela impetrante, bem como à retomada da posse direta e continuidade de obras, sob o fundamento de inadequação da via eleita diante da necessidade de dilação probatória.
+II. QUESTÃO EM DISCUSSÃO
+2) Há duas questões em discussão: (i) definir se estão presentes os requisitos para concessão de liminar em mandado de segurança, notadamente a demonstração de direito líquido e certo; (ii) estabelecer se a controvérsia acerca da boa-fé da adquirente e da origem lícita do bem pode ser apreciada na via mandamental, sem necessidade de dilação probatória.
+III. RAZÕES DE DECIDIR
+3) A concessão de liminar em mandado de segurança exige a presença concomitante do fumus boni iuris e do periculum in mora, nos termos do art. 7º, III, da Lei nº 12.016/2009.
+4) A controvérsia envolve elementos fáticos relevantes, como a cronologia da aquisição, a eventual vinculação do bem aos fatos delitivos e a alegada boa-fé da adquirente, os quais demandam dilação probatória incompatível com a via mandamental.
+5) A existência de embargos de terceiro em trâmite na origem evidencia a adequação de via própria para a análise aprofundada da matéria fática e probatória.
+6) A presença de terceiro interessado e de impugnação quanto à licitude da aquisição reforça a necessidade de preservação do contraditório e da ampla defesa.
+7) Não se verifica, de plano, direito líquido e certo apto a justificar o levantamento imediato da constrição, nem ilegalidade manifesta ou teratologia na decisão impugnada.
+8) A possibilidade de substituição da constrição por caução, prevista no art. 131 do CPP, não foi apreciada definitivamente na origem, de modo que a intervenção do Tribunal implicaria supressão de instância.
+IV. DISPOSITIVO E TESE
+9) Recurso desprovido.
+Tese de julgamento:
+1. A concessão de liminar em mandado de segurança exige demonstração inequívoca de direito líquido e certo, não sendo admitida quando a controvérsia demanda dilação probatória.
+2. A discussão sobre boa-fé de terceiro adquirente e origem de bem sequestrado deve ser realizada em via própria, como embargos de terceiro, e não em mandado de segurança.
+3. A ausência de ilegalidade manifesta ou teratologia na decisão impugnada impede a concessão de medida liminar na via mandamental.
+Dispositivos relevantes citados: Lei nº 12.016/2009, art. 7º, III; CPP, art. 131.
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) Magistrados(as) do(a) 1ª Seção Criminal do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade e contra o parecer, negaram provimento ao agravo interno, nos termos do voto do Relator.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>78&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877319" cdForo="0" >
+										0801737-10.2024.8.12.0016
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877319" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877319);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877319" style="display: none;" >
+	<div id="textAreaDados_1877319" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E PEDIDO DE REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; RECURSO DA PARTE REQUERIDA &ndash; INDEFERIMENTO DA JUSTI&Ccedil;A GRATUITA &ndash; AUS&Ecirc;NCIA DE RECOLHIMENTO DE PREPARO &ndash; DESER&Ccedil;&Atilde;O &ndash; RECURSO N&Atilde;O CONHECIDO.
+Ap&oacute;s o indeferimento da justi&ccedil;a gratuita, a r&eacute; n&atilde;o procedeu ao recolhimento do preparo recursal, sendo imperioso o reconhecimento da deser&ccedil;&atilde;o.
+Recurso n&atilde;o conhecido.
+RECURSO DA PARTE AUTORA &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA INEXISTENTE &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA PELA ASSOCIA&Ccedil;&Atilde;O R&Eacute; &ndash; ATO IL&Iacute;CITO CONFIGURADO &ndash; INEXIST&Ecirc;NCIA DE DANO MORAL &ndash; MERO ABORRECIMENTO &ndash; REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO EM DOBRO &ndash; OBSERV&Acirc;NCIA DOS EMBARGOS DE DIVERG&Ecirc;NCIA EM AGRAVO EM RECURSO ESPECIAL N&ordm; 676.608/RS &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O mero aborrecimento n&atilde;o pode ser tratado como dano moral, raz&atilde;o pela qual n&atilde;o se pode consubstanciar um dano moral capaz de gerar sofrimento ou atentar contra a reputa&ccedil;&atilde;o, a integridade psicol&oacute;gica ou a honra, tampouco, repita-se, que a situa&ccedil;&atilde;o influenciou negativamente em seu sustento, de modo que o ocorrido n&atilde;o ultrapassa o mero dissabor ou aborrecimento da vida cotidiana.
+Inexistindo comprova&ccedil;&atilde;o acerca da exist&ecirc;ncia de contrato que autorizasse os descontos diretamente dos proventos da parte autora e, considerando que os descontos indevidos ocorreram a partir de novembro de 2022, revela-se devido a repeti&ccedil;&atilde;o em dobro dos valores indevidamente abatidos apenas a partir da modula&ccedil;&atilde;o dos efeitos da decis&atilde;o pela Corte Especial do Superior Tribunal de Justi&ccedil;a, por meio do julgamento do Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, ou seja, a partir de 30/03/2021.
+Recurso conhecido e provido em parte.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801737-10.2024.8.12.0016,&nbsp; Mundo Novo,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(35 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Descontos dos benefícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Mundo Novo
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E PEDIDO DE REPARAÇÃO POR DANOS MORAIS – RECURSO DA PARTE REQUERIDA – INDEFERIMENTO DA JUSTIÇA GRATUITA – AUSÊNCIA DE RECOLHIMENTO DE PREPARO – DESERÇÃO – RECURSO NÃO CONHECIDO.
+Após o indeferimento da justiça gratuita, a ré não procedeu ao recolhimento do preparo recursal, sendo imperioso o reconhecimento
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E PEDIDO DE REPARAÇÃO POR DANOS MORAIS – RECURSO DA PARTE REQUERIDA – INDEFERIMENTO DA JUSTIÇA GRATUITA – AUSÊNCIA DE RECOLHIMENTO DE PREPARO – DESERÇÃO – RECURSO NÃO CONHECIDO.
+Após o indeferimento da justiça gratuita, a ré não procedeu ao recolhimento do preparo recursal, sendo imperioso o reconhecimento da deserção.
+Recurso não conhecido.
+RECURSO DA PARTE AUTORA – RELAÇÃO JURÍDICA INEXISTENTE – CONTRATAÇÃO NÃO COMPROVADA PELA ASSOCIAÇÃO RÉ – ATO ILÍCITO CONFIGURADO – INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em> – MERO ABORRECIMENTO – REPETIÇÃO DO INDÉBITO EM DOBRO – OBSERVÂNCIA DOS EMBARGOS DE DIVERGÊNCIA EM AGRAVO EM RECURSO ESPECIAL Nº 676.608/RS – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O mero aborrecimento não pode ser tratado como <em>dano</em> <em>moral</em>, razão pela qual não se pode consubstanciar um <em>dano</em> <em>moral</em> capaz de gerar sofrimento ou atentar contra a reputação, a integridade psicológica ou a honra, tampouco, repita-se, que a situação influenciou negativamente em seu sustento, de modo que o ocorrido não ultrapassa o mero dissabor ou aborrecimento da vida cotidiana.
+Inexistindo comprovação acerca da existência de contrato que autorizasse os descontos diretamente dos proventos da parte autora e, considerando que os descontos indevidos ocorreram a partir de novembro de 2022, revela-se devido a repetição em dobro dos valores indevidamente abatidos apenas a partir da modulação dos efeitos da decisão pela Corte Especial do Superior Tribunal de Justiça, por meio do julgamento do Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, ou seja, a partir de 30/03/2021.
+Recurso conhecido e provido em parte.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>79&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877327" cdForo="0" >
+										1403005-30.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877327" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877327);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877327" style="display: none;" >
+	<div id="textAreaDados_1877327" class="mensagemSemFormatacao" >
+		DIREITO DE FAM&Iacute;LIA &ndash; AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DE DISSOLU&Ccedil;&Atilde;O DE UNI&Atilde;O EST&Aacute;VEL C/C PARTILHA DE BENS, PENS&Atilde;O ALIMENT&Iacute;CIA, OBRIGA&Ccedil;&Atilde;O DE FAZER E REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; TUTELA DE URG&Ecirc;NCIA  &ndash; FIXA&Ccedil;&Atilde;O DE ALIMENTOS PROVIS&Oacute;RIOS &ndash;  CONTROV&Eacute;RSIA SOBRE EXIST&Ecirc;NCIA ATUAL DE UNI&Atilde;O EST&Aacute;VEL &ndash;  AUS&Ecirc;NCIA DE PROVA ROBUSTA DA DEPEND&Ecirc;NCIA ECON&Ocirc;MICA &ndash; AUS&Ecirc;NCIA DE PREENCHIMENTO DOS REQUISITOS &ndash; INDEFERIMENTO &ndash; DECIS&Atilde;O REFORMADA &ndash; RECURSO CONHECIDO E  PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento contra decis&atilde;o que deferiu parcialmente tutela de urg&ecirc;ncia para fixar alimentos provis&oacute;rios em favor da autora e determinar sua manuten&ccedil;&atilde;o em plano de sa&uacute;de e assist&ecirc;ncia funer&aacute;ria.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso o preenchimento, ou n&atilde;o, dos requisitos legais para o deferimento de tutela provis&oacute;ria de natureza antecipada, consistente na fixa&ccedil;&atilde;o de alimentos provis&oacute;rios entre ex-conviventes e na manuten&ccedil;&atilde;o da agravada como dependente em plano de sa&uacute;de.
+III. RAZ&Otilde;ES DE DECIDIR
+3.  O art. 300, do CPC/2015, prev&ecirc; que a tutela de urg&ecirc;ncia, esp&eacute;cie de tutela provis&oacute;ria (art. 294, CPC/15), ser&aacute; concedida quando houver elementos  que  evidenciem  a  probabilidade  do  direito  e  o perigo de dano, ou  de  risco ao resultado &uacute;til do processo, podendo ser de natureza cautelar  ou  antecipada.
+4.  N&atilde;o estando  presente,  simultaneamente,  a  verossimilhan&ccedil;a das   alega&ccedil;&otilde;es  (fumus boni iuris)  e  o  perigo  de   les&atilde;o   grave   e  de dif&iacute;cil repara&ccedil;&atilde;o ao direito da parte  (periculum in mora), e n&atilde;o havendo,  ainda,  risco  de irreversibilidade  da   medida,   &eacute;  de  ser   indeferida   a    antecipa&ccedil;&atilde;o dos  efeitos  da  tutela pleiteada pela parte autora-agravada.
+5. A fixa&ccedil;&atilde;o de alimentos provis&oacute;rios entre ex-companheiros possui natureza excepcional e exige demonstra&ccedil;&atilde;o m&iacute;nima da probabilidade do direito, especialmente quanto &agrave; exist&ecirc;ncia atual de v&iacute;nculo familiar ou de depend&ecirc;ncia econ&ocirc;mica, o que n&atilde;o se verificou no caso, diante da controv&eacute;rsia acerca da cessa&ccedil;&atilde;o da conviv&ecirc;ncia e da insufici&ecirc;ncia probat&oacute;ria. Assim, imp&otilde;e-se a reforma da decis&atilde;o recorrida.
+IV. DISPOSITIVO
+6. Agravo de Instrumento conhecido e provido. <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1403005-30.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Fixação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DE FAMÍLIA – AGRAVO DE INSTRUMENTO – AÇÃO DE DISSOLUÇÃO DE UNIÃO ESTÁVEL C/C PARTILHA DE BENS, PENSÃO ALIMENTÍCIA, OBRIGAÇÃO DE FAZER E REPARAÇÃO POR DANOS MORAIS – TUTELA DE URGÊNCIA  – FIXAÇÃO DE ALIMENTOS PROVISÓRIOS –  CONTROVÉRSIA SOBRE EXISTÊNCIA ATUAL DE UNIÃO ESTÁVEL –  AUSÊNCIA DE PROVA ROBUSTA DA DEPENDÊNCIA ECONÔMICA – AUSÊNCIA DE PREENCHIMENTO DOS REQUISITOS – INDEFERIMENTO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DE FAMÍLIA – AGRAVO DE INSTRUMENTO – AÇÃO DE DISSOLUÇÃO DE UNIÃO ESTÁVEL C/C PARTILHA DE BENS, PENSÃO ALIMENTÍCIA, OBRIGAÇÃO DE FAZER E REPARAÇÃO POR DANOS MORAIS – TUTELA DE URGÊNCIA  – FIXAÇÃO DE ALIMENTOS PROVISÓRIOS –  CONTROVÉRSIA SOBRE EXISTÊNCIA ATUAL DE UNIÃO ESTÁVEL –  AUSÊNCIA DE PROVA ROBUSTA DA DEPENDÊNCIA ECONÔMICA – AUSÊNCIA DE PREENCHIMENTO DOS REQUISITOS – INDEFERIMENTO – DECISÃO REFORMADA – RECURSO CONHECIDO E  PROVIDO.
+I. CASO EM EXAME
+1. Agravo de Instrumento contra decisão que deferiu parcialmente tutela de urgência para fixar alimentos provisórios em favor da autora e determinar sua manutenção em plano de saúde e assistência funerária.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso o preenchimento, ou não, dos requisitos legais para o deferimento de tutela provisória de natureza antecipada, consistente na fixação de alimentos provisórios entre ex-conviventes e na manutenção da agravada como dependente em plano de saúde.
+III. RAZÕES DE DECIDIR
+3.  O art. 300, do CPC/2015, prevê que a tutela de urgência, espécie de tutela provisória (art. 294, CPC/15), será concedida quando houver elementos  que  evidenciem  a  probabilidade  do  direito  e  o perigo de <em>dano</em>, ou  de  risco ao resultado útil do processo, podendo ser de natureza cautelar  ou  antecipada.
+4.  Não estando  presente,  simultaneamente,  a  verossimilhança das   alegações  (fumus boni iuris)  e  o  perigo  de   lesão   grave   e  de difícil reparação ao direito da parte  (periculum in mora), e não havendo,  ainda,  risco  de irreversibilidade  da   medida,   é  de  ser   indeferida   a    antecipação dos  efeitos  da  tutela pleiteada pela parte autora-agravada.
+5. A fixação de alimentos provisórios entre ex-companheiros possui natureza excepcional e exige demonstração mínima da probabilidade do direito, especialmente quanto à existência atual de vínculo familiar ou de dependência econômica, o que não se verificou no caso, diante da controvérsia acerca da cessação da convivência e da insuficiência probatória. Assim, impõe-se a reforma da decisão recorrida.
+IV. DISPOSITIVO
+6. Agravo de Instrumento conhecido e provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>80&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877336" cdForo="0" >
+										0871112-46.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877336" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877336);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877336" style="display: none;" >
+	<div id="textAreaDados_1877336" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O &ndash; N&Atilde;O EXIST&Ecirc;NCIA DE OMISS&Atilde;O, CONTRADI&Ccedil;&Atilde;O, OBSCURIDADE OU ERRO MATERIAL &ndash; PRETENS&Atilde;O DE REDISCUTIR A MAT&Eacute;RIA &ndash; RECURSO CONHECIDO E N&Atilde;O ACOLHIDO.
+1. O embargos de declara&ccedil;&atilde;o visam ao aperfei&ccedil;oamento da decis&atilde;o ou ac&oacute;rd&atilde;o, nos termos dos arts. 1.008 e 1.026 do C&oacute;digo de Processo Civil.
+2. A mera rediscuss&atilde;o do decidido &eacute; vedada nos embargos de declara&ccedil;&atilde;o.
+3. Recurso conhecido e n&atilde;o acolhido.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0871112-46.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									871112462024812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO EXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO, OBSCURIDADE OU ERRO MATERIAL – PRETENSÃO DE REDISCUTIR A MATÉRIA – RECURSO CONHECIDO E NÃO ACOLHIDO.
+1. O embargos de declaração visam ao aperfeiçoamento da decisão ou acórdão, nos termos dos arts. 1.008 e 1.026 do Código de Processo Civil.
+2. A mera rediscussão do decidido é vedada nos embargos de declaração.
+3. Recurso
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO – NÃO EXISTÊNCIA DE OMISSÃO, CONTRADIÇÃO, OBSCURIDADE OU ERRO MATERIAL – PRETENSÃO DE REDISCUTIR A MATÉRIA – RECURSO CONHECIDO E NÃO ACOLHIDO.
+1. O embargos de declaração visam ao aperfeiçoamento da decisão ou acórdão, nos termos dos arts. 1.008 e 1.026 do Código de Processo Civil.
+2. A mera rediscussão do decidido é vedada nos embargos de declaração.
+3. Recurso conhecido e não acolhido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>81&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877339" cdForo="0" >
+										0816752-35.2022.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877339" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877339);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877339" style="display: none;" >
+	<div id="textAreaDados_1877339" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E LUCROS CESSANTES &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; DANOS MORAIS &ndash; N&Atilde;O CONFIGURADOS &ndash; ACIDENTE QUE CAUSOU APENAS DANOS MATERIAIS &ndash; INTEGRIDADE F&Iacute;SICA OU PS&Iacute;QUICA N&Atilde;O AFETADAS PELO EVENTO &ndash;LUCROS CESSANTES &ndash; RENDIMENTO MENSAL N&Atilde;O TOTALMENTE DEMONSTRADO &ndash; VALOR DA INDENIZA&Ccedil;&Atilde;O REDUZIDO &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+N&atilde;o caracteriza dano moral in re ipsa os danos decorrentes de acidentes de ve&iacute;culos automotores sem v&iacute;timas, os quais normalmente se resolvem por meio de repara&ccedil;&atilde;o de danos patrimoniais. De mais a mais, nesses casos, a condena&ccedil;&atilde;o &agrave; compensa&ccedil;&atilde;o de danos morais depende de comprova&ccedil;&atilde;o de circunst&acirc;ncias peculiares que demonstrem o extrapolamento da esfera exclusivamente patrimonial (STJ - REsp: 1653413 RJ 2016/0193046-6, Relator.: Ministro MARCO AUR&Eacute;LIO BELLIZZE, Data de Julgamento: 05/06/2018, T3 - TERCEIRA TURMA, Data de Publica&ccedil;&atilde;o: DJe 08/06/2018).
+No que concerne aos lucros cessantes, para o seu deferimento &eacute; indispens&aacute;vel que haja prova objetiva de sua ocorr&ecirc;ncia, n&atilde;o bastando mera expectativa, pois n&atilde;o se trata de dano hipot&eacute;tico, pelo que devem ter bases seguras, nos termos do artigo 402 do C&oacute;digo Civil.
+O relat&oacute;rio do Uber apresentado &eacute; referente apenas ao m&ecirc;s do acidente, fevereiro/2022, no qual o recorrido trabalhou apenas 7 dias. Em rela&ccedil;&atilde;o aos meses anteriores n&atilde;o restou demonstrado. Deve-se utilizar para aferir o rendimento m&eacute;dio mensal o valor informado pelo pr&oacute;prio apelado na emenda &agrave; inicial, qual seja, R$2.500,00.
+Logo, a renda m&eacute;dia mensal informada na emenda da inicial de R$2.500,00 equivale a R$83,33 por dia (R$2.500/30), o que multiplicado pelo per&iacute;odo em que o apelado ficou impossibilitado de utilizar o ve&iacute;culo como motorista de aplicativo, 9 dias, totaliza R$749,97.
+Recurso conhecido e parcialmente provido.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816752-35.2022.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(75 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E LUCROS CESSANTES – ACIDENTE DE TRÂNSITO – DANOS MORAIS – NÃO CONFIGURADOS – ACIDENTE QUE CAUSOU APENAS DANOS MATERIAIS – INTEGRIDADE FÍSICA OU PSÍQUICA NÃO AFETADAS PELO EVENTO –LUCROS CESSANTES – RENDIMENTO MENSAL NÃO TOTALMENTE DEMONSTRADO – VALOR DA INDENIZAÇÃO REDUZIDO – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Não
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E LUCROS CESSANTES – ACIDENTE DE TRÂNSITO – DANOS MORAIS – NÃO CONFIGURADOS – ACIDENTE QUE CAUSOU APENAS DANOS MATERIAIS – INTEGRIDADE FÍSICA OU PSÍQUICA NÃO AFETADAS PELO EVENTO –LUCROS CESSANTES – RENDIMENTO MENSAL NÃO TOTALMENTE DEMONSTRADO – VALOR DA INDENIZAÇÃO REDUZIDO – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Não caracteriza <em>dano</em> <em>moral</em> in re ipsa os danos decorrentes de acidentes de veículos automotores sem vítimas, os quais normalmente se resolvem por meio de reparação de danos patrimoniais. De mais a mais, nesses casos, a condenação à compensação de danos morais depende de comprovação de circunstâncias peculiares que demonstrem o extrapolamento da esfera exclusivamente patrimonial (STJ - REsp: 1653413 RJ 2016/0193046-6, Relator.: Ministro MARCO AURÉLIO BELLIZZE, Data de Julgamento: 05/06/2018, T3 - TERCEIRA TURMA, Data de Publicação: DJe 08/06/2018).
+No que concerne aos lucros cessantes, para o seu deferimento é indispensável que haja prova objetiva de sua ocorrência, não bastando mera expectativa, pois não se trata de <em>dano</em> hipotético, pelo que devem ter bases seguras, nos termos do artigo 402 do Código Civil.
+O relatório do Uber apresentado é referente apenas ao mês do acidente, fevereiro/2022, no qual o recorrido trabalhou apenas 7 dias. Em relação aos meses anteriores não restou demonstrado. Deve-se utilizar para aferir o rendimento médio mensal o valor informado pelo próprio apelado na emenda à inicial, qual seja, R$2.500,00.
+Logo, a renda média mensal informada na emenda da inicial de R$2.500,00 equivale a R$83,33 por dia (R$2.500/30), o que multiplicado pelo período em que o apelado ficou impossibilitado de utilizar o veículo como motorista de aplicativo, 9 dias, totaliza R$749,97.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>82&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877350" cdForo="0" >
+										0809166-13.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877350" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877350);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877350" style="display: none;" >
+	<div id="textAreaDados_1877350" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. DESCONTOS INDEVIDOS EM CONTA BANC&Aacute;RIA. RESPONSABILIDADE EXTRACONTRATUAL. TERMO INICIAL DOS JUROS MORAT&Oacute;RIOS. EVENTO DANOSO. S&Uacute;MULA 54 DO STJ. MANUTEN&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+1. A senten&ccedil;a reconhece a inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica v&aacute;lida entre as partes e declara nulo o contrato que originou os descontos, por aus&ecirc;ncia de comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o, caracterizando falha na presta&ccedil;&atilde;o do servi&ccedil;o e ato il&iacute;cito.
+2. O reconhecimento de ato il&iacute;cito desvinculado de contrato v&aacute;lido enquadra a responsabilidade no &acirc;mbito extracontratual.
+3. Em hip&oacute;teses de responsabilidade extracontratual, os juros morat&oacute;rios incidem a partir do evento danoso, conforme a S&uacute;mula 54 do STJ.
+4. O preju&iacute;zo material se concretiza no momento de cada desconto indevido, ocasi&atilde;o em que ocorre diminui&ccedil;&atilde;o patrimonial imediata, configurando mora autom&aacute;tica.
+5. O valor fixado a t&iacute;tulo de danos morais observa os princ&iacute;pios da razoabilidade e da proporcionalidade, atende ao car&aacute;ter compensat&oacute;rio e pedag&oacute;gico da indeniza&ccedil;&atilde;o e se alinha aos par&acirc;metros adotados pelo Tribunal em casos an&aacute;logos.
+6. Recurso parcialmente provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0809166-13.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS. DESCONTOS INDEVIDOS EM CONTA BANCÁRIA. RESPONSABILIDADE EXTRACONTRATUAL. TERMO INICIAL DOS JUROS MORATÓRIOS. EVENTO DANOSO. SÚMULA 54 DO STJ. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+1. A sentença reconhece a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS. DESCONTOS INDEVIDOS EM CONTA BANCÁRIA. RESPONSABILIDADE EXTRACONTRATUAL. TERMO INICIAL DOS JUROS MORATÓRIOS. EVENTO DANOSO. SÚMULA 54 DO STJ. MANUTENÇÃO DO QUANTUM INDENIZATÓRIO. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+1. A sentença reconhece a inexistência de relação jurídica válida entre as partes e declara nulo o contrato que originou os descontos, por ausência de comprovação da contratação, caracterizando falha na prestação do serviço e ato ilícito.
+2. O reconhecimento de ato ilícito desvinculado de contrato válido enquadra a responsabilidade no âmbito extracontratual.
+3. Em hipóteses de responsabilidade extracontratual, os juros moratórios incidem a partir do evento danoso, conforme a Súmula 54 do STJ.
+4. O prejuízo material se concretiza no momento de cada desconto indevido, ocasião em que ocorre diminuição patrimonial imediata, configurando mora automática.
+5. O valor fixado a título de danos morais observa os princípios da razoabilidade e da proporcionalidade, atende ao caráter compensatório e pedagógico da indenização e se alinha aos parâmetros adotados pelo Tribunal em casos análogos.
+6. Recurso parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>83&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877352" cdForo="0" >
+										0802129-07.2025.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877352" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877352);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877352" style="display: none;" >
+	<div id="textAreaDados_1877352" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS COM TUTELA DE URG&Ecirc;NCIA &ndash; AUS&Ecirc;NCIA DE LAUDO PERICIAL &ndash; NULIDADE ARGUIDA DE OF&Iacute;CIO PELO JULGADOR &ndash; CERCEAMENTO DE DEFESA &ndash; NECESSIDADE DE DILA&Ccedil;&Atilde;O PROBAT&Oacute;RIA &ndash; PROVA PERICIAL IMPRESCIND&Iacute;VEL AO JULGAMENTO DO M&Eacute;RITO &ndash; ALEGA&Ccedil;&Atilde;O DE FRAUDE NA CONTRATA&Ccedil;&Atilde;O DIGITAL &ndash; SENTEN&Ccedil;A TORNADA INSUBSISTENTE &ndash; RECURSO PREJUDICADO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802129-07.2025.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Cartão de Crédito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS COM TUTELA DE URGÊNCIA – AUSÊNCIA DE LAUDO PERICIAL – NULIDADE ARGUIDA DE OFÍCIO PELO JULGADOR – CERCEAMENTO DE DEFESA – NECESSIDADE DE DILAÇÃO PROBATÓRIA – PROVA PERICIAL IMPRESCINDÍVEL AO JULGAMENTO DO MÉRITO – ALEGAÇÃO DE FRAUDE NA CONTRATAÇÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS COM TUTELA DE URGÊNCIA – AUSÊNCIA DE LAUDO PERICIAL – NULIDADE ARGUIDA DE OFÍCIO PELO JULGADOR – CERCEAMENTO DE DEFESA – NECESSIDADE DE DILAÇÃO PROBATÓRIA – PROVA PERICIAL IMPRESCINDÍVEL AO JULGAMENTO DO MÉRITO – ALEGAÇÃO DE FRAUDE NA CONTRATAÇÃO DIGITAL – SENTENÇA TORNADA INSUBSISTENTE – RECURSO PREJUDICADO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>84&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877354" cdForo="0" >
+										0800907-14.2024.8.12.0026
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877354" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877354);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877354" style="display: none;" >
+	<div id="textAreaDados_1877354" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL E RECURSO ADESIVO. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER CUMULADA COM REPARA&Ccedil;&Atilde;O DE DANOS. PLANO DE SA&Uacute;DE. CRIAN&Ccedil;A PORTADORA DE TRANSTORNO DO NEURODESENVOLVIMENTO (TDAH E DISLEXIA). RECURSO ADESIVO DA OPERADORA DE SA&Uacute;DE. COBERTURA OBRIGAT&Oacute;RIA PARA PSICOMOTRICIDADE. ROL DA ANS E LEI N.&ordm; 14.454/2022. COBERTURA DEVIDA. PRESCRI&Ccedil;&Atilde;O DO M&Eacute;DICO ASSISTENTE. RECURSO ADESIVO DESPROVIDO. APELA&Ccedil;&Atilde;O DO AUTOR. DANOS MORAIS DEVIDOS.  NEGATIVA DE COBERTURA DE TERAPIA ESSENCIAL PARA PACIENTE HIPERVULNER&Aacute;VEL. QUANTUM FIXADO EM R$ 5.000,00 (CINCO MIL REAIS). DANOS MATERIAIS. PEDIDO DE LIQUIDA&Ccedil;&Atilde;O FUTURA. IMPOSSIBILIDADE. AUS&Ecirc;NCIA DE PROVA DO DESEMBOLSO (AN DEBEATUR) NA FASE COGNITIVA. INDEFERIMENTO MANTIDO. SENTEN&Ccedil;A PARCIALMENTE REFORMADA. RECURSO DO AUTOR PROVIDO EM PARTE. RECURSO ADESIVO DESPROVIDO. DECIS&Atilde;O PARCIALMENTE COM O PARECER. 1. A Ag&ecirc;ncia Nacional de Sa&uacute;de tornou obrigat&oacute;ria a cobertura, pela operadora de plano de sa&uacute;de, de qualquer m&eacute;todo ou t&eacute;cnica indicada pelo profissional de sa&uacute;de respons&aacute;vel pelo tratamento de Transtornos Globais do Desenvolvimento (TEA&acute;s), dentre os quais a paralisia cerebral.&nbsp;2. A jurisprud&ecirc;ncia no Superior Tribunal de Justi&ccedil;a &eacute; assente no sentido de que, em regra, sendo desarrazoada a negativa de cobertura pela operadora do plano de sa&uacute;de do tratamento m&eacute;dico pleiteado, caracterizado fica o il&iacute;cito civil ensejador da repara&ccedil;&atilde;o por danos morais. 3. O valor indenizat&oacute;rio n&atilde;o pode ser insignificante a ponto de n&atilde;o ser capaz de mitigar ou amenizar os il&iacute;citos que atingem este setor de servi&ccedil;os da sociedade, tampouco deve revelar-se excessivo a tal ponto que venha a causar enriquecimento il&iacute;cito da parte requerente. No caso, considerando os par&acirc;metros apontados, entendo que o valor de R$ 5.000,00 (cinco mil reais) mostra-se razo&aacute;vel para reparar o dano infligido &agrave; paciente, al&eacute;m de mostrar-se em conson&acirc;ncia com os crit&eacute;rios indicados pela doutrina e pela jurisprud&ecirc;ncia. 4. A indeniza&ccedil;&atilde;o por danos materiais exige a demonstra&ccedil;&atilde;o efetiva do preju&iacute;zo patrimonial na fase de conhecimento (art. 373, I, do C&oacute;digo de Processo Civil). Inexistindo comprova&ccedil;&atilde;o do desembolso, &eacute; vedado relegar a mat&eacute;ria &agrave; fase de liquida&ccedil;&atilde;o de senten&ccedil;a. 5. Recurso do autor parcialmente provido. Recurso adesivo desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800907-14.2024.8.12.0026,&nbsp; Bataguassu,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. S&eacute;rgio Fernandes Martins, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Sérgio Fernandes Martins
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Bataguassu
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO. AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM REPARAÇÃO DE DANOS. PLANO DE SAÚDE. CRIANÇA PORTADORA DE TRANSTORNO DO NEURODESENVOLVIMENTO (TDAH E DISLEXIA). RECURSO ADESIVO DA OPERADORA DE SAÚDE. COBERTURA OBRIGATÓRIA PARA PSICOMOTRICIDADE. ROL DA ANS E LEI N.º 14.454/2022. COBERTURA DEVIDA. PRESCRIÇÃO DO MÉDICO ASSISTENTE. RECURSO ADESIVO DESPROVIDO. APELAÇÃO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL E RECURSO ADESIVO. AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM REPARAÇÃO DE DANOS. PLANO DE SAÚDE. CRIANÇA PORTADORA DE TRANSTORNO DO NEURODESENVOLVIMENTO (TDAH E DISLEXIA). RECURSO ADESIVO DA OPERADORA DE SAÚDE. COBERTURA OBRIGATÓRIA PARA PSICOMOTRICIDADE. ROL DA ANS E LEI N.º 14.454/2022. COBERTURA DEVIDA. PRESCRIÇÃO DO MÉDICO ASSISTENTE. RECURSO ADESIVO DESPROVIDO. APELAÇÃO DO AUTOR. DANOS MORAIS DEVIDOS.  NEGATIVA DE COBERTURA DE TERAPIA ESSENCIAL PARA PACIENTE HIPERVULNERÁVEL. QUANTUM FIXADO EM R$ 5.000,00 (CINCO MIL REAIS). DANOS MATERIAIS. PEDIDO DE LIQUIDAÇÃO FUTURA. IMPOSSIBILIDADE. AUSÊNCIA DE PROVA DO DESEMBOLSO (AN DEBEATUR) NA FASE COGNITIVA. INDEFERIMENTO MANTIDO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO DO AUTOR PROVIDO EM PARTE. RECURSO ADESIVO DESPROVIDO. DECISÃO PARCIALMENTE COM O PARECER. 1. A Agência Nacional de Saúde tornou obrigatória a cobertura, pela operadora de plano de saúde, de qualquer método ou técnica indicada pelo profissional de saúde responsável pelo tratamento de Transtornos Globais do Desenvolvimento (TEA´s), dentre os quais a paralisia cerebral. 2. A jurisprudência no Superior Tribunal de Justiça é assente no sentido de que, em regra, sendo desarrazoada a negativa de cobertura pela operadora do plano de saúde do tratamento médico pleiteado, caracterizado fica o ilícito civil ensejador da reparação por danos morais. 3. O valor indenizatório não pode ser insignificante a ponto de não ser capaz de mitigar ou amenizar os ilícitos que atingem este setor de serviços da sociedade, tampouco deve revelar-se excessivo a tal ponto que venha a causar enriquecimento ilícito da parte requerente. No caso, considerando os parâmetros apontados, entendo que o valor de R$ 5.000,00 (cinco mil reais) mostra-se razoável para reparar o <em>dano</em> infligido à paciente, além de mostrar-se em consonância com os critérios indicados pela doutrina e pela jurisprudência. 4. A indenização por danos materiais exige a demonstração efetiva do prejuízo patrimonial na fase de conhecimento (art. 373, I, do Código de Processo Civil). Inexistindo comprovação do desembolso, é vedado relegar a matéria à fase de liquidação de sentença. 5. Recurso do autor parcialmente provido. Recurso adesivo desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>85&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877363" cdForo="0" >
+										0862825-31.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877363" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877363);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877363" style="display: none;" >
+	<div id="textAreaDados_1877363" class="mensagemSemFormatacao" >
+		TR&Ecirc;S APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER. PLANO DE SA&Uacute;DE. LEGITIMIDADE UNIMED CAMPO GRANDE, UNIMED RIO E UNIMED VALE DO SEPOTUBA CONFIRMADA. NEGATIVA DE COBERTURA DE ATENDIMENTOS. INDENIZA&Ccedil;&Atilde;O MATERIAL E MORAL CAB&Iacute;VEL. QUANTUM RAZO&Aacute;VEL. SENTEN&Ccedil;A MANTIDA. RECURSOS CONHECIDOS E DESPROVIDOS. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0862825-31.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1877363" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												TRÊS APELAÇÕES CÍVEIS. AÇÃO DE OBRIGAÇÃO DE FAZER. PLANO DE SAÚDE. LEGITIMIDADE UNIMED CAMPO GRANDE, UNIMED RIO E UNIMED VALE DO SEPOTUBA CONFIRMADA. NEGATIVA DE COBERTURA DE ATENDIMENTOS. INDENIZAÇÃO MATERIAL E <em>MORAL</em> CABÍVEL. QUANTUM RAZOÁVEL. SENTENÇA MANTIDA. RECURSOS CONHECIDOS E DESPROVIDOS.
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>86&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877365" cdForo="0" >
+										0816824-87.2020.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877365" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877365);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877365" style="display: none;" >
+	<div id="textAreaDados_1877365" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER COM PEDIDO DE INDENIZA&Ccedil;&Atilde;O DE DANOS MATERIAIS E MORAIS &ndash; CONTRATO DE FINANCIAMENTO COM GARANTIA FIDUCI&Aacute;RIA &ndash; AJUIZAMENTO INDEVIDO DE A&Ccedil;&Atilde;O DE BUSCA E APREENS&Atilde;O &ndash; EXTIN&Ccedil;&Atilde;O DA DEMANDA POR AUS&Ecirc;NCIA DE CONSTITUI&Ccedil;&Atilde;O V&Aacute;LIDA EM MORA &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; TRANSFER&Ecirc;NCIA DO VE&Iacute;CULO PARA OUTRA UNIDADE DA FEDERA&Ccedil;&Atilde;O &ndash; ALTERA&Ccedil;&Atilde;O DE PLACA E AUS&Ecirc;NCIA DE PRONTA REGULARIZA&Ccedil;&Atilde;O DOCUMENTAL &ndash; DEVOLU&Ccedil;&Atilde;O DO BEM EM CONDI&Ccedil;&Otilde;ES DIVERSAS DAQUELAS EM QUE APREENDIDO &ndash; DANO MATERIAL N&Atilde;O COMPROVADO &ndash; DANOS MORAIS CONFIGURADOS &ndash; QUANTUM INDENIZAT&Oacute;RIO FIXADO CONFORME A RAZOABILIDADE E PROPORCIONALIDADE &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A apreens&atilde;o indevida de ve&iacute;culo em a&ccedil;&atilde;o de busca e apreens&atilde;o posteriormente extinta por aus&ecirc;ncia de constitui&ccedil;&atilde;o v&aacute;lida em mora afasta a tese de exerc&iacute;cio regular de direito e evidencia falha na presta&ccedil;&atilde;o do servi&ccedil;o, nos termos do art. 14, do C&oacute;digo de Defesa do Consumidor.
+Para a configura&ccedil;&atilde;o do dano material e consequente condena&ccedil;&atilde;o em indeniza&ccedil;&atilde;o, &eacute; indispens&aacute;vel a exist&ecirc;ncia de provas concretas sobre as perdas patrimoniais sofridas pela parte ofendida.
+Demonstrada a priva&ccedil;&atilde;o indevida do uso de ve&iacute;culo, somada &agrave; devolu&ccedil;&atilde;o do bem em situa&ccedil;&atilde;o irregular, por per&iacute;odo de tempo consider&aacute;vel, &eacute; evidente a caracteriza&ccedil;&atilde;o do dano moral, dado o sofrimento, a frustra&ccedil;&atilde;o e o sentimento de impot&ecirc;ncia vivenciados pela consumidora, que ultrapassa o mero dissabor cotidiano e atinge a esfera da dignidade do consumidor.
+O valor da indeniza&ccedil;&atilde;o deve atender aos princ&iacute;pios da razoabilidade e da proporcionalidade, cumprindo fun&ccedil;&atilde;o compensat&oacute;ria para a v&iacute;tima e pedag&oacute;gica para o ofensor, sem importar enriquecimento indevido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0816824-87.2020.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER COM PEDIDO DE INDENIZAÇÃO DE DANOS MATERIAIS E MORAIS – CONTRATO DE FINANCIAMENTO COM GARANTIA FIDUCIÁRIA – AJUIZAMENTO INDEVIDO DE AÇÃO DE BUSCA E APREENSÃO – EXTINÇÃO DA DEMANDA POR AUSÊNCIA DE CONSTITUIÇÃO VÁLIDA EM MORA – FALHA NA PRESTAÇÃO DO SERVIÇO – TRANSFERÊNCIA DO VEÍCULO PARA OUTRA UNIDADE DA FEDERAÇÃO – ALTERAÇÃO DE PLACA E AUSÊNCIA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER COM PEDIDO DE INDENIZAÇÃO DE DANOS MATERIAIS E MORAIS – CONTRATO DE FINANCIAMENTO COM GARANTIA FIDUCIÁRIA – AJUIZAMENTO INDEVIDO DE AÇÃO DE BUSCA E APREENSÃO – EXTINÇÃO DA DEMANDA POR AUSÊNCIA DE CONSTITUIÇÃO VÁLIDA EM MORA – FALHA NA PRESTAÇÃO DO SERVIÇO – TRANSFERÊNCIA DO VEÍCULO PARA OUTRA UNIDADE DA FEDERAÇÃO – ALTERAÇÃO DE PLACA E AUSÊNCIA DE PRONTA REGULARIZAÇÃO DOCUMENTAL – DEVOLUÇÃO DO BEM EM CONDIÇÕES DIVERSAS DAQUELAS EM QUE APREENDIDO – <em>DANO</em> MATERIAL NÃO COMPROVADO – DANOS MORAIS CONFIGURADOS – QUANTUM INDENIZATÓRIO FIXADO CONFORME A RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+A apreensão indevida de veículo em ação de busca e apreensão posteriormente extinta por ausência de constituição válida em mora afasta a tese de exercício regular de direito e evidencia falha na prestação do serviço, nos termos do art. 14, do Código de Defesa do Consumidor.
+Para a configuração do <em>dano</em> material e consequente condenação em indenização, é indispensável a existência de provas concretas sobre as perdas patrimoniais sofridas pela parte ofendida.
+Demonstrada a privação indevida do uso de veículo, somada à devolução do bem em situação irregular, por período de tempo considerável, é evidente a caracterização do <em>dano</em> <em>moral</em>, dado o sofrimento, a frustração e o sentimento de impotência vivenciados pela consumidora, que ultrapassa o mero dissabor cotidiano e atinge a esfera da dignidade do consumidor.
+O valor da indenização deve atender aos princípios da razoabilidade e da proporcionalidade, cumprindo função compensatória para a vítima e pedagógica para o ofensor, sem importar enriquecimento indevido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>87&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877375" cdForo="0" >
+										0800803-45.2021.8.12.0020
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877375" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877375);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877375" style="display: none;" >
+	<div id="textAreaDados_1877375" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; EMPR&Eacute;STIMO CONSIGNADO &ndash; PRELIMINAR DE ILEGITIMIDADE AFASTADA - CONTRATA&Ccedil;&Atilde;O VIA TELEFONE &ndash; PER&Iacute;CIA FON&Eacute;TICA REALIZADA &ndash; VONTADE DO CONSUMIDOR N&Atilde;O DEMONSTRADA &ndash; VOZ QUE N&Atilde;O PERTENCE AO AUTOR &ndash; FRAUDE CONFIGURADA &ndash; INEXIST&Ecirc;NCIA DO D&Eacute;BITO MANTIDA &ndash; DANOS MORAIS CONFIGURADOS &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO NA FORMA SIMPLES &ndash; AUS&Ecirc;NCIA DE PROVA DE M&Aacute;-F&Eacute; DO BANCO &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Restando comprovado por per&iacute;cia t&eacute;cnica fon&eacute;tica que a voz constante na grava&ccedil;&atilde;o utilizada para a contrata&ccedil;&atilde;o do empr&eacute;stimo n&atilde;o pertence ao consumidor, deve ser mantida a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito e do contrato.
+A contrata&ccedil;&atilde;o fraudulenta que enseja descontos indevidos em verba alimentar de pessoa idosa ultrapassa o mero aborrecimento, configurando dano moral in re ipsa.
+O valor da indeniza&ccedil;&atilde;o deve ser mantido em R$ 5.000,00, por estar em conson&acirc;ncia com os princ&iacute;pios da razoabilidade e proporcionalidade.
+A repeti&ccedil;&atilde;o do ind&eacute;bito deve ocorrer na forma simples, uma vez que a dobra prevista no art. 42, par&aacute;grafo &uacute;nico, do CDC, pressup&otilde;e a exist&ecirc;ncia de m&aacute;-f&eacute;, a qual n&atilde;o restou cabalmente demonstrada no caso, tratando-se de falha na seguran&ccedil;a do sistema banc&aacute;rio diante de fraude de terceiros. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800803-45.2021.8.12.0020,&nbsp; Rio Brilhante,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. N&eacute;lio St&aacute;bile, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Nélio Stábile
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Brilhante
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – PRELIMINAR DE ILEGITIMIDADE AFASTADA - CONTRATAÇÃO VIA TELEFONE – PERÍCIA FONÉTICA REALIZADA – VONTADE DO CONSUMIDOR NÃO DEMONSTRADA – VOZ QUE NÃO PERTENCE AO AUTOR – FRAUDE CONFIGURADA – INEXISTÊNCIA DO DÉBITO MANTIDA – DANOS MORAIS CONFIGURADOS – QUANTUM INDENIZATÓRIO MANTIDO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – PRELIMINAR DE ILEGITIMIDADE AFASTADA - CONTRATAÇÃO VIA TELEFONE – PERÍCIA FONÉTICA REALIZADA – VONTADE DO CONSUMIDOR NÃO DEMONSTRADA – VOZ QUE NÃO PERTENCE AO AUTOR – FRAUDE CONFIGURADA – INEXISTÊNCIA DO DÉBITO MANTIDA – DANOS MORAIS CONFIGURADOS – QUANTUM INDENIZATÓRIO MANTIDO – REPETIÇÃO DO INDÉBITO NA FORMA SIMPLES – AUSÊNCIA DE PROVA DE MÁ-FÉ DO BANCO – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Restando comprovado por perícia técnica fonética que a voz constante na gravação utilizada para a contratação do empréstimo não pertence ao consumidor, deve ser mantida a declaração de inexistência do débito e do contrato.
+A contratação fraudulenta que enseja descontos indevidos em verba alimentar de pessoa idosa ultrapassa o mero aborrecimento, configurando <em>dano</em> <em>moral</em> in re ipsa.
+O valor da indenização deve ser mantido em R$ 5.000,00, por estar em consonância com os princípios da razoabilidade e proporcionalidade.
+A repetição do indébito deve ocorrer na forma simples, uma vez que a dobra prevista no art. 42, parágrafo único, do CDC, pressupõe a existência de má-fé, a qual não restou cabalmente demonstrada no caso, tratando-se de falha na segurança do sistema bancário diante de fraude de terceiros.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>88&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877378" cdForo="0" >
+										0016419-92.2017.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877378" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877378);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877378" style="display: none;" >
+	<div id="textAreaDados_1877378" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O COMUM &ndash; V&Iacute;CIOS EM IM&Oacute;VEL RESIDENCIAL OBJETO DE COMPRA E VENDA ENTRE AS PARTES LITIGANTES &ndash; PRECLUS&Atilde;O CONSUMATIVA DA SEGUNDA CONTESTA&Ccedil;&Atilde;O REJEITADA &ndash; AUS&Ecirc;NCIA DE PREJU&Iacute;ZO &ndash; ALEGA&Ccedil;&Atilde;O DE REVELIA &ndash; EFEITOS AFASTADOS &ndash; APLICA&Ccedil;&Atilde;O DO ARTIGO 345, I, DO CPC &ndash; M&Eacute;RITO &ndash; DANOS MATERIAIS J&Aacute; ABRANGIDOS POR ACORDO &ndash; IMPOSSIBILIDADE DE NOVA CONDENA&Ccedil;&Atilde;O &ndash; PERDAS E DANOS &ndash; LIMITES DO PEDIDO E DA CAUSA DE PEDIR CORRETAMENTE DEFINIDOS NA SENTEN&Ccedil;A &ndash; DANO MORAL CONFIGURADO &ndash; QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; JUROS MORAT&Oacute;RIOS &ndash; TERMO INICIAL &ndash; PRIMEIRA CITA&Ccedil;&Atilde;O V&Aacute;LIDA &ndash; RESPONSABILIDADE SOLID&Aacute;RIA &ndash; RECURSO DA AUTORA CONHECIDO E PARCIALMENTE PROVIDO &ndash; RECURSO DO REQUERIDO CONHECIDO E DESPROVIDO.
+A apresenta&ccedil;&atilde;o da segunda pe&ccedil;a de contesta&ccedil;&atilde;o, embora atraia, em tese, a preclus&atilde;o consumativa, n&atilde;o enseja a reforma da senten&ccedil;a se ausente demonstra&ccedil;&atilde;o de preju&iacute;zo e quando o julgamento se apoia em todo o conjunto probat&oacute;rio produzido nos autos.
+Em havendo pluralidade de r&eacute;us, a contesta&ccedil;&atilde;o apresentada por um deles, com impugna&ccedil;&atilde;o de fatos comuns, afasta os efeitos materiais da revelia, nos termos do art. 345, I, do CPC. Invi&aacute;vel, ademais, o reconhecimento da revelia sem cita&ccedil;&atilde;o v&aacute;lida.
+A condena&ccedil;&atilde;o deve observar os limites do pedido e da causa de pedir, n&atilde;o sendo poss&iacute;vel a convers&atilde;o ampla da obriga&ccedil;&atilde;o em perdas e danos por v&iacute;cios n&atilde;o deduzidos originariamente na peti&ccedil;&atilde;o inicial.
+N&atilde;o h&aacute; falar em mero aborrecimento na aquisi&ccedil;&atilde;o de im&oacute;vel residencial com v&iacute;cios, em que constatado por laudo pericial o retorno de esgoto para o interior da resid&ecirc;ncia, mau cheiro e alagamento de &aacute;reas do im&oacute;vel, por se tratarem de circunst&acirc;ncias que ultrapassam os dissabores cotidianos, gerando enorme frustra&ccedil;&atilde;o por quem adquire casa nova esperando condi&ccedil;&otilde;es m&iacute;nimas de moradia adequada.
+O quantum indenizat&oacute;rio deve ser fixado de forma proporcional &agrave; gravidade do dano e &agrave;s peculiaridades do caso concreto, sem causar enriquecimento il&iacute;cito.
+Havendo condena&ccedil;&atilde;o solid&aacute;ria imposta aos r&eacute;us, os juros morat&oacute;rios sobre indeniza&ccedil;&atilde;o por dano moral devem incidir a partir da primeira cita&ccedil;&atilde;o v&aacute;lida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0016419-92.2017.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Vícios de Construção
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO COMUM – VÍCIOS EM IMÓVEL RESIDENCIAL OBJETO DE COMPRA E VENDA ENTRE AS PARTES LITIGANTES – PRECLUSÃO CONSUMATIVA DA SEGUNDA CONTESTAÇÃO REJEITADA – AUSÊNCIA DE PREJUÍZO – ALEGAÇÃO DE REVELIA – EFEITOS AFASTADOS – APLICAÇÃO DO ARTIGO 345, I, DO CPC – MÉRITO – DANOS MATERIAIS JÁ ABRANGIDOS POR ACORDO – IMPOSSIBILIDADE DE NOVA CONDENAÇÃO – PERDAS E DANOS – LIMITES DO PEDIDO E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO COMUM – VÍCIOS EM IMÓVEL RESIDENCIAL OBJETO DE COMPRA E VENDA ENTRE AS PARTES LITIGANTES – PRECLUSÃO CONSUMATIVA DA SEGUNDA CONTESTAÇÃO REJEITADA – AUSÊNCIA DE PREJUÍZO – ALEGAÇÃO DE REVELIA – EFEITOS AFASTADOS – APLICAÇÃO DO ARTIGO 345, I, DO CPC – MÉRITO – DANOS MATERIAIS JÁ ABRANGIDOS POR ACORDO – IMPOSSIBILIDADE DE NOVA CONDENAÇÃO – PERDAS E DANOS – LIMITES DO PEDIDO E DA CAUSA DE PEDIR CORRETAMENTE DEFINIDOS NA SENTENÇA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM INDENIZATÓRIO MANTIDO – JUROS MORATÓRIOS – TERMO INICIAL – PRIMEIRA CITAÇÃO VÁLIDA – RESPONSABILIDADE SOLIDÁRIA – RECURSO DA AUTORA CONHECIDO E PARCIALMENTE PROVIDO – RECURSO DO REQUERIDO CONHECIDO E DESPROVIDO.
+A apresentação da segunda peça de contestação, embora atraia, em tese, a preclusão consumativa, não enseja a reforma da sentença se ausente demonstração de prejuízo e quando o julgamento se apoia em todo o conjunto probatório produzido nos autos.
+Em havendo pluralidade de réus, a contestação apresentada por um deles, com impugnação de fatos comuns, afasta os efeitos materiais da revelia, nos termos do art. 345, I, do CPC. Inviável, ademais, o reconhecimento da revelia sem citação válida.
+A condenação deve observar os limites do pedido e da causa de pedir, não sendo possível a conversão ampla da obrigação em perdas e danos por vícios não deduzidos originariamente na petição inicial.
+Não há falar em mero aborrecimento na aquisição de imóvel residencial com vícios, em que constatado por laudo pericial o retorno de esgoto para o interior da residência, mau cheiro e alagamento de áreas do imóvel, por se tratarem de circunstâncias que ultrapassam os dissabores cotidianos, gerando enorme frustração por quem adquire casa nova esperando condições mínimas de moradia adequada.
+O quantum indenizatório deve ser fixado de forma proporcional à gravidade do <em>dano</em> e às peculiaridades do caso concreto, sem causar enriquecimento ilícito.
+Havendo condenação solidária imposta aos réus, os juros moratórios sobre indenização por <em>dano</em> <em>moral</em> devem incidir a partir da primeira citação válida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>89&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877400" cdForo="0" >
+										0800893-68.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877400" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877400);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877400" style="display: none;" >
+	<div id="textAreaDados_1877400" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER CUMULADA COM INDENIZAT&Oacute;RIA &ndash; PLANO DE SA&Uacute;DE &ndash; MANUTEN&Ccedil;&Atilde;O DO VALOR DA CAUSA - RECUSA DO FORNECIMENTO DO MEDICAMENTO Rituximabe &ndash; DEVER DE COBERTURA - DANOS MORAIS N&Atilde;O CONFIGURADOS &ndash;  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+&Eacute; abusiva a recusa&nbsp;de&nbsp;cobertura&nbsp;de&nbsp;medicamento regularmente registrado na ANVISA, prescrito por profissional habilitado, ainda que utilizado em car&aacute;ter off-label ou fora das diretrizes da ANS, desde que demonstrada sua efic&aacute;cia e necessidade cl&iacute;nica.
+A simples recusa indevida de cobertura m&eacute;dico-assistencial por operadora de plano de sa&uacute;de n&atilde;o gera, por si s&oacute;, dano moral presumido (in re ipsa), sendo imprescind&iacute;vel a presen&ccedil;a de outros elementos que permitam constatar a altera&ccedil;&atilde;o an&iacute;mica da v&iacute;tima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo&nbsp;n.&ordm; 1365, do STJ).
+N&atilde;o comprovados os danos morais sofridos pela parte autora, o que afasta o dever de indenizar. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800893-68.2025.8.12.0002,&nbsp; Dourados,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Fornecimento de medicamentos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – PLANO DE SAÚDE – MANUTENÇÃO DO VALOR DA CAUSA - RECUSA DO FORNECIMENTO DO MEDICAMENTO Rituximabe – DEVER DE COBERTURA - DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+É abusiva a recusa de cobertura de medicamento regularmente registrado na ANVISA, prescrito por profissional habilitado,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZATÓRIA – PLANO DE SAÚDE – MANUTENÇÃO DO VALOR DA CAUSA - RECUSA DO FORNECIMENTO DO MEDICAMENTO Rituximabe – DEVER DE COBERTURA - DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+É abusiva a recusa de cobertura de medicamento regularmente registrado na ANVISA, prescrito por profissional habilitado, ainda que utilizado em caráter off-label ou fora das diretrizes da ANS, desde que demonstrada sua eficácia e necessidade clínica.
+A simples recusa indevida de cobertura médico-assistencial por operadora de plano de saúde não gera, por si só, <em>dano</em> <em>moral</em> presumido (in re ipsa), sendo imprescindível a presença de outros elementos que permitam constatar a alteração anímica da vítima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo n.º 1365, do STJ).
+Não comprovados os danos morais sofridos pela parte autora, o que afasta o dever de indenizar.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>90&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877415" cdForo="0" >
+										0843605-52.2020.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877415" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877415);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877415" style="display: none;" >
+	<div id="textAreaDados_1877415" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER &ndash; PLANO DE SA&Uacute;DE &ndash; FORNECIMENTO DE TRATAMENTOS M&Eacute;DICOS &ndash; TRANSTORNO DO ESPECTRO AUTISTA &ndash; COBERTURA EXPRESSA PARA A DOEN&Ccedil;A (TRANSTORNO DO ESPECTRO DO&nbsp;AUTISMO&nbsp;- TEA) &ndash; AUS&Ecirc;NCIA DE EXCLUS&Atilde;O CONTRATUAL ESPEC&Iacute;FICA DAS TERAP&Ecirc;UTICAS PRETENDIDAS PELA AUTORA &ndash;  IMPOSSIBILIDADE DE SE IMPOR LIMITA&Ccedil;&Otilde;ES A DETERMINADO M&Eacute;TODO DE TRATAMENTO &ndash; ROL DE  PROCEDIMENTOS E EVENTOS EM SA&Uacute;DE DA AG&Ecirc;NCIA NACIONAL DE SA&Uacute;DE SUPLEMENTAR (ANS) &ndash; EXEMPLIFICATIVO - ADI n. 7265 &ndash; SUPRESS&Atilde;O DE INST&Acirc;NCIA - SENTEN&Ccedil;A MANTIDA - RECURSO CONHECIDO EM PARTE E NA PARTE CONHECIDA N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte autora contra senten&ccedil;a que julgou procedentes os pedidos formulados em A&ccedil;&atilde;o de Obriga&ccedil;&atilde;o de Fazer.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso a (im)possibilidade de fornecimento, pela operadora de plano de sa&uacute;de, do tratamento com terapia pelo m&eacute;todo ABA, terapia fonoaudiol&oacute;gica especializada no m&eacute;todo PROMPT e de terapia ocupacional especializada em integra&ccedil;&atilde;o sensorial, para crian&ccedil;a portadora de Transtorno do Espectro Autista (TEA).
+III. RAZ&Otilde;ES DE DECIDIR
+3. Os contratos de plano de sa&uacute;de est&atilde;o submetidos ao C&oacute;digo de Defesa do Consumidor (S&uacute;mula 469/STJ), devendo ser afastadas cl&aacute;usulas abusivas que contrariem a boa-f&eacute; objetiva e o equil&iacute;brio contratual (arts. 6&ordm;, III, IV; 46; 51; 54, CDC).
+4. O Superior Tribunal de Justi&ccedil;a entende que  &quot;ainda que admitida a possibilidade de o contrato de plano de sa&uacute;de conter cl&aacute;usulas limitativas dos direitos do consumidor, revela-se abusiva a que exclui o custeio dos meios e materiais necess&aacute;rios ao melhor desempenho do tratamento da doen&ccedil;a coberta pelo plano&quot; (STJ - AgRg no AREsp 740203 / RJ, Ministro Marco Buzzi, Quarta Turma, DJe 14/12/2016),   sendo  que  &quot;revela-se  abusiva  a recusa de custeio do medicamento prescrito pelo  m&eacute;dico  respons&aacute;vel pelo tratamento do benefici&aacute;rio,  ainda que ministrado em ambiente domiciliar. Precedentes do STJ.&quot; (STJ - AgInt no AREsp 1064435 / GO, Ministra Maria Isabel Gallotti, 4&ordf; Turma,  DJe 23/11/2017).
+5.  Assim, em havendo cobertura expressa para a doen&ccedil;a, aliada &agrave; aus&ecirc;ncia de exclus&atilde;o contratual espec&iacute;fica das terap&ecirc;uticas pretendidas pela autora, n&atilde;o pode a r&eacute; impor limita&ccedil;&otilde;es a determinado m&eacute;todo de tratamento, pois &eacute; o m&eacute;dico ou o profissional habilitado, e n&atilde;o o plano de sa&uacute;de, quem estabelece, na busca da cura, a orienta&ccedil;&atilde;o terap&ecirc;utica a ser dada ao usu&aacute;rio acometido de doen&ccedil;a coberta. Precedentes do STJ.
+6. O fato de o tratamento prescrito n&atilde;o constar no rol da Ag&ecirc;ncia Nacional de Sa&uacute;de Suplementar (ANS) n&atilde;o significa que n&atilde;o possa ser exigido pelo usu&aacute;rio, uma vez que se trata de rol exemplificativo. Precedentes do STJ.
+7. No caso da patologia Transtorno do Espectro do&nbsp;Autismo&nbsp;(TEA), as rotinas do tratamento n&atilde;o podem ser modificadas de forma repentina pelo plano de sa&uacute;de. Al&eacute;m disso, especialmente quanto ao tratamento pelo m&eacute;todo ABA&nbsp;(Applied&nbsp;Behavior Analysis), o v&iacute;nculo com o profissional &eacute; muito importante para a evolu&ccedil;&atilde;o como ser humano e cada profissional contribui para o desenvolvimento e a socializa&ccedil;&atilde;o das pessoas com autismo. Precedentes do TJMS.
+8. A prop&oacute;sito, o mesmo se diga acerca da continuidade do tratamento com os profissionais que est&atilde;o incumbidos da fonoterapia e da terapia ocupacional com integra&ccedil;&atilde;o sensorial, n&atilde;o sendo aconselh&aacute;vel, portanto, que haja altera&ccedil;&atilde;o nessa rotina.
+9. Al&eacute;m disso, as especialidades requeridas pela autora (terapia fonoaudiol&oacute;gica especializada no m&eacute;todo PROMPT e de terapia ocupacional especializada em integra&ccedil;&atilde;o sensorial), ao que parece, tamb&eacute;m n&atilde;o foram deferidas pela r&eacute;, apesar da cobertura contratual para a patologia Transtorno do Espectro do&nbsp;Autismo&nbsp;(TEA), o que se afigura inadequado, j&aacute; que &eacute; vedado &agrave;s operadoras de plano de sa&uacute;de limitar os tratamentos recomendados pelo m&eacute;dico do consumidor, quando a doen&ccedil;a em si &eacute; coberta pelo plano de sa&uacute;de.
+10. Por fim, pelos mesmos fundamentos, n&atilde;o subsiste o pedido subsidi&aacute;rio, de custeio dos tratamentos no limite da tabela de procedimentos da r&eacute;-agravante, bem para que os servi&ccedil;os sejam prestados por profissionais por esta credenciados, pois, al&eacute;m de ser obriga&ccedil;&atilde;o contratual a cobertura do tratamento indicado pelo m&eacute;dico da autora, quaisquer destas limita&ccedil;&otilde;es podem, em tese, comprometer a efic&aacute;cia do tratamento pleiteado, o que, &agrave; luz dos valores fundamentais que est&atilde;o em jogo, n&atilde;o se afigura razo&aacute;vel, tampouco recomend&aacute;vel.
+IV. DISPOSITIVO
+12. Apela&ccedil;&atilde;o C&iacute;vel conhecida em parte e na parte conhecida n&atilde;o provida.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0843605-52.2020.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – FORNECIMENTO DE TRATAMENTOS MÉDICOS – TRANSTORNO DO ESPECTRO AUTISTA – COBERTURA EXPRESSA PARA A DOENÇA (TRANSTORNO DO ESPECTRO DO AUTISMO - TEA) – AUSÊNCIA DE EXCLUSÃO CONTRATUAL ESPECÍFICA DAS TERAPÊUTICAS PRETENDIDAS PELA AUTORA –  IMPOSSIBILIDADE DE SE IMPOR LIMITAÇÕES A DETERMINADO MÉTODO DE TRATAMENTO – ROL DE  PROCEDIMENTOS E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER – PLANO DE SAÚDE – FORNECIMENTO DE TRATAMENTOS MÉDICOS – TRANSTORNO DO ESPECTRO AUTISTA – COBERTURA EXPRESSA PARA A DOENÇA (TRANSTORNO DO ESPECTRO DO AUTISMO - TEA) – AUSÊNCIA DE EXCLUSÃO CONTRATUAL ESPECÍFICA DAS TERAPÊUTICAS PRETENDIDAS PELA AUTORA –  IMPOSSIBILIDADE DE SE IMPOR LIMITAÇÕES A DETERMINADO MÉTODO DE TRATAMENTO – ROL DE  PROCEDIMENTOS E EVENTOS EM SAÚDE DA AGÊNCIA NACIONAL DE SAÚDE SUPLEMENTAR (ANS) – EXEMPLIFICATIVO - ADI n. 7265 – SUPRESSÃO DE INSTÂNCIA - SENTENÇA MANTIDA - RECURSO CONHECIDO EM PARTE E NA PARTE CONHECIDA NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta pela parte autora contra sentença que julgou procedentes os pedidos formulados em Ação de Obrigação de Fazer.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso a (im)possibilidade de fornecimento, pela operadora de plano de saúde, do tratamento com terapia pelo método ABA, terapia fonoaudiológica especializada no método PROMPT e de terapia ocupacional especializada em integração sensorial, para criança portadora de Transtorno do Espectro Autista (TEA).
+III. RAZÕES DE DECIDIR
+3. Os contratos de plano de saúde estão submetidos ao Código de Defesa do Consumidor (Súmula 469/STJ), devendo ser afastadas cláusulas abusivas que contrariem a boa-fé objetiva e o equilíbrio contratual (arts. 6º, III, IV; 46; 51; 54, CDC).
+4. O Superior Tribunal de Justiça entende que  "ainda que admitida a possibilidade de o contrato de plano de saúde conter cláusulas limitativas dos direitos do consumidor, revela-se abusiva a que exclui o custeio dos meios e materiais necessários ao melhor desempenho do tratamento da doença coberta pelo plano" (STJ - AgRg no AREsp 740203 / RJ, Ministro Marco Buzzi, Quarta Turma, DJe 14/12/2016),   sendo  que  "revela-se  abusiva  a recusa de custeio do medicamento prescrito pelo  médico  responsável pelo tratamento do beneficiário,  ainda que ministrado em ambiente domiciliar. Precedentes do STJ." (STJ - AgInt no AREsp 1064435 / GO, Ministra Maria Isabel Gallotti, 4ª Turma,  DJe 23/11/2017).
+5.  Assim, em havendo cobertura expressa para a doença, aliada à ausência de exclusão contratual específica das terapêuticas pretendidas pela autora, não pode a ré impor limitações a determinado método de tratamento, pois é o médico ou o profissional habilitado, e não o plano de saúde, quem estabelece, na busca da cura, a orientação terapêutica a ser dada ao usuário acometido de doença coberta. Precedentes do STJ.
+6. O fato de o tratamento prescrito não constar no rol da Agência Nacional de Saúde Suplementar (ANS) não significa que não possa ser exigido pelo usuário, uma vez que se trata de rol exemplificativo. Precedentes do STJ.
+7. No caso da patologia Transtorno do Espectro do Autismo (TEA), as rotinas do tratamento não podem ser modificadas de forma repentina pelo plano de saúde. Além disso, especialmente quanto ao tratamento pelo método ABA (Applied Behavior Analysis), o vínculo com o profissional é muito importante para a evolução como ser humano e cada profissional contribui para o desenvolvimento e a socialização das pessoas com autismo. Precedentes do TJMS.
+8. A propósito, o mesmo se diga acerca da continuidade do tratamento com os profissionais que estão incumbidos da fonoterapia e da terapia ocupacional com integração sensorial, não sendo aconselhável, portanto, que haja alteração nessa rotina.
+9. Além disso, as especialidades requeridas pela autora (terapia fonoaudiológica especializada no método PROMPT e de terapia ocupacional especializada em integração sensorial), ao que parece, também não foram deferidas pela ré, apesar da cobertura contratual para a patologia Transtorno do Espectro do Autismo (TEA), o que se afigura inadequado, já que é vedado às operadoras de plano de saúde limitar os tratamentos recomendados pelo médico do consumidor, quando a doença em si é coberta pelo plano de saúde.
+10. Por fim, pelos mesmos fundamentos, não subsiste o pedido subsidiário, de custeio dos tratamentos no limite da tabela de procedimentos da ré-agravante, bem para que os serviços sejam prestados por profissionais por esta credenciados, pois, além de ser obrigação contratual a cobertura do tratamento indicado pelo médico da autora, quaisquer destas limitações podem, em tese, comprometer a eficácia do tratamento pleiteado, o que, à luz dos valores fundamentais que estão em jogo, não se afigura razoável, tampouco recomendável.
+IV. DISPOSITIVO
+12. Apelação Cível conhecida em parte e na parte conhecida não provida.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>91&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877422" cdForo="0" >
+										0801823-51.2023.8.12.0004
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877422" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877422);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877422" style="display: none;" >
+	<div id="textAreaDados_1877422" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA  C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANO MORAL &ndash; EMPR&Eacute;STIMOS &ndash; CONTRATA&Ccedil;&Atilde;O  N&Atilde;O COMPROVADA &ndash;  VIOLA&Ccedil;&Atilde;O AO DIREITO DA PERSONALIDADE &ndash; DANOS MORAIS CONFIGURADOS &ndash; FIXA&Ccedil;&Atilde;O EM OBSERV&Acirc;NCIA AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE   &ndash;  RECURSO CONHECIDO E  DESPROVIDO.
+Para que o dano moral seja caracterizado &eacute; necess&aacute;rio que se demonstre, pela prova dos autos, que dos fatos e provas trazidos ao conhecimento do Poder Judici&aacute;rio emana o nexo de causalidade necess&aacute;rio para sua configura&ccedil;&atilde;o. Restando patente a responsabilidade do recorrente pelo evento danoso suportado pela recorrida, a indeniza&ccedil;&atilde;o por danos morais &eacute; medida que se imp&otilde;e.
+Quanto ao valor da indeniza&ccedil;&atilde;o, destaca-se que n&atilde;o existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercuss&atilde;o dos fatos, estabelecer a indeniza&ccedil;&atilde;o que venha ressarcir a parte lesada (car&aacute;ter indenizat&oacute;rio) e que tamb&eacute;m iniba a reitera&ccedil;&atilde;o de condutas an&aacute;logas (aspecto pedag&oacute;gico).
+ Na quantifica&ccedil;&atilde;o do dano moral foram considerados os crit&eacute;rios de razoabilidade e da proporcionalidade, observando-se o conjunto f&aacute;tico-probat&oacute;rio reunido, raz&atilde;o pela qual o quantum fixado deve ser mantido.
+ Recurso conhecido e desprovido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801823-51.2023.8.12.0004,&nbsp; Amambai,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Amambai
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA  C/C REPETIÇÃO DE INDÉBITO E <em>DANO</em> <em>MORAL</em> – EMPRÉSTIMOS – CONTRATAÇÃO  NÃO COMPROVADA –  VIOLAÇÃO AO DIREITO DA PERSONALIDADE – DANOS MORAIS CONFIGURADOS – FIXAÇÃO EM OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE   –  RECURSO CONHECIDO E  DESPROVIDO.
+Para que o <em>dano</em> <em>moral</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA  C/C REPETIÇÃO DE INDÉBITO E <em>DANO</em> <em>MORAL</em> – EMPRÉSTIMOS – CONTRATAÇÃO  NÃO COMPROVADA –  VIOLAÇÃO AO DIREITO DA PERSONALIDADE – DANOS MORAIS CONFIGURADOS – FIXAÇÃO EM OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE   –  RECURSO CONHECIDO E  DESPROVIDO.
+Para que o <em>dano</em> <em>moral</em> seja caracterizado é necessário que se demonstre, pela prova dos autos, que dos fatos e provas trazidos ao conhecimento do Poder Judiciário emana o nexo de causalidade necessário para sua configuração. Restando patente a responsabilidade do recorrente pelo evento danoso suportado pela recorrida, a indenização por danos morais é medida que se impõe.
+Quanto ao valor da indenização, destaca-se que não existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercussão dos fatos, estabelecer a indenização que venha ressarcir a parte lesada (caráter indenizatório) e que também iniba a reiteração de condutas análogas (aspecto pedagógico).
+ Na quantificação do <em>dano</em> <em>moral</em> foram considerados os critérios de razoabilidade e da proporcionalidade, observando-se o conjunto fático-probatório reunido, razão pela qual o quantum fixado deve ser mantido.
+ Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>92&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877440" cdForo="0" >
+										0802552-80.2024.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877440" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877440);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877440" style="display: none;" >
+	<div id="textAreaDados_1877440" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E RESPONSABILIDADE CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. AUS&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O. FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. DANO MORAL IN RE IPSA. MAJORA&Ccedil;&Atilde;O DA INDENIZA&Ccedil;&Atilde;O PARA VALOR RAZO&Aacute;VEL E PROPORCIONAL. RECURSO PROVIDO.
+1. A responsabilidade civil do fornecedor de servi&ccedil;os nas rela&ccedil;&otilde;es de consumo &eacute; objetiva, bastando a demonstra&ccedil;&atilde;o da conduta il&iacute;cita, do dano e do nexo causal para a configura&ccedil;&atilde;o do dever de indenizar.
+2. A inexist&ecirc;ncia de contrata&ccedil;&atilde;o v&aacute;lida que justificasse os descontos evidencia falha na presta&ccedil;&atilde;o do servi&ccedil;o e caracteriza ato il&iacute;cito.
+3. Descontos indevidos em benef&iacute;cio previdenci&aacute;rio, verba de natureza alimentar, ultrapassam o mero dissabor cotidiano e configuram dano moral presumido, sobretudo quando atingem consumidor aposentado.
+4. A fixa&ccedil;&atilde;o do valor da indeniza&ccedil;&atilde;o por dano moral deve observar os princ&iacute;pios da razoabilidade e da proporcionalidade, considerando a gravidade da conduta, a extens&atilde;o do dano e as fun&ccedil;&otilde;es compensat&oacute;ria e pedag&oacute;gica da condena&ccedil;&atilde;o.
+5. Recurso provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802552-80.2024.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(29 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E RESPONSABILIDADE CIVIL. APELAÇÃO CÍVEL. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE CONTRATAÇÃO. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MAJORAÇÃO DA INDENIZAÇÃO PARA VALOR RAZOÁVEL E PROPORCIONAL. RECURSO PROVIDO.
+1. A responsabilidade civil do fornecedor de serviços nas relações de consumo é objetiva, bastando a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E RESPONSABILIDADE CIVIL. APELAÇÃO CÍVEL. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. AUSÊNCIA DE CONTRATAÇÃO. FALHA NA PRESTAÇÃO DO SERVIÇO. <em>DANO</em> <em>MORAL</em> IN RE IPSA. MAJORAÇÃO DA INDENIZAÇÃO PARA VALOR RAZOÁVEL E PROPORCIONAL. RECURSO PROVIDO.
+1. A responsabilidade civil do fornecedor de serviços nas relações de consumo é objetiva, bastando a demonstração da conduta ilícita, do <em>dano</em> e do nexo causal para a configuração do dever de indenizar.
+2. A inexistência de contratação válida que justificasse os descontos evidencia falha na prestação do serviço e caracteriza ato ilícito.
+3. Descontos indevidos em benefício previdenciário, verba de natureza alimentar, ultrapassam o mero dissabor cotidiano e configuram <em>dano</em> <em>moral</em> presumido, sobretudo quando atingem consumidor aposentado.
+4. A fixação do valor da indenização por <em>dano</em> <em>moral</em> deve observar os princípios da razoabilidade e da proporcionalidade, considerando a gravidade da conduta, a extensão do <em>dano</em> e as funções compensatória e pedagógica da condenação.
+5. Recurso provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>93&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877445" cdForo="0" >
+										0800191-41.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877445" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877445);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877445" style="display: none;" >
+	<div id="textAreaDados_1877445" class="mensagemSemFormatacao" >
+		DIREITO ADMINISTRATIVO E CONSTITUCIONAL &ndash; Apela&ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; PRELIMINAR &ndash; CERCEAMENTO DEFESA &ndash; REJEITADA &ndash;   M&Eacute;RITO &ndash; RESPONSABILIDADE CIVIL DO ESTADO &ndash; SUPERLOTA&Ccedil;&Atilde;O CARCER&Aacute;RIA &ndash; DANOS MORAIS &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DE DANO INDIVIDUALIZADO &ndash; TEMA 365 DO STF &ndash; IMPROCED&Ecirc;NCIA &ndash; SENTEN&Ccedil;A MANTIDA &ndash;  RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o C&iacute;vel interposta pela parte autora contra senten&ccedil;a que julgou improcedente pedido de indeniza&ccedil;&atilde;o por danos morais decorrentes de alegadas condi&ccedil;&otilde;es degradantes no Estabelecimento Penal Masculino de Corumb&aacute;, notadamente superlota&ccedil;&atilde;o e insalubridade.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) em preliminar, se houve cerceamento de defesa em raz&atilde;o do indeferimento de provas; e b) no m&eacute;rito, a exist&ecirc;ncia de responsabilidade civil do Estado decorrente da alegada superlota&ccedil;&atilde;o carcer&aacute;ria e das condi&ccedil;&otilde;es insalubres do estabelecimento prisional.
+III. RAZ&Otilde;ES DE DECIDIR
+3. N&atilde;o h&aacute; cerceamento de defesa quando o Magistrado indefere, de forma fundamentada, a produ&ccedil;&atilde;o de provas consideradas desnecess&aacute;rias, diante da sufici&ecirc;ncia do conjunto probat&oacute;rio, nos termos dos arts. 369 e 370 do CPC/15. Preliminar Rejeitada.
+4. A responsabilidade civil do Estado, nos termos do art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal, &eacute; objetiva, exigindo a comprova&ccedil;&atilde;o do dano e do nexo causal.
+5. O Supremo Tribunal Federal, no julgamento do Tema 365, firmou entendimento de que n&atilde;o h&aacute; dano moral presumido em raz&atilde;o de condi&ccedil;&otilde;es prec&aacute;rias do sistema prisional, sendo necess&aacute;ria a demonstra&ccedil;&atilde;o concreta e individualizada do preju&iacute;zo suportado pelo detento  (RE 580252, Relator(a): TEORI ZAVASCKI, Relator(a) p/ Ac&oacute;rd&atilde;o: GILMAR MENDES, Tribunal Pleno, julgado em 16-02-2017, AC&Oacute;RD&Atilde;O ELETR&Ocirc;NICO REPERCUSS&Atilde;O GERAL - M&Eacute;RITO DJe-204  DIVULG 08-09-2017  PUBLIC 11-09-2017).
+6. Alega&ccedil;&otilde;es gen&eacute;ricas de superlota&ccedil;&atilde;o e insalubridade, desacompanhadas de prova de repercuss&atilde;o espec&iacute;fica na esfera pessoal do autor, s&atilde;o insuficientes para ensejar indeniza&ccedil;&atilde;o por danos morais.
+IV. DISPOSITIVO
+7. Apela&ccedil;&atilde;o C&iacute;vel conhecida e n&atilde;o provida, com majora&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800191-41.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(66 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO E CONSTITUCIONAL – ApelaçÃO CÍVEL – AÇÃO DE REPARAÇÃO POR DANOS MORAIS – PRELIMINAR – CERCEAMENTO DEFESA – REJEITADA –   MÉRITO – RESPONSABILIDADE CIVIL DO ESTADO – SUPERLOTAÇÃO CARCERÁRIA – DANOS MORAIS – AUSÊNCIA DE COMPROVAÇÃO DE <em>DANO</em> INDIVIDUALIZADO – TEMA 365 DO STF – IMPROCEDÊNCIA – SENTENÇA MANTIDA –  RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO ADMINISTRATIVO E CONSTITUCIONAL – ApelaçÃO CÍVEL – AÇÃO DE REPARAÇÃO POR DANOS MORAIS – PRELIMINAR – CERCEAMENTO DEFESA – REJEITADA –   MÉRITO – RESPONSABILIDADE CIVIL DO ESTADO – SUPERLOTAÇÃO CARCERÁRIA – DANOS MORAIS – AUSÊNCIA DE COMPROVAÇÃO DE <em>DANO</em> INDIVIDUALIZADO – TEMA 365 DO STF – IMPROCEDÊNCIA – SENTENÇA MANTIDA –  RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação Cível interposta pela parte autora contra sentença que julgou improcedente pedido de indenização por danos morais decorrentes de alegadas condições degradantes no Estabelecimento Penal Masculino de Corumbá, notadamente superlotação e insalubridade.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso: a) em preliminar, se houve cerceamento de defesa em razão do indeferimento de provas; e b) no mérito, a existência de responsabilidade civil do Estado decorrente da alegada superlotação carcerária e das condições insalubres do estabelecimento prisional.
+III. RAZÕES DE DECIDIR
+3. Não há cerceamento de defesa quando o Magistrado indefere, de forma fundamentada, a produção de provas consideradas desnecessárias, diante da suficiência do conjunto probatório, nos termos dos arts. 369 e 370 do CPC/15. Preliminar Rejeitada.
+4. A responsabilidade civil do Estado, nos termos do art. 37, § 6º, da Constituição Federal, é objetiva, exigindo a comprovação do <em>dano</em> e do nexo causal.
+5. O Supremo Tribunal Federal, no julgamento do Tema 365, firmou entendimento de que não há <em>dano</em> <em>moral</em> presumido em razão de condições precárias do sistema prisional, sendo necessária a demonstração concreta e individualizada do prejuízo suportado pelo detento  (RE 580252, Relator(a): TEORI ZAVASCKI, Relator(a) p/ Acórdão: GILMAR MENDES, Tribunal Pleno, julgado em 16-02-2017, ACÓRDÃO ELETRÔNICO REPERCUSSÃO GERAL - MÉRITO DJe-204  DIVULG 08-09-2017  PUBLIC 11-09-2017).
+6. Alegações genéricas de superlotação e insalubridade, desacompanhadas de prova de repercussão específica na esfera pessoal do autor, são insuficientes para ensejar indenização por danos morais.
+IV. DISPOSITIVO
+7. Apelação Cível conhecida e não provida, com majoração dos honorários sucumbenciais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>94&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877459" cdForo="0" >
+										0803978-39.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877459" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877459);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877459" style="display: none;" >
+	<div id="textAreaDados_1877459" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; EXECU&Ccedil;&Atilde;O DE T&Iacute;TULO EXTRAJUDICIAL &ndash; SENTEN&Ccedil;A DE EXTIN&Ccedil;&Atilde;O DO FEITO &ndash; APLICA&Ccedil;&Atilde;O INCORRETA DA LITISPEND&Ecirc;NCIA &ndash; PROCESSO ANTERIOR EXTINTO POR DESIST&Ecirc;NCIA - ERRO IN PROCEDENDO &ndash; SENTEN&Ccedil;A CASSADA &ndash; RECURSO CONHECIDO E PROVIDO.
+Embora a parte autora tenha ajuizado a&ccedil;&atilde;o id&ecirc;ntica n&ordm; 0805195-20.2024.8.12.0021, requereu a sua desist&ecirc;ncia, diante da constata&ccedil;&atilde;o de duplicidade de demandas, o que foi devidamente homologado pelo ju&iacute;zo.
+Assim, indevida a extin&ccedil;&atilde;o desta a&ccedil;&atilde;o, configurado o error&nbsp;in&nbsp;procedendo, a justificar a cassa&ccedil;&atilde;o da senten&ccedil;a prolatada.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803978-39.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Assinatura Básica Mensal
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – EXECUÇÃO DE TÍTULO EXTRAJUDICIAL – SENTENÇA DE EXTINÇÃO DO FEITO – APLICAÇÃO INCORRETA DA LITISPENDÊNCIA – PROCESSO ANTERIOR EXTINTO POR DESISTÊNCIA - ERRO IN PROCEDENDO – SENTENÇA CASSADA – RECURSO CONHECIDO E PROVIDO.
+Embora a parte autora tenha ajuizado ação idêntica nº 0805195-20.2024.8.12.0021, requereu a sua desistência, diante da constatação de duplicidade de demandas, o
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – EXECUÇÃO DE TÍTULO EXTRAJUDICIAL – SENTENÇA DE EXTINÇÃO DO FEITO – APLICAÇÃO INCORRETA DA LITISPENDÊNCIA – PROCESSO ANTERIOR EXTINTO POR DESISTÊNCIA - ERRO IN PROCEDENDO – SENTENÇA CASSADA – RECURSO CONHECIDO E PROVIDO.
+Embora a parte autora tenha ajuizado ação idêntica nº 0805195-20.2024.8.12.0021, requereu a sua desistência, diante da constatação de duplicidade de demandas, o que foi devidamente homologado pelo juízo.
+Assim, indevida a extinção desta ação, configurado o error in procedendo, a justificar a cassação da sentença prolatada.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>95&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877462" cdForo="0" >
+										0802122-73.2024.8.12.0010
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877462" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877462);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877462" style="display: none;" >
+	<div id="textAreaDados_1877462" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash; PLANO DE SA&Uacute;DE &ndash; RECUSA DO FORNECIMENTO DE TRATAMENTO DOMICILIAR &ndash; DANOS MORAIS N&Atilde;O CONFIGURADOS &ndash;  RECURSO CONHECIDO E PROVIDO.
+A simples recusa indevida de cobertura m&eacute;dico-assistencial por operadora de plano de sa&uacute;de n&atilde;o gera, por si s&oacute;, dano moral presumido (in re ipsa), sendo imprescind&iacute;vel a presen&ccedil;a de outros elementos que permitam constatar a altera&ccedil;&atilde;o an&iacute;mica da v&iacute;tima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo&nbsp;n.&ordm; 1365 do STJ).
+N&atilde;o comprovados os danos morais sofrido pela parte autora, o que afasta o dever de indenizar. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802122-73.2024.8.12.0010,&nbsp; F&aacute;tima do Sul,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(13 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Serviços de Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fátima do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO INDENIZATÓRIA – PLANO DE SAÚDE – RECUSA DO FORNECIMENTO DE TRATAMENTO DOMICILIAR – DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PROVIDO.
+A simples recusa indevida de cobertura médico-assistencial por operadora de plano de saúde não gera, por si só, <em>dano</em> <em>moral</em> presumido (in re ipsa), sendo imprescindível a presença de outros elementos que
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO INDENIZATÓRIA – PLANO DE SAÚDE – RECUSA DO FORNECIMENTO DE TRATAMENTO DOMICILIAR – DANOS MORAIS NÃO CONFIGURADOS –  RECURSO CONHECIDO E PROVIDO.
+A simples recusa indevida de cobertura médico-assistencial por operadora de plano de saúde não gera, por si só, <em>dano</em> <em>moral</em> presumido (in re ipsa), sendo imprescindível a presença de outros elementos que permitam constatar a alteração anímica da vítima em grau suficiente para ultrapassar o mero aborrecimento ou dissabor (Tema Repetitivo n.º 1365 do STJ).
+Não comprovados os danos morais sofrido pela parte autora, o que afasta o dever de indenizar.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>96&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877466" cdForo="0" >
+										1403132-65.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877466" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877466);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877466" style="display: none;" >
+	<div id="textAreaDados_1877466" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPARA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; FIXA&Ccedil;&Atilde;O DE MULTA DI&Aacute;RIA POR DESCUMPRIMENTO DE ORDEM &ndash; POSSIBILIDADE &ndash; VALOR RAZO&Aacute;VEL E PROPORCIONAL &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+Sopesando as particularidades da casu&iacute;stica, sobretudo as condi&ccedil;&otilde;es financeiras do agravante, que &eacute; institui&ccedil;&atilde;o financeira de grande porte, o objeto da a&ccedil;&atilde;o &ndash; qual seja, a suspens&atilde;o das cobran&ccedil;as com rela&ccedil;&atilde;o aos d&eacute;bitos questionados pelo agravada &ndash; e a import&acirc;ncia do bem jur&iacute;dico que se busca tutelar, bem como o valor fixado e a periodicidade estipulada para a incid&ecirc;ncia das astreintes &ndash; que incidir&atilde;o no valor de R$100,00 por dia de descumprimento, limitada a 100 vezes esse valor &ndash;, tenho que a multa arbitrada &eacute; razo&aacute;vel, necess&aacute;ria e suscet&iacute;vel de alcan&ccedil;ar o desiderato de compelir o agravante a cumprir a determina&ccedil;&atilde;o judicial.
+Recurso conhecido e n&atilde;o provido.   <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1403132-65.2026.8.12.0000,&nbsp; Parana&iacute;ba,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – FIXAÇÃO DE MULTA DIÁRIA POR DESCUMPRIMENTO DE ORDEM – POSSIBILIDADE – VALOR RAZOÁVEL E PROPORCIONAL – RECURSO CONHECIDO E NÃO PROVIDO.
+Sopesando as particularidades da casuística, sobretudo as condições financeiras do agravante, que é instituição financeira de grande porte, o objeto da ação –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO POR DANOS MORAIS – FIXAÇÃO DE MULTA DIÁRIA POR DESCUMPRIMENTO DE ORDEM – POSSIBILIDADE – VALOR RAZOÁVEL E PROPORCIONAL – RECURSO CONHECIDO E NÃO PROVIDO.
+Sopesando as particularidades da casuística, sobretudo as condições financeiras do agravante, que é instituição financeira de grande porte, o objeto da ação – qual seja, a suspensão das cobranças com relação aos débitos questionados pelo agravada – e a importância do bem jurídico que se busca tutelar, bem como o valor fixado e a periodicidade estipulada para a incidência das astreintes – que incidirão no valor de R$100,00 por dia de descumprimento, limitada a 100 vezes esse valor –, tenho que a multa arbitrada é razoável, necessária e suscetível de alcançar o desiderato de compelir o agravante a cumprir a determinação judicial.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>97&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877468" cdForo="0" >
+										0806338-25.2021.8.12.0029
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877468" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877468);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877468" style="display: none;" >
+	<div id="textAreaDados_1877468" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E ADMINISTRATIVO &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E EST&Eacute;TICOS DECORRENTES DE ACIDENTE DE TR&Acirc;NSITO &ndash;  M&Eacute;RITO - ACIDENTE DE TR&Acirc;NSITO  &ndash; COLIS&Atilde;O COM TUBO DE CONCRETO EM VIA P&Uacute;BLICA &ndash; RESPONSABILIDADE SUBJETIVA DA ADMINISTRA&Ccedil;&Atilde;O P&Uacute;BLICA &ndash; AUS&Ecirc;NCIA DE SINALIZA&Ccedil;&Atilde;O - - OMISS&Atilde;O DO ENTE P&Uacute;BLICO &ndash; OBRA P&Uacute;BLICA PROMOVIDA E EXECUTADA PELO ESTADO, E N&Atilde;O PELO MUNIC&Iacute;PIO R&Eacute;U &ndash; AUS&Ecirc;NCIA DE CONDUTA E DE NEXO CAUSAL DO MUNIC&Iacute;PIO R&Eacute;U -  SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA &ndash; RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte auto racontra a senten&ccedil;a que julgou IMprocedentes os pedidos formulados em A&ccedil;&atilde;o de Indeniza&ccedil;&atilde;o por Danos Morais e Est&eacute;ticos decorrentes de Acidente de Tr&acirc;nsito.
+II. HIP&Oacute;TESE EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a responsabilidade civil pelo evento danoso; b) a exist&ecirc;ncia de danos morais e est&eacute;ticos.
+III. RAZ&Otilde;ES DE DECIDIR
+3.  Em se tratando de omiss&atilde;o da Administra&ccedil;&atilde;o P&uacute;blica, a responsabilidade civil do Estado &eacute; subjetiva, fundada na teoria da  &quot;faute du service&quot; ou da falta do servi&ccedil;o,  exigindo-se a demonstra&ccedil;&atilde;o da culpa para ensejar a responsabiliza&ccedil;&atilde;o. No caso, responsabilidade civil configurada, visto que comprovado que o acidente de tr&acirc;nsito ocorreu  por culpa do ente p&uacute;blico, que por omiss&atilde;o e neglig&ecirc;ncia, n&atilde;o providenciou a correta manuten&ccedil;&atilde;o da via p&uacute;blica. Aquele que, por a&ccedil;&atilde;o ou omiss&atilde;o volunt&aacute;ria, neglig&ecirc;ncia ou imprud&ecirc;ncia, violar direito e causar dano a outrem, ainda que exclusivamente moral, comete ato il&iacute;cito. Por sua vez, aquele que, por ato il&iacute;cito, causar dano a outrem, fica obrigado a repar&aacute;-lo. (artigos 187 e 927 do CC/2002).
+4. O conjunto probat&oacute;rio demonstra de forma inequ&iacute;voca que a obra de canaliza&ccedil;&atilde;o de esgoto e drenagem foi promovida e executada exclusivamente pelo Estado de Mato Grosso do Sul, e n&atilde;o pelo Munic&iacute;pio de Navira&iacute;. Restando comprovado que a interven&ccedil;&atilde;o na via p&uacute;blica era de responsabilidade de terceiro, resta rompido o nexo causal em rela&ccedil;&atilde;o &agrave; municipalidade. N&atilde;o demonstrada qualquer conduta (omissiva ou comissiva) do Munic&iacute;pio que tenha concorrido para o evento danoso, a improced&ecirc;ncia do pleito indenizat&oacute;rio &eacute; medida que se imp&otilde;e.
+IV. DISPOSITIVO
+5. Apela&ccedil;&atilde;o C&iacute;vel conhecida e n&atilde;o provida.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0806338-25.2021.8.12.0029,&nbsp; Navira&iacute;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Naviraí
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E ADMINISTRATIVO – APELAÇÃO CÍVEL - AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E ESTÉTICOS DECORRENTES DE ACIDENTE DE TRÂNSITO –  MÉRITO - ACIDENTE DE TRÂNSITO  – COLISÃO COM TUBO DE CONCRETO EM VIA PÚBLICA – RESPONSABILIDADE SUBJETIVA DA ADMINISTRAÇÃO PÚBLICA – AUSÊNCIA DE SINALIZAÇÃO - - OMISSÃO DO ENTE PÚBLICO – OBRA PÚBLICA PROMOVIDA E EXECUTADA PELO ESTADO, E NÃO PELO MUNICÍPIO RÉU –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E ADMINISTRATIVO – APELAÇÃO CÍVEL - AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E ESTÉTICOS DECORRENTES DE ACIDENTE DE TRÂNSITO –  MÉRITO - ACIDENTE DE TRÂNSITO  – COLISÃO COM TUBO DE CONCRETO EM VIA PÚBLICA – RESPONSABILIDADE SUBJETIVA DA ADMINISTRAÇÃO PÚBLICA – AUSÊNCIA DE SINALIZAÇÃO - - OMISSÃO DO ENTE PÚBLICO – OBRA PÚBLICA PROMOVIDA E EXECUTADA PELO ESTADO, E NÃO PELO MUNICÍPIO RÉU – AUSÊNCIA DE CONDUTA E DE NEXO CAUSAL DO MUNICÍPIO RÉU -  SENTENÇA DE IMPROCEDÊNCIA MANTIDA – RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta pela parte auto racontra a sentença que julgou IMprocedentes os pedidos formulados em Ação de Indenização por Danos Morais e Estéticos decorrentes de Acidente de Trânsito.
+II. HIPÓTESE EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a responsabilidade civil pelo evento danoso; b) a existência de danos morais e estéticos.
+III. RAZÕES DE DECIDIR
+3.  Em se tratando de omissão da Administração Pública, a responsabilidade civil do Estado é subjetiva, fundada na teoria da  "faute du service" ou da falta do serviço,  exigindo-se a demonstração da culpa para ensejar a responsabilização. No caso, responsabilidade civil configurada, visto que comprovado que o acidente de trânsito ocorreu  por culpa do ente público, que por omissão e negligência, não providenciou a correta manutenção da via pública. Aquele que, por ação ou omissão voluntária, negligência ou imprudência, violar direito e causar <em>dano</em> a outrem, ainda que exclusivamente <em>moral</em>, comete ato ilícito. Por sua vez, aquele que, por ato ilícito, causar <em>dano</em> a outrem, fica obrigado a repará-lo. (artigos 187 e 927 do CC/2002).
+4. O conjunto probatório demonstra de forma inequívoca que a obra de canalização de esgoto e drenagem foi promovida e executada exclusivamente pelo Estado de Mato Grosso do Sul, e não pelo Município de Naviraí. Restando comprovado que a intervenção na via pública era de responsabilidade de terceiro, resta rompido o nexo causal em relação à municipalidade. Não demonstrada qualquer conduta (omissiva ou comissiva) do Município que tenha concorrido para o evento danoso, a improcedência do pleito indenizatório é medida que se impõe.
+IV. DISPOSITIVO
+5. Apelação Cível conhecida e não provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>98&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877469" cdForo="0" >
+										0813070-98.2024.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877469" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877469);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877469" style="display: none;" >
+	<div id="textAreaDados_1877469" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CONTRATO DE SEGURO &ndash; DESCONTOS EM CONTA CORRENTE &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA &ndash;  RESTITUI&Ccedil;&Atilde;O DE VALORES DEVIDA &ndash; DANOS MORAIS CONFIGURADOS &ndash; PROCED&Ecirc;NCIA DOS PEDIDOS &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PROVIDO.
+CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte autora contra senten&ccedil;a que julgou improcedentes os pedidos iniciais formulados em A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de D&eacute;bito c/c Indeniza&ccedil;&atilde;o por Danos Morais e Materiais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a (i)legalidade da cobran&ccedil;a de mensalidades de contrato de seguro;  b) o cabimento da restitui&ccedil;&atilde;o dos valores pagos; e c) a ocorr&ecirc;ncia de danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O neg&oacute;cio jur&iacute;dico deve ser examinado sob o prisma de tr&ecirc;s (3) planos &ndash; exist&ecirc;ncia, validade e efic&aacute;cia &ndash;, com a finalidade de se verificar se ele obt&eacute;m plena realiza&ccedil;&atilde;o. No plano da exist&ecirc;ncia, verifica-se, t&atilde;o somente, se est&atilde;o presentes as condi&ccedil;&otilde;es m&iacute;nimas para que o neg&oacute;cio jur&iacute;dico possa produzir efeitos (v.g, agente; objeto; forma, e vontade exteriorizada), n&atilde;o se discutindo, desta forma, a validade ou invalidade do neg&oacute;cio e tampouco a sua efic&aacute;cia.
+4. Comprovada a ocorr&ecirc;ncia de descontos na conta banc&aacute;ria da parte autora e n&atilde;o demonstrada, pela parte r&eacute;, a regular contrata&ccedil;&atilde;o, resta caracterizado o descumprimento do &ocirc;nus probat&oacute;rio previsto no art. 373, II, do CPC/15.
+5. O par&aacute;grafo &uacute;nico, do art. 42, da Lei n&ordm; 8.078, de 11/09/1990 (C&oacute;digo de Defesa do Consumidor) disp&otilde;e que o consumidor cobrado em quantia indevida tem direito &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, por valor igual ao dobro do que pagou em excesso, acrescido de corre&ccedil;&atilde;o monet&aacute;ria e juros legais, salvo hip&oacute;tese de &quot;engano justific&aacute;vel&quot;.
+6. Inexistente contrato v&aacute;lido, s&atilde;o indevidos os descontos realizados, impondo-se a restitui&ccedil;&atilde;o em dobro dos valores indevidamente debitados.
+7. A realiza&ccedil;&atilde;o de descontos indevidos em conta banc&aacute;ria, decorrentes de contrata&ccedil;&atilde;o n&atilde;o comprovada, configura dano moral in re ipsa, conforme entendimento consolidado do STJ.
+8. Segundo o m&eacute;todo bif&aacute;sico de fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, na primeira etapa, deve-se estabelecer um valor b&aacute;sico, &agrave; luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jur&iacute;dico lesado; e, na segunda etapa, devem ser consideradas as circunst&acirc;ncias do caso, para a fixa&ccedil;&atilde;o definitiva do valor da indeniza&ccedil;&atilde;o, atendendo-se, assim, a determina&ccedil;&atilde;o legal de arbitramento equitativo pelo Juiz.
+9. Considerando-se o referido grupo de precedentes, e levando-se em conta a condi&ccedil;&atilde;o financeira das partes, a finalidade educativa e preventiva da condena&ccedil;&atilde;o, a razo&aacute;vel gravidade do dano, reputo ser adequado arbitrar o valor da indeniza&ccedil;&atilde;o por danos morais em R$ 5.000,00, montante que se afigura adequado e proporcional &agrave;s especificidades do caso em an&aacute;lise.
+IV. DISPOSITIVO
+10. Apela&ccedil;&atilde;o C&iacute;vel conhecida e provida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0813070-98.2024.8.12.0002,&nbsp; Dourados,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(65 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE SEGURO – DESCONTOS EM CONTA CORRENTE – CONTRATAÇÃO NÃO COMPROVADA –  RESTITUIÇÃO DE VALORES DEVIDA – DANOS MORAIS CONFIGURADOS – PROCEDÊNCIA DOS PEDIDOS – SENTENÇA REFORMADA – RECURSO CONHECIDO E PROVIDO.
+CASO EM EXAME
+1. Apelação interposta pela parte autora
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS – CONTRATO DE SEGURO – DESCONTOS EM CONTA CORRENTE – CONTRATAÇÃO NÃO COMPROVADA –  RESTITUIÇÃO DE VALORES DEVIDA – DANOS MORAIS CONFIGURADOS – PROCEDÊNCIA DOS PEDIDOS – SENTENÇA REFORMADA – RECURSO CONHECIDO E PROVIDO.
+CASO EM EXAME
+1. Apelação interposta pela parte autora contra sentença que julgou improcedentes os pedidos iniciais formulados em Ação Declaratória de Inexistência de Débito c/c Indenização por Danos Morais e Materiais.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a (i)legalidade da cobrança de mensalidades de contrato de seguro;  b) o cabimento da restituição dos valores pagos; e c) a ocorrência de danos morais.
+III. RAZÕES DE DECIDIR
+3. O negócio jurídico deve ser examinado sob o prisma de três (3) planos – existência, validade e eficácia –, com a finalidade de se verificar se ele obtém plena realização. No plano da existência, verifica-se, tão somente, se estão presentes as condições mínimas para que o negócio jurídico possa produzir efeitos (v.g, agente; objeto; forma, e vontade exteriorizada), não se discutindo, desta forma, a validade ou invalidade do negócio e tampouco a sua eficácia.
+4. Comprovada a ocorrência de descontos na conta bancária da parte autora e não demonstrada, pela parte ré, a regular contratação, resta caracterizado o descumprimento do ônus probatório previsto no art. 373, II, do CPC/15.
+5. O parágrafo único, do art. 42, da Lei nº 8.078, de 11/09/1990 (Código de Defesa do Consumidor) dispõe que o consumidor cobrado em quantia indevida tem direito à repetição do indébito, por valor igual ao dobro do que pagou em excesso, acrescido de correção monetária e juros legais, salvo hipótese de "engano justificável".
+6. Inexistente contrato válido, são indevidos os descontos realizados, impondo-se a restituição em dobro dos valores indevidamente debitados.
+7. A realização de descontos indevidos em conta bancária, decorrentes de contratação não comprovada, configura <em>dano</em> <em>moral</em> in re ipsa, conforme entendimento consolidado do STJ.
+8. Segundo o método bifásico de fixação de indenização por danos morais, na primeira etapa, deve-se estabelecer um valor básico, à luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jurídico lesado; e, na segunda etapa, devem ser consideradas as circunstâncias do caso, para a fixação definitiva do valor da indenização, atendendo-se, assim, a determinação legal de arbitramento equitativo pelo Juiz.
+9. Considerando-se o referido grupo de precedentes, e levando-se em conta a condição financeira das partes, a finalidade educativa e preventiva da condenação, a razoável gravidade do <em>dano</em>, reputo ser adequado arbitrar o valor da indenização por danos morais em R$ 5.000,00, montante que se afigura adequado e proporcional às especificidades do caso em análise.
+IV. DISPOSITIVO
+10. Apelação Cível conhecida e provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>99&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877473" cdForo="0" >
+										0809261-43.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877473" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877473);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877473" style="display: none;" >
+	<div id="textAreaDados_1877473" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C PEDIDO DE TUTELA ANTECIPADA, INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; PRELIMINAR &ndash; AUS&Ecirc;NCIA DE INTERESSE DE AGIR &ndash; AFASTADA &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; N&Atilde;O COMPROVADA &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; APLICA&Ccedil;&Atilde;O DA MODULA&Ccedil;&Atilde;O DOS EFEITOS DO EARESP N. 676.608/RS &ndash; DESCONTOS ANTERIORES A 30.3.2021 &ndash;  DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash;  DESCONTOS A PARTIR  30.3.2021 &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; VALOR ALTERADO  &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+Nos termos do art. 17 do C&oacute;digo de Processo Civil, para postular em ju&iacute;zo &eacute; necess&aacute;rio ter interesse e legitimidade. O interesse processual ou interesse de agir &eacute; uma das condi&ccedil;&otilde;es da a&ccedil;&atilde;o, devendo ser analisado sob o aspecto da necessidade de obten&ccedil;&atilde;o da tutela jurisdicional pleiteada e da adequa&ccedil;&atilde;o da via eleita para alcan&ccedil;ar aquele fim.
+N&atilde;o bastasse, no pr&oacute;prio julgamento da tese supramencionada, o Supremo Tribunal Federal ressaltou que &quot;A exig&ecirc;ncia de pr&eacute;vio requerimento administrativo n&atilde;o deve prevalecer quando o entendimento da Administra&ccedil;&atilde;o for not&oacute;ria e reiteradamente contr&aacute;rio &agrave; postula&ccedil;&atilde;o do segurado&quot;, e tal conduta, evidentemente, se observa no caso presente, posto que, em todas as suas manifesta&ccedil;&otilde;es nestes autos, as r&eacute;s se posicionaram de forma contr&aacute;ria &agrave; pretens&atilde;o da parte autora.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+A rela&ccedil;&atilde;o jur&iacute;dica vincula os sujeitos de direito em decorr&ecirc;ncia dos fatos jur&iacute;dicos suficientemente comprovados, que s&atilde;o a causa da instaura&ccedil;&atilde;o, da modifica&ccedil;&atilde;o ou da extin&ccedil;&atilde;o de obriga&ccedil;&otilde;es. Especificamente no contrato de m&uacute;tuo ou de empr&eacute;stimo, a tradi&ccedil;&atilde;o da coisa mutuada &eacute; suficiente para se concluir pela exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, cujos efeitos devem operar regulamente, nos termos do art. 586 do C&oacute;digo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que, nos termos art. 42, par&aacute;grafo &uacute;nico, da Lei n&ordm; 8.078/1990 (C&oacute;digo de Defesa do Consumidor), a restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe da natureza do elemento volitivo do fornecedor que realizou a cobran&ccedil;a indevida, revelando-se cab&iacute;vel quando a referida cobran&ccedil;a consubstanciar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva. N&atilde;o obstante, houve modula&ccedil;&atilde;o dos efeitos, impondo a aplica&ccedil;&atilde;o dessa tese a partir de 30.3.2021, data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o dos Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, e unicamente para as cobran&ccedil;as indevidas em contratos de consumo que n&atilde;o envolvam presta&ccedil;&atilde;o de servi&ccedil;os p&uacute;blicos pelo Estado ou por concession&aacute;rias, as quais apenas ser&atilde;o atingidas pelo novo entendimento quando pagas ap&oacute;s a data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso conhecido e provido parcialmente. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0809261-43.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(27 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C PEDIDO DE TUTELA ANTECIPADA, INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR – AUSÊNCIA DE INTERESSE DE AGIR – AFASTADA – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C PEDIDO DE TUTELA ANTECIPADA, INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR – AUSÊNCIA DE INTERESSE DE AGIR – AFASTADA – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR ALTERADO  – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+Nos termos do art. 17 do Código de Processo Civil, para postular em juízo é necessário ter interesse e legitimidade. O interesse processual ou interesse de agir é uma das condições da ação, devendo ser analisado sob o aspecto da necessidade de obtenção da tutela jurisdicional pleiteada e da adequação da via eleita para alcançar aquele fim.
+Não bastasse, no próprio julgamento da tese supramencionada, o Supremo Tribunal Federal ressaltou que "A exigência de prévio requerimento administrativo não deve prevalecer quando o entendimento da Administração for notória e reiteradamente contrário à postulação do segurado", e tal conduta, evidentemente, se observa no caso presente, posto que, em todas as suas manifestações nestes autos, as rés se posicionaram de forma contrária à pretensão da parte autora.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+A relação jurídica vincula os sujeitos de direito em decorrência dos fatos jurídicos suficientemente comprovados, que são a causa da instauração, da modificação ou da extinção de obrigações. Especificamente no contrato de mútuo ou de empréstimo, a tradição da coisa mutuada é suficiente para se concluir pela existência da relação jurídica, cujos efeitos devem operar regulamente, nos termos do art. 586 do Código Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que, nos termos art. 42, parágrafo único, da Lei nº 8.078/1990 (Código de Defesa do Consumidor), a restituição em dobro do indébito independe da natureza do elemento volitivo do fornecedor que realizou a cobrança indevida, revelando-se cabível quando a referida cobrança consubstanciar conduta contrária à boa-fé objetiva. Não obstante, houve modulação dos efeitos, impondo a aplicação dessa tese a partir de 30.3.2021, data da publicação do acórdão dos Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, e unicamente para as cobranças indevidas em contratos de consumo que não envolvam prestação de serviços públicos pelo Estado ou por concessionárias, as quais apenas serão atingidas pelo novo entendimento quando pagas após a data da publicação do acórdão (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso conhecido e provido parcialmente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>100&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877474" cdForo="0" >
+										0800239-96.2022.8.12.0031
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877474" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877474);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877474" style="display: none;" >
+	<div id="textAreaDados_1877474" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE RESCIS&Atilde;O/ANULA&Ccedil;&Atilde;O DE RELA&Ccedil;&Atilde;O CONTRATUAL DE EMPR&Eacute;STIMO CONSIGNADO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E MATERIAIS &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; APLICA&Ccedil;&Atilde;O DA MODULA&Ccedil;&Atilde;O DOS EFEITOS DO EARESP N. 676.608/RS &ndash; DESCONTOS ANTERIORES A 30.3.2021 &ndash;  DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash;  DESCONTOS A PARTIR  30.3.2021 &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; ALTERADOS &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que, nos termos art. 42, par&aacute;grafo &uacute;nico, da Lei n&ordm; 8.078/1990 (C&oacute;digo de Defesa do Consumidor), a restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe da natureza do elemento volitivo do fornecedor que realizou a cobran&ccedil;a indevida, revelando-se cab&iacute;vel quando a referida cobran&ccedil;a consubstanciar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva. N&atilde;o obstante, houve modula&ccedil;&atilde;o dos efeitos, impondo a aplica&ccedil;&atilde;o dessa tese a partir de 30.3.2021, data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o dos Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, e unicamente para as cobran&ccedil;as indevidas em contratos de consumo que n&atilde;o envolvam presta&ccedil;&atilde;o de servi&ccedil;os p&uacute;blicos pelo Estado ou por concession&aacute;rias, as quais apenas ser&atilde;o atingidas pelo novo entendimento quando pagas ap&oacute;s a data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a, nos julgamentos dos Recursos Especiais n&ordm; 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixa&ccedil;&atilde;o dos honor&aacute;rios por aprecia&ccedil;&atilde;o equitativa n&atilde;o &eacute; permitida quando os valores da condena&ccedil;&atilde;o ou da causa, ou o proveito econ&ocirc;mico da demanda, forem elevados. &Eacute; obrigat&oacute;ria, nesses casos, a observ&acirc;ncia dos percentuais previstos nos par&aacute;grafos 2&ordm; ou 3&ordm; do artigo 85 do C&oacute;digo de Processo Civil (CPC) &ndash; a depender da presen&ccedil;a da Fazenda P&uacute;blica na lide &ndash;, os quais ser&atilde;o subsequentemente calculados sobre o valor: (a) da condena&ccedil;&atilde;o; ou (b) do proveito econ&ocirc;mico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honor&aacute;rios por equidade quando, havendo ou n&atilde;o condena&ccedil;&atilde;o: (a) o proveito econ&ocirc;mico obtido pelo vencedor for inestim&aacute;vel ou irris&oacute;rio; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso conhecido e provido parcialmente. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800239-96.2022.8.12.0031,&nbsp; Caarap&oacute;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(27 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Caarapó
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE RESCISÃO/ANULAÇÃO DE RELAÇÃO CONTRATUAL DE EMPRÉSTIMO CONSIGNADO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS E MATERIAIS – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE RESCISÃO/ANULAÇÃO DE RELAÇÃO CONTRATUAL DE EMPRÉSTIMO CONSIGNADO C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS E MATERIAIS – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES –  DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – HONORÁRIOS ADVOCATÍCIOS – ALTERADOS – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que, nos termos art. 42, parágrafo único, da Lei nº 8.078/1990 (Código de Defesa do Consumidor), a restituição em dobro do indébito independe da natureza do elemento volitivo do fornecedor que realizou a cobrança indevida, revelando-se cabível quando a referida cobrança consubstanciar conduta contrária à boa-fé objetiva. Não obstante, houve modulação dos efeitos, impondo a aplicação dessa tese a partir de 30.3.2021, data da publicação do acórdão dos Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, e unicamente para as cobranças indevidas em contratos de consumo que não envolvam prestação de serviços públicos pelo Estado ou por concessionárias, as quais apenas serão atingidas pelo novo entendimento quando pagas após a data da publicação do acórdão (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça, nos julgamentos dos Recursos Especiais nº 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixação dos honorários por apreciação equitativa não é permitida quando os valores da condenação ou da causa, ou o proveito econômico da demanda, forem elevados. É obrigatória, nesses casos, a observância dos percentuais previstos nos parágrafos 2º ou 3º do artigo 85 do Código de Processo Civil (CPC) – a depender da presença da Fazenda Pública na lide –, os quais serão subsequentemente calculados sobre o valor: (a) da condenação; ou (b) do proveito econômico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honorários por equidade quando, havendo ou não condenação: (a) o proveito econômico obtido pelo vencedor for inestimável ou irrisório; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso conhecido e provido parcialmente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="RECURSO">
+									<label for="ckTermo1">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="APELAÇÃO">
+									<label for="ckTermo2">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="AÇÃO">
+									<label for="ckTermo3">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="CÍVEL">
+									<label for="ckTermo4">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="DANOS">
+									<label for="ckTermo5">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="EMENTA">
+									<label for="ckTermo6">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="MORAIS">
+									<label for="ckTermo7">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="INDENIZAÇÃO">
+									<label for="ckTermo8">
+										INDENIZAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="PROVIDO">
+									<label for="ckTermo9">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="CONHECIDO">
+									<label for="ckTermo10">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="DECLARATÓRIA">
+									<label for="ckTermo11">
+										DECLARATÓRIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="DANO">
+									<label for="ckTermo12">
+										DANO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="MORAL">
+									<label for="ckTermo13">
+										MORAL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="INEXISTÊNCIA">
+									<label for="ckTermo14">
+										INEXISTÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="danos">
+									<label for="ckTermo15">
+										danos
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 100
+			</strong>
+			de 149670
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+					<a name="A2" style="padding-left:4px" >
+						2
+					</a>
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A2" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjms/samples/cjsg/results_normal_page_02.html
+++ b/tests/tjms/samples/cjsg/results_normal_page_02.html
@@ -1,0 +1,16701 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(149670)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="149670" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>101&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877480" cdForo="0" >
+										0803964-26.2022.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877480" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877480);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877480" style="display: none;" >
+	<div id="textAreaDados_1877480" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL INTERPOSTA PELO REQUERIDO &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA C/C INDENIZAT&Oacute;RIA &ndash;&ndash; DESCONTOS INDEVIDOS &ndash; CONTRATO DE EMPR&Eacute;STIMO CONSIGNADO &ndash; PROVA PERICIAL &ndash; ASSINATURAS FALSIFICADAS &ndash; RESTITUI&Ccedil;&Atilde;O DAS PARTES AO STATUS QUO &ndash; DANOS MORAIS MANTIDOS &ndash; VALOR INDENIZAT&Oacute;RIO &ndash; RAZOABILIDADE E PROPORCIONALIDADE &ndash; TERMO INICIAL DA CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA E DOS JUROS MORA &ndash; RESPONSABILIDADE EXTRACONTRATUAL &ndash; RECURSO CONHECIDO E DESPROVIDO.
+Diante da incid&ecirc;ncia das regras de consumo, competia ao Requerido a demonstra&ccedil;&atilde;o da regularidade das cobran&ccedil;as que realizou, o que n&atilde;o ocorreu na esp&eacute;cie. Ali&aacute;s, a prova pericial demonstrou que as assinaturas constantes do contrato de empr&eacute;stimo consignado n&atilde;o partiram do punho subscritor da Requerente.
+A conduta lesiva perpetrada pela Institui&ccedil;&atilde;o Requerida foi a causa dos descontos mensais na conta banc&aacute;ria da Requerente, agravada pela exposi&ccedil;&atilde;o indevida dos dados pessoais, de modo a revelar falha operacional suficiente para caracterizar danos morais.
+Com rela&ccedil;&atilde;o ao valor da indeniza&ccedil;&atilde;o, destaca-se que n&atilde;o existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercuss&atilde;o dos fatos, estabelecer a indeniza&ccedil;&atilde;o que venha ressarcir a parte lesada (car&aacute;ter indenizat&oacute;rio) e que tamb&eacute;m iniba a reitera&ccedil;&atilde;o de condutas an&aacute;logas (aspecto pedag&oacute;gico). Diante desses par&acirc;metros, mostram-se razo&aacute;veis os valores fixados em primeiro grau.
+A corre&ccedil;&atilde;o monet&aacute;ria do valor da indeniza&ccedil;&atilde;o do dano moral incide desde a data do arbitramento (S&uacute;mula 362, do STJ). Os juros morat&oacute;rios, por sua vez, incidem do evento danoso (S&uacute;mula n&ordm; 54, do STJ).
+Recurso conhecido e desprovido.
+EMENTA &ndash;  APELA&Ccedil;&Atilde;O C&Iacute;VEL INTERPOSTA PELA REQUERENTE DE FORMA ADESIVA &ndash;  A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA C/C INDENIZAT&Oacute;RIA &ndash;  DESCONTOS INDEVIDOS &ndash;  DANOS MORAIS &ndash;  QUANTUM INDENIZAT&Oacute;RIO &ndash;  OBSERV&Acirc;NCIA AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash;  REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO &ndash; TERMO INICIAL DOS JUROS MORAT&Oacute;RIO &ndash; COMPENSA&Ccedil;&Atilde;O COM OS VALORES CREDITADOS &ndash; VEDA&Ccedil;&Atilde;O AO ENRIQUECIMENTO IL&Iacute;CITO &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Deve ser mantida a compensa&ccedil;&atilde;o com os valores depositados em favor da Requerente, sob pena de enriquecimento il&iacute;cito, na forma do art. 884 do CC.
+Recurso conhecido e parcialmente provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803964-26.2022.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL INTERPOSTA PELO REQUERIDO – AÇÃO DECLARATÓRIA C/C INDENIZATÓRIA –– DESCONTOS INDEVIDOS – CONTRATO DE EMPRÉSTIMO CONSIGNADO – PROVA PERICIAL – ASSINATURAS FALSIFICADAS – RESTITUIÇÃO DAS PARTES AO STATUS QUO – DANOS MORAIS MANTIDOS – VALOR INDENIZATÓRIO – RAZOABILIDADE E PROPORCIONALIDADE – TERMO INICIAL DA CORREÇÃO MONETÁRIA E DOS JUROS MORA – RESPONSABILIDADE EXTRACONTRATUAL –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL INTERPOSTA PELO REQUERIDO – AÇÃO DECLARATÓRIA C/C INDENIZATÓRIA –– DESCONTOS INDEVIDOS – CONTRATO DE EMPRÉSTIMO CONSIGNADO – PROVA PERICIAL – ASSINATURAS FALSIFICADAS – RESTITUIÇÃO DAS PARTES AO STATUS QUO – DANOS MORAIS MANTIDOS – VALOR INDENIZATÓRIO – RAZOABILIDADE E PROPORCIONALIDADE – TERMO INICIAL DA CORREÇÃO MONETÁRIA E DOS JUROS MORA – RESPONSABILIDADE EXTRACONTRATUAL – RECURSO CONHECIDO E DESPROVIDO.
+Diante da incidência das regras de consumo, competia ao Requerido a demonstração da regularidade das cobranças que realizou, o que não ocorreu na espécie. Aliás, a prova pericial demonstrou que as assinaturas constantes do contrato de empréstimo consignado não partiram do punho subscritor da Requerente.
+A conduta lesiva perpetrada pela Instituição Requerida foi a causa dos descontos mensais na conta bancária da Requerente, agravada pela exposição indevida dos dados pessoais, de modo a revelar falha operacional suficiente para caracterizar danos morais.
+Com relação ao valor da indenização, destaca-se que não existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercussão dos fatos, estabelecer a indenização que venha ressarcir a parte lesada (caráter indenizatório) e que também iniba a reiteração de condutas análogas (aspecto pedagógico). Diante desses parâmetros, mostram-se razoáveis os valores fixados em primeiro grau.
+A correção monetária do valor da indenização do <em>dano</em> <em>moral</em> incide desde a data do arbitramento (Súmula 362, do STJ). Os juros moratórios, por sua vez, incidem do evento danoso (Súmula nº 54, do STJ).
+Recurso conhecido e desprovido.
+EMENTA –  APELAÇÃO CÍVEL INTERPOSTA PELA REQUERENTE DE FORMA ADESIVA –  AÇÃO DECLARATÓRIA C/C INDENIZATÓRIA –  DESCONTOS INDEVIDOS –  DANOS MORAIS –  QUANTUM INDENIZATÓRIO –  OBSERVÂNCIA AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE –  REPETIÇÃO DO INDÉBITO – TERMO INICIAL DOS JUROS MORATÓRIO – COMPENSAÇÃO COM OS VALORES CREDITADOS – VEDAÇÃO AO ENRIQUECIMENTO ILÍCITO – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Deve ser mantida a compensação com os valores depositados em favor da Requerente, sob pena de enriquecimento ilícito, na forma do art. 884 do CC.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>102&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877481" cdForo="0" >
+										0805313-93.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877481" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877481);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877481" style="display: none;" >
+	<div id="textAreaDados_1877481" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O INDENIZAT&Oacute;RIA &ndash; AQUISI&Ccedil;&Atilde;O DE VE&Iacute;CULO &ndash; REGISTRO DE LEIL&Atilde;O N&Atilde;O INFORMADO &ndash; AUS&Ecirc;NCIA DE DANO OU SINISTRO &ndash; DESVALORIZA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA &ndash; DEVER DE INDENIZAR INEXISTENTE &ndash; RECURSO CONHECIDO E DESPROVIDO.
+Insurge-se a Requerente/Apelante contra a senten&ccedil;a proferida em primeiro grau, que julgou improcedente o pedido.
+&Eacute; obriga&ccedil;&atilde;o do fornecedor dar ci&ecirc;ncia ao consumidor acerca da situa&ccedil;&atilde;o f&aacute;tica e registral do autom&oacute;vel posto no mercado, mormente quando se trata de autom&oacute;vel usado. Isso porque &eacute; direito b&aacute;sico do consumidor receber &quot;a informa&ccedil;&atilde;o adequada e clara sobre os diferentes produtos e servi&ccedil;os, com especifica&ccedil;&atilde;o correta de quantidade, caracter&iacute;sticas, composi&ccedil;&atilde;o, qualidade e pre&ccedil;o, bem como sobre os riscos que apresentem&quot; (art. 6&ordm;, III, do CDC).
+No caso concreto, no entanto, a omiss&atilde;o de tal informa&ccedil;&atilde;o, por si s&oacute;, n&atilde;o enseja a proced&ecirc;ncia dos pedidos indenizat&oacute;rios formulados, pois n&atilde;o h&aacute; indicativos de que o ve&iacute;culo possua avarias ou restri&ccedil;&otilde;es.
+O alegado dano material, correspondente ao desconto que a garagem revendedora supostamente deu &agrave; nova compradora, n&atilde;o pode ser imputado &agrave; Requerida/Apelada, na medida em que, ao que parece, se tratou de mera estrat&eacute;gia de negocia&ccedil;&atilde;o, eis que n&atilde;o h&aacute; nos autos qualquer prova de que a desvaloriza&ccedil;&atilde;o do bem equivale ao mencionado montante.
+Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0805313-93.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Perdas e Danos
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – AQUISIÇÃO DE VEÍCULO – REGISTRO DE LEILÃO NÃO INFORMADO – AUSÊNCIA DE <em>DANO</em> OU SINISTRO – DESVALORIZAÇÃO NÃO COMPROVADA – DEVER DE INDENIZAR INEXISTENTE – RECURSO CONHECIDO E DESPROVIDO.
+Insurge-se a Requerente/Apelante contra a sentença proferida em primeiro grau, que julgou improcedente o pedido.
+É obrigação do fornecedor dar ciência ao consumidor
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO INDENIZATÓRIA – AQUISIÇÃO DE VEÍCULO – REGISTRO DE LEILÃO NÃO INFORMADO – AUSÊNCIA DE <em>DANO</em> OU SINISTRO – DESVALORIZAÇÃO NÃO COMPROVADA – DEVER DE INDENIZAR INEXISTENTE – RECURSO CONHECIDO E DESPROVIDO.
+Insurge-se a Requerente/Apelante contra a sentença proferida em primeiro grau, que julgou improcedente o pedido.
+É obrigação do fornecedor dar ciência ao consumidor acerca da situação fática e registral do automóvel posto no mercado, mormente quando se trata de automóvel usado. Isso porque é direito básico do consumidor receber "a informação adequada e clara sobre os diferentes produtos e serviços, com especificação correta de quantidade, características, composição, qualidade e preço, bem como sobre os riscos que apresentem" (art. 6º, III, do CDC).
+No caso concreto, no entanto, a omissão de tal informação, por si só, não enseja a procedência dos pedidos indenizatórios formulados, pois não há indicativos de que o veículo possua avarias ou restrições.
+O alegado <em>dano</em> material, correspondente ao desconto que a garagem revendedora supostamente deu à nova compradora, não pode ser imputado à Requerida/Apelada, na medida em que, ao que parece, se tratou de mera estratégia de negociação, eis que não há nos autos qualquer prova de que a desvalorização do bem equivale ao mencionado montante.
+Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>103&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877486" cdForo="0" >
+										0854358-29.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877486" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877486);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877486" style="display: none;" >
+	<div id="textAreaDados_1877486" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Iacute;VIDA C/C REPARA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; GOLPE DA FALSA CENTRAL DE ATENDIMENTO &ndash; FORTUITO EXTERNO &ndash; CULPA EXCLUSIVA DA V&Iacute;TIMA E DE TERCEIRO &ndash; INEXIST&Ecirc;NCIA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; IMPROCED&Ecirc;NCIA &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte autora contra senten&ccedil;a que julgou improcedentes os pedidos formulados em A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de D&eacute;bito c/c Indeniza&ccedil;&atilde;o por Danos Morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso a eventual responsabilidade da institui&ccedil;&atilde;o financeira pelos preju&iacute;zos suportados pela consumidora em raz&atilde;o do golpe.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Nos termos do art. 14 do CDC, as institui&ccedil;&otilde;es financeiras respondem objetivamente pelos danos causados ao consumidor em raz&atilde;o de falhas na presta&ccedil;&atilde;o de servi&ccedil;os. No entanto, essa responsabilidade pode ser afastada quando comprovada a culpa exclusiva da v&iacute;tima ou de terceiro (art. 14, &sect; 3&ordm;, II, do CDC).
+4. Compulsando os autos, verifica-se que n&atilde;o houve fortuito interno (falha na presta&ccedil;&atilde;o do servi&ccedil;o), mas sim fortuito externo, causado por terceiros, o que afasta a responsabilidade da institui&ccedil;&atilde;o financeira, conforme interpreta&ccedil;&atilde;o extra&iacute;da da S&uacute;mula 479 do STJ: &quot;As institui&ccedil;&otilde;es financeiras respondem objetivamente pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no &acirc;mbito de opera&ccedil;&otilde;es banc&aacute;rias&quot;.
+IV. DISPOSITIVO
+5. Apela&ccedil;&atilde;o C&iacute;vel conhecida e n&atilde;o provida, com majora&ccedil;&atilde;o dos honor&aacute;rios de sucumb&ecirc;ncia.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0854358-29.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA C/C REPARAÇÃO POR DANOS MATERIAIS E MORAIS – GOLPE DA FALSA CENTRAL DE ATENDIMENTO – FORTUITO EXTERNO – CULPA EXCLUSIVA DA VÍTIMA E DE TERCEIRO – INEXISTÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO – IMPROCEDÊNCIA – SENTENÇA MANTIDA – RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta pela parte
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA C/C REPARAÇÃO POR DANOS MATERIAIS E MORAIS – GOLPE DA FALSA CENTRAL DE ATENDIMENTO – FORTUITO EXTERNO – CULPA EXCLUSIVA DA VÍTIMA E DE TERCEIRO – INEXISTÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO – IMPROCEDÊNCIA – SENTENÇA MANTIDA – RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta pela parte autora contra sentença que julgou improcedentes os pedidos formulados em Ação Declaratória de Inexistência de Débito c/c Indenização por Danos Morais.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso a eventual responsabilidade da instituição financeira pelos prejuízos suportados pela consumidora em razão do golpe.
+III. RAZÕES DE DECIDIR
+3. Nos termos do art. 14 do CDC, as instituições financeiras respondem objetivamente pelos danos causados ao consumidor em razão de falhas na prestação de serviços. No entanto, essa responsabilidade pode ser afastada quando comprovada a culpa exclusiva da vítima ou de terceiro (art. 14, § 3º, II, do CDC).
+4. Compulsando os autos, verifica-se que não houve fortuito interno (falha na prestação do serviço), mas sim fortuito externo, causado por terceiros, o que afasta a responsabilidade da instituição financeira, conforme interpretação extraída da Súmula 479 do STJ: "As instituições financeiras respondem objetivamente pelos danos gerados por fortuito interno relativo a fraudes e delitos praticados por terceiros no âmbito de operações bancárias".
+IV. DISPOSITIVO
+5. Apelação Cível conhecida e não provida, com majoração dos honorários de sucumbência.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>104&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877489" cdForo="0" >
+										0800145-39.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877489" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877489);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877489" style="display: none;" >
+	<div id="textAreaDados_1877489" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO  &ndash; PRELIMINARES &ndash; CERCEAMENTO DE DEFESA &ndash; INOCORR&Ecirc;NCIA -  PEDIDO DE  CONCESS&Atilde;O DE JUSTI&Ccedil;A GRATUITA FORMULADO POR INSTITUI&Ccedil;&Atilde;O FILANTR&Oacute;PICA QUE PRESTA SERVI&Ccedil;OS EM FAVOR DE IDOSOS &ndash; GRATUIDADE N&Atilde;O CONCEDIDA - ILEGITIMIDADE PASSIVA &ndash; INOCORR&Ecirc;NCIA &ndash; SUSPENS&Atilde;O DO PROCESSO &ndash; ADPF N&ordm; 1236/DF &ndash; AUS&Ecirc;NCIA DE DETERMINA&Ccedil;&Atilde;O EXPRESSA DE SOBRESTAMENTO PELO STF &ndash; INEXIST&Ecirc;NCIA DE IDENTIDADE ESTRITA ENTRE A CONTROV&Eacute;RSIA CONSTITUCIONAL E A DEMANDA INDIVIDUAL - CHAMAMENTO DO INSS E INCOMPET&Ecirc;NCIA DA JUSTI&Ccedil;A ESTADUAL &ndash; INVIABILIDADE &ndash; AUTARQUIA QUE ATUA COMO MERO AGENTE OPERACIONAL DOS DESCONTOS &ndash; M&Eacute;RITO - DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO - RELA&Ccedil;&Atilde;O DE CONSUMO CONFIGURADA -  DESCONTOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO  A T&Iacute;TULO DE CONTRIBUI&Ccedil;&Atilde;O A CONFEDERA&Ccedil;&Atilde;O &ndash; INEXIST&Ecirc;NCIA DO D&Eacute;BITO &ndash; DANOS MORAIS &ndash; OCORR&Ecirc;NCIA &ndash; RESTITUI&Ccedil;&Atilde;O DOS VALORES &ndash; CAB&Iacute;VEL &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o em A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de D&eacute;bito c/c Repeti&ccedil;&atilde;o de Ind&eacute;bito c/c Indeniza&ccedil;&atilde;o por Danos Morais com pedido julgado parcialmente procedente.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2.  Discute-se no presente recurso: a) nulidade da senten&ccedil;a por cerceamento de defesa e omiss&atilde;o; b) a concess&atilde;o de gratuidade da justi&ccedil;a; c) a ilegitimidade passiva; d) a suspens&atilde;o do processo em raz&atilde;o da ADPF n&ordm; 1236/DF; e) a necessidade de chamamento do INSS e incompet&ecirc;ncia da Justi&ccedil;a Estadual; f) a incid&ecirc;ncia do CDC; g) a ocorr&ecirc;ncia, ou n&atilde;o, de danos morais; e  h) se &eacute; cab&iacute;vel a restitui&ccedil;&atilde;o dos valores descontados indevidamente em benef&iacute;cio previdenci&aacute;rio.
+III. RAZ&Otilde;ES DE DECIDIR
+3.  A aus&ecirc;ncia &agrave; audi&ecirc;ncia e a n&atilde;o apresenta&ccedil;&atilde;o de contesta&ccedil;&atilde;o decorreram de des&iacute;dia da pr&oacute;pria parte, n&atilde;o configurando cerceamento de defesa.
+4. Nos termos do art. 51, da Lei n&ordm; 10.741, de 1&ordm;/10/2003 (Estatuto do Idoso), &quot;as institui&ccedil;&otilde;es filantr&oacute;picas ou sem fins lucrativos prestadoras de servi&ccedil;o &agrave;s pessoas idosas ter&atilde;o direito &agrave; assist&ecirc;ncia judici&aacute;ria gratuita&quot;, e, conforme entendimento firmado no STJ, &quot;n&atilde;o havendo, no art. 51 do Estatuto do Idoso, refer&ecirc;ncia &agrave; hipossufici&ecirc;ncia financeira da entidade requerente, cabe ao int&eacute;rprete verificar somente o seu car&aacute;ter filantr&oacute;pico e a natureza do p&uacute;blico por ela atendido&quot; (REsp n. 1.742.251/MG, relator Ministro S&eacute;rgio Kukina, Primeira Turma, julgado em 23/8/2022, DJe de 31/8/2022).
+5. No caso dos autos, o que se verifica &eacute; que a r&eacute;, em vez de defender o interesse prim&aacute;rio dos idosos, aposentados e pensionistas, tratou de realizar, ilegalmente, descontos sobre o benef&iacute;cio previdenci&aacute;rio da parte autora, pessoa idosa e aposentada, sem nenhuma prova apta a justificar tais cobran&ccedil;as. Portanto, se a r&eacute; n&atilde;o prestou, legalmente, servi&ccedil;os compat&iacute;veis com as suas finalidades essenciais, n&atilde;o pode ser benefici&aacute;ria da Justi&ccedil;a Gratuita.
+6. Aplica-se a l&oacute;gica da responsabilidade solid&aacute;ria entre os integrantes da cadeia de fornecimento/servi&ccedil;o, especialmente em rela&ccedil;&otilde;es que envolvem o consumidor final, nos termos dos arts. 7&ordm;, par&aacute;grafo &uacute;nico, e 25, &sect;1&ordm;, do C&oacute;digo de Defesa do Consumidor.
+7. Ainda que se trate de rela&ccedil;&atilde;o associativa, havendo descontos diretos em benef&iacute;cio previdenci&aacute;rio, a atividade assume contornos de presta&ccedil;&atilde;o de servi&ccedil;o, atraindo a incid&ecirc;ncia das normas consumeristas, sobretudo para fins de prote&ccedil;&atilde;o do hipossuficiente.
+8. No caso concreto, a apelante n&atilde;o comprovou a exist&ecirc;ncia de decis&atilde;o espec&iacute;fica do STF que tenha determinado a suspens&atilde;o nacional de todos os processos que versem sobre descontos associativos em benef&iacute;cios previdenci&aacute;rios, limitando-se a alega&ccedil;&atilde;o gen&eacute;rica da exist&ecirc;ncia da referida a&ccedil;&atilde;o constitucional.
+9. No caso, n&atilde;o h&aacute; imputa&ccedil;&atilde;o de conduta il&iacute;cita &agrave; autarquia, nem pretens&atilde;o condenat&oacute;ria dirigida contra ela, sendo certo que a simples participa&ccedil;&atilde;o do INSS como intermediador t&eacute;cnico n&atilde;o configura interesse jur&iacute;dico apto a justificar sua inclus&atilde;o no polo passivo, tampouco desloca a compet&ecirc;ncia para a Justi&ccedil;a Federal.
+10. No tocante ao danos morais sofrido pela parte autora, que sobrevive de seus proventos de aposentadoria, &eacute; certo que o desconto indevido de qualquer valor da pequena quantia que disp&otilde;e para prover sua subsist&ecirc;ncia &eacute; suficiente para lhe causar n&atilde;o s&oacute; o agravamento da sua condi&ccedil;&atilde;o hipossuficiente, como tamb&eacute;m o sentimento de ang&uacute;stia e afli&ccedil;&atilde;o, restando configurado o dano moral.
+11. Se n&atilde;o restou comprovada a regular pactua&ccedil;&atilde;o da aven&ccedil;a, s&atilde;o indevidos os descontos realizados na folha de pagamento da parte autora, e, assim, cab&iacute;vel a condena&ccedil;&atilde;o &agrave; restitui&ccedil;&atilde;o dos valores indevidamente descontados.
+IV. DISPOSITIVO
+12. Apela&ccedil;&atilde;o C&iacute;vel conhecida e n&atilde;o provida, com majora&ccedil;&atilde;o dos honor&aacute;rios sucumbenciais.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800145-39.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(55 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO  – PRELIMINARES – CERCEAMENTO DE DEFESA – INOCORRÊNCIA -  PEDIDO DE  CONCESSÃO DE JUSTIÇA GRATUITA FORMULADO POR INSTITUIÇÃO FILANTRÓPICA QUE PRESTA SERVIÇOS EM FAVOR DE IDOSOS – GRATUIDADE NÃO CONCEDIDA - ILEGITIMIDADE PASSIVA – INOCORRÊNCIA – SUSPENSÃO DO PROCESSO – ADPF Nº
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS E REPETIÇÃO DE INDÉBITO  – PRELIMINARES – CERCEAMENTO DE DEFESA – INOCORRÊNCIA -  PEDIDO DE  CONCESSÃO DE JUSTIÇA GRATUITA FORMULADO POR INSTITUIÇÃO FILANTRÓPICA QUE PRESTA SERVIÇOS EM FAVOR DE IDOSOS – GRATUIDADE NÃO CONCEDIDA - ILEGITIMIDADE PASSIVA – INOCORRÊNCIA – SUSPENSÃO DO PROCESSO – ADPF Nº 1236/DF – AUSÊNCIA DE DETERMINAÇÃO EXPRESSA DE SOBRESTAMENTO PELO STF – INEXISTÊNCIA DE IDENTIDADE ESTRITA ENTRE A CONTROVÉRSIA CONSTITUCIONAL E A DEMANDA INDIVIDUAL - CHAMAMENTO DO INSS E INCOMPETÊNCIA DA JUSTIÇA ESTADUAL – INVIABILIDADE – AUTARQUIA QUE ATUA COMO MERO AGENTE OPERACIONAL DOS DESCONTOS – MÉRITO - DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO - RELAÇÃO DE CONSUMO CONFIGURADA -  DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO  A TÍTULO DE CONTRIBUIÇÃO A CONFEDERAÇÃO – INEXISTÊNCIA DO DÉBITO – DANOS MORAIS – OCORRÊNCIA – RESTITUIÇÃO DOS VALORES – CABÍVEL – SENTENÇA MANTIDA – RECURSO CONHECIDO E NÃO PROVIDO.
+I. CASO EM EXAME
+1. Apelação em Ação Declaratória de Inexistência de Débito c/c Repetição de Indébito c/c Indenização por Danos Morais com pedido julgado parcialmente procedente.
+II. QUESTÃO EM DISCUSSÃO
+2.  Discute-se no presente recurso: a) nulidade da sentença por cerceamento de defesa e omissão; b) a concessão de gratuidade da justiça; c) a ilegitimidade passiva; d) a suspensão do processo em razão da ADPF nº 1236/DF; e) a necessidade de chamamento do INSS e incompetência da Justiça Estadual; f) a incidência do CDC; g) a ocorrência, ou não, de danos morais; e  h) se é cabível a restituição dos valores descontados indevidamente em benefício previdenciário.
+III. RAZÕES DE DECIDIR
+3.  A ausência à audiência e a não apresentação de contestação decorreram de desídia da própria parte, não configurando cerceamento de defesa.
+4. Nos termos do art. 51, da Lei nº 10.741, de 1º/10/2003 (Estatuto do Idoso), "as instituições filantrópicas ou sem fins lucrativos prestadoras de serviço às pessoas idosas terão direito à assistência judiciária gratuita", e, conforme entendimento firmado no STJ, "não havendo, no art. 51 do Estatuto do Idoso, referência à hipossuficiência financeira da entidade requerente, cabe ao intérprete verificar somente o seu caráter filantrópico e a natureza do público por ela atendido" (REsp n. 1.742.251/MG, relator Ministro Sérgio Kukina, Primeira Turma, julgado em 23/8/2022, DJe de 31/8/2022).
+5. No caso dos autos, o que se verifica é que a ré, em vez de defender o interesse primário dos idosos, aposentados e pensionistas, tratou de realizar, ilegalmente, descontos sobre o benefício previdenciário da parte autora, pessoa idosa e aposentada, sem nenhuma prova apta a justificar tais cobranças. Portanto, se a ré não prestou, legalmente, serviços compatíveis com as suas finalidades essenciais, não pode ser beneficiária da Justiça Gratuita.
+6. Aplica-se a lógica da responsabilidade solidária entre os integrantes da cadeia de fornecimento/serviço, especialmente em relações que envolvem o consumidor final, nos termos dos arts. 7º, parágrafo único, e 25, §1º, do Código de Defesa do Consumidor.
+7. Ainda que se trate de relação associativa, havendo descontos diretos em benefício previdenciário, a atividade assume contornos de prestação de serviço, atraindo a incidência das normas consumeristas, sobretudo para fins de proteção do hipossuficiente.
+8. No caso concreto, a apelante não comprovou a existência de decisão específica do STF que tenha determinado a suspensão nacional de todos os processos que versem sobre descontos associativos em benefícios previdenciários, limitando-se a alegação genérica da existência da referida ação constitucional.
+9. No caso, não há imputação de conduta ilícita à autarquia, nem pretensão condenatória dirigida contra ela, sendo certo que a simples participação do INSS como intermediador técnico não configura interesse jurídico apto a justificar sua inclusão no polo passivo, tampouco desloca a competência para a Justiça Federal.
+10. No tocante ao danos morais sofrido pela parte autora, que sobrevive de seus proventos de aposentadoria, é certo que o desconto indevido de qualquer valor da pequena quantia que dispõe para prover sua subsistência é suficiente para lhe causar não só o agravamento da sua condição hipossuficiente, como também o sentimento de angústia e aflição, restando configurado o <em>dano</em> <em>moral</em>.
+11. Se não restou comprovada a regular pactuação da avença, são indevidos os descontos realizados na folha de pagamento da parte autora, e, assim, cabível a condenação à restituição dos valores indevidamente descontados.
+IV. DISPOSITIVO
+12. Apelação Cível conhecida e não provida, com majoração dos honorários sucumbenciais.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>105&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877497" cdForo="0" >
+										0900082-64.2023.8.12.0042
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877497" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877497);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877497" style="display: none;" >
+	<div id="textAreaDados_1877497" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. LES&Atilde;O CORPORAL SEGUIDA DE MORTE. INDENIZA&Ccedil;&Atilde;O M&Iacute;NIMA POR DANOS MORAIS FIXADA DE OF&Iacute;CIO NA SENTEN&Ccedil;A. AUS&Ecirc;NCIA DE PEDIDO EXPRESSO NA DEN&Uacute;NCIA. VIOLA&Ccedil;&Atilde;O AO CONTRADIT&Oacute;RIO, &Agrave; AMPLA DEFESA E &Agrave; CORRELA&Ccedil;&Atilde;O ENTRE ACUSA&Ccedil;&Atilde;O E SENTEN&Ccedil;A. RECURSO PROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o criminal interposta por r&eacute;u condenado pela pr&aacute;tica do delito de les&atilde;o corporal seguida de morte, previsto no art. 129, &sect; 3&ordm;, do C&oacute;digo Penal, &agrave; pena de 4 anos e 2 meses de reclus&atilde;o, em regime inicial semiaberto, al&eacute;m do pagamento de indeniza&ccedil;&atilde;o m&iacute;nima por danos morais no valor de R$ 15.000,00, fixada em favor dos herdeiros da v&iacute;tima com fundamento no art. 387, IV, do C&oacute;digo de Processo Penal. A defesa requer a reforma parcial da senten&ccedil;a para afastar ou reduzir o valor da repara&ccedil;&atilde;o m&iacute;nima, ao argumento de aus&ecirc;ncia de par&acirc;metros objetivos e viola&ccedil;&atilde;o ao contradit&oacute;rio, &agrave; ampla defesa e ao devido processo legal.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; 2 quest&otilde;es em discuss&atilde;o: (i) definir se &eacute; v&aacute;lida a fixa&ccedil;&atilde;o, de of&iacute;cio, de indeniza&ccedil;&atilde;o m&iacute;nima por danos morais na senten&ccedil;a penal condenat&oacute;ria, sem pedido expresso formulado na den&uacute;ncia; e (ii) estabelecer se, ausente requerimento acusat&oacute;rio com delimita&ccedil;&atilde;o m&iacute;nima da pretens&atilde;o indenizat&oacute;ria, deve ser exclu&iacute;do o cap&iacute;tulo condenat&oacute;rio fundado no art. 387, IV, do C&oacute;digo de Processo Penal.
+III. RAZ&Otilde;ES DE DECIDIR
+A fixa&ccedil;&atilde;o de valor m&iacute;nimo para repara&ccedil;&atilde;o dos danos causados pela infra&ccedil;&atilde;o penal, fora das hip&oacute;teses de viol&ecirc;ncia dom&eacute;stica e familiar contra a mulher, exige pedido expresso formulado na pe&ccedil;a acusat&oacute;ria, com indica&ccedil;&atilde;o minimamente delimitada da pretens&atilde;o indenizat&oacute;ria, em observ&acirc;ncia aos princ&iacute;pios do contradit&oacute;rio, da ampla defesa e da congru&ecirc;ncia.
+A den&uacute;ncia, no caso concreto, limita-se &agrave; imputa&ccedil;&atilde;o do crime e ao requerimento de regular processamento da a&ccedil;&atilde;o penal, sem formular pedido de fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima em favor dos sucessores da v&iacute;tima e sem indicar qualquer valor pretendido a esse t&iacute;tulo.
+A senten&ccedil;a, ap&oacute;s desclassificar a conduta inicialmente imputada para o delito de les&atilde;o corporal seguida de morte, fixa, de of&iacute;cio, indeniza&ccedil;&atilde;o m&iacute;nima por danos morais no valor de R$ 15.000,00, sem pr&eacute;via postula&ccedil;&atilde;o ministerial, o que impede o exerc&iacute;cio efetivo do contradit&oacute;rio sobre o cap&iacute;tulo indenizat&oacute;rio.
+O Superior Tribunal de Justi&ccedil;a, no julgamento do REsp n. 1.986.672/SC, afirma que, embora a produ&ccedil;&atilde;o de prova espec&iacute;fica possa ser dispensada em hip&oacute;teses de dano moral in re ipsa, permanecem indispens&aacute;veis o requerimento expresso e a indica&ccedil;&atilde;o do valor pretendido na den&uacute;ncia.
+A flexibiliza&ccedil;&atilde;o admitida pelo STJ no Tema 983 n&atilde;o incide na esp&eacute;cie, pois se restringe &agrave;s hip&oacute;teses de viol&ecirc;ncia dom&eacute;stica e familiar contra a mulher, desde que exista pedido expresso, situa&ccedil;&atilde;o distinta da condena&ccedil;&atilde;o por les&atilde;o corporal seguida de morte.
+A exclus&atilde;o da indeniza&ccedil;&atilde;o m&iacute;nima na esfera penal n&atilde;o impede que os sucessores da v&iacute;tima busquem eventual repara&ccedil;&atilde;o civil em a&ccedil;&atilde;o pr&oacute;pria perante o ju&iacute;zo competente.
+IV. DISPOSITIVO E TESE
+Recurso provido.
+Tese de julgamento: 1. A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima por danos morais na senten&ccedil;a penal condenat&oacute;ria, com fundamento no art. 387, IV, do CPP, exige pedido expresso da acusa&ccedil;&atilde;o com delimita&ccedil;&atilde;o m&iacute;nima da pretens&atilde;o indenizat&oacute;ria, ressalvadas as hip&oacute;teses excepcionais reconhecidas pela jurisprud&ecirc;ncia. 2. A aus&ecirc;ncia de requerimento expresso na den&uacute;ncia inviabiliza a condena&ccedil;&atilde;o ao pagamento de repara&ccedil;&atilde;o m&iacute;nima, por viola&ccedil;&atilde;o ao contradit&oacute;rio, &agrave; ampla defesa e &agrave; correla&ccedil;&atilde;o entre acusa&ccedil;&atilde;o e senten&ccedil;a. 3. A exclus&atilde;o da indeniza&ccedil;&atilde;o m&iacute;nima na senten&ccedil;a penal n&atilde;o afasta a possibilidade de repara&ccedil;&atilde;o civil em a&ccedil;&atilde;o pr&oacute;pria.
+Dispositivos relevantes citados: CP, art. 129, &sect; 3&ordm;; CPP, art. 387, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n. 1.986.672/SC, Terceira Se&ccedil;&atilde;o; STJ, Tema Repetitivo 983. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0900082-64.2023.8.12.0042,&nbsp; Rio Verde de Mato Grosso,&nbsp; 1&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. Jonas Hass Silva J&uacute;nior, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Seguida de Morte
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Jonas Hass Silva Júnior
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Verde de Mato Grosso
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. LESÃO CORPORAL SEGUIDA DE MORTE. INDENIZAÇÃO MÍNIMA POR DANOS MORAIS FIXADA DE OFÍCIO NA SENTENÇA. AUSÊNCIA DE PEDIDO EXPRESSO NA DENÚNCIA. VIOLAÇÃO AO CONTRADITÓRIO, À AMPLA DEFESA E À CORRELAÇÃO ENTRE ACUSAÇÃO E SENTENÇA. RECURSO PROVIDO.
+I. CASO EM EXAME
+Apelação criminal interposta por réu condenado pela prática do delito de lesão
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. LESÃO CORPORAL SEGUIDA DE MORTE. INDENIZAÇÃO MÍNIMA POR DANOS MORAIS FIXADA DE OFÍCIO NA SENTENÇA. AUSÊNCIA DE PEDIDO EXPRESSO NA DENÚNCIA. VIOLAÇÃO AO CONTRADITÓRIO, À AMPLA DEFESA E À CORRELAÇÃO ENTRE ACUSAÇÃO E SENTENÇA. RECURSO PROVIDO.
+I. CASO EM EXAME
+Apelação criminal interposta por réu condenado pela prática do delito de lesão corporal seguida de morte, previsto no art. 129, § 3º, do Código Penal, à pena de 4 anos e 2 meses de reclusão, em regime inicial semiaberto, além do pagamento de indenização mínima por danos morais no valor de R$ 15.000,00, fixada em favor dos herdeiros da vítima com fundamento no art. 387, IV, do Código de Processo Penal. A defesa requer a reforma parcial da sentença para afastar ou reduzir o valor da reparação mínima, ao argumento de ausência de parâmetros objetivos e violação ao contraditório, à ampla defesa e ao devido processo legal.
+II. QUESTÃO EM DISCUSSÃO
+Há 2 questões em discussão: (i) definir se é válida a fixação, de ofício, de indenização mínima por danos morais na sentença penal condenatória, sem pedido expresso formulado na denúncia; e (ii) estabelecer se, ausente requerimento acusatório com delimitação mínima da pretensão indenizatória, deve ser excluído o capítulo condenatório fundado no art. 387, IV, do Código de Processo Penal.
+III. RAZÕES DE DECIDIR
+A fixação de valor mínimo para reparação dos danos causados pela infração penal, fora das hipóteses de violência doméstica e familiar contra a mulher, exige pedido expresso formulado na peça acusatória, com indicação minimamente delimitada da pretensão indenizatória, em observância aos princípios do contraditório, da ampla defesa e da congruência.
+A denúncia, no caso concreto, limita-se à imputação do crime e ao requerimento de regular processamento da ação penal, sem formular pedido de fixação de indenização mínima em favor dos sucessores da vítima e sem indicar qualquer valor pretendido a esse título.
+A sentença, após desclassificar a conduta inicialmente imputada para o delito de lesão corporal seguida de morte, fixa, de ofício, indenização mínima por danos morais no valor de R$ 15.000,00, sem prévia postulação ministerial, o que impede o exercício efetivo do contraditório sobre o capítulo indenizatório.
+O Superior Tribunal de Justiça, no julgamento do REsp n. 1.986.672/SC, afirma que, embora a produção de prova específica possa ser dispensada em hipóteses de <em>dano</em> <em>moral</em> in re ipsa, permanecem indispensáveis o requerimento expresso e a indicação do valor pretendido na denúncia.
+A flexibilização admitida pelo STJ no Tema 983 não incide na espécie, pois se restringe às hipóteses de violência doméstica e familiar contra a mulher, desde que exista pedido expresso, situação distinta da condenação por lesão corporal seguida de morte.
+A exclusão da indenização mínima na esfera penal não impede que os sucessores da vítima busquem eventual reparação civil em ação própria perante o juízo competente.
+IV. DISPOSITIVO E TESE
+Recurso provido.
+Tese de julgamento: 1. A fixação de indenização mínima por danos morais na sentença penal condenatória, com fundamento no art. 387, IV, do CPP, exige pedido expresso da acusação com delimitação mínima da pretensão indenizatória, ressalvadas as hipóteses excepcionais reconhecidas pela jurisprudência. 2. A ausência de requerimento expresso na denúncia inviabiliza a condenação ao pagamento de reparação mínima, por violação ao contraditório, à ampla defesa e à correlação entre acusação e sentença. 3. A exclusão da indenização mínima na sentença penal não afasta a possibilidade de reparação civil em ação própria.
+Dispositivos relevantes citados: CP, art. 129, § 3º; CPP, art. 387, IV.
+Jurisprudência relevante citada: STJ, REsp n. 1.986.672/SC, Terceira Seção; STJ, Tema Repetitivo 983.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>106&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877503" cdForo="0" >
+										0808087-96.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877503" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877503);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877503" style="display: none;" >
+	<div id="textAreaDados_1877503" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E PEDIDO DE TUTELA DE URG&Ecirc;NCIA &ndash;  RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; N&Atilde;O COMPROVADA &ndash; DEVOLU&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; DEVIDO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; VALOR ALTERADO &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+A rela&ccedil;&atilde;o jur&iacute;dica vincula os sujeitos de direito em decorr&ecirc;ncia dos fatos jur&iacute;dicos suficientemente comprovados, que s&atilde;o a causa da instaura&ccedil;&atilde;o, da modifica&ccedil;&atilde;o ou da extin&ccedil;&atilde;o de obriga&ccedil;&otilde;es. Especificamente no contrato de m&uacute;tuo ou de empr&eacute;stimo, a tradi&ccedil;&atilde;o da coisa mutuada &eacute; suficiente para se concluir pela exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, cujos efeitos devem operar regulamente, nos termos do art. 586 do C&oacute;digo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso conhecido e provido parcialmente. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0808087-96.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(30 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS C/C REPETIÇÃO DE INDÉBITO E PEDIDO DE TUTELA DE URGÊNCIA –  RELAÇÃO JURÍDICA – NÃO COMPROVADA – DEVOLUÇÃO DE INDÉBITO – DEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR ALTERADO – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS C/C REPETIÇÃO DE INDÉBITO E PEDIDO DE TUTELA DE URGÊNCIA –  RELAÇÃO JURÍDICA – NÃO COMPROVADA – DEVOLUÇÃO DE INDÉBITO – DEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR ALTERADO – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO CONHECIDO E PROVIDO PARCIALMENTE.
+A relação jurídica vincula os sujeitos de direito em decorrência dos fatos jurídicos suficientemente comprovados, que são a causa da instauração, da modificação ou da extinção de obrigações. Especificamente no contrato de mútuo ou de empréstimo, a tradição da coisa mutuada é suficiente para se concluir pela existência da relação jurídica, cujos efeitos devem operar regulamente, nos termos do art. 586 do Código Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso conhecido e provido parcialmente.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>107&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877505" cdForo="0" >
+										0802701-91.2024.8.12.0019
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877505" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877505);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877505" style="display: none;" >
+	<div id="textAreaDados_1877505" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE EMPR&Eacute;STIMO CONSIGNADO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E CONDENA&Ccedil;&Atilde;O EM DANOS MORAIS - EMPR&Eacute;STIMO CONSIGNADO &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; RELA&Ccedil;&Atilde;O DE CONSUMO &ndash; INVERS&Atilde;O DO &Ocirc;NUS DA PROVA &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; RESPONSABILIDADE OBJETIVA &ndash; DANO MORAL IN RE IPSA CONFIGURADO &ndash; QUANTUM MANTIDO &ndash; RESTITUI&Ccedil;&Atilde;O EM DOBRO &ndash; CABIMENTO &ndash; MODULA&Ccedil;&Atilde;O DE EFEITOS DO STJ (EARESP 676.608/RS) &ndash; COMPENSA&Ccedil;&Atilde;O DE VALORES &ndash; IMPOSSIBILIDADE &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I - Tratando-se de rela&ccedil;&atilde;o de consumo, incide a responsabilidade civil objetiva da institui&ccedil;&atilde;o financeira, em raz&atilde;o da teoria do risco do empreendimento, cabendo a ela o &ocirc;nus de comprovar a regularidade da contrata&ccedil;&atilde;o impugnada pelo consumidor, nos termos do art. 14 e art. 6&ordm;, VIII, do CDC c/c art. 373, II, do CPC.
+II - A aus&ecirc;ncia de juntada do instrumento contratual v&aacute;lido ou de comprovante de transfer&ecirc;ncia do valor do m&uacute;tuo para a conta do autor evidencia a falha na presta&ccedil;&atilde;o do servi&ccedil;o e imp&otilde;e a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito.
+III - Os descontos indevidos realizados diretamente em benef&iacute;cio previdenci&aacute;rio, verba de natureza alimentar, geram dano moral presumido, in re ipsa, sendo o valor de R$ 3.000,00 (tr&ecirc;s mil reais) proporcional e razo&aacute;vel para compensar o abalo sofrido, atendendo ao car&aacute;ter pedag&oacute;gico e punitivo da medida, sem gerar enriquecimento il&iacute;cito.
+IV - A restitui&ccedil;&atilde;o dos valores descontados indevidamente deve ocorrer em dobro, independentemente da comprova&ccedil;&atilde;o de m&aacute;-f&eacute;, conforme tese firmada pelo STJ (EAREsp 600.663/RS), observada a modula&ccedil;&atilde;o dos efeitos (EAREsp 676.608/RS) para cobran&ccedil;as realizadas ap&oacute;s 30/03/2021.
+V - &Eacute; incab&iacute;vel o pedido subsidi&aacute;rio de compensa&ccedil;&atilde;o de valores quando a institui&ccedil;&atilde;o financeira n&atilde;o comprova a efetiva disponibiliza&ccedil;&atilde;o e o proveito econ&ocirc;mico do cr&eacute;dito na conta banc&aacute;ria do consumidor.
+VI - Senten&ccedil;a mantida. Recurso conhecido e n&atilde;o provido.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802701-91.2024.8.12.0019,&nbsp; Ponta Por&atilde;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(21 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Ponta Porã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE EMPRÉSTIMO CONSIGNADO C/C REPETIÇÃO DE INDÉBITO E CONDENAÇÃO EM DANOS MORAIS - EMPRÉSTIMO CONSIGNADO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – RELAÇÃO DE CONSUMO – INVERSÃO DO ÔNUS DA PROVA – CONTRATAÇÃO NÃO COMPROVADA – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> IN RE IPSA CONFIGURADO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE EMPRÉSTIMO CONSIGNADO C/C REPETIÇÃO DE INDÉBITO E CONDENAÇÃO EM DANOS MORAIS - EMPRÉSTIMO CONSIGNADO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – RELAÇÃO DE CONSUMO – INVERSÃO DO ÔNUS DA PROVA – CONTRATAÇÃO NÃO COMPROVADA – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – <em>DANO</em> <em>MORAL</em> IN RE IPSA CONFIGURADO – QUANTUM MANTIDO – RESTITUIÇÃO EM DOBRO – CABIMENTO – MODULAÇÃO DE EFEITOS DO STJ (EARESP 676.608/RS) – COMPENSAÇÃO DE VALORES – IMPOSSIBILIDADE – RECURSO CONHECIDO E NÃO PROVIDO.
+I - Tratando-se de relação de consumo, incide a responsabilidade civil objetiva da instituição financeira, em razão da teoria do risco do empreendimento, cabendo a ela o ônus de comprovar a regularidade da contratação impugnada pelo consumidor, nos termos do art. 14 e art. 6º, VIII, do CDC c/c art. 373, II, do CPC.
+II - A ausência de juntada do instrumento contratual válido ou de comprovante de transferência do valor do mútuo para a conta do autor evidencia a falha na prestação do serviço e impõe a declaração de inexistência do débito.
+III - Os descontos indevidos realizados diretamente em benefício previdenciário, verba de natureza alimentar, geram <em>dano</em> <em>moral</em> presumido, in re ipsa, sendo o valor de R$ 3.000,00 (três mil reais) proporcional e razoável para compensar o abalo sofrido, atendendo ao caráter pedagógico e punitivo da medida, sem gerar enriquecimento ilícito.
+IV - A restituição dos valores descontados indevidamente deve ocorrer em dobro, independentemente da comprovação de má-fé, conforme tese firmada pelo STJ (EAREsp 600.663/RS), observada a modulação dos efeitos (EAREsp 676.608/RS) para cobranças realizadas após 30/03/2021.
+V - É incabível o pedido subsidiário de compensação de valores quando a instituição financeira não comprova a efetiva disponibilização e o proveito econômico do crédito na conta bancária do consumidor.
+VI - Sentença mantida. Recurso conhecido e não provido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>108&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877519" cdForo="0" >
+										0025989-97.2020.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877519" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877519);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877519" style="display: none;" >
+	<div id="textAreaDados_1877519" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. LES&Atilde;O CORPORAL GRAVE. DOSIMETRIA DA PENA. VALORA&Ccedil;&Atilde;O NEGATIVA DAS CIRCUNST&Acirc;NCIAS JUDICIAIS. CONFISS&Atilde;O QUALIFICADA. ATENUANTE APLICADA EM MENOR PROPOR&Ccedil;&Atilde;O. INDENIZA&Ccedil;&Atilde;O M&Iacute;NIMA POR DANOS MORAIS EM CONTEXTO DE VIOL&Ecirc;NCIA DOM&Eacute;STICA. REDU&Ccedil;&Atilde;O DO QUANTUM. RECURSO PARCIALMENTE PROVIDO.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0025989-97.2020.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. Jonas Hass Silva J&uacute;nior, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Homicídio Simples
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Jonas Hass Silva Júnior
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1877519" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. LESÃO CORPORAL GRAVE. DOSIMETRIA DA PENA. VALORAÇÃO NEGATIVA DAS CIRCUNSTÂNCIAS JUDICIAIS. CONFISSÃO QUALIFICADA. ATENUANTE APLICADA EM MENOR PROPORÇÃO. INDENIZAÇÃO MÍNIMA POR DANOS MORAIS EM CONTEXTO DE VIOLÊNCIA DOMÉSTICA. REDUÇÃO DO QUANTUM. RECURSO PARCIALMENTE PROVIDO.
+
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>109&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877528" cdForo="0" >
+										0800356-64.2025.8.12.0037
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877528" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877528);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877528" style="display: none;" >
+	<div id="textAreaDados_1877528" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. NEGATIVA&Ccedil;&Atilde;O. EXIST&Ecirc;NCIA DO D&Eacute;BITO. EXERC&Iacute;CIO REGULAR DE DIREITO. AUS&Ecirc;NCIA DE NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA. IRRELEV&Acirc;NCIA NO CASO CONCRETO. DANOS MORAIS N&Atilde;O CONFIGURADOS. REFORMA DA SENTEN&Ccedil;A. RECURSO PROVIDO.
+1. A parte requerida comprova a exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica mediante documentos que evidenciam a aquisi&ccedil;&atilde;o de produto, o valor da opera&ccedil;&atilde;o e as condi&ccedil;&otilde;es de pagamento.
+2. A autora n&atilde;o impugna especificamente a contrata&ccedil;&atilde;o, atraindo a presun&ccedil;&atilde;o de veracidade dos fatos n&atilde;o contestados, nos termos do art. 341 do CPC.
+3. A exist&ecirc;ncia do d&eacute;bito e o inadimplemento configuram exerc&iacute;cio regular de direito do credor ao promover a inscri&ccedil;&atilde;o do nome do devedor em cadastros restritivos, nos termos do art. 188, I, do C&oacute;digo Civil.
+4. A negativa&ccedil;&atilde;o fundada em d&iacute;vida existente n&atilde;o configura ato il&iacute;cito, conforme entendimento consolidado do Superior Tribunal de Justi&ccedil;a.
+5. A aus&ecirc;ncia de notifica&ccedil;&atilde;o pr&eacute;via, embora exigida pelo art. 43, &sect;2&ordm;, do CDC, n&atilde;o enseja, por si s&oacute;, indeniza&ccedil;&atilde;o quando o devedor possui ci&ecirc;ncia inequ&iacute;voca da d&iacute;vida e n&atilde;o h&aacute; surpresa ou abuso na inscri&ccedil;&atilde;o.
+6. A responsabilidade civil exige a presen&ccedil;a de ato il&iacute;cito e dano, inexistentes no caso concreto, afastando o dever de indenizar, nos termos dos arts. 186 e 927 do C&oacute;digo Civil.
+7. A concess&atilde;o de indeniza&ccedil;&atilde;o em tais circunst&acirc;ncias violaria a boa-f&eacute; objetiva e ensejaria enriquecimento sem causa.
+8. Recurso provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800356-64.2025.8.12.0037,&nbsp; Itapor&atilde;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Itaporã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. NEGATIVAÇÃO. EXISTÊNCIA DO DÉBITO. EXERCÍCIO REGULAR DE DIREITO. AUSÊNCIA DE NOTIFICAÇÃO PRÉVIA. IRRELEVÂNCIA NO CASO CONCRETO. DANOS MORAIS NÃO CONFIGURADOS. REFORMA DA SENTENÇA. RECURSO PROVIDO.
+1. A parte requerida comprova a existência da relação jurídica mediante documentos que evidenciam a aquisição de produto, o valor da operação e as
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. NEGATIVAÇÃO. EXISTÊNCIA DO DÉBITO. EXERCÍCIO REGULAR DE DIREITO. AUSÊNCIA DE NOTIFICAÇÃO PRÉVIA. IRRELEVÂNCIA NO CASO CONCRETO. DANOS MORAIS NÃO CONFIGURADOS. REFORMA DA SENTENÇA. RECURSO PROVIDO.
+1. A parte requerida comprova a existência da relação jurídica mediante documentos que evidenciam a aquisição de produto, o valor da operação e as condições de pagamento.
+2. A autora não impugna especificamente a contratação, atraindo a presunção de veracidade dos fatos não contestados, nos termos do art. 341 do CPC.
+3. A existência do débito e o inadimplemento configuram exercício regular de direito do credor ao promover a inscrição do nome do devedor em cadastros restritivos, nos termos do art. 188, I, do Código Civil.
+4. A negativação fundada em dívida existente não configura ato ilícito, conforme entendimento consolidado do Superior Tribunal de Justiça.
+5. A ausência de notificação prévia, embora exigida pelo art. 43, §2º, do CDC, não enseja, por si só, indenização quando o devedor possui ciência inequívoca da dívida e não há surpresa ou abuso na inscrição.
+6. A responsabilidade civil exige a presença de ato ilícito e <em>dano</em>, inexistentes no caso concreto, afastando o dever de indenizar, nos termos dos arts. 186 e 927 do Código Civil.
+7. A concessão de indenização em tais circunstâncias violaria a boa-fé objetiva e ensejaria enriquecimento sem causa.
+8. Recurso provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>110&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877529" cdForo="0" >
+										0808856-67.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877529" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877529);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877529" style="display: none;" >
+	<div id="textAreaDados_1877529" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS  &ndash;  QUANTUM INDENIZAT&Oacute;RIO MANTIDO &ndash; RAZOABILIDADE E PROPORCIONALIDADE &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+1. O desconto indevido de valores na conta corrente da parte autora configura dano moral puro, sendo desnecess&aacute;ria a prova do efetivo preju&iacute;zo, mostrando-se razo&aacute;vel e proporcional a indeniza&ccedil;&atilde;o fixada na origem em R$ 3.000,00 (tr&ecirc;s mil reais).
+2. Recurso conhecido e n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0808856-67.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS  –  QUANTUM INDENIZATÓRIO MANTIDO – RAZOABILIDADE E PROPORCIONALIDADE – RECURSO CONHECIDO E NÃO PROVIDO.
+1. O desconto indevido de valores na conta corrente da parte autora configura <em>dano</em> <em>moral</em> puro, sendo desnecessária a prova do efetivo prejuízo, mostrando-se razoável e proporcional
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS  –  QUANTUM INDENIZATÓRIO MANTIDO – RAZOABILIDADE E PROPORCIONALIDADE – RECURSO CONHECIDO E NÃO PROVIDO.
+1. O desconto indevido de valores na conta corrente da parte autora configura <em>dano</em> <em>moral</em> puro, sendo desnecessária a prova do efetivo prejuízo, mostrando-se razoável e proporcional a indenização fixada na origem em R$ 3.000,00 (três mil reais).
+2. Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>111&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877539" cdForo="0" >
+										0804889-77.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877539" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877539);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877539" style="display: none;" >
+	<div id="textAreaDados_1877539" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO. RESERVA DE MARGEM CONSIGN&Aacute;VEL (RMC). ALEGA&Ccedil;&Atilde;O DE CONTRATA&Ccedil;&Atilde;O N&Atilde;O RECONHECIDA. COMPROVA&Ccedil;&Atilde;O DA CONTRATA&Ccedil;&Atilde;O E DA DISPONIBILIZA&Ccedil;&Atilde;O DO CR&Eacute;DITO. REGULARIDADE DOS DESCONTOS. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO DESPROVIDO.
+1. A institui&ccedil;&atilde;o financeira se desincumbe do &ocirc;nus probat&oacute;rio ao apresentar termos de ades&atilde;o de cart&atilde;o de cr&eacute;dito consignado devidamente assinados, e comprovantes de transfer&ecirc;ncia eletr&ocirc;nica demonstrando a disponibiliza&ccedil;&atilde;o do cr&eacute;dito ao consumidor.
+2. Comprovada a contrata&ccedil;&atilde;o e a disponibiliza&ccedil;&atilde;o do cr&eacute;dito, mostram-se leg&iacute;timos os descontos realizados, afastando-se a declara&ccedil;&atilde;o de inexist&ecirc;ncia do d&eacute;bito, a restitui&ccedil;&atilde;o de valores e a indeniza&ccedil;&atilde;o por danos morais.
+6. Recurso desprovido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0804889-77.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. CARTÃO DE CRÉDITO CONSIGNADO. RESERVA DE MARGEM CONSIGNÁVEL (RMC). ALEGAÇÃO DE CONTRATAÇÃO NÃO RECONHECIDA. COMPROVAÇÃO DA CONTRATAÇÃO E DA DISPONIBILIZAÇÃO DO CRÉDITO. REGULARIDADE DOS DESCONTOS. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+1. A instituição financeira se desincumbe do ônus probatório ao apresentar termos de adesão de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. CARTÃO DE CRÉDITO CONSIGNADO. RESERVA DE MARGEM CONSIGNÁVEL (RMC). ALEGAÇÃO DE CONTRATAÇÃO NÃO RECONHECIDA. COMPROVAÇÃO DA CONTRATAÇÃO E DA DISPONIBILIZAÇÃO DO CRÉDITO. REGULARIDADE DOS DESCONTOS. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+1. A instituição financeira se desincumbe do ônus probatório ao apresentar termos de adesão de cartão de crédito consignado devidamente assinados, e comprovantes de transferência eletrônica demonstrando a disponibilização do crédito ao consumidor.
+2. Comprovada a contratação e a disponibilização do crédito, mostram-se legítimos os descontos realizados, afastando-se a declaração de inexistência do débito, a restituição de valores e a indenização por danos morais.
+6. Recurso desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>112&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877555" cdForo="0" >
+										1404483-73.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877555" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877555);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877555" style="display: none;" >
+	<div id="textAreaDados_1877555" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO DA PARTE AUTORA &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O &ndash;  BENEF&Iacute;CIO DA JUSTI&Ccedil;A GRATUITA &ndash; INDEFERIMENTO DO PEDIDO &ndash; COMPROVA&Ccedil;&Atilde;O EFETIVA DA HIPOSSUFICI&Ecirc;NCIA ECON&Ocirc;MICA &ndash; DECIS&Atilde;O REFORMADA &ndash; RECURSO CONHECIDO E PROVIDO.
+Nos termos da legisla&ccedil;&atilde;o vigente, a afirma&ccedil;&atilde;o das partes autoras, de n&atilde;o possuir meios para arcar com as despesas processuais sem preju&iacute;zo do seu sustento e de sua fam&iacute;lia, aliado aos documentos juntados que demonstram a condi&ccedil;&atilde;o hipossuficiente implica no deferimento da justi&ccedil;a gratuita, cabendo &agrave; parte contr&aacute;ria o &ocirc;nus da prova capaz de desconstituir o benef&iacute;cio.
+Recurso conhecido e provido.
+
+  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1404483-73.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Assistência Judiciária Gratuita
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO DA PARTE AUTORA – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO –  BENEFÍCIO DA JUSTIÇA GRATUITA – INDEFERIMENTO DO PEDIDO – COMPROVAÇÃO EFETIVA DA HIPOSSUFICIÊNCIA ECONÔMICA – DECISÃO REFORMADA – RECURSO CONHECIDO E PROVIDO.
+Nos termos da legislação vigente, a afirmação das partes autoras, de não possuir meios para arcar com as despesas processuais sem
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO DA PARTE AUTORA – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO –  BENEFÍCIO DA JUSTIÇA GRATUITA – INDEFERIMENTO DO PEDIDO – COMPROVAÇÃO EFETIVA DA HIPOSSUFICIÊNCIA ECONÔMICA – DECISÃO REFORMADA – RECURSO CONHECIDO E PROVIDO.
+Nos termos da legislação vigente, a afirmação das partes autoras, de não possuir meios para arcar com as despesas processuais sem prejuízo do seu sustento e de sua família, aliado aos documentos juntados que demonstram a condição hipossuficiente implica no deferimento da justiça gratuita, cabendo à parte contrária o ônus da prova capaz de desconstituir o benefício.
+Recurso conhecido e provido.
+
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>113&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877565" cdForo="0" >
+										0813038-33.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877565" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877565);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877565" style="display: none;" >
+	<div id="textAreaDados_1877565" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; N&Atilde;O COMPROVADA &ndash; REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; APLICA&Ccedil;&Atilde;O DA MODULA&Ccedil;&Atilde;O DOS EFEITOS DO EARESP N. 676.608/RS &ndash; DESCONTOS ANTERIORES A 30.3.2021 &ndash;  DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash; DESCONTOS A PARTIR  30.3.2021 &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; VALOR ALTERADO &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; MANTIDOS &ndash; TAXA SELIC &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; TEMA 1368 DO STJ &ndash; RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO. RECURSO DA PARTE R&Eacute; CONHECIDO E PARCIALMENTE PROVIDO.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+A rela&ccedil;&atilde;o jur&iacute;dica vincula os sujeitos de direito em decorr&ecirc;ncia dos fatos jur&iacute;dicos suficientemente comprovados, que s&atilde;o a causa da instaura&ccedil;&atilde;o, da modifica&ccedil;&atilde;o ou da extin&ccedil;&atilde;o de obriga&ccedil;&otilde;es. Especificamente no contrato de m&uacute;tuo ou de empr&eacute;stimo, a tradi&ccedil;&atilde;o da coisa mutuada &eacute; suficiente para se concluir pela exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, cujos efeitos devem operar regulamente, nos termos do art. 586 do C&oacute;digo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que, nos termos art. 42, par&aacute;grafo &uacute;nico, da Lei n&ordm; 8.078/1990 (C&oacute;digo de Defesa do Consumidor), a restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe da natureza do elemento volitivo do fornecedor que realizou a cobran&ccedil;a indevida, revelando-se cab&iacute;vel quando a referida cobran&ccedil;a consubstanciar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva. N&atilde;o obstante, houve modula&ccedil;&atilde;o dos efeitos, impondo a aplica&ccedil;&atilde;o dessa tese a partir de 30.3.2021, data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o dos Embargos de Diverg&ecirc;ncia em Agravo em Recurso Especial n&ordm; 676.608/RS, e unicamente para as cobran&ccedil;as indevidas em contratos de consumo que n&atilde;o envolvam presta&ccedil;&atilde;o de servi&ccedil;os p&uacute;blicos pelo Estado ou por concession&aacute;rias, as quais apenas ser&atilde;o atingidas pelo novo entendimento quando pagas ap&oacute;s a data da publica&ccedil;&atilde;o do ac&oacute;rd&atilde;o (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a, nos julgamentos dos Recursos Especiais n&ordm; 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixa&ccedil;&atilde;o dos honor&aacute;rios por aprecia&ccedil;&atilde;o equitativa n&atilde;o &eacute; permitida quando os valores da condena&ccedil;&atilde;o ou da causa, ou o proveito econ&ocirc;mico da demanda, forem elevados. &Eacute; obrigat&oacute;ria, nesses casos, a observ&acirc;ncia dos percentuais previstos nos par&aacute;grafos 2&ordm; ou 3&ordm; do artigo 85 do C&oacute;digo de Processo Civil (CPC) &ndash; a depender da presen&ccedil;a da Fazenda P&uacute;blica na lide &ndash;, os quais ser&atilde;o subsequentemente calculados sobre o valor: (a) da condena&ccedil;&atilde;o; ou (b) do proveito econ&ocirc;mico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honor&aacute;rios por equidade quando, havendo ou n&atilde;o condena&ccedil;&atilde;o: (a) o proveito econ&ocirc;mico obtido pelo vencedor for inestim&aacute;vel ou irris&oacute;rio; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso da parte autora conhecido e provido. Recurso da parte r&eacute; conhecido e parcialmente provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0813038-33.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(35 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DÉBITO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES – DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DÉBITO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – RELAÇÃO JURÍDICA – NÃO COMPROVADA – REPETIÇÃO DE INDÉBITO – APLICAÇÃO DA MODULAÇÃO DOS EFEITOS DO EARESP N. 676.608/RS – DESCONTOS ANTERIORES A 30.3.2021 –  DEVOLUÇÃO SIMPLES – DESCONTOS A PARTIR  30.3.2021 – DEVOLUÇÃO EM DOBRO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR ALTERADO – HONORÁRIOS ADVOCATÍCIOS – MANTIDOS – TAXA SELIC – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – TEMA 1368 DO STJ – RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO. RECURSO DA PARTE RÉ CONHECIDO E PARCIALMENTE PROVIDO.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+A relação jurídica vincula os sujeitos de direito em decorrência dos fatos jurídicos suficientemente comprovados, que são a causa da instauração, da modificação ou da extinção de obrigações. Especificamente no contrato de mútuo ou de empréstimo, a tradição da coisa mutuada é suficiente para se concluir pela existência da relação jurídica, cujos efeitos devem operar regulamente, nos termos do art. 586 do Código Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que, nos termos art. 42, parágrafo único, da Lei nº 8.078/1990 (Código de Defesa do Consumidor), a restituição em dobro do indébito independe da natureza do elemento volitivo do fornecedor que realizou a cobrança indevida, revelando-se cabível quando a referida cobrança consubstanciar conduta contrária à boa-fé objetiva. Não obstante, houve modulação dos efeitos, impondo a aplicação dessa tese a partir de 30.3.2021, data da publicação do acórdão dos Embargos de Divergência em Agravo em Recurso Especial nº 676.608/RS, e unicamente para as cobranças indevidas em contratos de consumo que não envolvam prestação de serviços públicos pelo Estado ou por concessionárias, as quais apenas serão atingidas pelo novo entendimento quando pagas após a data da publicação do acórdão (EAREsp n. 676.608/RS, relator Ministro Og Fernandes, Corte Especial, julgado em 21/10/2020, DJe de 30/3/2021.).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça, nos julgamentos dos Recursos Especiais nº 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixação dos honorários por apreciação equitativa não é permitida quando os valores da condenação ou da causa, ou o proveito econômico da demanda, forem elevados. É obrigatória, nesses casos, a observância dos percentuais previstos nos parágrafos 2º ou 3º do artigo 85 do Código de Processo Civil (CPC) – a depender da presença da Fazenda Pública na lide –, os quais serão subsequentemente calculados sobre o valor: (a) da condenação; ou (b) do proveito econômico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honorários por equidade quando, havendo ou não condenação: (a) o proveito econômico obtido pelo vencedor for inestimável ou irrisório; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso da parte autora conhecido e provido. Recurso da parte ré conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>114&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877571" cdForo="0" >
+										0823960-41.2020.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877571" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877571);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877571" style="display: none;" >
+	<div id="textAreaDados_1877571" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; CONDENA&Ccedil;&Atilde;O EM REPARA&Ccedil;&Atilde;O MORAL &ndash; QUANTUM INDENIZAT&Oacute;RIO &ndash; MANUTEN&Ccedil;&Atilde;O DO VALOR FIXADO NA SENTEN&Ccedil;A &ndash; RAZOABILIDADE E PROPORCIONALIDADE &ndash; CONDI&Ccedil;&Otilde;ES PESSOAIS DO OFENSOR &ndash; IRRELEV&Acirc;NCIA PARA REDU&Ccedil;&Atilde;O DO VALOR EM FACE DA INCAPACIDADE PERMANENTE E PARCIAL DA V&Iacute;TIMA &ndash; FUN&Ccedil;&Atilde;O PEDAG&Oacute;GICA &ndash; RECURSO DESPROVIDO.
+O valor de repara&ccedil;&atilde;o moral fixado em R$ 10.000,00 (dez mil reais) &eacute; compat&iacute;vel com os par&acirc;metros jurisprudenciais adotados em casos semelhantes de acidente de tr&acirc;nsito, n&atilde;o se mostrando &iacute;nfimo nem excessivo.
+Embora as condi&ccedil;&otilde;es pessoais do ofensor, como idade e situa&ccedil;&atilde;o econ&ocirc;mica, constituam elementos a serem considerados na segunda fase do m&eacute;todo bif&aacute;sico, tais circunst&acirc;ncias n&atilde;o justificam a redu&ccedil;&atilde;o da indeniza&ccedil;&atilde;o quando evidenciada a gravidade do dano suportado pela v&iacute;tima. A ocorr&ecirc;ncia de incapacidade permanente e parcial do ofendido configura fator relevante que imp&otilde;e a manuten&ccedil;&atilde;o do valor de repara&ccedil;&atilde;o, em aten&ccedil;&atilde;o &agrave;s fun&ccedil;&otilde;es compensat&oacute;ria e pedag&oacute;gica da repara&ccedil;&atilde;o civil, nos termos dos arts. 186 e 927, CC. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0823960-41.2020.8.12.0001,&nbsp; Campo Grande,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(38 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – CONDENAÇÃO EM REPARAÇÃO <em>MORAL</em> – QUANTUM INDENIZATÓRIO – MANUTENÇÃO DO VALOR FIXADO NA SENTENÇA – RAZOABILIDADE E PROPORCIONALIDADE – CONDIÇÕES PESSOAIS DO OFENSOR – IRRELEVÂNCIA PARA REDUÇÃO DO VALOR EM FACE DA INCAPACIDADE PERMANENTE E PARCIAL DA VÍTIMA – FUNÇÃO PEDAGÓGICA – RECURSO DESPROVIDO.
+O valor de reparação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – CONDENAÇÃO EM REPARAÇÃO <em>MORAL</em> – QUANTUM INDENIZATÓRIO – MANUTENÇÃO DO VALOR FIXADO NA SENTENÇA – RAZOABILIDADE E PROPORCIONALIDADE – CONDIÇÕES PESSOAIS DO OFENSOR – IRRELEVÂNCIA PARA REDUÇÃO DO VALOR EM FACE DA INCAPACIDADE PERMANENTE E PARCIAL DA VÍTIMA – FUNÇÃO PEDAGÓGICA – RECURSO DESPROVIDO.
+O valor de reparação <em>moral</em> fixado em R$ 10.000,00 (dez mil reais) é compatível com os parâmetros jurisprudenciais adotados em casos semelhantes de acidente de trânsito, não se mostrando ínfimo nem excessivo.
+Embora as condições pessoais do ofensor, como idade e situação econômica, constituam elementos a serem considerados na segunda fase do método bifásico, tais circunstâncias não justificam a redução da indenização quando evidenciada a gravidade do <em>dano</em> suportado pela vítima. A ocorrência de incapacidade permanente e parcial do ofendido configura fator relevante que impõe a manutenção do valor de reparação, em atenção às funções compensatória e pedagógica da reparação civil, nos termos dos arts. 186 e 927, CC.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>115&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877573" cdForo="0" >
+										0800214-84.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877573" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877573);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877573" style="display: none;" >
+	<div id="textAreaDados_1877573" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; RESPONSABILIDADE CIVIL DO ESTADO &ndash; SISTEMA PRISIONAL &ndash; ALEGA&Ccedil;&Atilde;O DE SUPERLOTA&Ccedil;&Atilde;O E INSALUBRIDADE &ndash; TEMA 365 DO STF &ndash; DANO MORAL N&Atilde;O PRESUMIDO &ndash; NECESSIDADE DE COMPROVA&Ccedil;&Atilde;O DE PREJU&Iacute;ZO CONCRETO E INDIVIDUALIZADO &ndash; N&Atilde;O DEMONSTRADO &ndash; PROVAS DOS AUTOS QUE INDICAM EXIST&Ecirc;NCIA DE ASSIST&Ecirc;NCIA MATERIAL E &Agrave; SA&Uacute;DE &ndash; ALEGA&Ccedil;&Otilde;ES GEN&Eacute;RICAS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+A responsabilidade civil do Estado por condi&ccedil;&otilde;es de encarceramento exige a demonstra&ccedil;&atilde;o de dano efetivo e individualizado, n&atilde;o se configurando de forma autom&aacute;tica a partir de defici&ecirc;ncias estruturais do sistema prisional.
+ Nos termos do Tema 365, do STF, a superlota&ccedil;&atilde;o ou precariedade gen&eacute;rica n&atilde;o enseja indeniza&ccedil;&atilde;o por dano moral quando ausente prova concreta de viola&ccedil;&atilde;o &agrave; dignidade do custodiado.
+No caso, o conjunto probat&oacute;rio indica a exist&ecirc;ncia de assist&ecirc;ncia &agrave; sa&uacute;de e atendimento b&aacute;sico ao interno, inexistindo demonstra&ccedil;&atilde;o de situa&ccedil;&atilde;o excepcional apta a caracterizar o dever de indenizar. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800214-84.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – RESPONSABILIDADE CIVIL DO ESTADO – SISTEMA PRISIONAL – ALEGAÇÃO DE SUPERLOTAÇÃO E INSALUBRIDADE – TEMA 365 DO STF – <em>DANO</em> <em>MORAL</em> NÃO PRESUMIDO – NECESSIDADE DE COMPROVAÇÃO DE PREJUÍZO CONCRETO E INDIVIDUALIZADO – NÃO DEMONSTRADO – PROVAS DOS AUTOS QUE INDICAM EXISTÊNCIA DE ASSISTÊNCIA MATERIAL E À SAÚDE – ALEGAÇÕES GENÉRICAS
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS – RESPONSABILIDADE CIVIL DO ESTADO – SISTEMA PRISIONAL – ALEGAÇÃO DE SUPERLOTAÇÃO E INSALUBRIDADE – TEMA 365 DO STF – <em>DANO</em> <em>MORAL</em> NÃO PRESUMIDO – NECESSIDADE DE COMPROVAÇÃO DE PREJUÍZO CONCRETO E INDIVIDUALIZADO – NÃO DEMONSTRADO – PROVAS DOS AUTOS QUE INDICAM EXISTÊNCIA DE ASSISTÊNCIA MATERIAL E À SAÚDE – ALEGAÇÕES GENÉRICAS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+A responsabilidade civil do Estado por condições de encarceramento exige a demonstração de <em>dano</em> efetivo e individualizado, não se configurando de forma automática a partir de deficiências estruturais do sistema prisional.
+ Nos termos do Tema 365, do STF, a superlotação ou precariedade genérica não enseja indenização por <em>dano</em> <em>moral</em> quando ausente prova concreta de violação à dignidade do custodiado.
+No caso, o conjunto probatório indica a existência de assistência à saúde e atendimento básico ao interno, inexistindo demonstração de situação excepcional apta a caracterizar o dever de indenizar.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>116&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877574" cdForo="0" >
+										0818117-22.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877574" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877574);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877574" style="display: none;" >
+	<div id="textAreaDados_1877574" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER CUMULADA COM INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash;  PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA &ndash; M&Eacute;RITO &ndash; REPORTAGEM JORNAL&Iacute;STICA &ndash; ALEGA&Ccedil;&Atilde;O DE USO INDEVIDO DE IMAGEM &ndash;  LIBERDADE DE IMPRENSA &ndash; MAT&Eacute;RIA INFORMATIVA &ndash;  AUS&Ecirc;NCIA DE ABUSO &ndash; INEXIST&Ecirc;NCIA DE ATO IL&Iacute;CITO &ndash; DANO MORAL N&Atilde;O CONFIGURADO &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO DESPROVIDO.
+N&atilde;o configura cerceamento de defesa o julgamento antecipado da lide quando a controv&eacute;rsia &eacute; eminentemente de direito e os elementos constantes dos autos s&atilde;o suficientes para a forma&ccedil;&atilde;o do convencimento do julgador.
+A liberdade de imprensa e de informa&ccedil;&atilde;o, assegurada constitucionalmente (art. 5.&ordm;, IX e X, e  220, da CF), somente admite responsabiliza&ccedil;&atilde;o a posteriori quando evidenciado abuso, nos termos da ADPF 130 e do Tema 995, do STF. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0818117-22.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marcelo C&acirc;mara Rasslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(7 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marcelo Câmara Rasslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZAÇÃO POR DANOS MORAIS –  PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA – MÉRITO – REPORTAGEM JORNALÍSTICA – ALEGAÇÃO DE USO INDEVIDO DE IMAGEM –  LIBERDADE DE IMPRENSA – MATÉRIA INFORMATIVA –  AUSÊNCIA DE ABUSO – INEXISTÊNCIA DE ATO ILÍCITO – <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO – SENTENÇA MANTIDA – RECURSO DESPROVIDO.
+Não
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER CUMULADA COM INDENIZAÇÃO POR DANOS MORAIS –  PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA – MÉRITO – REPORTAGEM JORNALÍSTICA – ALEGAÇÃO DE USO INDEVIDO DE IMAGEM –  LIBERDADE DE IMPRENSA – MATÉRIA INFORMATIVA –  AUSÊNCIA DE ABUSO – INEXISTÊNCIA DE ATO ILÍCITO – <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO – SENTENÇA MANTIDA – RECURSO DESPROVIDO.
+Não configura cerceamento de defesa o julgamento antecipado da lide quando a controvérsia é eminentemente de direito e os elementos constantes dos autos são suficientes para a formação do convencimento do julgador.
+A liberdade de imprensa e de informação, assegurada constitucionalmente (art. 5.º, IX e X, e  220, da CF), somente admite responsabilização a posteriori quando evidenciado abuso, nos termos da ADPF 130 e do Tema 995, do STF.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>117&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877580" cdForo="0" >
+										0828510-74.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877580" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877580);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877580" style="display: none;" >
+	<div id="textAreaDados_1877580" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL INTERPOSTA PELA REQUERIDA &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA C/C INDENIZAT&Oacute;RIA &ndash; RECUPERA&Ccedil;&Atilde;O DE ENERGIA EL&Eacute;TRICA &ndash; DEFEITO NO MEDIDOR &ndash; OBSERV&Acirc;NCIA DA RESOLU&Ccedil;&Atilde;O ANEEL N&ordm; 1.000/2021 &ndash; COBRAN&Ccedil;A PRET&Eacute;RITA AFASTADA &ndash; CONSUMO POSTERIOR &Agrave; REGULARIZA&Ccedil;&Atilde;O ID&Ecirc;NTICO AO PER&Iacute;ODO DE RECUPERA&Ccedil;&Atilde;O &ndash; AUMENTO REAL N&Atilde;O VERIFICADO &ndash; SUSPENS&Atilde;O DO FORNECIMENTO INDEVIDA &ndash; DANOS MORAIS CONFIGURADOS &ndash; SELIC &ndash; RECURSO PARCIALMENTE CONHECIDO E, NESTA EXTENS&Atilde;O, DESPROVIDO.
+Cinge-se a controv&eacute;rsia recursal em definir se foi observada a legisla&ccedil;&atilde;o de reg&ecirc;ncia no procedimento administrativo adotado pela Requerida, destinado &agrave; apura&ccedil;&atilde;o de suposta irregularidade no rel&oacute;gio medidor de energia, assim como se s&atilde;o devidos danos morais pela suspens&atilde;o do servi&ccedil;o na unidade consumidora da Requerente.
+Em se tratando de rela&ccedil;&atilde;o de consumo, compete &agrave; prestadora de servi&ccedil;os demonstrar a regularidade da cobran&ccedil;a, o que ocorreu no caso concreto, haja vista o cumprimento do procedimento estabelecido na Resolu&ccedil;&atilde;o ANEEL n&ordm; 1000/2021, notadamente as notifica&ccedil;&otilde;es pr&eacute;vias para envio do TOI e realiza&ccedil;&atilde;o da per&iacute;cia.
+N&atilde;o obstante, ap&oacute;s a regulariza&ccedil;&atilde;o do rel&oacute;gio medidor, n&atilde;o se observou aumento do consumo de energia no im&oacute;vel, revelando-se manifestamente desproporcional a cobran&ccedil;a extrajudicial, em valores excessivos para o caso. Utilizou-se inclusive de par&acirc;metros que n&atilde;o est&atilde;o mais vigentes.
+Uma vez declarada a nulidade da cobran&ccedil;a, deve-se reconhecer o direito aos danos morais, haja vista a suspens&atilde;o indevida no fornecimento de energia el&eacute;trica &agrave; parte autora.
+N&atilde;o se conhece do recurso no ponto em que pleiteia a aplica&ccedil;&atilde;o da Selic, pois tal &iacute;ndice foi determinado em senten&ccedil;a.
+Recurso parcialmente conhecido e, nesta extens&atilde;o, desprovido.
+EMENTA &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL INTERPOSTA PELA REQUERENTE DE FORMA ADESIVA &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZAT&Oacute;RIA &ndash; MAJORA&Ccedil;&Atilde;O DOS DANOS MORAIS &ndash; TERMO INICIAL DOS JUROS MORAT&Oacute;RIOS &ndash; RESPONSABILIDADE CONTRATUAL &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Em rela&ccedil;&atilde;o ao valor da indeniza&ccedil;&atilde;o por danos morais, destaca-se que n&atilde;o existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercuss&atilde;o dos fatos, estabelecer a indeniza&ccedil;&atilde;o que venha ressarcir a parte lesada (car&aacute;ter indenizat&oacute;rio) e que tamb&eacute;m iniba a reitera&ccedil;&atilde;o de condutas an&aacute;logas (aspecto pedag&oacute;gico).
+No caso, devem ser majorados os danos morais para R$ 7.000,00 (sete mil reais), montante compat&iacute;vel com as circunst&acirc;ncias do caso concreto.
+Em se tratando de responsabilidade contratual, n&atilde;o se aplica a S&uacute;mula 54 do STJ, destinada &agrave; responsabilidade extracontratual.
+Recurso conhecido e parcialmente provido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0828510-74.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Eliane de Freitas Lima Vicente, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(20 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Eliane de Freitas Lima Vicente
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL INTERPOSTA PELA REQUERIDA – AÇÃO DECLARATÓRIA C/C INDENIZATÓRIA – RECUPERAÇÃO DE ENERGIA ELÉTRICA – DEFEITO NO MEDIDOR – OBSERVÂNCIA DA RESOLUÇÃO ANEEL Nº 1.000/2021 – COBRANÇA PRETÉRITA AFASTADA – CONSUMO POSTERIOR À REGULARIZAÇÃO IDÊNTICO AO PERÍODO DE RECUPERAÇÃO – AUMENTO REAL NÃO VERIFICADO – SUSPENSÃO DO FORNECIMENTO INDEVIDA – DANOS MORAIS CONFIGURADOS – SELIC – RECURSO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL INTERPOSTA PELA REQUERIDA – AÇÃO DECLARATÓRIA C/C INDENIZATÓRIA – RECUPERAÇÃO DE ENERGIA ELÉTRICA – DEFEITO NO MEDIDOR – OBSERVÂNCIA DA RESOLUÇÃO ANEEL Nº 1.000/2021 – COBRANÇA PRETÉRITA AFASTADA – CONSUMO POSTERIOR À REGULARIZAÇÃO IDÊNTICO AO PERÍODO DE RECUPERAÇÃO – AUMENTO REAL NÃO VERIFICADO – SUSPENSÃO DO FORNECIMENTO INDEVIDA – DANOS MORAIS CONFIGURADOS – SELIC – RECURSO PARCIALMENTE CONHECIDO E, NESTA EXTENSÃO, DESPROVIDO.
+Cinge-se a controvérsia recursal em definir se foi observada a legislação de regência no procedimento administrativo adotado pela Requerida, destinado à apuração de suposta irregularidade no relógio medidor de energia, assim como se são devidos danos morais pela suspensão do serviço na unidade consumidora da Requerente.
+Em se tratando de relação de consumo, compete à prestadora de serviços demonstrar a regularidade da cobrança, o que ocorreu no caso concreto, haja vista o cumprimento do procedimento estabelecido na Resolução ANEEL nº 1000/2021, notadamente as notificações prévias para envio do TOI e realização da perícia.
+Não obstante, após a regularização do relógio medidor, não se observou aumento do consumo de energia no imóvel, revelando-se manifestamente desproporcional a cobrança extrajudicial, em valores excessivos para o caso. Utilizou-se inclusive de parâmetros que não estão mais vigentes.
+Uma vez declarada a nulidade da cobrança, deve-se reconhecer o direito aos danos morais, haja vista a suspensão indevida no fornecimento de energia elétrica à parte autora.
+Não se conhece do recurso no ponto em que pleiteia a aplicação da Selic, pois tal índice foi determinado em sentença.
+Recurso parcialmente conhecido e, nesta extensão, desprovido.
+EMENTA – APELAÇÃO CÍVEL INTERPOSTA PELA REQUERENTE DE FORMA ADESIVA – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZATÓRIA – MAJORAÇÃO DOS DANOS MORAIS – TERMO INICIAL DOS JUROS MORATÓRIOS – RESPONSABILIDADE CONTRATUAL – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Em relação ao valor da indenização por danos morais, destaca-se que não existe um sistema escalonado e com patamares fixos para estabelecer o respectivo quantum, devendo o juiz, diante do caso concreto e observada a repercussão dos fatos, estabelecer a indenização que venha ressarcir a parte lesada (caráter indenizatório) e que também iniba a reiteração de condutas análogas (aspecto pedagógico).
+No caso, devem ser majorados os danos morais para R$ 7.000,00 (sete mil reais), montante compatível com as circunstâncias do caso concreto.
+Em se tratando de responsabilidade contratual, não se aplica a Súmula 54 do STJ, destinada à responsabilidade extracontratual.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>118&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877582" cdForo="0" >
+										0848946-20.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877582" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877582);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877582" style="display: none;" >
+	<div id="textAreaDados_1877582" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; EXTRAVIO DEFINITIVO DE CARGA/BAGAGEM &ndash; TRANSPORTE A&Eacute;REO &ndash; FORTUITO INTERNO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DE SERVI&Ccedil;O &ndash; DANOS MATERIAIS E MORAIS CONFIGURADOS &ndash; VALOR DA INDENIZA&Ccedil;&Atilde;O MANTIDO &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+O fornecedor de servi&ccedil;os responde, independentemente da exist&ecirc;ncia de culpa, pela repara&ccedil;&atilde;o dos danos causados aos consumidores por defeitos relativos &agrave; presta&ccedil;&atilde;o dos servi&ccedil;os (art. 14 do CDC).
+O extravio da bagagem/carga n&atilde;o constitui fato imprevis&iacute;vel, mas fortuito interno, de modo que n&atilde;o exclui a responsabilidade da companhia a&eacute;rea pela falha na presta&ccedil;&atilde;o do servi&ccedil;o contratado pelo consumidor.
+Tratando-se de fato incontroverso o extravio da bagagem/carga, est&aacute; demonstrado que houve falha na presta&ccedil;&atilde;o do servi&ccedil;o, bem como que restou configurado o dano moral, n&atilde;o havendo falar em mero aborrecimento.
+Em caso de extravio definitivo da carga/bagagem, revela-se desarrazoada a exig&ecirc;ncia de comprova&ccedil;&atilde;o espec&iacute;fica de todos os bens existentes no interior da bagagem em raz&atilde;o da dificuldade para o consumidor de produzir tal prova, devendo tal pedido recair sobre os bens supostamente perdidos, seus respectivos valores e a compatibilidade com a situa&ccedil;&atilde;o.
+Considerando a extens&atilde;o do dano e o abalo ps&iacute;quico e emocional causados &agrave; Apelada, os danos morais arbitrados em R$5.000,00 atende ao cen&aacute;rio dos autos e aos crit&eacute;rios de razoabilidade e proporcionalidade, bem como o car&aacute;ter preventivo e pedag&oacute;gico da medida.
+Recurso conhecido e n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0848946-20.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(76 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – EXTRAVIO DEFINITIVO DE CARGA/BAGAGEM – TRANSPORTE AÉREO – FORTUITO INTERNO – FALHA NA PRESTAÇÃO DE SERVIÇO – DANOS MATERIAIS E MORAIS CONFIGURADOS – VALOR DA INDENIZAÇÃO MANTIDO – RECURSO CONHECIDO E NÃO PROVIDO.
+O fornecedor de serviços responde, independentemente da existência de culpa, pela reparação dos danos causados aos
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – EXTRAVIO DEFINITIVO DE CARGA/BAGAGEM – TRANSPORTE AÉREO – FORTUITO INTERNO – FALHA NA PRESTAÇÃO DE SERVIÇO – DANOS MATERIAIS E MORAIS CONFIGURADOS – VALOR DA INDENIZAÇÃO MANTIDO – RECURSO CONHECIDO E NÃO PROVIDO.
+O fornecedor de serviços responde, independentemente da existência de culpa, pela reparação dos danos causados aos consumidores por defeitos relativos à prestação dos serviços (art. 14 do CDC).
+O extravio da bagagem/carga não constitui fato imprevisível, mas fortuito interno, de modo que não exclui a responsabilidade da companhia aérea pela falha na prestação do serviço contratado pelo consumidor.
+Tratando-se de fato incontroverso o extravio da bagagem/carga, está demonstrado que houve falha na prestação do serviço, bem como que restou configurado o <em>dano</em> <em>moral</em>, não havendo falar em mero aborrecimento.
+Em caso de extravio definitivo da carga/bagagem, revela-se desarrazoada a exigência de comprovação específica de todos os bens existentes no interior da bagagem em razão da dificuldade para o consumidor de produzir tal prova, devendo tal pedido recair sobre os bens supostamente perdidos, seus respectivos valores e a compatibilidade com a situação.
+Considerando a extensão do <em>dano</em> e o abalo psíquico e emocional causados à Apelada, os danos morais arbitrados em R$5.000,00 atende ao cenário dos autos e aos critérios de razoabilidade e proporcionalidade, bem como o caráter preventivo e pedagógico da medida.
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>119&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877583" cdForo="0" >
+										0835556-46.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877583" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877583);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877583" style="display: none;" >
+	<div id="textAreaDados_1877583" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O MONIT&Oacute;RIA &ndash; NULIDADE DA CITA&Ccedil;&Atilde;O N&Atilde;O CONFIGURADA &ndash; AR RECEBIDA NO ENDERE&Ccedil;O DA R&Eacute; (PESSOA JUR&Iacute;DICA) - TEORIA DA APAR&Ecirc;NCIA &ndash; REVELIA - MAT&Eacute;RIA F&Aacute;TICA VENTILADA NAS RAZ&Otilde;ES RECURSAIS &ndash; IMPOSSIBILIDADE &ndash; RECURSO CONHECIDO E DESPROVIDO.
+&Eacute; v&aacute;lida a carta de cita&ccedil;&atilde;o recebida no endere&ccedil;o da r&eacute; (pessoa jur&iacute;dica), ainda que n&atilde;o recebida por seu representante legal, &agrave; luz da teoria da apar&ecirc;ncia.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0835556-46.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Geraldo de Almeida Santiago, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Duplicata
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Geraldo de Almeida Santiago
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1877583" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												AÇÃO MONITÓRIA – NULIDADE DA CITAÇÃO NÃO CONFIGURADA – AR RECEBIDA NO ENDEREÇO DA RÉ (PESSOA JURÍDICA) - TEORIA DA APARÊNCIA – REVELIA - MATÉRIA FÁTICA VENTILADA NAS RAZÕES RECURSAIS – IMPOSSIBILIDADE – RECURSO CONHECIDO E DESPROVIDO.
+É válida a carta de citação recebida no endereço da ré (pessoa jurídica), ainda que não recebida por seu representante legal, à luz da teoria da aparência.
+
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>120&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877587" cdForo="0" >
+										0804770-32.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877587" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877587);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877587" style="display: none;" >
+	<div id="textAreaDados_1877587" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. TRANSPORTE A&Eacute;REO. ATRASO DE VOO. DANOS MORAIS. QUANTUM INDENIZAT&Oacute;RIO. MANUTEN&Ccedil;&Atilde;O. EMBARGOS DE DECLARA&Ccedil;&Atilde;O. MULTA POR CAR&Aacute;TER PROTELAT&Oacute;RIO. AFASTAMENTO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta contra senten&ccedil;a que, em a&ccedil;&atilde;o de repara&ccedil;&atilde;o de danos morais ajuizada em face de companhia a&eacute;rea, julgou parcialmente procedentes os pedidos para condenar a r&eacute; ao pagamento de R$ 3.000,00 a cada autor em raz&atilde;o de atraso de voo, bem como rejeitou embargos de declara&ccedil;&atilde;o com aplica&ccedil;&atilde;o de multa de 2% sobre o valor da causa, sob fundamento de car&aacute;ter protelat&oacute;rio.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se o quantum indenizat&oacute;rio fixado a t&iacute;tulo de danos morais comporta majora&ccedil;&atilde;o; (ii) estabelecer se &eacute; devida a multa aplicada em embargos de declara&ccedil;&atilde;o por suposto car&aacute;ter protelat&oacute;rio.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Afasta-se a suspens&atilde;o do processo com base no Tema 1.417 do STF, pois a companhia a&eacute;rea n&atilde;o comprova que o cancelamento decorreu de manuten&ccedil;&atilde;o n&atilde;o programada, deixando de se desincumbir do &ocirc;nus probat&oacute;rio previsto no art. 373, II, do CPC.
+4. Rejeita-se a preliminar de ofensa ao princ&iacute;pio da dialeticidade, uma vez que a parte apelante impugna especificamente os fundamentos da senten&ccedil;a e busca a majora&ccedil;&atilde;o do valor indenizat&oacute;rio.
+5. Mant&eacute;m-se o quantum indenizat&oacute;rio quando fixado em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano, a capacidade econ&ocirc;mica das partes e o car&aacute;ter pedag&oacute;gico da condena&ccedil;&atilde;o.
+6. Considera-se adequado o valor de R$ 3.000,00 por autor, diante de atraso de voo que ocasiona transtornos, mas sem demonstra&ccedil;&atilde;o de preju&iacute;zos extraordin&aacute;rios, evitando enriquecimento sem causa.
+7. Reconhece-se que a exist&ecirc;ncia de precedentes com valores superiores n&atilde;o vincula o julgador, que deve fixar a indeniza&ccedil;&atilde;o conforme as peculiaridades do caso concreto.
+8. Afasta-se a multa prevista no art. 1.026, &sect; 2&ordm;, do CPC quando os embargos de declara&ccedil;&atilde;o s&atilde;o opostos para suprir omiss&atilde;o, sem evid&ecirc;ncia de intuito manifestamente protelat&oacute;rio.
+9. Assegura-se o direito de recorrer como express&atilde;o da boa-f&eacute; processual, n&atilde;o sendo cab&iacute;vel penaliza&ccedil;&atilde;o quando ausente abuso.
+IV. DISPOSITIVO E TESE
+10. Recurso parcialmente provido.
+Tese de julgamento:
+1. A fixa&ccedil;&atilde;o do dano moral por atraso de voo deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, sendo mantido o valor quando adequado &agrave;s circunst&acirc;ncias do caso concreto.
+2. A diverg&ecirc;ncia em rela&ccedil;&atilde;o a precedentes com valores distintos n&atilde;o imp&otilde;e, por si s&oacute;, a majora&ccedil;&atilde;o da indeniza&ccedil;&atilde;o.
+3. A multa por embargos de declara&ccedil;&atilde;o somente &eacute; cab&iacute;vel quando evidenciado car&aacute;ter manifestamente protelat&oacute;rio, n&atilde;o se aplicando quando o recurso visa suprir omiss&atilde;o.
+Dispositivos relevantes citados: CPC, art. 373, II; CPC, art. 1.026, &sect; 2&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgRg no REsp 1182912/RS, Rel. Min. Napole&atilde;o Nunes Maia Filho, 1&ordf; Turma, j. 19.04.2016, DJe 29.04.2016; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0815829-38.2024.8.12.0001, Rel. Des&ordf; Elisabeth Rosa Baisch, j. 14.11.2025. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0804770-32.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Wagner Mansur Saad, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(14 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Wagner Mansur Saad
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. TRANSPORTE AÉREO. ATRASO DE VOO. DANOS MORAIS. QUANTUM INDENIZATÓRIO. MANUTENÇÃO. EMBARGOS DE DECLARAÇÃO. MULTA POR CARÁTER PROTELATÓRIO. AFASTAMENTO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta contra sentença que, em ação de reparação de danos morais ajuizada em face de companhia aérea, julgou parcialmente
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. TRANSPORTE AÉREO. ATRASO DE VOO. DANOS MORAIS. QUANTUM INDENIZATÓRIO. MANUTENÇÃO. EMBARGOS DE DECLARAÇÃO. MULTA POR CARÁTER PROTELATÓRIO. AFASTAMENTO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta contra sentença que, em ação de reparação de danos morais ajuizada em face de companhia aérea, julgou parcialmente procedentes os pedidos para condenar a ré ao pagamento de R$ 3.000,00 a cada autor em razão de atraso de voo, bem como rejeitou embargos de declaração com aplicação de multa de 2% sobre o valor da causa, sob fundamento de caráter protelatório.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se o quantum indenizatório fixado a título de danos morais comporta majoração; (ii) estabelecer se é devida a multa aplicada em embargos de declaração por suposto caráter protelatório.
+III. RAZÕES DE DECIDIR
+3. Afasta-se a suspensão do processo com base no Tema 1.417 do STF, pois a companhia aérea não comprova que o cancelamento decorreu de manutenção não programada, deixando de se desincumbir do ônus probatório previsto no art. 373, II, do CPC.
+4. Rejeita-se a preliminar de ofensa ao princípio da dialeticidade, uma vez que a parte apelante impugna especificamente os fundamentos da sentença e busca a majoração do valor indenizatório.
+5. Mantém-se o quantum indenizatório quando fixado em observância aos princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em>, a capacidade econômica das partes e o caráter pedagógico da condenação.
+6. Considera-se adequado o valor de R$ 3.000,00 por autor, diante de atraso de voo que ocasiona transtornos, mas sem demonstração de prejuízos extraordinários, evitando enriquecimento sem causa.
+7. Reconhece-se que a existência de precedentes com valores superiores não vincula o julgador, que deve fixar a indenização conforme as peculiaridades do caso concreto.
+8. Afasta-se a multa prevista no art. 1.026, § 2º, do CPC quando os embargos de declaração são opostos para suprir omissão, sem evidência de intuito manifestamente protelatório.
+9. Assegura-se o direito de recorrer como expressão da boa-fé processual, não sendo cabível penalização quando ausente abuso.
+IV. DISPOSITIVO E TESE
+10. Recurso parcialmente provido.
+Tese de julgamento:
+1. A fixação do <em>dano</em> <em>moral</em> por atraso de voo deve observar os princípios da razoabilidade e proporcionalidade, sendo mantido o valor quando adequado às circunstâncias do caso concreto.
+2. A divergência em relação a precedentes com valores distintos não impõe, por si só, a majoração da indenização.
+3. A multa por embargos de declaração somente é cabível quando evidenciado caráter manifestamente protelatório, não se aplicando quando o recurso visa suprir omissão.
+Dispositivos relevantes citados: CPC, art. 373, II; CPC, art. 1.026, § 2º.
+Jurisprudência relevante citada: STJ, AgRg no REsp 1182912/RS, Rel. Min. Napoleão Nunes Maia Filho, 1ª Turma, j. 19.04.2016, DJe 29.04.2016; TJMS, Apelação Cível nº 0815829-38.2024.8.12.0001, Rel. Desª Elisabeth Rosa Baisch, j. 14.11.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>121&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877602" cdForo="0" >
+										0801899-92.2025.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877602" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877602);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877602" style="display: none;" >
+	<div id="textAreaDados_1877602" class="mensagemSemFormatacao" >
+		DIREITO CIVIL, DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO C/C DECLARAT&Oacute;RIA DE NULIDADE PARCIAL E COMPENSA&Ccedil;&Atilde;O DE VALORES. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC). ALEGA&Ccedil;&Atilde;O DE V&Iacute;CIO DE CONSENTIMENTO. REGULARIDADE DA CONTRATA&Ccedil;&Atilde;O COMPROVADA. AUS&Ecirc;NCIA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. SENTEN&Ccedil;A FUNDAMENTADA. IMPROCED&Ecirc;NCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que, nos autos de a&ccedil;&atilde;o revisional de contrato c/c declarat&oacute;ria de nulidade parcial e compensa&ccedil;&atilde;o de valores ajuizada em face de institui&ccedil;&atilde;o financeira, julgou improcedentes os pedidos de declara&ccedil;&atilde;o de inexist&ecirc;ncia de contrato de cart&atilde;o de cr&eacute;dito consignado (RMC), restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais, sob o fundamento de regularidade da contrata&ccedil;&atilde;o.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se a senten&ccedil;a padece de nulidade por aus&ecirc;ncia de fundamenta&ccedil;&atilde;o, nos termos do art. 489, &sect;1&ordm;, do CPC; (ii) estabelecer se houve v&iacute;cio de consentimento na contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado, apto a ensejar sua anula&ccedil;&atilde;o, convers&atilde;o em empr&eacute;stimo consignado e condena&ccedil;&atilde;o &agrave; restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A senten&ccedil;a apresenta fundamenta&ccedil;&atilde;o suficiente, pois exp&otilde;e as raz&otilde;es de fato e de direito que embasam a conclus&atilde;o, sendo desnecess&aacute;ria a an&aacute;lise de todos os argumentos quando j&aacute; resolvida a controv&eacute;rsia, conforme entendimento do STF em repercuss&atilde;o geral.
+4. Aplica-se o C&oacute;digo de Defesa do Consumidor &agrave;s institui&ccedil;&otilde;es financeiras, impondo-se ao fornecedor o &ocirc;nus de comprovar a regularidade da contrata&ccedil;&atilde;o quando impugnada pelo consumidor.
+5. O banco comprova a contrata&ccedil;&atilde;o mediante apresenta&ccedil;&atilde;o de termo de ades&atilde;o, termo de consentimento esclarecido, c&eacute;dula de cr&eacute;dito banc&aacute;rio, dossi&ecirc; de contrata&ccedil;&atilde;o e valida&ccedil;&atilde;o por biometria facial, al&eacute;m de demonstrar a disponibiliza&ccedil;&atilde;o dos valores ao consumidor.
+6. A alega&ccedil;&atilde;o de erro substancial n&atilde;o se sustenta, pois ausente prova de v&iacute;cio de consentimento escus&aacute;vel, especialmente diante de documento contratual claro quanto &agrave; natureza de cart&atilde;o de cr&eacute;dito consignado.
+7. A modalidade de cart&atilde;o de cr&eacute;dito consignado (RMC) &eacute; l&iacute;cita, sendo v&aacute;lidos os descontos autorizados em benef&iacute;cio previdenci&aacute;rio, conforme pactuado.
+8. A inexist&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o afasta a responsabilidade civil da institui&ccedil;&atilde;o financeira, inviabilizando a restitui&ccedil;&atilde;o de valores e a indeniza&ccedil;&atilde;o por danos morais.
+9. A mera alega&ccedil;&atilde;o de desconhecimento do contrato, desacompanhada de prova, n&atilde;o autoriza a revis&atilde;o ou convers&atilde;o da aven&ccedil;a regularmente firmada.
+IV. DISPOSITIVO E TESE
+10. Recurso desprovido.
+Tese de julgamento:
+1. N&atilde;o h&aacute; nulidade da senten&ccedil;a quando a decis&atilde;o apresenta fundamenta&ccedil;&atilde;o suficiente para a solu&ccedil;&atilde;o da controv&eacute;rsia, ainda que n&atilde;o enfrente todos os argumentos das partes.
+2. A contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado (RMC) &eacute; v&aacute;lida quando comprovada por documenta&ccedil;&atilde;o id&ocirc;nea e pela disponibiliza&ccedil;&atilde;o dos valores ao consumidor.
+3. A alega&ccedil;&atilde;o de v&iacute;cio de consentimento exige prova de erro substancial escus&aacute;vel, n&atilde;o se configurando pela mera alega&ccedil;&atilde;o de desconhecimento da natureza do contrato.
+4. Ausente falha na presta&ccedil;&atilde;o do servi&ccedil;o, n&atilde;o h&aacute; dever de restitui&ccedil;&atilde;o de valores nem de indeniza&ccedil;&atilde;o por danos morais.
+Dispositivos relevantes citados: CF/1988, art. 93, IX; CPC, arts. 489, &sect;1&ordm;, 373, II, 98, &sect;3&ordm;, 1.021, &sect;4&ordm;, e 1.026, &sect;2&ordm;; CDC, art. 6&ordm;, VIII; CC, art. 138.
+Jurisprud&ecirc;ncia relevante citada: STF, AI 791292 QO-RG, Rel. Min. Gilmar Mendes, j. 12/08/2010; STJ, S&uacute;mula 297; STJ, EDcl no RMS 22067/DF; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0807999-39.2021.8.12.0029, Rel. Des&ordf; Elisabeth Rosa Baisch, j. 11/09/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802552-14.2024.8.12.0046, Rel. Des. Vilson Bertelli, j. 29/08/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0800614-23.2024.8.12.0033, Rel. Ju&iacute;za Denize de Barros Dodero, j. 31/10/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0849709-21.2024.8.12.0001, Rel. Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j. 23/10/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0830783-26.2023.8.12.0001, Rel. Des. Marcelo C&acirc;mara Rasslan, j. 23/10/2025; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0855847-04.2024.8.12.0001, Rel. Juiz Vitor Luis de Oliveira Guibo, j. 16/10/2025.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801899-92.2025.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Wagner Mansur Saad, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Wagner Mansur Saad
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL, DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO REVISIONAL DE CONTRATO C/C DECLARATÓRIA DE NULIDADE PARCIAL E COMPENSAÇÃO DE VALORES. CARTÃO DE CRÉDITO CONSIGNADO (RMC). ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO. REGULARIDADE DA CONTRATAÇÃO COMPROVADA. AUSÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO. SENTENÇA FUNDAMENTADA. IMPROCEDÊNCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL, DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO REVISIONAL DE CONTRATO C/C DECLARATÓRIA DE NULIDADE PARCIAL E COMPENSAÇÃO DE VALORES. CARTÃO DE CRÉDITO CONSIGNADO (RMC). ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO. REGULARIDADE DA CONTRATAÇÃO COMPROVADA. AUSÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO. SENTENÇA FUNDAMENTADA. IMPROCEDÊNCIA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que, nos autos de ação revisional de contrato c/c declaratória de nulidade parcial e compensação de valores ajuizada em face de instituição financeira, julgou improcedentes os pedidos de declaração de inexistência de contrato de cartão de crédito consignado (RMC), restituição de valores e indenização por danos morais, sob o fundamento de regularidade da contratação.
+II. QUESTÃO EM DISCUSSÃO
+2. Há duas questões em discussão: (i) definir se a sentença padece de nulidade por ausência de fundamentação, nos termos do art. 489, §1º, do CPC; (ii) estabelecer se houve vício de consentimento na contratação de cartão de crédito consignado, apto a ensejar sua anulação, conversão em empréstimo consignado e condenação à restituição de valores e indenização por danos morais.
+III. RAZÕES DE DECIDIR
+3. A sentença apresenta fundamentação suficiente, pois expõe as razões de fato e de direito que embasam a conclusão, sendo desnecessária a análise de todos os argumentos quando já resolvida a controvérsia, conforme entendimento do STF em repercussão geral.
+4. Aplica-se o Código de Defesa do Consumidor às instituições financeiras, impondo-se ao fornecedor o ônus de comprovar a regularidade da contratação quando impugnada pelo consumidor.
+5. O banco comprova a contratação mediante apresentação de termo de adesão, termo de consentimento esclarecido, cédula de crédito bancário, dossiê de contratação e validação por biometria facial, além de demonstrar a disponibilização dos valores ao consumidor.
+6. A alegação de erro substancial não se sustenta, pois ausente prova de vício de consentimento escusável, especialmente diante de documento contratual claro quanto à natureza de cartão de crédito consignado.
+7. A modalidade de cartão de crédito consignado (RMC) é lícita, sendo válidos os descontos autorizados em benefício previdenciário, conforme pactuado.
+8. A inexistência de falha na prestação do serviço afasta a responsabilidade civil da instituição financeira, inviabilizando a restituição de valores e a indenização por danos morais.
+9. A mera alegação de desconhecimento do contrato, desacompanhada de prova, não autoriza a revisão ou conversão da avença regularmente firmada.
+IV. DISPOSITIVO E TESE
+10. Recurso desprovido.
+Tese de julgamento:
+1. Não há nulidade da sentença quando a decisão apresenta fundamentação suficiente para a solução da controvérsia, ainda que não enfrente todos os argumentos das partes.
+2. A contratação de cartão de crédito consignado (RMC) é válida quando comprovada por documentação idônea e pela disponibilização dos valores ao consumidor.
+3. A alegação de vício de consentimento exige prova de erro substancial escusável, não se configurando pela mera alegação de desconhecimento da natureza do contrato.
+4. Ausente falha na prestação do serviço, não há dever de restituição de valores nem de indenização por danos morais.
+Dispositivos relevantes citados: CF/1988, art. 93, IX; CPC, arts. 489, §1º, 373, II, 98, §3º, 1.021, §4º, e 1.026, §2º; CDC, art. 6º, VIII; CC, art. 138.
+Jurisprudência relevante citada: STF, AI 791292 QO-RG, Rel. Min. Gilmar Mendes, j. 12/08/2010; STJ, Súmula 297; STJ, EDcl no RMS 22067/DF; TJMS, Apelação Cível n. 0807999-39.2021.8.12.0029, Rel. Desª Elisabeth Rosa Baisch, j. 11/09/2025; TJMS, Apelação Cível n. 0802552-14.2024.8.12.0046, Rel. Des. Vilson Bertelli, j. 29/08/2025; TJMS, Apelação Cível n. 0800614-23.2024.8.12.0033, Rel. Juíza Denize de Barros Dodero, j. 31/10/2025; TJMS, Apelação Cível n. 0849709-21.2024.8.12.0001, Rel. Des. Luiz Antônio Cavassa de Almeida, j. 23/10/2025; TJMS, Apelação Cível n. 0830783-26.2023.8.12.0001, Rel. Des. Marcelo Câmara Rasslan, j. 23/10/2025; TJMS, Apelação Cível n. 0855847-04.2024.8.12.0001, Rel. Juiz Vitor Luis de Oliveira Guibo, j. 16/10/2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>122&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877603" cdForo="0" >
+										0802257-85.2024.8.12.0010
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877603" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877603);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877603" style="display: none;" >
+	<div id="textAreaDados_1877603" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL E RECURSO ADESIVO. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. CONTRATO DE SEGURO. DESCONTOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. SENTEN&Ccedil;A DE PROCED&Ecirc;NCIA. RECURSO DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA ALEGANDO REGULARIDADE DA CONTRATA&Ccedil;&Atilde;O. RECURSO DA AUTORA PLEITEANDO MAJORA&Ccedil;&Atilde;O DOS DANOS MORAIS. AMBOS OS RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1) Recursos de Apela&ccedil;&atilde;o e Adesivo contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria, reconheceu a nulidade de contrato de seguro n&atilde;o solicitado, com descontos em benef&iacute;cio previdenci&aacute;rio, e condenou a institui&ccedil;&atilde;o financeira &agrave; restitui&ccedil;&atilde;o em dobro e ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 5.000,00.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) No recurso principal, discute-se a responsabilidade da institui&ccedil;&atilde;o financeira pela falha na presta&ccedil;&atilde;o do servi&ccedil;o, a validade da contrata&ccedil;&atilde;o via call center e a forma de restitui&ccedil;&atilde;o do ind&eacute;bito. No recurso adesivo, a controv&eacute;rsia cinge-se &agrave; adequa&ccedil;&atilde;o do quantum indenizat&oacute;rio, buscando-se sua majora&ccedil;&atilde;o.
+III. RAZ&Otilde;ES DE DECIDIR
+3) A responsabilidade das institui&ccedil;&otilde;es financeiras por danos decorrentes de falha na presta&ccedil;&atilde;o de servi&ccedil;os &eacute; objetiva, configurando fortuito interno a realiza&ccedil;&atilde;o de cobran&ccedil;as sem a devida comprova&ccedil;&atilde;o da contrata&ccedil;&atilde;o, nos termos do art. 14 do CDC e da S&uacute;mula 479 do STJ.
+4) Compete ao fornecedor o &ocirc;nus de provar a validade da contrata&ccedil;&atilde;o, n&atilde;o sendo suficiente a mera alega&ccedil;&atilde;o de celebra&ccedil;&atilde;o por telefone, desacompanhada de prova inequ&iacute;voca da manifesta&ccedil;&atilde;o de vontade do consumidor.
+5) A restitui&ccedil;&atilde;o em dobro do ind&eacute;bito (art. 42, par&aacute;grafo &uacute;nico, do CDC) &eacute; cab&iacute;vel quando a cobran&ccedil;a indevida configurar conduta contr&aacute;ria &agrave; boa-f&eacute; objetiva, prescindindo da demonstra&ccedil;&atilde;o de m&aacute;-f&eacute;, conforme tese firmada pelo STJ no EAREsp 676.608/RS.
+6) Os descontos indevidos em verba de natureza alimentar configuram dano moral in re ipsa.
+7) O valor da indeniza&ccedil;&atilde;o por danos morais, fixado em R$ 5.000,00, deve ser mantido por se mostrar razo&aacute;vel e proporcional &agrave;s circunst&acirc;ncias do caso, atendendo &agrave; dupla finalidade da repara&ccedil;&atilde;o (compensat&oacute;ria e pedag&oacute;gica) e alinhando-se aos par&acirc;metros adotados por este Tribunal, sem gerar enriquecimento il&iacute;cito.
+IV. DISPOSITIVO E TESE
+8) Recursos de Apela&ccedil;&atilde;o e Adesivo conhecidos e desprovidos. Senten&ccedil;a mantida.
+
+Tese de julgamento: 1)A falha na presta&ccedil;&atilde;o de servi&ccedil;o banc&aacute;rio, consistente na realiza&ccedil;&atilde;o de descontos em benef&iacute;cio previdenci&aacute;rio com base em contrato de seguro cuja validade n&atilde;o foi comprovada, acarreta a responsabilidade objetiva da institui&ccedil;&atilde;o financeira, por se tratar de fortuito interno (S&uacute;mula 479/STJ). 2) A cobran&ccedil;a de valores com base em contrato inexistente, por violar a boa-f&eacute; objetiva, enseja a restitui&ccedil;&atilde;o em dobro, nos termos do art. 42, par&aacute;grafo &uacute;nico, do CDC, e da tese firmada no EAREsp 676.608/RS. 3) Deve ser mantido o valor da indeniza&ccedil;&atilde;o por danos morais quando arbitrado em patamar que observa os princ&iacute;pios da razoabilidade e da proporcionalidade, bem como os precedentes da Corte para casos an&aacute;logos.
+Dispositivos relevantes citados: Lei n&ordm; 14.181/2021; C&oacute;digo de Defesa do Consumidor, art. 104-A; C&oacute;digo de Processo Civil, arts. 85, &sect; 11, 98, &sect; 3&ordm;, e 321.
+Jurisprud&ecirc;ncia relevante citada: TJ-MS, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0804284-31.2025.8.12.0002, Rel. Des. Jo&atilde;o Maria L&oacute;s, 1&ordf; C&acirc;mara C&iacute;vel, j. 29.01.2026; TJ-MS, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0803474-56.2025.8.12.0002, Rel. Des&ordf; Sandra Regina da Silva R. Artioli, 2&ordf; C&acirc;mara C&iacute;vel, j. 02.02.2026. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802257-85.2024.8.12.0010,&nbsp; F&aacute;tima do Sul,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Wagner Mansur Saad, j: 15/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Descontos dos benefícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Wagner Mansur Saad
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fátima do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL E RECURSO ADESIVO. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CONTRATO DE SEGURO. DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO. SENTENÇA DE PROCEDÊNCIA. RECURSO DA INSTITUIÇÃO FINANCEIRA ALEGANDO REGULARIDADE DA CONTRATAÇÃO. RECURSO DA AUTORA PLEITEANDO MAJORAÇÃO DOS DANOS MORAIS. AMBOS OS RECURSOS DESPROVIDOS.
+I. CASO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL E RECURSO ADESIVO. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CONTRATO DE SEGURO. DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO. SENTENÇA DE PROCEDÊNCIA. RECURSO DA INSTITUIÇÃO FINANCEIRA ALEGANDO REGULARIDADE DA CONTRATAÇÃO. RECURSO DA AUTORA PLEITEANDO MAJORAÇÃO DOS DANOS MORAIS. AMBOS OS RECURSOS DESPROVIDOS.
+I. CASO EM EXAME
+1) Recursos de Apelação e Adesivo contra sentença que, em ação declaratória, reconheceu a nulidade de contrato de seguro não solicitado, com descontos em benefício previdenciário, e condenou a instituição financeira à restituição em dobro e ao pagamento de indenização por danos morais no valor de R$ 5.000,00.
+II. QUESTÃO EM DISCUSSÃO
+2) No recurso principal, discute-se a responsabilidade da instituição financeira pela falha na prestação do serviço, a validade da contratação via call center e a forma de restituição do indébito. No recurso adesivo, a controvérsia cinge-se à adequação do quantum indenizatório, buscando-se sua majoração.
+III. RAZÕES DE DECIDIR
+3) A responsabilidade das instituições financeiras por danos decorrentes de falha na prestação de serviços é objetiva, configurando fortuito interno a realização de cobranças sem a devida comprovação da contratação, nos termos do art. 14 do CDC e da Súmula 479 do STJ.
+4) Compete ao fornecedor o ônus de provar a validade da contratação, não sendo suficiente a mera alegação de celebração por telefone, desacompanhada de prova inequívoca da manifestação de vontade do consumidor.
+5) A restituição em dobro do indébito (art. 42, parágrafo único, do CDC) é cabível quando a cobrança indevida configurar conduta contrária à boa-fé objetiva, prescindindo da demonstração de má-fé, conforme tese firmada pelo STJ no EAREsp 676.608/RS.
+6) Os descontos indevidos em verba de natureza alimentar configuram <em>dano</em> <em>moral</em> in re ipsa.
+7) O valor da indenização por danos morais, fixado em R$ 5.000,00, deve ser mantido por se mostrar razoável e proporcional às circunstâncias do caso, atendendo à dupla finalidade da reparação (compensatória e pedagógica) e alinhando-se aos parâmetros adotados por este Tribunal, sem gerar enriquecimento ilícito.
+IV. DISPOSITIVO E TESE
+8) Recursos de Apelação e Adesivo conhecidos e desprovidos. Sentença mantida.
+
+Tese de julgamento: 1)A falha na prestação de serviço bancário, consistente na realização de descontos em benefício previdenciário com base em contrato de seguro cuja validade não foi comprovada, acarreta a responsabilidade objetiva da instituição financeira, por se tratar de fortuito interno (Súmula 479/STJ). 2) A cobrança de valores com base em contrato inexistente, por violar a boa-fé objetiva, enseja a restituição em dobro, nos termos do art. 42, parágrafo único, do CDC, e da tese firmada no EAREsp 676.608/RS. 3) Deve ser mantido o valor da indenização por danos morais quando arbitrado em patamar que observa os princípios da razoabilidade e da proporcionalidade, bem como os precedentes da Corte para casos análogos.
+Dispositivos relevantes citados: Lei nº 14.181/2021; Código de Defesa do Consumidor, art. 104-A; Código de Processo Civil, arts. 85, § 11, 98, § 3º, e 321.
+Jurisprudência relevante citada: TJ-MS, Apelação Cível nº 0804284-31.2025.8.12.0002, Rel. Des. João Maria Lós, 1ª Câmara Cível, j. 29.01.2026; TJ-MS, Apelação Cível nº 0803474-56.2025.8.12.0002, Rel. Desª Sandra Regina da Silva R. Artioli, 2ª Câmara Cível, j. 02.02.2026.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>123&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1877627" cdForo="0" >
+										0800200-58.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1877627" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1877627);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1877627" style="display: none;" >
+	<div id="textAreaDados_1877627" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. RECURSO DA ARQUIVISTA. PRELIMINAR DE ILEGITIMIDADE PASSIVA REJEITADA. M&Eacute;RITO. INSCRI&Ccedil;&Atilde;O EM CADASTRO DE INADIMPLENTES. NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA N&Atilde;O COMPROVADA. RECURSO DESPROVIDO.
+O STJ reconhece a legitimidade passiva dos &oacute;rg&atilde;os mantenedores de cadastro em a&ccedil;&otilde;es que discutem inscri&ccedil;&otilde;es indevidas, inclusive por aus&ecirc;ncia de notifica&ccedil;&atilde;o pr&eacute;via.
+O art. 43, &sect; 2&ordm;, do CDC imp&otilde;e ao &oacute;rg&atilde;o de prote&ccedil;&atilde;o ao cr&eacute;dito o dever de notificar previamente o consumidor, o qual se considera cumprido com a comprova&ccedil;&atilde;o da postagem da correspond&ecirc;ncia ao endere&ccedil;o fornecido pelo credor, sendo desnecess&aacute;rio aviso de recebimento.
+Considerando que n&atilde;o comprovou a arquivista o envio da notifica&ccedil;&atilde;o pr&eacute;via, deve ser mantida a determina&ccedil;&atilde;o de exclus&atilde;o da negativa&ccedil;&atilde;o impugnada.
+Recurso conhecido e desprovido.
+
+EMENTA. DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. RECURSO DA AUTORA. PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA. M&Eacute;RITO. DANOS MORAIS. INSCRI&Ccedil;&Atilde;O LEG&Iacute;TIMA PREEXISTENTE. &Oacute;BICE DA S&Uacute;MULA 385 DO STJ. RECURSO CONHECIDO E DESPROVIDO.
+O indeferimento de produ&ccedil;&atilde;o probat&oacute;ria n&atilde;o configura cerceamento de defesa quando as provas constantes dos autos s&atilde;o suficientes para o julgamento da lide, em observ&acirc;ncia ao princ&iacute;pio do livre convencimento motivado.
+A exist&ecirc;ncia de inscri&ccedil;&atilde;o desabonadora preexistente leg&iacute;tima afasta o dever de indenizar por danos morais, nos termos da S&uacute;mula 385 do STJ.
+Recurso conhecido e improvido.
+
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator..  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800200-58.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 14/04/2026, p:&nbsp; 16/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(16 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									16/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. RECURSO DA ARQUIVISTA. PRELIMINAR DE ILEGITIMIDADE PASSIVA REJEITADA. MÉRITO. INSCRIÇÃO EM CADASTRO DE INADIMPLENTES. NOTIFICAÇÃO PRÉVIA NÃO COMPROVADA. RECURSO DESPROVIDO.
+O STJ reconhece a legitimidade passiva dos órgãos mantenedores de cadastro em ações que discutem inscrições indevidas, inclusive por ausência de notificação prévia.
+O
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. RECURSO DA ARQUIVISTA. PRELIMINAR DE ILEGITIMIDADE PASSIVA REJEITADA. MÉRITO. INSCRIÇÃO EM CADASTRO DE INADIMPLENTES. NOTIFICAÇÃO PRÉVIA NÃO COMPROVADA. RECURSO DESPROVIDO.
+O STJ reconhece a legitimidade passiva dos órgãos mantenedores de cadastro em ações que discutem inscrições indevidas, inclusive por ausência de notificação prévia.
+O art. 43, § 2º, do CDC impõe ao órgão de proteção ao crédito o dever de notificar previamente o consumidor, o qual se considera cumprido com a comprovação da postagem da correspondência ao endereço fornecido pelo credor, sendo desnecessário aviso de recebimento.
+Considerando que não comprovou a arquivista o envio da notificação prévia, deve ser mantida a determinação de exclusão da negativação impugnada.
+Recurso conhecido e desprovido.
+
+EMENTA. DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. RECURSO DA AUTORA. PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA. MÉRITO. DANOS MORAIS. INSCRIÇÃO LEGÍTIMA PREEXISTENTE. ÓBICE DA SÚMULA 385 DO STJ. RECURSO CONHECIDO E DESPROVIDO.
+O indeferimento de produção probatória não configura cerceamento de defesa quando as provas constantes dos autos são suficientes para o julgamento da lide, em observância ao princípio do livre convencimento motivado.
+A existência de inscrição desabonadora preexistente legítima afasta o dever de indenizar por danos morais, nos termos da Súmula 385 do STJ.
+Recurso conhecido e improvido.
+
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>124&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876517" cdForo="0" >
+										1417511-45.2025.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876517" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876517);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876517" style="display: none;" >
+	<div id="textAreaDados_1876517" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSO PENAL. REVIS&Atilde;O CRIMINAL. HOMIC&Iacute;DIO QUALIFICADO. ART. 621, I E III, DO CPP. ALEGA&Ccedil;&Atilde;O DE QUE A CONDENA&Ccedil;&Atilde;O ESTARIA CONTR&Aacute;RIA &Agrave; EVID&Ecirc;NCIA DOS AUTOS, AL&Eacute;M DE EXISTIR PROVA NOVA APTA A EMBASAR O PEDIDO DE ABSOLVI&Ccedil;&Atilde;O. N&Atilde;O OCORR&Ecirc;NCIA. DOSIMETRIA DA PENA. NEGATIVA&Ccedil;&Atilde;O DAS CIRCUNST&Acirc;NCIAS JUDICIAIS. CONDUTA SOCIAL, PERSONALIDADE E CONSEQU&Ecirc;NCIAS DO CRIME. POSSIBILIDADE. N&Iacute;TIDA PRETENS&Atilde;O AO REEXAME PROBAT&Oacute;RIO. AUS&Ecirc;NCIA DE DECIS&Atilde;O FRONTALMENTE CONTR&Aacute;RIA &Agrave; PROVA DOS AUTOS. REVIS&Atilde;O CRIMINAL CONHECIDA E JULGADA IMPROCEDENTE.
+I. CASO EM EXAME
+1)Revis&atilde;o criminal proposta por condenado a 15 (quinze) anos de reclus&atilde;o, em regime inicial fechado, por homic&iacute;dio qualificado (CP, art. 121, &sect; 2&ordm;, I), contra senten&ccedil;a do Tribunal do J&uacute;ri.
+2) Pretens&atilde;o principal de absolvi&ccedil;&atilde;o, sob o argumento de contrariedade &agrave; evid&ecirc;ncia dos autos, em raz&atilde;o de absolvi&ccedil;&atilde;o posterior do corr&eacute;u apontado como executor. Pretens&atilde;o subsidi&aacute;ria de redimensionamento da pena-base, por alegada indevida valora&ccedil;&atilde;o de circunst&acirc;ncias judiciais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+3) H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) saber se a condena&ccedil;&atilde;o &eacute; contr&aacute;ria &agrave; evid&ecirc;ncia dos autos (CPP, art. 621, I) em raz&atilde;o da absolvi&ccedil;&atilde;o do corr&eacute;u indicado como executor; (ii) saber se h&aacute; prova nova, com aptid&atilde;o decisiva, a autorizar revis&atilde;o (CPP, art. 621, III); (iii) saber se h&aacute; ilegalidade na dosimetria, especialmente na valora&ccedil;&atilde;o negativa da conduta social/personalidade e das consequ&ecirc;ncias do crime.
+III. RAZ&Otilde;ES DE DECIDIR
+4) A revis&atilde;o criminal tem car&aacute;ter excepcional e n&atilde;o se presta &agrave; rediscuss&atilde;o ampla do conjunto f&aacute;tico-probat&oacute;rio como suced&acirc;neo recursal, exigindo contrariedade frontal &agrave;s provas ou demonstra&ccedil;&atilde;o dos estritos fundamentos do CPP, art. 621.
+5) A absolvi&ccedil;&atilde;o do corr&eacute;u n&atilde;o implica, por si, contradi&ccedil;&atilde;o evidente quanto &agrave; condena&ccedil;&atilde;o do revisionando como mandante, pois o j&uacute;ri, no julgamento do corr&eacute;u, reconheceu a materialidade e a letalidade, afastando apenas a autoria do disparo atribu&iacute;da a ele, sem infirmar a ocorr&ecirc;ncia do homic&iacute;dio.
+6) N&atilde;o foi demonstrada prova nova n&atilde;o apreciada anteriormente, com peso decisivo e inquestion&aacute;vel, apta a conduzir &agrave; absolvi&ccedil;&atilde;o ou &agrave; redu&ccedil;&atilde;o especial da pena.
+7) Quanto &agrave; dosimetria, entendeu-se inexistir contrariedade &agrave; lei ou &agrave; evid&ecirc;ncia dos autos: a valora&ccedil;&atilde;o negativa de conduta social e personalidade foi fundamentada em elementos concretos (admiss&atilde;o de venda de drogas e temor social mencionado nos autos, inclusive relacionado ao desaforamento), e a idade da v&iacute;tima foi considerada no vetor consequ&ecirc;ncias do crime, reputada fundamenta&ccedil;&atilde;o id&ocirc;nea no caso examinado.
+IV. DISPOSITIVO E TESE
+8) Revis&atilde;o criminal conhecida e julgada improcedente, com o deferimento da justi&ccedil;a gratuita ao autor. Com o parecer.
+Tese de julgamento: &quot;1. A absolvi&ccedil;&atilde;o do corr&eacute;u apontado como executor n&atilde;o imp&otilde;e, por si s&oacute;, a absolvi&ccedil;&atilde;o do condenado indicado como mandante, quando reconhecidas a materialidade e a letalidade do crime e inexistente contrariedade manifesta &agrave; evid&ecirc;ncia dos autos. 2. A revis&atilde;o criminal n&atilde;o se presta ao reexame amplo de provas e somente se admite, excepcionalmente, nas hip&oacute;teses do art. 621 do CPP, exigida prova nova decisiva ou contradi&ccedil;&atilde;o patente.&quot;
+Dispositivo(s) relevante(s) citado(s): CPP, arts. 621 e 623; CPC, art. 98; CPP, art. 3&ordm;; CP, arts. 121, &sect; 2&ordm;, I, 59, 61 e 68; CF/1988, art. 5&ordm;, XXXVI; CF/1988, art. 93, IX.
+Jurisprud&ecirc;ncia relevante citada: REsp 1.764.740/MS, Sexta Turma, Rel. Min. Sebasti&atilde;o Reis J&uacute;nior, DJe 26.02.2019; AgRg no AREsp 1.830.788/PI, Quinta Turma, Rel. Min. Jesu&iacute;no Rissato (Des. Conv.), DJe 04.11.2021; REsp 1.794.854/DF (Tema Repetitivo 1.077), Terceira Se&ccedil;&atilde;o, Rel&ordf;. Min&ordf;. Laurita Vaz, DJe 01.07.2021; AgRg no HC 629.109/ES, Quinta Turma, Rel. Min. Ribeiro Dantas, DJe 21.02.2022; HC n. 809.301/SP, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 5/11/2024, DJe de 11/11/2024.  <br><br>(<b>TJMS</b>. Revis&atilde;o Criminal n. 1417511-45.2025.8.12.0000,&nbsp; Campo Grande,&nbsp; 1&ordf; Se&ccedil;&atilde;o Criminal, Relator (a):&nbsp; Juiz Alexandre Corr&ecirc;a Leite, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Revisão Criminal / Homicídio Qualificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Alexandre Corrêa Leite
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Seção Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSO PENAL. REVISÃO CRIMINAL. HOMICÍDIO QUALIFICADO. ART. 621, I E III, DO CPP. ALEGAÇÃO DE QUE A CONDENAÇÃO ESTARIA CONTRÁRIA À EVIDÊNCIA DOS AUTOS, ALÉM DE EXISTIR PROVA NOVA APTA A EMBASAR O PEDIDO DE ABSOLVIÇÃO. NÃO OCORRÊNCIA. DOSIMETRIA DA PENA. NEGATIVAÇÃO DAS CIRCUNSTÂNCIAS JUDICIAIS. CONDUTA SOCIAL, PERSONALIDADE E CONSEQUÊNCIAS DO CRIME. POSSIBILIDADE. NÍTIDA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSO PENAL. REVISÃO CRIMINAL. HOMICÍDIO QUALIFICADO. ART. 621, I E III, DO CPP. ALEGAÇÃO DE QUE A CONDENAÇÃO ESTARIA CONTRÁRIA À EVIDÊNCIA DOS AUTOS, ALÉM DE EXISTIR PROVA NOVA APTA A EMBASAR O PEDIDO DE ABSOLVIÇÃO. NÃO OCORRÊNCIA. DOSIMETRIA DA PENA. NEGATIVAÇÃO DAS CIRCUNSTÂNCIAS JUDICIAIS. CONDUTA SOCIAL, PERSONALIDADE E CONSEQUÊNCIAS DO CRIME. POSSIBILIDADE. NÍTIDA PRETENSÃO AO REEXAME PROBATÓRIO. AUSÊNCIA DE DECISÃO FRONTALMENTE CONTRÁRIA À PROVA DOS AUTOS. REVISÃO CRIMINAL CONHECIDA E JULGADA IMPROCEDENTE.
+I. CASO EM EXAME
+1)Revisão criminal proposta por condenado a 15 (quinze) anos de reclusão, em regime inicial fechado, por homicídio qualificado (CP, art. 121, § 2º, I), contra sentença do Tribunal do Júri.
+2) Pretensão principal de absolvição, sob o argumento de contrariedade à evidência dos autos, em razão de absolvição posterior do corréu apontado como executor. Pretensão subsidiária de redimensionamento da pena-base, por alegada indevida valoração de circunstâncias judiciais.
+II. QUESTÃO EM DISCUSSÃO
+3) Há três questões em discussão: (i) saber se a condenação é contrária à evidência dos autos (CPP, art. 621, I) em razão da absolvição do corréu indicado como executor; (ii) saber se há prova nova, com aptidão decisiva, a autorizar revisão (CPP, art. 621, III); (iii) saber se há ilegalidade na dosimetria, especialmente na valoração negativa da conduta social/personalidade e das consequências do crime.
+III. RAZÕES DE DECIDIR
+4) A revisão criminal tem caráter excepcional e não se presta à rediscussão ampla do conjunto fático-probatório como sucedâneo recursal, exigindo contrariedade frontal às provas ou demonstração dos estritos fundamentos do CPP, art. 621.
+5) A absolvição do corréu não implica, por si, contradição evidente quanto à condenação do revisionando como mandante, pois o júri, no julgamento do corréu, reconheceu a materialidade e a letalidade, afastando apenas a autoria do disparo atribuída a ele, sem infirmar a ocorrência do homicídio.
+6) Não foi demonstrada prova nova não apreciada anteriormente, com peso decisivo e inquestionável, apta a conduzir à absolvição ou à redução especial da pena.
+7) Quanto à dosimetria, entendeu-se inexistir contrariedade à lei ou à evidência dos autos: a valoração negativa de conduta social e personalidade foi fundamentada em elementos concretos (admissão de venda de drogas e temor social mencionado nos autos, inclusive relacionado ao desaforamento), e a idade da vítima foi considerada no vetor consequências do crime, reputada fundamentação idônea no caso examinado.
+IV. DISPOSITIVO E TESE
+8) Revisão criminal conhecida e julgada improcedente, com o deferimento da justiça gratuita ao autor. Com o parecer.
+Tese de julgamento: "1. A absolvição do corréu apontado como executor não impõe, por si só, a absolvição do condenado indicado como mandante, quando reconhecidas a materialidade e a letalidade do crime e inexistente contrariedade manifesta à evidência dos autos. 2. A revisão criminal não se presta ao reexame amplo de provas e somente se admite, excepcionalmente, nas hipóteses do art. 621 do CPP, exigida prova nova decisiva ou contradição patente."
+Dispositivo(s) relevante(s) citado(s): CPP, arts. 621 e 623; CPC, art. 98; CPP, art. 3º; CP, arts. 121, § 2º, I, 59, 61 e 68; CF/1988, art. 5º, XXXVI; CF/1988, art. 93, IX.
+Jurisprudência relevante citada: REsp 1.764.740/MS, Sexta Turma, Rel. Min. Sebastião Reis Júnior, DJe 26.02.2019; AgRg no AREsp 1.830.788/PI, Quinta Turma, Rel. Min. Jesuíno Rissato (Des. Conv.), DJe 04.11.2021; REsp 1.794.854/DF (Tema Repetitivo 1.077), Terceira Seção, Relª. Minª. Laurita Vaz, DJe 01.07.2021; AgRg no HC 629.109/ES, Quinta Turma, Rel. Min. Ribeiro Dantas, DJe 21.02.2022; HC n. 809.301/SP, relatora Ministra Daniela Teixeira, Quinta Turma, julgado em 5/11/2024, DJe de 11/11/2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>125&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876527" cdForo="0" >
+										0801912-95.2024.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876527" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876527);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876527" style="display: none;" >
+	<div id="textAreaDados_1876527" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; RECURSO DA R&Eacute; &ndash; A&Ccedil;&Atilde;O DE CONHECIMENTO &ndash; GRATUIDADE DA JUSTI&Ccedil;A &ndash; INDEFERIMENTO EM DECIS&Atilde;O INTERLOCUT&Oacute;RIA &ndash; AUS&Ecirc;NCIA DE RECOLHIMENTO DO PREPARO &ndash; DESER&Ccedil;&Atilde;O &ndash; ART. 1.007, &sect; 4&ordm;, CPC &ndash; REN&Uacute;NCIA DE MANDATO &ndash; N&Atilde;O REGULARIZA&Ccedil;&Atilde;O DA REPRESENTA&Ccedil;&Atilde;O PROCESSUAL &ndash; ART. 76, &sect; 2&ordm;, I, CPC &ndash; RECURSO DA R&Eacute; N&Atilde;O CONHECIDO.
+RECURSO DA AUTORA &ndash; REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO EM DOBRO &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; M&Aacute;-F&Eacute; OBJETIVA &ndash; IRRELEV&Acirc;NCIA DO ELEMENTO VOLITIVO SUBJETIVO &ndash; ENTENDIMENTO DO STJ (EARESP 600.663/RS) &ndash; APLICA&Ccedil;&Atilde;O PARA COBRAN&Ccedil;AS POSTERIORES A MAR&Ccedil;O DE 2021 &ndash; DECLARA&Ccedil;&Atilde;O DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; RESPONSABILIDADE EXTRACONTRATUAL &ndash; JUROS DE MORA E CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA DOS DANOS MATERIAIS (REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO) &ndash; INCID&Ecirc;NCIA A PARTIR DO EVENTO DANOSO (CADA DESCONTO INDEVIDO) &ndash; S&Uacute;MULAS 43 E 54 DO STJ &ndash; DANOS MORAIS &ndash; MANUTEN&Ccedil;&Atilde;O DO QUANTUM ARBITRADO NA SENTEN&Ccedil;A (R$ 6.000,00) &ndash; VALOR INDIVIDUAL DO DESCONTO E DECURSO DO TEMPO ENTRE O PRIMEIRO DESCONTO E O AJUIZAMENTO DA A&Ccedil;&Atilde;O &ndash; RAZOABILIDADE E PROPORCIONALIDADE. TERMO INICIAL DOS JUROS DE MORA DOS DANOS MORAIS &ndash; EVENTO DANOSO (S&Uacute;MULA 54 DO STJ). HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; FIXA&Ccedil;&Atilde;O PERCENTUAL SOBRE O VALOR DA CONDENA&Ccedil;&Atilde;O &ndash; ART. 85, &sect; 2&ordm;, DO CPC &ndash; ADEQUA&Ccedil;&Atilde;O DA BASE DE C&Aacute;LCULO PELO PROVIMENTO RECURSAL &ndash; RECURSO PARCIALMENTE PROVIDO.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801912-95.2024.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – RECURSO DA RÉ – AÇÃO DE CONHECIMENTO – GRATUIDADE DA JUSTIÇA – INDEFERIMENTO EM DECISÃO INTERLOCUTÓRIA – AUSÊNCIA DE RECOLHIMENTO DO PREPARO – DESERÇÃO – ART. 1.007, § 4º, CPC – RENÚNCIA DE MANDATO – NÃO REGULARIZAÇÃO DA REPRESENTAÇÃO PROCESSUAL – ART. 76, § 2º, I, CPC – RECURSO DA RÉ NÃO CONHECIDO.
+RECURSO DA AUTORA – REPETIÇÃO DO INDÉBITO EM DOBRO – DESCONTOS INDEVIDOS EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – RECURSO DA RÉ – AÇÃO DE CONHECIMENTO – GRATUIDADE DA JUSTIÇA – INDEFERIMENTO EM DECISÃO INTERLOCUTÓRIA – AUSÊNCIA DE RECOLHIMENTO DO PREPARO – DESERÇÃO – ART. 1.007, § 4º, CPC – RENÚNCIA DE MANDATO – NÃO REGULARIZAÇÃO DA REPRESENTAÇÃO PROCESSUAL – ART. 76, § 2º, I, CPC – RECURSO DA RÉ NÃO CONHECIDO.
+RECURSO DA AUTORA – REPETIÇÃO DO INDÉBITO EM DOBRO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – MÁ-FÉ OBJETIVA – IRRELEVÂNCIA DO ELEMENTO VOLITIVO SUBJETIVO – ENTENDIMENTO DO STJ (EARESP 600.663/RS) – APLICAÇÃO PARA COBRANÇAS POSTERIORES A MARÇO DE 2021 – DECLARAÇÃO DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA – RESPONSABILIDADE EXTRACONTRATUAL – JUROS DE MORA E CORREÇÃO MONETÁRIA DOS DANOS MATERIAIS (REPETIÇÃO DE INDÉBITO) – INCIDÊNCIA A PARTIR DO EVENTO DANOSO (CADA DESCONTO INDEVIDO) – SÚMULAS 43 E 54 DO STJ – DANOS MORAIS – MANUTENÇÃO DO QUANTUM ARBITRADO NA SENTENÇA (R$ 6.000,00) – VALOR INDIVIDUAL DO DESCONTO E DECURSO DO TEMPO ENTRE O PRIMEIRO DESCONTO E O AJUIZAMENTO DA AÇÃO – RAZOABILIDADE E PROPORCIONALIDADE. TERMO INICIAL DOS JUROS DE MORA DOS DANOS MORAIS – EVENTO DANOSO (SÚMULA 54 DO STJ). HONORÁRIOS ADVOCATÍCIOS – FIXAÇÃO PERCENTUAL SOBRE O VALOR DA CONDENAÇÃO – ART. 85, § 2º, DO CPC – ADEQUAÇÃO DA BASE DE CÁLCULO PELO PROVIMENTO RECURSAL – RECURSO PARCIALMENTE PROVIDO.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>126&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876541" cdForo="0" >
+										0800109-52.2025.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876541" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876541);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876541" style="display: none;" >
+	<div id="textAreaDados_1876541" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL. JU&Iacute;ZO DE RETRATA&Ccedil;&Atilde;O. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS SUCUMBENCIAIS. ART. 85, &sect;&sect;2&ordm; E 8&ordm;, DO CPC. TEMA 1.076 DO SUPERIOR TRIBUNAL DE JUSTI&Ccedil;A. ARBITRAMENTO POR EQUIDADE. HIP&Oacute;TESES EXCEPCIONAIS. INOCORR&Ecirc;NCIA. PROVEITO ECON&Ocirc;MICO QUE N&Atilde;O SE REVELA IRRIS&Oacute;RIO NEM INESTIM&Aacute;VEL. OBSERV&Acirc;NCIA DOS CRIT&Eacute;RIOS LEGAIS. HONOR&Aacute;RIOS FIXADOS EM PERCENTUAL SOBRE O VALOR DA CONDENA&Ccedil;&Atilde;O. MANUTEN&Ccedil;&Atilde;O DO AC&Oacute;RD&Atilde;O. RETRATA&Ccedil;&Atilde;O N&Atilde;O EXERCIDA.
+Nos termos da tese firmada pelo Tema 1076 do STJ, a fixa&ccedil;&atilde;o de honor&aacute;rios advocat&iacute;cios por aprecia&ccedil;&atilde;o equitativa constitui medida excepcional, admitida apenas quando o proveito econ&ocirc;mico for inestim&aacute;vel ou irris&oacute;rio, ou quando o valor da causa for muito baixo, devendo, nas demais hip&oacute;teses, ser observados os percentuais previstos nos &sect;&sect;2&ordm; e 3&ordm; do art. 85 do C&oacute;digo de Processo Civil.
+No caso concreto, o ac&oacute;rd&atilde;o recorrido afastou expressamente o arbitramento por equidade e manteve os honor&aacute;rios advocat&iacute;cios fixados na senten&ccedil;a no percentual de 15% (quinze por cento) sobre o valor da condena&ccedil;&atilde;o, em observ&acirc;ncia aos crit&eacute;rios estabelecidos no art. 85, &sect;2&ordm;, do CPC.
+Proveito econ&ocirc;mico obtido pela parte vencedora que n&atilde;o se revela irris&oacute;rio, mostrando-se compat&iacute;vel com os par&acirc;metros usualmente adotados por esta C&acirc;mara em demandas an&aacute;logas.
+Inexist&ecirc;ncia de incompatibilidade entre o ac&oacute;rd&atilde;o proferido e a orienta&ccedil;&atilde;o firmada pelo Superior Tribunal de Justi&ccedil;a.
+Ju&iacute;zo de retrata&ccedil;&atilde;o n&atilde;o exercido.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800109-52.2025.8.12.0015,&nbsp; Miranda,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. JUÍZO DE RETRATAÇÃO. HONORÁRIOS ADVOCATÍCIOS SUCUMBENCIAIS. ART. 85, §§2º E 8º, DO CPC. TEMA 1.076 DO SUPERIOR TRIBUNAL DE JUSTIÇA. ARBITRAMENTO POR EQUIDADE. HIPÓTESES EXCEPCIONAIS. INOCORRÊNCIA. PROVEITO ECONÔMICO QUE NÃO SE REVELA IRRISÓRIO NEM INESTIMÁVEL. OBSERVÂNCIA DOS CRITÉRIOS LEGAIS. HONORÁRIOS FIXADOS EM PERCENTUAL SOBRE O VALOR DA CONDENAÇÃO. MANUTENÇÃO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL. JUÍZO DE RETRATAÇÃO. HONORÁRIOS ADVOCATÍCIOS SUCUMBENCIAIS. ART. 85, §§2º E 8º, DO CPC. TEMA 1.076 DO SUPERIOR TRIBUNAL DE JUSTIÇA. ARBITRAMENTO POR EQUIDADE. HIPÓTESES EXCEPCIONAIS. INOCORRÊNCIA. PROVEITO ECONÔMICO QUE NÃO SE REVELA IRRISÓRIO NEM INESTIMÁVEL. OBSERVÂNCIA DOS CRITÉRIOS LEGAIS. HONORÁRIOS FIXADOS EM PERCENTUAL SOBRE O VALOR DA CONDENAÇÃO. MANUTENÇÃO DO ACÓRDÃO. RETRATAÇÃO NÃO EXERCIDA.
+Nos termos da tese firmada pelo Tema 1076 do STJ, a fixação de honorários advocatícios por apreciação equitativa constitui medida excepcional, admitida apenas quando o proveito econômico for inestimável ou irrisório, ou quando o valor da causa for muito baixo, devendo, nas demais hipóteses, ser observados os percentuais previstos nos §§2º e 3º do art. 85 do Código de Processo Civil.
+No caso concreto, o acórdão recorrido afastou expressamente o arbitramento por equidade e manteve os honorários advocatícios fixados na sentença no percentual de 15% (quinze por cento) sobre o valor da condenação, em observância aos critérios estabelecidos no art. 85, §2º, do CPC.
+Proveito econômico obtido pela parte vencedora que não se revela irrisório, mostrando-se compatível com os parâmetros usualmente adotados por esta Câmara em demandas análogas.
+Inexistência de incompatibilidade entre o acórdão proferido e a orientação firmada pelo Superior Tribunal de Justiça.
+Juízo de retratação não exercido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>127&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876555" cdForo="0" >
+										0800455-03.2025.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876555" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876555);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876555" style="display: none;" >
+	<div id="textAreaDados_1876555" class="mensagemSemFormatacao" >
+		DIREITO PROCESSUAL CIVIL E DO CONSUMIDOR. JU&Iacute;ZO DE RETRATA&Ccedil;&Atilde;O. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS SUCUMBENCIAIS. ART. 85, &sect;&sect;2&ordm; E 8&ordm;, DO CPC. TEMA 1.076 DO SUPERIOR TRIBUNAL DE JUSTI&Ccedil;A. ARBITRAMENTO POR EQUIDADE. HIP&Oacute;TESES EXCEPCIONAIS. INOCORR&Ecirc;NCIA. PROVEITO ECON&Ocirc;MICO QUE N&Atilde;O SE REVELA IRRIS&Oacute;RIO NEM INESTIM&Aacute;VEL. OBSERV&Acirc;NCIA DOS CRIT&Eacute;RIOS LEGAIS. HONOR&Aacute;RIOS FIXADOS EM PERCENTUAL SOBRE O VALOR DA CONDENA&Ccedil;&Atilde;O. MANUTEN&Ccedil;&Atilde;O DO AC&Oacute;RD&Atilde;O. RETRATA&Ccedil;&Atilde;O N&Atilde;O EXERCIDA.
+Nos termos da tese firmada pelo Tema 1076 do STJ, a fixa&ccedil;&atilde;o de honor&aacute;rios advocat&iacute;cios por aprecia&ccedil;&atilde;o equitativa constitui medida excepcional, admitida apenas quando o proveito econ&ocirc;mico for inestim&aacute;vel ou irris&oacute;rio, ou quando o valor da causa for muito baixo, devendo, nas demais hip&oacute;teses, ser observados os percentuais previstos nos &sect;&sect;2&ordm; e 3&ordm; do art. 85 do C&oacute;digo de Processo Civil.
+No caso concreto, o ac&oacute;rd&atilde;o recorrido afastou expressamente o arbitramento por equidade e manteve os honor&aacute;rios advocat&iacute;cios fixados na senten&ccedil;a no percentual de 15% (quinze por cento) sobre o valor da condena&ccedil;&atilde;o, em observ&acirc;ncia aos crit&eacute;rios estabelecidos no art. 85, &sect;2&ordm;, do CPC.
+Proveito econ&ocirc;mico obtido pela parte vencedora que n&atilde;o se revela irris&oacute;rio, mostrando-se compat&iacute;vel com os par&acirc;metros usualmente adotados por esta C&acirc;mara em demandas an&aacute;logas.
+Inexist&ecirc;ncia de incompatibilidade entre o ac&oacute;rd&atilde;o proferido e a orienta&ccedil;&atilde;o firmada pelo Superior Tribunal de Justi&ccedil;a.
+Ju&iacute;zo de retrata&ccedil;&atilde;o n&atilde;o exercido.  <br><br>(<b>TJMS</b>. Agravo Interno C&iacute;vel n. 0800455-03.2025.8.12.0015,&nbsp; Miranda,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(5 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800455032025812001550000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DO CONSUMIDOR. JUÍZO DE RETRATAÇÃO. HONORÁRIOS ADVOCATÍCIOS SUCUMBENCIAIS. ART. 85, §§2º E 8º, DO CPC. TEMA 1.076 DO SUPERIOR TRIBUNAL DE JUSTIÇA. ARBITRAMENTO POR EQUIDADE. HIPÓTESES EXCEPCIONAIS. INOCORRÊNCIA. PROVEITO ECONÔMICO QUE NÃO SE REVELA IRRISÓRIO NEM INESTIMÁVEL. OBSERVÂNCIA DOS CRITÉRIOS LEGAIS. HONORÁRIOS FIXADOS EM PERCENTUAL SOBRE O VALOR DA CONDENAÇÃO.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PROCESSUAL CIVIL E DO CONSUMIDOR. JUÍZO DE RETRATAÇÃO. HONORÁRIOS ADVOCATÍCIOS SUCUMBENCIAIS. ART. 85, §§2º E 8º, DO CPC. TEMA 1.076 DO SUPERIOR TRIBUNAL DE JUSTIÇA. ARBITRAMENTO POR EQUIDADE. HIPÓTESES EXCEPCIONAIS. INOCORRÊNCIA. PROVEITO ECONÔMICO QUE NÃO SE REVELA IRRISÓRIO NEM INESTIMÁVEL. OBSERVÂNCIA DOS CRITÉRIOS LEGAIS. HONORÁRIOS FIXADOS EM PERCENTUAL SOBRE O VALOR DA CONDENAÇÃO. MANUTENÇÃO DO ACÓRDÃO. RETRATAÇÃO NÃO EXERCIDA.
+Nos termos da tese firmada pelo Tema 1076 do STJ, a fixação de honorários advocatícios por apreciação equitativa constitui medida excepcional, admitida apenas quando o proveito econômico for inestimável ou irrisório, ou quando o valor da causa for muito baixo, devendo, nas demais hipóteses, ser observados os percentuais previstos nos §§2º e 3º do art. 85 do Código de Processo Civil.
+No caso concreto, o acórdão recorrido afastou expressamente o arbitramento por equidade e manteve os honorários advocatícios fixados na sentença no percentual de 15% (quinze por cento) sobre o valor da condenação, em observância aos critérios estabelecidos no art. 85, §2º, do CPC.
+Proveito econômico obtido pela parte vencedora que não se revela irrisório, mostrando-se compatível com os parâmetros usualmente adotados por esta Câmara em demandas análogas.
+Inexistência de incompatibilidade entre o acórdão proferido e a orientação firmada pelo Superior Tribunal de Justiça.
+Juízo de retratação não exercido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>128&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876559" cdForo="0" >
+										2000991-58.2025.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876559" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876559);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876559" style="display: none;" >
+	<div id="textAreaDados_1876559" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO. DIREITO &Agrave; SA&Uacute;DE. INTERNA&Ccedil;&Atilde;O COMPULS&Oacute;RIA. TRANSTORNO MENTAL. RISCO &Agrave; INTEGRIDADE F&Iacute;SICA PR&Oacute;PRIA E DE TERCEIROS.  RESPONSABILIDADE SOLID&Aacute;RIA DOS ENTES FEDERADOS. DIRECIONAMENTO DA OBRIGA&Ccedil;&Atilde;O AO ENTE RESPONS&Aacute;VEL. EXIST&Ecirc;NCIA DE LAUDO M&Eacute;DICO CIRCUNSTANCIADO. REQUISITOS LEGAIS PREENCHIDOS. MANUTEN&Ccedil;&Atilde;O DA TUTELA DE URG&Ecirc;NCIA. PRETENS&Atilde;O DE LIMITA&Ccedil;&Atilde;O TEMPORAL DA INTERNA&Ccedil;&Atilde;O N&Atilde;O CONHECIDA. SUPRESS&Atilde;O DE INST&Acirc;NCIA. RECURSO PARCIALMENTE CONHECIDO E PARCIALMENTE PROVIDO.
+I. A pretens&atilde;o de limita&ccedil;&atilde;o temporal da interna&ccedil;&atilde;o n&atilde;o foi apreciada na decis&atilde;o objurgada, pois n&atilde;o foi suscitada em primeiro grau, de modo que n&atilde;o cabe ao ju&iacute;zo ad quem conhecer da quest&atilde;o de forma origin&aacute;ria, sob pena de supress&atilde;o de inst&acirc;ncia.
+II. A interna&ccedil;&atilde;o compuls&oacute;ria, de natureza c&iacute;vel e sanit&aacute;ria, pode ser validamente decretada por decis&atilde;o judicial quando demonstrado, por laudo m&eacute;dico circunstanciado, que o paciente apresenta transtorno mental grave, com risco concreto &agrave; vida ou &agrave; integridade f&iacute;sica.
+III. Relat&oacute;rio psicol&oacute;gico e parecer psiqui&aacute;trico juntados aos autos demonstram que a paciente sofre de transtorno de esquizofrenia, apresentando risco &agrave; sua pr&oacute;pria integridade e a de terceiros, evidenciando a inefic&aacute;cia dos tratamentos ambulatoriais e a urg&ecirc;ncia da medida excepcional.
+IV. Nos termos do Tema 793 do STF, os entes federativos respondem solidariamente pelas demandas prestacionais de sa&uacute;de, competindo ao magistrado direcionar o cumprimento da obriga&ccedil;&atilde;o conforme a reparti&ccedil;&atilde;o de compet&ecirc;ncias do SUS, com possibilidade de ressarcimento ao ente que suportar o &ocirc;nus financeiro. Existindo parecer t&eacute;cnico do N&uacute;cleo de Apoio T&eacute;cnico, leg&iacute;timo o direcionamento do cumprimento ao Munic&iacute;pio, sem afastamento da solidariedade do Estado.
+ V. Recurso parcialmente conhecido e, com o parecer, parcialmente provido.
+  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 2000991-58.2025.8.12.0000,&nbsp; Terenos,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Internação compulsória
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Terenos
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. DIREITO À SAÚDE. INTERNAÇÃO COMPULSÓRIA. TRANSTORNO MENTAL. RISCO À INTEGRIDADE FÍSICA PRÓPRIA E DE TERCEIROS.  RESPONSABILIDADE SOLIDÁRIA DOS ENTES FEDERADOS. DIRECIONAMENTO DA OBRIGAÇÃO AO ENTE RESPONSÁVEL. EXISTÊNCIA DE LAUDO MÉDICO CIRCUNSTANCIADO. REQUISITOS LEGAIS PREENCHIDOS. MANUTENÇÃO DA TUTELA DE URGÊNCIA. PRETENSÃO DE LIMITAÇÃO TEMPORAL DA INTERNAÇÃO NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. DIREITO À SAÚDE. INTERNAÇÃO COMPULSÓRIA. TRANSTORNO MENTAL. RISCO À INTEGRIDADE FÍSICA PRÓPRIA E DE TERCEIROS.  RESPONSABILIDADE SOLIDÁRIA DOS ENTES FEDERADOS. DIRECIONAMENTO DA OBRIGAÇÃO AO ENTE RESPONSÁVEL. EXISTÊNCIA DE LAUDO MÉDICO CIRCUNSTANCIADO. REQUISITOS LEGAIS PREENCHIDOS. MANUTENÇÃO DA TUTELA DE URGÊNCIA. PRETENSÃO DE LIMITAÇÃO TEMPORAL DA INTERNAÇÃO NÃO CONHECIDA. SUPRESSÃO DE INSTÂNCIA. RECURSO PARCIALMENTE CONHECIDO E PARCIALMENTE PROVIDO.
+I. A pretensão de limitação temporal da internação não foi apreciada na decisão objurgada, pois não foi suscitada em primeiro grau, de modo que não cabe ao juízo ad quem conhecer da questão de forma originária, sob pena de supressão de instância.
+II. A internação compulsória, de natureza cível e sanitária, pode ser validamente decretada por decisão judicial quando demonstrado, por laudo médico circunstanciado, que o paciente apresenta transtorno mental grave, com risco concreto à vida ou à integridade física.
+III. Relatório psicológico e parecer psiquiátrico juntados aos autos demonstram que a paciente sofre de transtorno de esquizofrenia, apresentando risco à sua própria integridade e a de terceiros, evidenciando a ineficácia dos tratamentos ambulatoriais e a urgência da medida excepcional.
+IV. Nos termos do Tema 793 do STF, os entes federativos respondem solidariamente pelas demandas prestacionais de saúde, competindo ao magistrado direcionar o cumprimento da obrigação conforme a repartição de competências do SUS, com possibilidade de ressarcimento ao ente que suportar o ônus financeiro. Existindo parecer técnico do Núcleo de Apoio Técnico, legítimo o direcionamento do cumprimento ao Município, sem afastamento da solidariedade do Estado.
+ V. Recurso parcialmente conhecido e, com o parecer, parcialmente provido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>129&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876592" cdForo="0" >
+										1401959-06.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876592" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876592);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876592" style="display: none;" >
+	<div id="textAreaDados_1876592" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O ANULAT&Oacute;RIA  DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; PRESCRI&Ccedil;&Atilde;O E DECAD&Ecirc;NCIA &ndash; NATUREZA DA A&Ccedil;&Atilde;O &ndash; PREPONDER&Acirc;NCIA DA CAUSA DE PEDIR E DOS PEDIDOS SOBRE O NOMEN IURIS &ndash; PRINC&Iacute;PIOS IURA NOVIT CURIA E DA MIHI FACTUM, DABO TIBI IUS &ndash; PRETENS&Atilde;O DE REVIS&Atilde;O E CONVERS&Atilde;O DE CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO EM EMPR&Eacute;STIMO CONSIGNADO &ndash; RELA&Ccedil;&Atilde;O JUR&Iacute;DICA DE TRATO SUCESSIVO &ndash; LES&Atilde;O QUE SE RENOVA A CADA DESCONTO &ndash; INAPLICABILIDADE DO PRAZO DECADENCIAL PARA ANULA&Ccedil;&Atilde;O DE NEG&Oacute;CIO JUR&Iacute;DICO POR V&Iacute;CIO DE CONSENTIMENTO (ART. 178, II, CC) A CONTRATOS DE TRATO SUCESSIVO &ndash;  RECURSO DESPROVIDO.
+  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1401959-06.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Prescrição e Decadência
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO ANULATÓRIA  DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – PRESCRIÇÃO E DECADÊNCIA – NATUREZA DA AÇÃO – PREPONDERÂNCIA DA CAUSA DE PEDIR E DOS PEDIDOS SOBRE O NOMEN IURIS – PRINCÍPIOS IURA NOVIT CURIA E DA MIHI FACTUM, DABO TIBI IUS – PRETENSÃO DE REVISÃO E CONVERSÃO DE CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO EM EMPRÉSTIMO CONSIGNADO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO ANULATÓRIA  DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS – PRESCRIÇÃO E DECADÊNCIA – NATUREZA DA AÇÃO – PREPONDERÂNCIA DA CAUSA DE PEDIR E DOS PEDIDOS SOBRE O NOMEN IURIS – PRINCÍPIOS IURA NOVIT CURIA E DA MIHI FACTUM, DABO TIBI IUS – PRETENSÃO DE REVISÃO E CONVERSÃO DE CONTRATO DE CARTÃO DE CRÉDITO CONSIGNADO EM EMPRÉSTIMO CONSIGNADO – RELAÇÃO JURÍDICA DE TRATO SUCESSIVO – LESÃO QUE SE RENOVA A CADA DESCONTO – INAPLICABILIDADE DO PRAZO DECADENCIAL PARA ANULAÇÃO DE NEGÓCIO JURÍDICO POR VÍCIO DE CONSENTIMENTO (ART. 178, II, CC) A CONTRATOS DE TRATO SUCESSIVO –  RECURSO DESPROVIDO.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>130&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876622" cdForo="0" >
+										2000147-74.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876622" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876622);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876622" style="display: none;" >
+	<div id="textAreaDados_1876622" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; DIREITO &Agrave; SA&Uacute;DE &ndash; INTERNA&Ccedil;&Atilde;O COMPULS&Oacute;RIA &ndash; TRANSTORNO MENTAL &ndash; RISCO &Agrave; INTEGRIDADE F&Iacute;SICA PR&Oacute;PRIA E DE TERCEIROS &ndash; RESPONSABILIDADE SOLID&Aacute;RIA DOS ENTES FEDERADOS &ndash; DIRECIONAMENTO DA OBRIGA&Ccedil;&Atilde;O AO ENTE RESPONS&Aacute;VEL &ndash; EXIST&Ecirc;NCIA DE LAUDO M&Eacute;DICO CIRCUNSTANCIADO &ndash; REQUISITOS LEGAIS PREENCHIDOS &ndash; MANUTEN&Ccedil;&Atilde;O DA TUTELA DE URG&Ecirc;NCIA &ndash; PRETENS&Atilde;O DE LIMITA&Ccedil;&Atilde;O TEMPORAL DA INTERNA&Ccedil;&Atilde;O N&Atilde;O CONHECIDA &ndash; SUPRESS&Atilde;O DE INST&Acirc;NCIA &ndash; POSSIBILIDADE DE FIXA&Ccedil;&Atilde;O DE MULTA &ndash; TEMA 98, DO STJ &ndash; RECURSO PARCIALMENTE CONHECIDO, E NA PARTE CONHECIDA, PARCIALMENTE PROVIDO.
+I) A pretens&atilde;o de limita&ccedil;&atilde;o temporal da interna&ccedil;&atilde;o n&atilde;o foi apreciada na decis&atilde;o objurgada, pois n&atilde;o foi suscitada em primeiro grau, de modo que n&atilde;o cabe ao ju&iacute;zo ad quem conhecer da quest&atilde;o de forma origin&aacute;ria, sob pena de supress&atilde;o de inst&acirc;ncia.
+II) A interna&ccedil;&atilde;o compuls&oacute;ria, de natureza c&iacute;vel e sanit&aacute;ria, pode ser validamente decretada por decis&atilde;o judicial quando demonstrado, por laudo m&eacute;dico circunstanciado, que o paciente apresenta transtorno mental grave, com risco concreto &agrave; vida ou &agrave; integridade f&iacute;sica.
+III) Relat&oacute;rio psicol&oacute;gico e parecer psiqui&aacute;trico juntados aos autos demonstram que a paciente sofre de transtorno de esquizofrenia, apresentando risco &agrave; sua pr&oacute;pria integridade e a de terceiros, evidenciando a inefic&aacute;cia dos tratamentos ambulatoriais e a urg&ecirc;ncia da medida excepcional.
+IV) Nos termos do Tema 793 do STF, os entes federativos respondem solidariamente pelas demandas prestacionais de sa&uacute;de, competindo ao magistrado direcionar o cumprimento da obriga&ccedil;&atilde;o conforme a reparti&ccedil;&atilde;o de compet&ecirc;ncias do SUS, com possibilidade de ressarcimento ao ente que suportar o &ocirc;nus financeiro. Existindo parecer t&eacute;cnico do N&uacute;cleo de Apoio T&eacute;cnico, leg&iacute;timo o direcionamento do cumprimento ao Munic&iacute;pio, sem afastamento da solidariedade do Estado.
+V) Conforme entendimento consolidado do Superior Tribunal de Justi&ccedil;a (Tema n&ordm; 98), &eacute; perfeitamente admiss&iacute;vel o arbitramento de multa sancionat&oacute;ria contra a Fazenda P&uacute;blica para compeli-la ao cumprimento de obriga&ccedil;&atilde;o judicial
+VI) Recurso parcialmente conhecido e, com o parecer, parcialmente provido.
+  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 2000147-74.2026.8.12.0000,&nbsp; Nova Andradina,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Internação involuntária
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Nova Andradina
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DIREITO À SAÚDE – INTERNAÇÃO COMPULSÓRIA – TRANSTORNO MENTAL – RISCO À INTEGRIDADE FÍSICA PRÓPRIA E DE TERCEIROS – RESPONSABILIDADE SOLIDÁRIA DOS ENTES FEDERADOS – DIRECIONAMENTO DA OBRIGAÇÃO AO ENTE RESPONSÁVEL – EXISTÊNCIA DE LAUDO MÉDICO CIRCUNSTANCIADO – REQUISITOS LEGAIS PREENCHIDOS – MANUTENÇÃO DA TUTELA DE URGÊNCIA – PRETENSÃO DE LIMITAÇÃO TEMPORAL DA INTERNAÇÃO NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DIREITO À SAÚDE – INTERNAÇÃO COMPULSÓRIA – TRANSTORNO MENTAL – RISCO À INTEGRIDADE FÍSICA PRÓPRIA E DE TERCEIROS – RESPONSABILIDADE SOLIDÁRIA DOS ENTES FEDERADOS – DIRECIONAMENTO DA OBRIGAÇÃO AO ENTE RESPONSÁVEL – EXISTÊNCIA DE LAUDO MÉDICO CIRCUNSTANCIADO – REQUISITOS LEGAIS PREENCHIDOS – MANUTENÇÃO DA TUTELA DE URGÊNCIA – PRETENSÃO DE LIMITAÇÃO TEMPORAL DA INTERNAÇÃO NÃO CONHECIDA – SUPRESSÃO DE INSTÂNCIA – POSSIBILIDADE DE FIXAÇÃO DE MULTA – TEMA 98, DO STJ – RECURSO PARCIALMENTE CONHECIDO, E NA PARTE CONHECIDA, PARCIALMENTE PROVIDO.
+I) A pretensão de limitação temporal da internação não foi apreciada na decisão objurgada, pois não foi suscitada em primeiro grau, de modo que não cabe ao juízo ad quem conhecer da questão de forma originária, sob pena de supressão de instância.
+II) A internação compulsória, de natureza cível e sanitária, pode ser validamente decretada por decisão judicial quando demonstrado, por laudo médico circunstanciado, que o paciente apresenta transtorno mental grave, com risco concreto à vida ou à integridade física.
+III) Relatório psicológico e parecer psiquiátrico juntados aos autos demonstram que a paciente sofre de transtorno de esquizofrenia, apresentando risco à sua própria integridade e a de terceiros, evidenciando a ineficácia dos tratamentos ambulatoriais e a urgência da medida excepcional.
+IV) Nos termos do Tema 793 do STF, os entes federativos respondem solidariamente pelas demandas prestacionais de saúde, competindo ao magistrado direcionar o cumprimento da obrigação conforme a repartição de competências do SUS, com possibilidade de ressarcimento ao ente que suportar o ônus financeiro. Existindo parecer técnico do Núcleo de Apoio Técnico, legítimo o direcionamento do cumprimento ao Município, sem afastamento da solidariedade do Estado.
+V) Conforme entendimento consolidado do Superior Tribunal de Justiça (Tema nº 98), é perfeitamente admissível o arbitramento de multa sancionatória contra a Fazenda Pública para compeli-la ao cumprimento de obrigação judicial
+VI) Recurso parcialmente conhecido e, com o parecer, parcialmente provido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>131&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876630" cdForo="0" >
+										0845980-84.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876630" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876630);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876630" style="display: none;" >
+	<div id="textAreaDados_1876630" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; V&Iacute;CIOS INEXISTENTES &ndash; REDISCUSS&Atilde;O DA MAT&Eacute;RIA &ndash; PREQUESTIONAMENTO &ndash;  RECURSO DESPROVIDO.
+I - Embargos de declara&ccedil;&atilde;o &eacute; recurso horizontal destinado ao &oacute;rg&atilde;o singular ou colegiado para suprir as falhas existentes no julgado. Inexistindo tais v&iacute;cios, &eacute; de se negar provimento ao recurso.
+II - O colegiado n&atilde;o est&aacute; obrigado a mencionar dispositivos da Constitui&ccedil;&atilde;o Federal, de lei ou de norma infralegal, para fins de prequestionamento, bastando declinar as raz&otilde;es pelas quais chegou &agrave; conclus&atilde;o exposta no ac&oacute;rd&atilde;o, fundamentando-o como ocorreu no caso em destaque.
+  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0845980-84.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									845980842024812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – VÍCIOS INEXISTENTES – REDISCUSSÃO DA MATÉRIA – PREQUESTIONAMENTO –  RECURSO DESPROVIDO.
+I - Embargos de declaração é recurso horizontal destinado ao órgão singular ou colegiado para suprir as falhas existentes no julgado. Inexistindo tais vícios, é de se negar provimento ao recurso.
+II - O colegiado não está obrigado a mencionar dispositivos da
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – VÍCIOS INEXISTENTES – REDISCUSSÃO DA MATÉRIA – PREQUESTIONAMENTO –  RECURSO DESPROVIDO.
+I - Embargos de declaração é recurso horizontal destinado ao órgão singular ou colegiado para suprir as falhas existentes no julgado. Inexistindo tais vícios, é de se negar provimento ao recurso.
+II - O colegiado não está obrigado a mencionar dispositivos da Constituição Federal, de lei ou de norma infralegal, para fins de prequestionamento, bastando declinar as razões pelas quais chegou à conclusão exposta no acórdão, fundamentando-o como ocorreu no caso em destaque.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>132&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876656" cdForo="0" >
+										0801827-78.2025.8.12.0017
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876656" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876656);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876656" style="display: none;" >
+	<div id="textAreaDados_1876656" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE DECLARA&Ccedil;&Atilde;O DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO C/C INDENIZAT&Oacute;RIA - SUPOSTA OMISS&Atilde;O - INOCORR&Ecirc;NCIA -  PRETENS&Atilde;O DE REDISCUSS&Atilde;O - IMPOSSIBILIDADE - ACLARAT&Oacute;RIOS REJEITADOS. 1. Os embargos de declara&ccedil;&atilde;o t&ecirc;m como escopo esclarecer senten&ccedil;as ou ac&oacute;rd&atilde;os que pade&ccedil;am de v&iacute;cios, como a obscuridade, omiss&atilde;o, contradi&ccedil;&atilde;o ou erro material. 2. Assim, ainda que os aclarat&oacute;rios possuam natureza recursal, n&atilde;o tem cond&atilde;o de serem opostos com a inten&ccedil;&atilde;o de rediscutir o julgado, da mesma forma n&atilde;o se presta para a manifesta&ccedil;&atilde;o expressa sobre aplica&ccedil;&atilde;o ou viola&ccedil;&atilde;o de dispositivos legais ou constitucionais com a finalidade &uacute;nica de prequestionamento.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0801827-78.2025.8.12.0017,&nbsp; Nova Andradina,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Assinatura Básica Mensal
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Nova Andradina
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									801827782025812001750000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO DE DECLARAÇÃO DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO C/C INDENIZATÓRIA - SUPOSTA OMISSÃO - INOCORRÊNCIA -  PRETENSÃO DE REDISCUSSÃO - IMPOSSIBILIDADE - ACLARATÓRIOS REJEITADOS. 1. Os embargos de declaração têm como escopo esclarecer sentenças ou acórdãos que padeçam de vícios, como a obscuridade, omissão, contradição ou erro material.
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL – AÇÃO DE DECLARAÇÃO DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO DE INDÉBITO C/C INDENIZATÓRIA - SUPOSTA OMISSÃO - INOCORRÊNCIA -  PRETENSÃO DE REDISCUSSÃO - IMPOSSIBILIDADE - ACLARATÓRIOS REJEITADOS. 1. Os embargos de declaração têm como escopo esclarecer sentenças ou acórdãos que padeçam de vícios, como a obscuridade, omissão, contradição ou erro material. 2. Assim, ainda que os aclaratórios possuam natureza recursal, não tem condão de serem opostos com a intenção de rediscutir o julgado, da mesma forma não se presta para a manifestação expressa sobre aplicação ou violação de dispositivos legais ou constitucionais com a finalidade única de prequestionamento.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>133&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876693" cdForo="0" >
+										0933411-25.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876693" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876693);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876693" style="display: none;" >
+	<div id="textAreaDados_1876693" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O CRIMINAL INTERPOSTA PELO MINIST&Eacute;RIO P&Uacute;BLICO. TR&Aacute;FICO DE DROGAS E POSSE ILEGAL DE ARMA DE FOGO DE USO RESTRITO. SENTEN&Ccedil;A QUE DECRETOU A NULIDADE DAS PROVAS POR OCORR&Ecirc;NCIA DE IRREGULARIDADES NO FLAGRANTE. DECIS&Atilde;O REFORMADA. PLEITO PELA CONDENA&Ccedil;&Atilde;O. PARCIALMENTE ACOLHIDO. DUVIDA PATENTE ACERCA DA TRAFIC&Acirc;NCIA. CONDENA&Ccedil;&Atilde;O QUANTO AO CRIME ASSENTE NO ART. 16, CAPUT, DA LEI N. 10.826/2003 DECRETADA.PEDIDO DE CONDENA&Ccedil;&Atilde;O EM DANOS MORAIS COLETIVOS. N&Atilde;O ACOLHIDO. AUS&Ecirc;NCIA DE INSTRU&Ccedil;&Atilde;O PROBAT&Oacute;RIA ESPEC&Iacute;FICA. DANO N&Atilde;O PRESUMIDO. JURISPRUD&Ecirc;NCIA PAC&Iacute;FICA DO STJ. RESPEITO AOS PRINC&Iacute;PIOS DO CONTRADIT&Oacute;RIO E DA AMPLA DEFESA. RECURSO PARCIALMENTE PROVIDO.
+1. Considerando que os testemunhos dos policiais militares prestados sob o crivo do contradit&oacute;rio, mostraram-se firmes, coerentes e detalhados, bem como que a jurisprud&ecirc;ncia p&aacute;tria atribui presun&ccedil;&atilde;o de legitimidade e f&eacute; p&uacute;blica &agrave; palavra dos agentes da lei, especialmente quando corroborada por outros elementos de convic&ccedil;&atilde;o materiais, e a defesa n&atilde;o logrou &ecirc;xito em demonstrar qualquer v&iacute;cio ou impedimento que pudesse desqualific&aacute;-los, n&atilde;o h&aacute; que se falar em nulidade processual ou viola&ccedil;&atilde;o de domic&iacute;lio, restando plenamente comprovada a guarda de entorpecentes pelo apelado e a posse de armamento e muni&ccedil;&otilde;es de uso restrito sem autoriza&ccedil;&atilde;o legal.
+2. Diante do conjunto probat&oacute;rio consistente nas particularidades da pris&atilde;o e na prova oral produzida em ju&iacute;zo, invi&aacute;vel o acolhimento do pedido de condena&ccedil;&atilde;o pela pr&aacute;tica do crime de tr&aacute;fico de drogas. Por outro lado,  a autoria quanto ao crime assente no art. 16, caput, da lei n. 10.826/2003 &eacute; certa e recai sobre o apelado.
+3. N&atilde;o assiste raz&atilde;o ao pleito ministerial de fixa&ccedil;&atilde;o de valor m&iacute;nimo reparat&oacute;rio a t&iacute;tulo de danos morais coletivos, pois conforme pacificado pelo Superior Tribunal de Justi&ccedil;a, a condena&ccedil;&atilde;o pressup&otilde;e instru&ccedil;&atilde;o probat&oacute;ria espec&iacute;fica para dimensionar a extens&atilde;o e a gravidade da les&atilde;o &agrave; coletividade. Por n&atilde;o se tratar de dano presumido, a aus&ecirc;ncia de dila&ccedil;&atilde;o probat&oacute;ria concreta inviabiliza o acolhimento do pedido, sob pena de viola&ccedil;&atilde;o aos princ&iacute;pios do contradit&oacute;rio e da ampla defesa.
+Em parte com o parecer, recurso parcialmente provido, para condenar Pedro Louren&ccedil;o Gomes Marques pela pr&aacute;tica do crime previsto art. 16, caput, da lei 10.826/2003, impondo-lhe a pena de 3 anos, 11 meses e 7 dias de reclus&atilde;o, em regime inicial fechado, e pagamento de 80 dias-multa; e desclassificar a infra&ccedil;&atilde;o prevista no art. 33, caput, da Lei 11.343/2006 para a imputa&ccedil;&atilde;o descrita no art. 28 do mesmo diploma legal.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0933411-25.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. Jos&eacute; Ale Ahmad Netto, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(9 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Tráfico de Drogas e Condutas Afins
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Ale Ahmad Netto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CRIMINAL INTERPOSTA PELO MINISTÉRIO PÚBLICO. TRÁFICO DE DROGAS E POSSE ILEGAL DE ARMA DE FOGO DE USO RESTRITO. SENTENÇA QUE DECRETOU A NULIDADE DAS PROVAS POR OCORRÊNCIA DE IRREGULARIDADES NO FLAGRANTE. DECISÃO REFORMADA. PLEITO PELA CONDENAÇÃO. PARCIALMENTE ACOLHIDO. DUVIDA PATENTE ACERCA DA TRAFICÂNCIA. CONDENAÇÃO QUANTO AO CRIME ASSENTE NO ART. 16, CAPUT, DA LEI N. 10.826/2003
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CRIMINAL INTERPOSTA PELO MINISTÉRIO PÚBLICO. TRÁFICO DE DROGAS E POSSE ILEGAL DE ARMA DE FOGO DE USO RESTRITO. SENTENÇA QUE DECRETOU A NULIDADE DAS PROVAS POR OCORRÊNCIA DE IRREGULARIDADES NO FLAGRANTE. DECISÃO REFORMADA. PLEITO PELA CONDENAÇÃO. PARCIALMENTE ACOLHIDO. DUVIDA PATENTE ACERCA DA TRAFICÂNCIA. CONDENAÇÃO QUANTO AO CRIME ASSENTE NO ART. 16, CAPUT, DA LEI N. 10.826/2003 DECRETADA.PEDIDO DE CONDENAÇÃO EM DANOS MORAIS COLETIVOS. NÃO ACOLHIDO. AUSÊNCIA DE INSTRUÇÃO PROBATÓRIA ESPECÍFICA. <em>DANO</em> NÃO PRESUMIDO. JURISPRUDÊNCIA PACÍFICA DO STJ. RESPEITO AOS PRINCÍPIOS DO CONTRADITÓRIO E DA AMPLA DEFESA. RECURSO PARCIALMENTE PROVIDO.
+1. Considerando que os testemunhos dos policiais militares prestados sob o crivo do contraditório, mostraram-se firmes, coerentes e detalhados, bem como que a jurisprudência pátria atribui presunção de legitimidade e fé pública à palavra dos agentes da lei, especialmente quando corroborada por outros elementos de convicção materiais, e a defesa não logrou êxito em demonstrar qualquer vício ou impedimento que pudesse desqualificá-los, não há que se falar em nulidade processual ou violação de domicílio, restando plenamente comprovada a guarda de entorpecentes pelo apelado e a posse de armamento e munições de uso restrito sem autorização legal.
+2. Diante do conjunto probatório consistente nas particularidades da prisão e na prova oral produzida em juízo, inviável o acolhimento do pedido de condenação pela prática do crime de tráfico de drogas. Por outro lado,  a autoria quanto ao crime assente no art. 16, caput, da lei n. 10.826/2003 é certa e recai sobre o apelado.
+3. Não assiste razão ao pleito ministerial de fixação de valor mínimo reparatório a título de danos morais coletivos, pois conforme pacificado pelo Superior Tribunal de Justiça, a condenação pressupõe instrução probatória específica para dimensionar a extensão e a gravidade da lesão à coletividade. Por não se tratar de <em>dano</em> presumido, a ausência de dilação probatória concreta inviabiliza o acolhimento do pedido, sob pena de violação aos princípios do contraditório e da ampla defesa.
+Em parte com o parecer, recurso parcialmente provido, para condenar Pedro Lourenço Gomes Marques pela prática do crime previsto art. 16, caput, da lei 10.826/2003, impondo-lhe a pena de 3 anos, 11 meses e 7 dias de reclusão, em regime inicial fechado, e pagamento de 80 dias-multa; e desclassificar a infração prevista no art. 33, caput, da Lei 11.343/2006 para a imputação descrita no art. 28 do mesmo diploma legal.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>134&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876696" cdForo="0" >
+										0801049-84.2024.8.12.0004
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876696" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876696);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876696" style="display: none;" >
+	<div id="textAreaDados_1876696" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS. CART&Atilde;O DE CR&Eacute;DITO CONSIGNADO (RMC). CONTRATA&Ccedil;&Atilde;O COMPROVADA. AUS&Ecirc;NCIA DE V&Iacute;CIO DE CONSENTIMENTO. DESCONTOS AUTORIZADOS. INEXIST&Ecirc;NCIA DE ATO IL&Iacute;CITO. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedentes os pedidos de declara&ccedil;&atilde;o de inexist&ecirc;ncia de d&eacute;bito, repeti&ccedil;&atilde;o de ind&eacute;bito e indeniza&ccedil;&atilde;o por danos morais, sob o fundamento de validade da contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado (RMC), com descontos em benef&iacute;cio previdenci&aacute;rio.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+H&aacute; duas quest&otilde;es em discuss&atilde;o: (i) definir se houve ofensa ao princ&iacute;pio da dialeticidade recursal; (ii) estabelecer se a contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado &eacute; inv&aacute;lida por v&iacute;cio de consentimento ou falha na presta&ccedil;&atilde;o do servi&ccedil;o, apta a ensejar restitui&ccedil;&atilde;o de valores e indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+Rejeita-se a preliminar de ofensa &agrave; dialeticidade, pois o recurso apresenta fundamentos suficientes e impugna especificamente a senten&ccedil;a, nos termos do art. 1.010, III, do CPC e da jurisprud&ecirc;ncia do STJ.
+Reconhece-se que a institui&ccedil;&atilde;o financeira se desincumbe do &ocirc;nus probat&oacute;rio ao apresentar contrato de ades&atilde;o ao cart&atilde;o consignado, termo de consentimento e documentos assinados pela parte autora.
+Verifica-se que o contrato cont&eacute;m autoriza&ccedil;&atilde;o expressa para descontos em folha/benef&iacute;cio, evidenciando ci&ecirc;ncia das condi&ccedil;&otilde;es pactuadas.
+Constata-se a disponibiliza&ccedil;&atilde;o do valor contratado em cart&atilde;o de cr&eacute;dito.
+Afasta-se a alega&ccedil;&atilde;o de v&iacute;cio de consentimento, pois a parte autora n&atilde;o produz prova m&iacute;nima capaz de evidenciar erro, dolo ou aus&ecirc;ncia de informa&ccedil;&atilde;o.
+Conclui-se pela validade e efic&aacute;cia do contrato, impondo-se o cumprimento das obriga&ccedil;&otilde;es pactuadas, &agrave; luz do princ&iacute;pio do pacta sunt servanda.
+Inexiste ato il&iacute;cito ou falha na presta&ccedil;&atilde;o do servi&ccedil;o, o que afasta o dever de restitui&ccedil;&atilde;o e de indeniza&ccedil;&atilde;o por danos morais.
+Aplica-se a jurisprud&ecirc;ncia consolidada do tribunal no sentido da licitude da contrata&ccedil;&atilde;o de RMC quando comprovada a ades&atilde;o e aus&ecirc;ncia de v&iacute;cios.
+Recurso desprovido.
+Tese de julgamento: 1. N&atilde;o h&aacute; ofensa ao princ&iacute;pio da dialeticidade quando o recurso apresenta fundamentos suficientes para impugnar a decis&atilde;o recorrida. 2. A apresenta&ccedil;&atilde;o de contrato assinado e documentos correlatos comprova a regularidade da contrata&ccedil;&atilde;o de cart&atilde;o de cr&eacute;dito consignado. 3. A aus&ecirc;ncia de prova de v&iacute;cio de consentimento mant&eacute;m a validade do contrato e legitima os descontos realizados. 4. Inexistente ato il&iacute;cito, n&atilde;o h&aacute; dever de restitui&ccedil;&atilde;o de valores nem de indenizar por danos morais.
+Dispositivos relevantes citados: CPC, art. 1.010, III; CPC, art. 373, I e II; CPC, art. 98, &sect; 3&ordm;; CC, art. 188, II; CDC, art. 54, &sect; 4&ordm;.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt nos EDcl no REsp 2111888/MG, Rel. Min., j. 2023; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801217-35.2024.8.12.0021, Rel. Des&ordf; Elisabeth Rosa Baisch, j. 18/11/2024; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0801533-96.2024.8.12.0005, Rel. Ju&iacute;za C&iacute;ntia Xavier Letteriello, j. 21/11/2024; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0868918-10.2023.8.12.0001, Rel. Des. Alexandre Bastos, j. 25/10/2024; TJMS, Apela&ccedil;&atilde;o C&iacute;vel n. 0802844-21.2022.8.12.0029, Rel. Des. Vladimir Abreu da Silva, j. 01/11/2024.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801049-84.2024.8.12.0004,&nbsp; Amambai,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Wagner Mansur Saad, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Crédito Rotativo
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Wagner Mansur Saad
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Amambai
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO (RMC). CONTRATAÇÃO COMPROVADA. AUSÊNCIA DE VÍCIO DE CONSENTIMENTO. DESCONTOS AUTORIZADOS. INEXISTÊNCIA DE ATO ILÍCITO. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação cível interposta contra sentença
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS. CARTÃO DE CRÉDITO CONSIGNADO (RMC). CONTRATAÇÃO COMPROVADA. AUSÊNCIA DE VÍCIO DE CONSENTIMENTO. DESCONTOS AUTORIZADOS. INEXISTÊNCIA DE ATO ILÍCITO. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+Apelação cível interposta contra sentença que julgou improcedentes os pedidos de declaração de inexistência de débito, repetição de indébito e indenização por danos morais, sob o fundamento de validade da contratação de cartão de crédito consignado (RMC), com descontos em benefício previdenciário.
+II. QUESTÃO EM DISCUSSÃO
+Há duas questões em discussão: (i) definir se houve ofensa ao princípio da dialeticidade recursal; (ii) estabelecer se a contratação de cartão de crédito consignado é inválida por vício de consentimento ou falha na prestação do serviço, apta a ensejar restituição de valores e indenização por danos morais.
+III. RAZÕES DE DECIDIR
+Rejeita-se a preliminar de ofensa à dialeticidade, pois o recurso apresenta fundamentos suficientes e impugna especificamente a sentença, nos termos do art. 1.010, III, do CPC e da jurisprudência do STJ.
+Reconhece-se que a instituição financeira se desincumbe do ônus probatório ao apresentar contrato de adesão ao cartão consignado, termo de consentimento e documentos assinados pela parte autora.
+Verifica-se que o contrato contém autorização expressa para descontos em folha/benefício, evidenciando ciência das condições pactuadas.
+Constata-se a disponibilização do valor contratado em cartão de crédito.
+Afasta-se a alegação de vício de consentimento, pois a parte autora não produz prova mínima capaz de evidenciar erro, dolo ou ausência de informação.
+Conclui-se pela validade e eficácia do contrato, impondo-se o cumprimento das obrigações pactuadas, à luz do princípio do pacta sunt servanda.
+Inexiste ato ilícito ou falha na prestação do serviço, o que afasta o dever de restituição e de indenização por danos morais.
+Aplica-se a jurisprudência consolidada do tribunal no sentido da licitude da contratação de RMC quando comprovada a adesão e ausência de vícios.
+Recurso desprovido.
+Tese de julgamento: 1. Não há ofensa ao princípio da dialeticidade quando o recurso apresenta fundamentos suficientes para impugnar a decisão recorrida. 2. A apresentação de contrato assinado e documentos correlatos comprova a regularidade da contratação de cartão de crédito consignado. 3. A ausência de prova de vício de consentimento mantém a validade do contrato e legitima os descontos realizados. 4. Inexistente ato ilícito, não há dever de restituição de valores nem de indenizar por danos morais.
+Dispositivos relevantes citados: CPC, art. 1.010, III; CPC, art. 373, I e II; CPC, art. 98, § 3º; CC, art. 188, II; CDC, art. 54, § 4º.
+Jurisprudência relevante citada: STJ, AgInt nos EDcl no REsp 2111888/MG, Rel. Min., j. 2023; TJMS, Apelação Cível n. 0801217-35.2024.8.12.0021, Rel. Desª Elisabeth Rosa Baisch, j. 18/11/2024; TJMS, Apelação Cível n. 0801533-96.2024.8.12.0005, Rel. Juíza Cíntia Xavier Letteriello, j. 21/11/2024; TJMS, Apelação Cível n. 0868918-10.2023.8.12.0001, Rel. Des. Alexandre Bastos, j. 25/10/2024; TJMS, Apelação Cível n. 0802844-21.2022.8.12.0029, Rel. Des. Vladimir Abreu da Silva, j. 01/11/2024.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>135&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876700" cdForo="0" >
+										0900070-40.2023.8.12.0013
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876700" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876700);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876700" style="display: none;" >
+	<div id="textAreaDados_1876700" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O CRIMINAL &ndash; RECURSO DEFENSIVO &ndash; FURTO QUALIFICADO E USO DE DOCUMENTO FALSO. REDU&Ccedil;&Atilde;O DA REPARA&Ccedil;&Atilde;O M&Iacute;NIMA DE DANOS MORAIS E MATERIAIS FIXADOS EM FAVOR DA V&Iacute;TIMA &ndash; IMPOSSIBILIDADE &ndash; INDENIZA&Ccedil;&Atilde;O PRECEDIDA DE PEDIDO E QUANTITATIVO EXPRESSO NA DEN&Uacute;NCIA &ndash; QUANTUM APLICADO EM CONFORMIDADE AS PARTICULARIDADES DO CASO. DETRA&Ccedil;&Atilde;O PENAL &ndash; COMPET&Ecirc;NCIA DO JU&Iacute;ZO DA EXECU&Ccedil;&Atilde;O &ndash; RECURSO DESPROVIDO.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0900070-40.2023.8.12.0013,&nbsp; Jardim,&nbsp; 2&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. Jos&eacute; Ale Ahmad Netto, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Estelionato
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Ale Ahmad Netto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Jardim
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1876700" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												APELAÇÃO CRIMINAL – RECURSO DEFENSIVO – FURTO QUALIFICADO E USO DE DOCUMENTO FALSO. REDUÇÃO DA REPARAÇÃO MÍNIMA DE DANOS MORAIS E MATERIAIS FIXADOS EM FAVOR DA VÍTIMA – IMPOSSIBILIDADE – INDENIZAÇÃO PRECEDIDA DE PEDIDO E QUANTITATIVO EXPRESSO NA DENÚNCIA – QUANTUM APLICADO EM CONFORMIDADE AS PARTICULARIDADES DO CASO. DETRAÇÃO PENAL – COMPETÊNCIA DO JUÍZO DA EXECUÇÃO – RECURSO DESPROVIDO.
+
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>136&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876703" cdForo="0" >
+										0800289-75.2025.8.12.0045
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876703" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876703);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876703" style="display: none;" >
+	<div id="textAreaDados_1876703" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; PLANO DE SA&Uacute;DE &ndash;  TRATAMENTO MULTIDISCIPLINAR &ndash; TRANSTORNO DO ESPECTRO AUTISTA (TEA) &ndash; M&Eacute;TODO DE INTEGRA&Ccedil;&Atilde;O GLOBAL (MIG) &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O CIENT&Iacute;FICA DE EFIC&Aacute;CIA &ndash; INEXIST&Ecirc;NCIA DE RECOMENDA&Ccedil;&Atilde;O DE &Oacute;RG&Atilde;OS T&Eacute;CNICOS &ndash; REQUISITOS LEGAIS PARA COBERTURA EXCEPCIONAL N&Atilde;O PREENCHIDOS &ndash; LEI N. 14.454/2022 &ndash; ROL DA ANS &ndash; RECUSA LEG&Iacute;TIMA DA OPERADORA &ndash; INOCORR&Ecirc;NCIA DE DANO MORAL &ndash; COPARTICIPA&Ccedil;&Atilde;O &ndash; MAT&Eacute;RIA N&Atilde;O CONHECIDA &ndash; RECURSO PARCIALMENTE CONHECIDO; NA PARTE CONHECIDA, PROVIDO.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800289-75.2025.8.12.0045,&nbsp; Sidrol&acirc;ndia,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Tratamento médico-hospitalar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sidrolândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – PLANO DE SAÚDE –  TRATAMENTO MULTIDISCIPLINAR – TRANSTORNO DO ESPECTRO AUTISTA (TEA) – MÉTODO DE INTEGRAÇÃO GLOBAL (MIG) – AUSÊNCIA DE COMPROVAÇÃO CIENTÍFICA DE EFICÁCIA – INEXISTÊNCIA DE RECOMENDAÇÃO DE ÓRGÃOS TÉCNICOS – REQUISITOS LEGAIS PARA COBERTURA EXCEPCIONAL NÃO PREENCHIDOS – LEI N. 14.454/2022 – ROL DA ANS – RECUSA LEGÍTIMA DA OPERADORA – INOCORRÊNCIA DE <em>DANO</em>
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – PLANO DE SAÚDE –  TRATAMENTO MULTIDISCIPLINAR – TRANSTORNO DO ESPECTRO AUTISTA (TEA) – MÉTODO DE INTEGRAÇÃO GLOBAL (MIG) – AUSÊNCIA DE COMPROVAÇÃO CIENTÍFICA DE EFICÁCIA – INEXISTÊNCIA DE RECOMENDAÇÃO DE ÓRGÃOS TÉCNICOS – REQUISITOS LEGAIS PARA COBERTURA EXCEPCIONAL NÃO PREENCHIDOS – LEI N. 14.454/2022 – ROL DA ANS – RECUSA LEGÍTIMA DA OPERADORA – INOCORRÊNCIA DE <em>DANO</em> <em>MORAL</em> – COPARTICIPAÇÃO – MATÉRIA NÃO CONHECIDA – RECURSO PARCIALMENTE CONHECIDO; NA PARTE CONHECIDA, PROVIDO.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>137&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876709" cdForo="0" >
+										1403345-71.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876709" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876709);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876709" style="display: none;" >
+	<div id="textAreaDados_1876709" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTEN&Ccedil;A. IMPUGNA&Ccedil;&Atilde;O AO CUMPRIMENTO DE SENTEN&Ccedil;A ACOLHIDA. DIVERG&Ecirc;NCIA ENTRE VALOR NUM&Eacute;RICO E VALOR POR EXTENSO NO T&Iacute;TULO EXECUTIVO. NECESSIDADE DE INTERPRETA&Ccedil;&Atilde;O SISTEM&Aacute;TICA DO AC&Oacute;RD&Atilde;O. ERRO MATERIAL CONFIGURADO. FIXA&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO EM R$ 5.000,00. AUS&Ecirc;NCIA DE VIOLA&Ccedil;&Atilde;O &Agrave; COISA JULGADA. HONOR&Aacute;RIOS SUCUMBENCIAIS DEVIDOS. DECIS&Atilde;O MANTIDA. RECURSO DESPROVIDO.
+1. A interpreta&ccedil;&atilde;o do t&iacute;tulo executivo judicial deve observar sua unidade l&oacute;gica, extraindo-se o real conte&uacute;do decis&oacute;rio a partir da leitura sistem&aacute;tica do ac&oacute;rd&atilde;o. Evidenciado que a fundamenta&ccedil;&atilde;o fixou expressamente a indeniza&ccedil;&atilde;o em R$ 5.000,00, a diverg&ecirc;ncia verificada no dispositivo configura erro material, pass&iacute;vel de corre&ccedil;&atilde;o, sem viola&ccedil;&atilde;o &agrave; coisa julgada.
+2. Tendo havido o acolhimento da impugna&ccedil;&atilde;o ao cumprimento de senten&ccedil;a, cab&iacute;vel a fixa&ccedil;&atilde;o de honor&aacute;rios sucumbenciais em favor do executado, porquanto, pelo princ&iacute;pio da causalidade, a parte credora deve suportar o &ocirc;nus sucumbenciais.
+3. Recurso conhecido e desprovido.
+  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1403345-71.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Honorários Advocatícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTENÇA. IMPUGNAÇÃO AO CUMPRIMENTO DE SENTENÇA ACOLHIDA. DIVERGÊNCIA ENTRE VALOR NUMÉRICO E VALOR POR EXTENSO NO TÍTULO EXECUTIVO. NECESSIDADE DE INTERPRETAÇÃO SISTEMÁTICA DO ACÓRDÃO. ERRO MATERIAL CONFIGURADO. FIXAÇÃO DO QUANTUM INDENIZATÓRIO EM R$ 5.000,00. AUSÊNCIA DE VIOLAÇÃO À COISA JULGADA. HONORÁRIOS SUCUMBENCIAIS DEVIDOS. DECISÃO MANTIDA. RECURSO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO. CUMPRIMENTO DE SENTENÇA. IMPUGNAÇÃO AO CUMPRIMENTO DE SENTENÇA ACOLHIDA. DIVERGÊNCIA ENTRE VALOR NUMÉRICO E VALOR POR EXTENSO NO TÍTULO EXECUTIVO. NECESSIDADE DE INTERPRETAÇÃO SISTEMÁTICA DO ACÓRDÃO. ERRO MATERIAL CONFIGURADO. FIXAÇÃO DO QUANTUM INDENIZATÓRIO EM R$ 5.000,00. AUSÊNCIA DE VIOLAÇÃO À COISA JULGADA. HONORÁRIOS SUCUMBENCIAIS DEVIDOS. DECISÃO MANTIDA. RECURSO DESPROVIDO.
+1. A interpretação do título executivo judicial deve observar sua unidade lógica, extraindo-se o real conteúdo decisório a partir da leitura sistemática do acórdão. Evidenciado que a fundamentação fixou expressamente a indenização em R$ 5.000,00, a divergência verificada no dispositivo configura erro material, passível de correção, sem violação à coisa julgada.
+2. Tendo havido o acolhimento da impugnação ao cumprimento de sentença, cabível a fixação de honorários sucumbenciais em favor do executado, porquanto, pelo princípio da causalidade, a parte credora deve suportar o ônus sucumbenciais.
+3. Recurso conhecido e desprovido.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>138&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876713" cdForo="0" >
+										0805768-81.2025.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876713" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876713);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876713" style="display: none;" >
+	<div id="textAreaDados_1876713" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE CONTRATOS &ndash; INEXIST&Ecirc;NCIA DE D&Eacute;BITO &ndash; INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; FRAUDE BANC&Aacute;RIA &ndash; &quot;GOLPE DA FALSA CENTRAL DE ATENDIMENTO&quot; &ndash; CONSUMIDORA QUE FORNECEU VOLUNTARIAMENTE DADOS SIGILOSOS E SENHA PESSOAL &ndash; CULPA EXCLUSIVA DA V&Iacute;TIMA OU DE TERCEIRO &ndash; FORTUITO EXTERNO &ndash; EXCLUDENTE DE RESPONSABILIDADE &ndash; ART. 14, &sect; 3&ordm;, II, CDC &ndash; ROMPIMENTO DO NEXO CAUSAL &ndash; AUS&Ecirc;NCIA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O BANC&Aacute;RIO &ndash; IMPROCED&Ecirc;NCIA DOS PEDIDOS &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO PROVIDO.
+Aplica-se o C&oacute;digo de Defesa do Consumidor &agrave;s rela&ccedil;&otilde;es estabelecidas entre as institui&ccedil;&otilde;es financeiras e seus clientes. Contudo, a responsabilidade objetiva do fornecedor pode ser afastada quando comprovada a culpa exclusiva do consumidor ou de terceiro.
+O &quot;golpe da falsa central de atendimento&quot;, em que o consumidor, por conta pr&oacute;pria, fornece dados sigilosos e senhas pessoais a fraudadores que se passam por funcion&aacute;rios do banco, configura fortuito externo. Tal conduta rompe o nexo de causalidade entre a a&ccedil;&atilde;o do banco e o dano sofrido, afastando o dever de indenizar, mesmo diante da incid&ecirc;ncia da S&uacute;mula n. 479/STJ, que se refere a fortuito interno.
+A utiliza&ccedil;&atilde;o regular dos sistemas de autentica&ccedil;&atilde;o e seguran&ccedil;a da institui&ccedil;&atilde;o financeira pela pr&oacute;pria v&iacute;tima, ainda que induzida a erro por terceiro, descaracteriza a falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio que justifique a responsabiliza&ccedil;&atilde;o do banco. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0805768-81.2025.8.12.0002,&nbsp; Dourados,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATOS – INEXISTÊNCIA DE DÉBITO – INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – FRAUDE BANCÁRIA – "GOLPE DA FALSA CENTRAL DE ATENDIMENTO" – CONSUMIDORA QUE FORNECEU VOLUNTARIAMENTE DADOS SIGILOSOS E SENHA PESSOAL – CULPA EXCLUSIVA DA VÍTIMA OU DE TERCEIRO – FORTUITO EXTERNO – EXCLUDENTE DE RESPONSABILIDADE – ART. 14, § 3º, II, CDC – ROMPIMENTO DO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATOS – INEXISTÊNCIA DE DÉBITO – INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – FRAUDE BANCÁRIA – "GOLPE DA FALSA CENTRAL DE ATENDIMENTO" – CONSUMIDORA QUE FORNECEU VOLUNTARIAMENTE DADOS SIGILOSOS E SENHA PESSOAL – CULPA EXCLUSIVA DA VÍTIMA OU DE TERCEIRO – FORTUITO EXTERNO – EXCLUDENTE DE RESPONSABILIDADE – ART. 14, § 3º, II, CDC – ROMPIMENTO DO NEXO CAUSAL – AUSÊNCIA DE FALHA NA PRESTAÇÃO DO SERVIÇO BANCÁRIO – IMPROCEDÊNCIA DOS PEDIDOS – SENTENÇA REFORMADA – RECURSO PROVIDO.
+Aplica-se o Código de Defesa do Consumidor às relações estabelecidas entre as instituições financeiras e seus clientes. Contudo, a responsabilidade objetiva do fornecedor pode ser afastada quando comprovada a culpa exclusiva do consumidor ou de terceiro.
+O "golpe da falsa central de atendimento", em que o consumidor, por conta própria, fornece dados sigilosos e senhas pessoais a fraudadores que se passam por funcionários do banco, configura fortuito externo. Tal conduta rompe o nexo de causalidade entre a ação do banco e o <em>dano</em> sofrido, afastando o dever de indenizar, mesmo diante da incidência da Súmula n. 479/STJ, que se refere a fortuito interno.
+A utilização regular dos sistemas de autenticação e segurança da instituição financeira pela própria vítima, ainda que induzida a erro por terceiro, descaracteriza a falha na prestação do serviço bancário que justifique a responsabilização do banco.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>139&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876732" cdForo="0" >
+										0800768-82.2025.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876732" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876732);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876732" style="display: none;" >
+	<div id="textAreaDados_1876732" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE RESTITUI&Ccedil;&Atilde;O DE VALORES C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CONTA POUPAN&Ccedil;A &ndash; ENCERRAMENTO SEM COMPROVA&Ccedil;&Atilde;O DA DESTINA&Ccedil;&Atilde;O DO SALDO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; RESPONSABILIDADE OBJETIVA &ndash; RESTITUI&Ccedil;&Atilde;O DEVIDA &ndash; DANO MORAL CONFIGURADO &ndash; REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO &ndash; JUROS E CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA &ndash; MANUTEN&Ccedil;&Atilde;O &ndash; RECURSO PARCIALMENTE PROVIDO.
+I - As institui&ccedil;&otilde;es financeiras respondem objetivamente pelos danos causados aos consumidores, nos termos do art. 14, CDC, bastando a demonstra&ccedil;&atilde;o do defeito na presta&ccedil;&atilde;o do servi&ccedil;o e do nexo causal.
+II - Comprovada a exist&ecirc;ncia de conta poupan&ccedil;a com saldo positivo anteriormente ao seu encerramento e n&atilde;o demonstrada, pela institui&ccedil;&atilde;o financeira, a destina&ccedil;&atilde;o dos valores ou a inexist&ecirc;ncia de saldo, evidencia-se a falha na presta&ccedil;&atilde;o do servi&ccedil;o, o que imp&otilde;e a restitui&ccedil;&atilde;o do montante indevidamente subtra&iacute;do.
+III - A aus&ecirc;ncia de informa&ccedil;&otilde;es claras acerca do encerramento da conta e a indisponibilidade injustificada de valores configuram dano moral indeniz&aacute;vel, por viola&ccedil;&atilde;o a direitos da personalidade, superando o mero aborrecimento.
+IV - O valor da indeniza&ccedil;&atilde;o por danos morais deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, sem implicar enriquecimento sem causa, raz&atilde;o pela qual se mostra adequada a redu&ccedil;&atilde;o do quantum fixado na origem.
+V - Mant&ecirc;m-se os crit&eacute;rios de incid&ecirc;ncia de juros de mora a partir da cita&ccedil;&atilde;o (art. 405, CC) e de corre&ccedil;&atilde;o monet&aacute;ria desde o arbitramento (S&uacute;mula 362/STJ) sobre a indeniza&ccedil;&atilde;o por danos morais, por se tratar de rela&ccedil;&atilde;o contratual.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800768-82.2025.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(34 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESTITUIÇÃO DE VALORES C/C INDENIZAÇÃO POR DANOS MORAIS – CONTA POUPANÇA – ENCERRAMENTO SEM COMPROVAÇÃO DA DESTINAÇÃO DO SALDO – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – RESTITUIÇÃO DEVIDA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – REDUÇÃO DO QUANTUM INDENIZATÓRIO – JUROS E CORREÇÃO MONETÁRIA – MANUTENÇÃO – RECURSO PARCIALMENTE PROVIDO.
+I - As
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESTITUIÇÃO DE VALORES C/C INDENIZAÇÃO POR DANOS MORAIS – CONTA POUPANÇA – ENCERRAMENTO SEM COMPROVAÇÃO DA DESTINAÇÃO DO SALDO – FALHA NA PRESTAÇÃO DO SERVIÇO – RESPONSABILIDADE OBJETIVA – RESTITUIÇÃO DEVIDA – <em>DANO</em> <em>MORAL</em> CONFIGURADO – REDUÇÃO DO QUANTUM INDENIZATÓRIO – JUROS E CORREÇÃO MONETÁRIA – MANUTENÇÃO – RECURSO PARCIALMENTE PROVIDO.
+I - As instituições financeiras respondem objetivamente pelos danos causados aos consumidores, nos termos do art. 14, CDC, bastando a demonstração do defeito na prestação do serviço e do nexo causal.
+II - Comprovada a existência de conta poupança com saldo positivo anteriormente ao seu encerramento e não demonstrada, pela instituição financeira, a destinação dos valores ou a inexistência de saldo, evidencia-se a falha na prestação do serviço, o que impõe a restituição do montante indevidamente subtraído.
+III - A ausência de informações claras acerca do encerramento da conta e a indisponibilidade injustificada de valores configuram <em>dano</em> <em>moral</em> indenizável, por violação a direitos da personalidade, superando o mero aborrecimento.
+IV - O valor da indenização por danos morais deve observar os princípios da razoabilidade e proporcionalidade, sem implicar enriquecimento sem causa, razão pela qual se mostra adequada a redução do quantum fixado na origem.
+V - Mantêm-se os critérios de incidência de juros de mora a partir da citação (art. 405, CC) e de correção monetária desde o arbitramento (Súmula 362/STJ) sobre a indenização por danos morais, por se tratar de relação contratual.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>140&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876739" cdForo="0" >
+										0800323-43.2025.8.12.0015
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876739" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876739);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876739" style="display: none;" >
+	<div id="textAreaDados_1876739" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. DESCONTOS EM CONTA DE BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. CESTA DE SERVI&Ccedil;OS BANC&Aacute;RIOS. AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DA CONTRATA&Ccedil;&Atilde;O. ASSINATURA ELETR&Ocirc;NICA SEM LASTRO PROBAT&Oacute;RIO. REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO. DANO MORAL N&Atilde;O CONFIGURADO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta contra senten&ccedil;a que, nos autos de A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de Neg&oacute;cio Jur&iacute;dico c/c Inexigibilidade de D&eacute;bitos e Danos Morais, julgou improcedentes os pedidos de declara&ccedil;&atilde;o de inexist&ecirc;ncia de contrata&ccedil;&atilde;o de cesta de servi&ccedil;os banc&aacute;rios, restitui&ccedil;&atilde;o de valores descontados e compensa&ccedil;&atilde;o financeira por danos morais, mantendo descontos realizados em conta destinada ao recebimento de benef&iacute;cio previdenci&aacute;rio.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. H&aacute; tr&ecirc;s quest&otilde;es em discuss&atilde;o: (i) definir se a Institui&ccedil;&atilde;o Financeira comprovou validamente a contrata&ccedil;&atilde;o da cesta de servi&ccedil;os; (ii) estabelecer se os descontos realizados ensejam restitui&ccedil;&atilde;o simples ou em dobro; (iii) determinar se os descontos indevidos configuram dano moral indeniz&aacute;vel.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O Banco n&atilde;o comprova a contrata&ccedil;&atilde;o v&aacute;lida da cesta de servi&ccedil;os, uma vez que o termo apresentado cont&eacute;m assinatura eletr&ocirc;nica desprovida de elementos m&iacute;nimos de autentica&ccedil;&atilde;o, sem metadados t&eacute;cnicos capazes de aferir sua legitimidade, incidindo o &ocirc;nus probat&oacute;rio do art. 429, II, do CPC.
+4. A exist&ecirc;ncia de conta banc&aacute;ria n&atilde;o autoriza a cobran&ccedil;a de servi&ccedil;os tarifados sem consentimento espec&iacute;fico e comprovado do consumidor, sendo que a aus&ecirc;ncia de prova de utiliza&ccedil;&atilde;o de servi&ccedil;os al&eacute;m da franquia gratuita prevista na Resolu&ccedil;&atilde;o CMN n. 3.919/2010 torna ileg&iacute;tima a cobran&ccedil;a da cesta de servi&ccedil;os.
+5. A Institui&ccedil;&atilde;o Financeira responde objetivamente pela falha na presta&ccedil;&atilde;o do servi&ccedil;o, nos termos do art. 14 do CDC, diante da cobran&ccedil;a indevida baseada em contrata&ccedil;&atilde;o n&atilde;o comprovada.
+6. A restitui&ccedil;&atilde;o do ind&eacute;bito &eacute; devida, sendo simples para descontos anteriores a 30/3/2021 e em dobro para os posteriores, conforme orienta&ccedil;&atilde;o do STJ (EAREsp 676.608/RS), diante da viola&ccedil;&atilde;o &agrave; boa-f&eacute; objetiva e aus&ecirc;ncia de engano justific&aacute;vel.
+7. O dano moral n&atilde;o se configura, pois os descontos apresentam valor &iacute;nfimo e o longo lapso temporal entre os descontos e o ajuizamento da a&ccedil;&atilde;o evidencia aus&ecirc;ncia de abalo relevante aos direitos da personalidade
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido e parcialmente provido.
+Tese de julgamento: &quot;1. A assinatura eletr&ocirc;nica impugnada exige comprova&ccedil;&atilde;o t&eacute;cnica de autenticidade pela institui&ccedil;&atilde;o financeira, sob pena de invalidade do contrato. 2. S&atilde;o indevidos os descontos de cesta de servi&ccedil;os sem prova de contrata&ccedil;&atilde;o v&aacute;lida ou de utiliza&ccedil;&atilde;o de servi&ccedil;os al&eacute;m da franquia gratuita. 3. A restitui&ccedil;&atilde;o em dobro do ind&eacute;bito independe de m&aacute;-f&eacute; e aplica-se &agrave;s cobran&ccedil;as posteriores a 30/03/2021, salvo engano justific&aacute;vel. 4. Descontos banc&aacute;rios de valor &iacute;nfimo, associados &agrave; demora no ajuizamento da a&ccedil;&atilde;o, n&atilde;o configuram dano moral indeniz&aacute;vel &quot;.
+___________
+Dispositivos relevantes citados: CF/1988, art. 5&ordm;; CDC, arts. 6&ordm;, VIII, 14 e 42, par&aacute;grafo &uacute;nico; CPC, arts. 373, II, 429, II, 487, I e 86; CC, arts. 389, par&aacute;grafo &uacute;nico, 398 e 406, &sect;1&ordm;; Resolu&ccedil;&atilde;o CMN n&ordm; 3.919/2010.
+Jurisprud&ecirc;ncia relevante citada: STJ, EAREsp 676.608/RS, Rel. Min. Og Fernandes, Corte Especial, j. 21/10/2020; STJ, AgInt no AREsp 2.845.227/BA, Rel. Min. Raul Ara&uacute;jo, j. 25/08/2025; STJ, S&uacute;mulas 43 e 54; STJ, S&uacute;mula 479; TJMS, IRDR n&ordm; 0801506-97.2016.8.12.0004, Rel. Des. N&eacute;lio St&aacute;bile, j. 20/09/2019; TJMS, AI n&ordm; 1418859-98.2025.8.12.0000, Rel. Des&ordf; Elisabeth Rosa Baisch, j. 28/01/2026; TJMS, AC n&ordm; 0800339-30.2025.8.12.0004, Rel. Juiz Wagner Mansur Saad, j. 30/01/2026. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800323-43.2025.8.12.0015,&nbsp; Miranda,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Wagner Mansur Saad, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(34 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Wagner Mansur Saad
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Miranda
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. DESCONTOS EM CONTA DE BENEFÍCIO PREVIDENCIÁRIO. CESTA DE SERVIÇOS BANCÁRIOS. AUSÊNCIA DE COMPROVAÇÃO DA CONTRATAÇÃO. ASSINATURA ELETRÔNICA SEM LASTRO PROBATÓRIO. REPETIÇÃO DO INDÉBITO. <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta contra sentença que, nos autos de Ação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. DESCONTOS EM CONTA DE BENEFÍCIO PREVIDENCIÁRIO. CESTA DE SERVIÇOS BANCÁRIOS. AUSÊNCIA DE COMPROVAÇÃO DA CONTRATAÇÃO. ASSINATURA ELETRÔNICA SEM LASTRO PROBATÓRIO. REPETIÇÃO DO INDÉBITO. <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta contra sentença que, nos autos de Ação Declaratória de Inexistência de Negócio Jurídico c/c Inexigibilidade de Débitos e Danos Morais, julgou improcedentes os pedidos de declaração de inexistência de contratação de cesta de serviços bancários, restituição de valores descontados e compensação financeira por danos morais, mantendo descontos realizados em conta destinada ao recebimento de benefício previdenciário.
+II. QUESTÃO EM DISCUSSÃO
+2. Há três questões em discussão: (i) definir se a Instituição Financeira comprovou validamente a contratação da cesta de serviços; (ii) estabelecer se os descontos realizados ensejam restituição simples ou em dobro; (iii) determinar se os descontos indevidos configuram <em>dano</em> <em>moral</em> indenizável.
+III. RAZÕES DE DECIDIR
+3. O Banco não comprova a contratação válida da cesta de serviços, uma vez que o termo apresentado contém assinatura eletrônica desprovida de elementos mínimos de autenticação, sem metadados técnicos capazes de aferir sua legitimidade, incidindo o ônus probatório do art. 429, II, do CPC.
+4. A existência de conta bancária não autoriza a cobrança de serviços tarifados sem consentimento específico e comprovado do consumidor, sendo que a ausência de prova de utilização de serviços além da franquia gratuita prevista na Resolução CMN n. 3.919/2010 torna ilegítima a cobrança da cesta de serviços.
+5. A Instituição Financeira responde objetivamente pela falha na prestação do serviço, nos termos do art. 14 do CDC, diante da cobrança indevida baseada em contratação não comprovada.
+6. A restituição do indébito é devida, sendo simples para descontos anteriores a 30/3/2021 e em dobro para os posteriores, conforme orientação do STJ (EAREsp 676.608/RS), diante da violação à boa-fé objetiva e ausência de engano justificável.
+7. O <em>dano</em> <em>moral</em> não se configura, pois os descontos apresentam valor ínfimo e o longo lapso temporal entre os descontos e o ajuizamento da ação evidencia ausência de abalo relevante aos direitos da personalidade
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido e parcialmente provido.
+Tese de julgamento: "1. A assinatura eletrônica impugnada exige comprovação técnica de autenticidade pela instituição financeira, sob pena de invalidade do contrato. 2. São indevidos os descontos de cesta de serviços sem prova de contratação válida ou de utilização de serviços além da franquia gratuita. 3. A restituição em dobro do indébito independe de má-fé e aplica-se às cobranças posteriores a 30/03/2021, salvo engano justificável. 4. Descontos bancários de valor ínfimo, associados à demora no ajuizamento da ação, não configuram <em>dano</em> <em>moral</em> indenizável ".
+___________
+Dispositivos relevantes citados: CF/1988, art. 5º; CDC, arts. 6º, VIII, 14 e 42, parágrafo único; CPC, arts. 373, II, 429, II, 487, I e 86; CC, arts. 389, parágrafo único, 398 e 406, §1º; Resolução CMN nº 3.919/2010.
+Jurisprudência relevante citada: STJ, EAREsp 676.608/RS, Rel. Min. Og Fernandes, Corte Especial, j. 21/10/2020; STJ, AgInt no AREsp 2.845.227/BA, Rel. Min. Raul Araújo, j. 25/08/2025; STJ, Súmulas 43 e 54; STJ, Súmula 479; TJMS, IRDR nº 0801506-97.2016.8.12.0004, Rel. Des. Nélio Stábile, j. 20/09/2019; TJMS, AI nº 1418859-98.2025.8.12.0000, Rel. Desª Elisabeth Rosa Baisch, j. 28/01/2026; TJMS, AC nº 0800339-30.2025.8.12.0004, Rel. Juiz Wagner Mansur Saad, j. 30/01/2026.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>141&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876745" cdForo="0" >
+										0800125-61.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876745" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876745);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876745" style="display: none;" >
+	<div id="textAreaDados_1876745" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL E ADMINISTRATIVO. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DE COMPENSA&Ccedil;&Atilde;O POR DANOS MORAIS. RESPONSABILIDADE CIVIL DO ESTADO. CONDI&Ccedil;&Otilde;ES DE ENCARCERAMENTO. PRELIMINAR DE CERCEAMENTO DE DEFESA AFASTADA. M&Eacute;RITO. SUPERLOTA&Ccedil;&Atilde;O CARCER&Aacute;RIA. TEMA 365/STF. NECESSIDADE DE COMPROVA&Ccedil;&Atilde;O INDIVIDUALIZADA DO DANO. &Ocirc;NUS DA PROVA DO AUTOR. ALEGA&Ccedil;&Otilde;ES GEN&Eacute;RICAS. DANO MORAL N&Atilde;O CONFIGURADO. SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposto contra senten&ccedil;a que julgou improcedente o pedido de compensa&ccedil;&atilde;o por danos morais formulado por detento, fundado na alega&ccedil;&atilde;o de submiss&atilde;o a condi&ccedil;&otilde;es degradantes de encarceramento &ndash; notadamente superlota&ccedil;&atilde;o e insalubridade &ndash; em estabelecimento penal localizado no Munic&iacute;pio de Corumb&aacute;/MS.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A controv&eacute;rsia cinge-se a: (i) verificar se o indeferimento da produ&ccedil;&atilde;o de prova pericial e a valora&ccedil;&atilde;o da prova testemunhal caracterizaram cerceamento de defesa; e (ii) definir se a superlota&ccedil;&atilde;o carcer&aacute;ria e as condi&ccedil;&otilde;es adversas do sistema prisional, por si s&oacute;s, ensejam dano moral presumido (in re ipsa) ou se exigem comprova&ccedil;&atilde;o individualizada do preju&iacute;zo sofrido pelo detento, &agrave; luz do Tema 365 do STF.
+III. RAZ&Otilde;ES DE DECIDIR
+3. O indeferimento de provas consideradas in&uacute;teis, impertinentes ou protelat&oacute;rias n&atilde;o configura cerceamento de defesa, porquanto o magistrado, na condi&ccedil;&atilde;o de destinat&aacute;rio final da prova, det&eacute;m discricionariedade t&eacute;cnica para indeferir dilig&ecirc;ncias prescind&iacute;veis &agrave; forma&ccedil;&atilde;o de seu convencimento, sobretudo quando a controv&eacute;rsia se resolve pela aplica&ccedil;&atilde;o de tese jur&iacute;dica firmada em precedente vinculante.
+4. O STF, ao julgar o RE 580.252/MS, sob a sistem&aacute;tica da repercuss&atilde;o geral (Tema 365), firmou entendimento no sentido de que a responsabilidade civil do Estado por viola&ccedil;&atilde;o &agrave; dignidade do preso, decorrente da falta ou insufici&ecirc;ncia das condi&ccedil;&otilde;es legais de encarceramento, exige a comprova&ccedil;&atilde;o do dano efetivamente sofrido.
+5. A situa&ccedil;&atilde;o estrutural de superlota&ccedil;&atilde;o carcer&aacute;ria, embora revele grave falha do sistema prisional e tenha sido reconhecida como &quot;estado de coisas inconstitucional&quot; (ADPF 347), n&atilde;o gera automaticamente o dever de compensa&ccedil;&atilde;o por dano moral individual, o qual n&atilde;o se presume (in re ipsa).
+6. Incumbe &agrave; parte autora, nos termos do art. 373, I, do CPC, o &ocirc;nus de comprovar o fato constitutivo de seu direito, demonstrando de forma concreta e individualizada como as condi&ccedil;&otilde;es de cust&oacute;dia lhe acarretaram les&atilde;o espec&iacute;fica &agrave; dignidade, para al&eacute;m dos gravames inerentes &agrave; pr&oacute;pria execu&ccedil;&atilde;o da pena, sendo certo que a aus&ecirc;ncia dessa demonstra&ccedil;&atilde;o, aliada &agrave; formula&ccedil;&atilde;o de alega&ccedil;&otilde;es gen&eacute;ricas e padronizadas, inviabiliza o acolhimento da pretens&atilde;o compensat&oacute;ria.
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido e desprovido.
+Tese de julgamento: &quot;1. A responsabilidade civil do Estado por danos morais suportados por detentos, embora objetiva, exige a comprova&ccedil;&atilde;o individualizada do dano, n&atilde;o sendo a superlota&ccedil;&atilde;o carcer&aacute;ria, por si s&oacute;, suficiente para caracterizar compensa&ccedil;&atilde;o in re ipsa, conforme a tese fixada pelo STF no Tema 365 da repercuss&atilde;o geral. 2. Incumbe &agrave; parte autora o &ocirc;nus de demonstrar a les&atilde;o concreta, espec&iacute;fica e pessoal decorrente das condi&ccedil;&otilde;es de encarceramento, sendo insuficientes alega&ccedil;&otilde;es gen&eacute;ricas acerca das defici&ecirc;ncias estruturais do sistema prisional, sob pena de improced&ecirc;ncia do pedido de compensa&ccedil;&atilde;o financeira por danos morais&quot;.
+___________
+Dispositivos relevantes citados: arts. 5&ordm;, XLIX, e 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal; arts. 85, &sect; 11, 370, 373, I, e 927 do CPC.
+Jurisprud&ecirc;ncia relevante citada: STF, RE 580.252/MS (Tema 365); STJ, EREsp 962.934/MS; TJ-MS, Apela&ccedil;&atilde;o C&iacute;vel 0804500-42.2023.8.12.0008; TJ-MS, Apela&ccedil;&atilde;o C&iacute;vel 0804418-11.2023.8.12.0008. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800125-61.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Wagner Mansur Saad, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(57 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Wagner Mansur Saad
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E ADMINISTRATIVO. APELAÇÃO CÍVEL. AÇÃO DE COMPENSAÇÃO POR DANOS MORAIS. RESPONSABILIDADE CIVIL DO ESTADO. CONDIÇÕES DE ENCARCERAMENTO. PRELIMINAR DE CERCEAMENTO DE DEFESA AFASTADA. MÉRITO. SUPERLOTAÇÃO CARCERÁRIA. TEMA 365/STF. NECESSIDADE DE COMPROVAÇÃO INDIVIDUALIZADA DO <em>DANO</em>. ÔNUS DA PROVA DO AUTOR. ALEGAÇÕES GENÉRICAS. <em>DANO</em> <em>MORAL</em> NÃO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E ADMINISTRATIVO. APELAÇÃO CÍVEL. AÇÃO DE COMPENSAÇÃO POR DANOS MORAIS. RESPONSABILIDADE CIVIL DO ESTADO. CONDIÇÕES DE ENCARCERAMENTO. PRELIMINAR DE CERCEAMENTO DE DEFESA AFASTADA. MÉRITO. SUPERLOTAÇÃO CARCERÁRIA. TEMA 365/STF. NECESSIDADE DE COMPROVAÇÃO INDIVIDUALIZADA DO <em>DANO</em>. ÔNUS DA PROVA DO AUTOR. ALEGAÇÕES GENÉRICAS. <em>DANO</em> <em>MORAL</em> NÃO CONFIGURADO. SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação interposto contra sentença que julgou improcedente o pedido de compensação por danos morais formulado por detento, fundado na alegação de submissão a condições degradantes de encarceramento – notadamente superlotação e insalubridade – em estabelecimento penal localizado no Município de Corumbá/MS.
+II. QUESTÃO EM DISCUSSÃO
+2. A controvérsia cinge-se a: (i) verificar se o indeferimento da produção de prova pericial e a valoração da prova testemunhal caracterizaram cerceamento de defesa; e (ii) definir se a superlotação carcerária e as condições adversas do sistema prisional, por si sós, ensejam <em>dano</em> <em>moral</em> presumido (in re ipsa) ou se exigem comprovação individualizada do prejuízo sofrido pelo detento, à luz do Tema 365 do STF.
+III. RAZÕES DE DECIDIR
+3. O indeferimento de provas consideradas inúteis, impertinentes ou protelatórias não configura cerceamento de defesa, porquanto o magistrado, na condição de destinatário final da prova, detém discricionariedade técnica para indeferir diligências prescindíveis à formação de seu convencimento, sobretudo quando a controvérsia se resolve pela aplicação de tese jurídica firmada em precedente vinculante.
+4. O STF, ao julgar o RE 580.252/MS, sob a sistemática da repercussão geral (Tema 365), firmou entendimento no sentido de que a responsabilidade civil do Estado por violação à dignidade do preso, decorrente da falta ou insuficiência das condições legais de encarceramento, exige a comprovação do <em>dano</em> efetivamente sofrido.
+5. A situação estrutural de superlotação carcerária, embora revele grave falha do sistema prisional e tenha sido reconhecida como "estado de coisas inconstitucional" (ADPF 347), não gera automaticamente o dever de compensação por <em>dano</em> <em>moral</em> individual, o qual não se presume (in re ipsa).
+6. Incumbe à parte autora, nos termos do art. 373, I, do CPC, o ônus de comprovar o fato constitutivo de seu direito, demonstrando de forma concreta e individualizada como as condições de custódia lhe acarretaram lesão específica à dignidade, para além dos gravames inerentes à própria execução da pena, sendo certo que a ausência dessa demonstração, aliada à formulação de alegações genéricas e padronizadas, inviabiliza o acolhimento da pretensão compensatória.
+IV. DISPOSITIVO E TESE
+7. Recurso conhecido e desprovido.
+Tese de julgamento: "1. A responsabilidade civil do Estado por danos morais suportados por detentos, embora objetiva, exige a comprovação individualizada do <em>dano</em>, não sendo a superlotação carcerária, por si só, suficiente para caracterizar compensação in re ipsa, conforme a tese fixada pelo STF no Tema 365 da repercussão geral. 2. Incumbe à parte autora o ônus de demonstrar a lesão concreta, específica e pessoal decorrente das condições de encarceramento, sendo insuficientes alegações genéricas acerca das deficiências estruturais do sistema prisional, sob pena de improcedência do pedido de compensação financeira por danos morais".
+___________
+Dispositivos relevantes citados: arts. 5º, XLIX, e 37, § 6º, da Constituição Federal; arts. 85, § 11, 370, 373, I, e 927 do CPC.
+Jurisprudência relevante citada: STF, RE 580.252/MS (Tema 365); STJ, EREsp 962.934/MS; TJ-MS, Apelação Cível 0804500-42.2023.8.12.0008; TJ-MS, Apelação Cível 0804418-11.2023.8.12.0008.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>142&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876749" cdForo="0" >
+										0800158-23.2025.8.12.0006
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876749" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876749);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876749" style="display: none;" >
+	<div id="textAreaDados_1876749" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE CONHECIMENTO &ndash; ERRO NA IDENTIFICA&Ccedil;&Atilde;O DE R&Eacute;U EM PROCESSO CRIMINAL &ndash; INCLUS&Atilde;O INDEVIDA DE DADOS PESSOAIS DE HOM&Ocirc;NIMO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O P&Uacute;BLICO &ndash; AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DE DANO MORAL EFETIVO &ndash; MERO ABORRECIMENTO &ndash; RECURSO DESPROVIDO.
+A inclus&atilde;o indevida de dados pessoais de hom&ocirc;nimo em processo criminal, decorrente de erro na identifica&ccedil;&atilde;o do verdadeiro r&eacute;u, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o p&uacute;blico. Contudo, para a configura&ccedil;&atilde;o do dano moral indeniz&aacute;vel &eacute; necess&aacute;ria a comprova&ccedil;&atilde;o de efetivo abalo &agrave; honra ou imagem do indiv&iacute;duo, al&eacute;m do mero aborrecimento.
+No caso, em que pese a inser&ccedil;&atilde;o de informa&ccedil;&otilde;es incorretas no cadastro da a&ccedil;&atilde;o penal, as corre&ccedil;&otilde;es a ela relativas foram efetuadas prontamente ap&oacute;s o comparecimento do recorrente ao f&oacute;rum, sem maiores desdobramentos ou constrangimentos adicionais que pudessem configurar dano moral efetivo. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800158-23.2025.8.12.0006,&nbsp; Camapu&atilde;,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Tadeu Barbosa Silva, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Tadeu Barbosa Silva
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Camapuã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE CONHECIMENTO – ERRO NA IDENTIFICAÇÃO DE RÉU EM PROCESSO CRIMINAL – INCLUSÃO INDEVIDA DE DADOS PESSOAIS DE HOMÔNIMO – FALHA NA PRESTAÇÃO DO SERVIÇO PÚBLICO – AUSÊNCIA DE COMPROVAÇÃO DE <em>DANO</em> <em>MORAL</em> EFETIVO – MERO ABORRECIMENTO – RECURSO DESPROVIDO.
+A inclusão indevida de dados pessoais de homônimo em processo criminal, decorrente de erro na identificação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE CONHECIMENTO – ERRO NA IDENTIFICAÇÃO DE RÉU EM PROCESSO CRIMINAL – INCLUSÃO INDEVIDA DE DADOS PESSOAIS DE HOMÔNIMO – FALHA NA PRESTAÇÃO DO SERVIÇO PÚBLICO – AUSÊNCIA DE COMPROVAÇÃO DE <em>DANO</em> <em>MORAL</em> EFETIVO – MERO ABORRECIMENTO – RECURSO DESPROVIDO.
+A inclusão indevida de dados pessoais de homônimo em processo criminal, decorrente de erro na identificação do verdadeiro réu, configura falha na prestação do serviço público. Contudo, para a configuração do <em>dano</em> <em>moral</em> indenizável é necessária a comprovação de efetivo abalo à honra ou imagem do indivíduo, além do mero aborrecimento.
+No caso, em que pese a inserção de informações incorretas no cadastro da ação penal, as correções a ela relativas foram efetuadas prontamente após o comparecimento do recorrente ao fórum, sem maiores desdobramentos ou constrangimentos adicionais que pudessem configurar <em>dano</em> <em>moral</em> efetivo.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>143&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876750" cdForo="0" >
+										0800435-79.2025.8.12.0025
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876750" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876750);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876750" style="display: none;" >
+	<div id="textAreaDados_1876750" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. FRAUDE BANC&Aacute;RIA. TRANSFER&Ecirc;NCIA VIA PIX. AUS&Ecirc;NCIA DE PROVA DE FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O. INEXIST&Ecirc;NCIA DE DANO MORAL INDENIZ&Aacute;VEL. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que, em a&ccedil;&atilde;o de repara&ccedil;&atilde;o por danos materiais e morais, condenou institui&ccedil;&atilde;o financeira ao ressarcimento de valores subtra&iacute;dos via PIX (R$ 12.600,00), mas julgou improcedente o pedido de indeniza&ccedil;&atilde;o por danos morais, sob o fundamento de mero aborrecimento.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. A quest&atilde;o em discuss&atilde;o consiste em definir se a aus&ecirc;ncia de comprova&ccedil;&atilde;o de falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio afasta o dever de indenizar por danos morais em hip&oacute;tese de alegada fraude banc&aacute;ria.
+III. RAZ&Otilde;ES DE DECIDIR
+3. A responsabilidade objetiva da institui&ccedil;&atilde;o financeira exige a demonstra&ccedil;&atilde;o de defeito na presta&ccedil;&atilde;o do servi&ccedil;o e nexo de causalidade com o dano, nos termos do art. 14 do CDC.
+4. O &ocirc;nus da prova quanto ao fato constitutivo do direito incumbe &agrave; parte autora, conforme art. 373, I, do CPC, n&atilde;o sendo a invers&atilde;o do &ocirc;nus da prova suficiente para suprir a aus&ecirc;ncia de prova m&iacute;nima.
+5. O boletim de ocorr&ecirc;ncia constitui prova unilateral e n&atilde;o comprova a veracidade dos fatos alegados nem a ocorr&ecirc;ncia de falha sist&ecirc;mica na institui&ccedil;&atilde;o financeira.
+6. A aus&ecirc;ncia de elementos t&eacute;cnicos ou ind&iacute;cios consistentes de invas&atilde;o ou vulnerabilidade do sistema banc&aacute;rio impede o reconhecimento de defeito na presta&ccedil;&atilde;o do servi&ccedil;o.
+7. Inexistindo prova de ato il&iacute;cito ou falha do banco, n&atilde;o se configura o nexo de causalidade necess&aacute;rio &agrave; responsabiliza&ccedil;&atilde;o por danos morais.
+8. A manuten&ccedil;&atilde;o da condena&ccedil;&atilde;o por danos materiais decorre da aus&ecirc;ncia de recurso da institui&ccedil;&atilde;o financeira, sendo vedada a reformatio in pejus, sem que isso implique reconhecimento de falha do servi&ccedil;o.
+IV. DISPOSITIVO E TESE
+9. Recurso desprovido.
+Tese de julgamento:
+A responsabiliza&ccedil;&atilde;o objetiva da institui&ccedil;&atilde;o financeira por fraude banc&aacute;ria exige prova m&iacute;nima da falha na presta&ccedil;&atilde;o do servi&ccedil;o e do nexo causal.
+O boletim de ocorr&ecirc;ncia, isoladamente, n&atilde;o comprova a ocorr&ecirc;ncia de fraude nem a responsabilidade do banco.
+A aus&ecirc;ncia de demonstra&ccedil;&atilde;o de defeito na presta&ccedil;&atilde;o do servi&ccedil;o afasta o dever de indenizar por danos morais, ainda que haja ressarcimento material mantido por veda&ccedil;&atilde;o &agrave; reformatio in pejus.
+Jurisprud&ecirc;ncia relevante citada: TJ-MS, Apela&ccedil;&atilde;o C&iacute;vel n&ordm; 0805607-11.2024.8.12.0001, Rel. Juiz Wagner Mansur Saad, 4&ordf; C&acirc;mara C&iacute;vel, j. 30.01.2026, pub. 03.02.2026.
+ <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800435-79.2025.8.12.0025,&nbsp; Bandeirantes,&nbsp; 4&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz Wagner Mansur Saad, j: 13/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Repetição do Indébito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Wagner Mansur Saad
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Bandeirantes
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									4ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. FRAUDE BANCÁRIA. TRANSFERÊNCIA VIA PIX. AUSÊNCIA DE PROVA DE FALHA NA PRESTAÇÃO DO SERVIÇO. INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em> INDENIZÁVEL. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que, em ação de reparação por danos materiais e morais, condenou instituição financeira ao
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. APELAÇÃO CÍVEL. FRAUDE BANCÁRIA. TRANSFERÊNCIA VIA PIX. AUSÊNCIA DE PROVA DE FALHA NA PRESTAÇÃO DO SERVIÇO. INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em> INDENIZÁVEL. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1. Apelação cível interposta contra sentença que, em ação de reparação por danos materiais e morais, condenou instituição financeira ao ressarcimento de valores subtraídos via PIX (R$ 12.600,00), mas julgou improcedente o pedido de indenização por danos morais, sob o fundamento de mero aborrecimento.
+II. QUESTÃO EM DISCUSSÃO
+2. A questão em discussão consiste em definir se a ausência de comprovação de falha na prestação do serviço bancário afasta o dever de indenizar por danos morais em hipótese de alegada fraude bancária.
+III. RAZÕES DE DECIDIR
+3. A responsabilidade objetiva da instituição financeira exige a demonstração de defeito na prestação do serviço e nexo de causalidade com o <em>dano</em>, nos termos do art. 14 do CDC.
+4. O ônus da prova quanto ao fato constitutivo do direito incumbe à parte autora, conforme art. 373, I, do CPC, não sendo a inversão do ônus da prova suficiente para suprir a ausência de prova mínima.
+5. O boletim de ocorrência constitui prova unilateral e não comprova a veracidade dos fatos alegados nem a ocorrência de falha sistêmica na instituição financeira.
+6. A ausência de elementos técnicos ou indícios consistentes de invasão ou vulnerabilidade do sistema bancário impede o reconhecimento de defeito na prestação do serviço.
+7. Inexistindo prova de ato ilícito ou falha do banco, não se configura o nexo de causalidade necessário à responsabilização por danos morais.
+8. A manutenção da condenação por danos materiais decorre da ausência de recurso da instituição financeira, sendo vedada a reformatio in pejus, sem que isso implique reconhecimento de falha do serviço.
+IV. DISPOSITIVO E TESE
+9. Recurso desprovido.
+Tese de julgamento:
+A responsabilização objetiva da instituição financeira por fraude bancária exige prova mínima da falha na prestação do serviço e do nexo causal.
+O boletim de ocorrência, isoladamente, não comprova a ocorrência de fraude nem a responsabilidade do banco.
+A ausência de demonstração de defeito na prestação do serviço afasta o dever de indenizar por danos morais, ainda que haja ressarcimento material mantido por vedação à reformatio in pejus.
+Jurisprudência relevante citada: TJ-MS, Apelação Cível nº 0805607-11.2024.8.12.0001, Rel. Juiz Wagner Mansur Saad, 4ª Câmara Cível, j. 30.01.2026, pub. 03.02.2026.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>144&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876806" cdForo="0" >
+										0801302-34.2022.8.12.0007
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876806" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876806);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876806" style="display: none;" >
+	<div id="textAreaDados_1876806" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. SEGURO DE VIDA. INVALIDEZ PERMANENTE POR ACIDENTE. DOEN&Ccedil;A PREEXISTENTE. NEGATIVA INDEVIDA DE COBERTURA. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. MERO DESCUMPRIMENTO CONTRATUAL. SENTEN&Ccedil;A REFORMADA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I) A rela&ccedil;&atilde;o jur&iacute;dica &eacute; de consumo, sendo aplic&aacute;vel o CDC, que imp&otilde;e interpreta&ccedil;&atilde;o mais favor&aacute;vel ao consumidor e exige transpar&ecirc;ncia das cl&aacute;usulas limitativas.
+II) A ocorr&ecirc;ncia do acidente restou comprovada por laudos m&eacute;dicos e prova testemunhal, que evidenciam o evento traum&aacute;tico e o in&iacute;cio do quadro incapacitante. O magistrado n&atilde;o est&aacute; vinculado ao laudo pericial quando outros elementos probat&oacute;rios indicam o nexo entre o acidente e a incapacidade.
+III) A exist&ecirc;ncia de doen&ccedil;a preexistente n&atilde;o afasta a cobertura, pois n&atilde;o demonstrada m&aacute;-f&eacute; do segurado nem realiza&ccedil;&atilde;o de exame pr&eacute;vio pela seguradora, nos termos da S&uacute;mula 609/STJ.
+IV) Demonstrado o nexo causal entre o acidente e a invalidez permanente, &eacute; devida a indeniza&ccedil;&atilde;o securit&aacute;ria integral prevista na ap&oacute;lice.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801302-34.2022.8.12.0007,&nbsp; Cassil&acirc;ndia,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Cassilândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. SEGURO DE VIDA. INVALIDEZ PERMANENTE POR ACIDENTE. DOENÇA PREEXISTENTE. NEGATIVA INDEVIDA DE COBERTURA. INDENIZAÇÃO POR DANOS MORAIS. MERO DESCUMPRIMENTO CONTRATUAL. SENTENÇA REFORMADA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I) A relação jurídica é de consumo, sendo aplicável o CDC, que impõe interpretação mais favorável ao consumidor e exige transparência das cláusulas
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. SEGURO DE VIDA. INVALIDEZ PERMANENTE POR ACIDENTE. DOENÇA PREEXISTENTE. NEGATIVA INDEVIDA DE COBERTURA. INDENIZAÇÃO POR DANOS MORAIS. MERO DESCUMPRIMENTO CONTRATUAL. SENTENÇA REFORMADA. RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I) A relação jurídica é de consumo, sendo aplicável o CDC, que impõe interpretação mais favorável ao consumidor e exige transparência das cláusulas limitativas.
+II) A ocorrência do acidente restou comprovada por laudos médicos e prova testemunhal, que evidenciam o evento traumático e o início do quadro incapacitante. O magistrado não está vinculado ao laudo pericial quando outros elementos probatórios indicam o nexo entre o acidente e a incapacidade.
+III) A existência de doença preexistente não afasta a cobertura, pois não demonstrada má-fé do segurado nem realização de exame prévio pela seguradora, nos termos da Súmula 609/STJ.
+IV) Demonstrado o nexo causal entre o acidente e a invalidez permanente, é devida a indenização securitária integral prevista na apólice.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>145&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876836" cdForo="0" >
+										0872978-89.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876836" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876836);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876836" style="display: none;" >
+	<div id="textAreaDados_1876836" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C.C. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. MANUTEN&Ccedil;&Atilde;O INDEVIDA EM CADASTRO DE INADIMPLENTES. D&Iacute;VIDA PAGA. DANOS MORAIS IN RE IPSA. CARACTERIZADOS. VALOR FIXADO. SENTEN&Ccedil;A PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO.
+I) A manuten&ccedil;&atilde;o indevida do nome do consumidor nos &oacute;rg&atilde;os de prote&ccedil;&atilde;o ao cr&eacute;dito, mesmo ap&oacute;s quitada a d&iacute;vida, d&aacute; ensejo &agrave; indeniza&ccedil;&atilde;o por dano moral, sem necessidade de demonstra&ccedil;&atilde;o do efetivo preju&iacute;zo.
+III) O valor a ser fixado a t&iacute;tulo de danos morais deve observar os princ&iacute;pios de modera&ccedil;&atilde;o e razoabilidade, limitando-se &agrave; justa repara&ccedil;&atilde;o dos preju&iacute;zos advindos do fato danoso, motivo pelo qual deve ser mantido.
+IV) Recurso conhecido e provido.
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os magistrados da 3&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator..
+
+Campo Grande, 14 de abril de 2026
+
+Juiz F&aacute;bio Possik Salamene
+              Relator <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0872978-89.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 14/04/2026, p:&nbsp; 15/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									15/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C. INDENIZAÇÃO POR DANOS MORAIS. MANUTENÇÃO INDEVIDA EM CADASTRO DE INADIMPLENTES. DÍVIDA PAGA. DANOS MORAIS IN RE IPSA. CARACTERIZADOS. VALOR FIXADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO.
+I) A manutenção indevida do nome do consumidor nos órgãos de proteção ao crédito, mesmo após quitada a dívida, dá ensejo à
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C. INDENIZAÇÃO POR DANOS MORAIS. MANUTENÇÃO INDEVIDA EM CADASTRO DE INADIMPLENTES. DÍVIDA PAGA. DANOS MORAIS IN RE IPSA. CARACTERIZADOS. VALOR FIXADO. SENTENÇA PARCIALMENTE REFORMADA. RECURSO CONHECIDO E PROVIDO.
+I) A manutenção indevida do nome do consumidor nos órgãos de proteção ao crédito, mesmo após quitada a dívida, dá ensejo à indenização por <em>dano</em> <em>moral</em>, sem necessidade de demonstração do efetivo prejuízo.
+III) O valor a ser fixado a título de danos morais deve observar os princípios de moderação e razoabilidade, limitando-se à justa reparação dos prejuízos advindos do fato danoso, motivo pelo qual deve ser mantido.
+IV) Recurso conhecido e provido.
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os magistrados da 3ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator..
+
+Campo Grande, 14 de abril de 2026
+
+Juiz Fábio Possik Salamene
+              Relator
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>146&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875855" cdForo="0" >
+										0842519-41.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875855" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875855);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875855" style="display: none;" >
+	<div id="textAreaDados_1875855" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. RESPONSABILIDADE CIVIL. TRANSPORTE COLETIVO. QUEDA DE PASSAGEIRA DURANTE DESEMBARQUE. DANOS MORAIS. JU&Iacute;ZO DE RETRATA&Ccedil;&Atilde;O. TEMA 1368/STJ. APLICA&Ccedil;&Atilde;O DA TAXA SELIC. ADEQUA&Ccedil;&Atilde;O DO AC&Oacute;RD&Atilde;O.
+
+I. CASO EM EXAME
+
+Trata-se de apela&ccedil;&otilde;es interpostas por Via&ccedil;&atilde;o Campo Grande Ltda., Cons&oacute;rcio Guaicurus e Jackelliny Teodoro de Oliveira contra senten&ccedil;a proferida pelo Ju&iacute;zo da 6&ordf; Vara C&iacute;vel da Comarca de Campo Grande, que julgou parcialmente procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais decorrentes de queda da autora ao desembarcar de &ocirc;nibus do transporte coletivo.
+
+A senten&ccedil;a condenou os r&eacute;us, solidariamente, ao pagamento de R$ 5.000,00 a t&iacute;tulo de danos morais, com atualiza&ccedil;&atilde;o monet&aacute;ria pelo IPCA-IBGE desde a senten&ccedil;a e juros de mora de 1% ao m&ecirc;s a partir do evento danoso, nos termos da S&uacute;mula 54 do STJ, at&eacute; 27/08/2024, e, a partir de 28/08/2024, pela taxa SELIC.
+
+Os r&eacute;us sustentaram, em s&iacute;ntese, culpa exclusiva da autora, inexist&ecirc;ncia de conduta il&iacute;cita do motorista e aus&ecirc;ncia de dano moral indeniz&aacute;vel, requerendo subsidiariamente a redu&ccedil;&atilde;o do quantum indenizat&oacute;rio ou o reconhecimento de culpa concorrente.
+
+Ap&oacute;s o julgamento das apela&ccedil;&otilde;es por esta C&acirc;mara, a Vice-Presid&ecirc;ncia do Tribunal determinou o retorno dos autos para eventual ju&iacute;zo de retrata&ccedil;&atilde;o, em raz&atilde;o da tese firmada pelo Superior Tribunal de Justi&ccedil;a no Tema 1368, relativa &agrave; interpreta&ccedil;&atilde;o do art. 406 do C&oacute;digo Civil quanto aos juros de mora em obriga&ccedil;&otilde;es civis.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+A quest&atilde;o em discuss&atilde;o consiste em verificar se o ac&oacute;rd&atilde;o anteriormente proferido deve ser adequado &agrave; tese firmada no Tema 1368 do STJ, no que se refere &agrave; forma de incid&ecirc;ncia dos juros morat&oacute;rios e da corre&ccedil;&atilde;o monet&aacute;ria nas condena&ccedil;&otilde;es de natureza civil.
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+O Superior Tribunal de Justi&ccedil;a, ao julgar o Tema 1368 dos recursos repetitivos, fixou a tese de que a taxa SELIC constitui a taxa legal de juros morat&oacute;rios aplic&aacute;vel &agrave;s d&iacute;vidas civis, conforme interpreta&ccedil;&atilde;o do art. 406 do C&oacute;digo Civil, antes da entrada em vigor da Lei n&ordm; 14.905/2024.
+
+A Corte Superior estabeleceu que a SELIC engloba simultaneamente juros de mora e corre&ccedil;&atilde;o monet&aacute;ria, raz&atilde;o pela qual n&atilde;o admite cumula&ccedil;&atilde;o com outros &iacute;ndices de atualiza&ccedil;&atilde;o.
+
+No caso concreto, o ac&oacute;rd&atilde;o anteriormente proferido por esta C&acirc;mara determinou a aplica&ccedil;&atilde;o de juros morat&oacute;rios pela taxa SELIC descontado o &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria (IPCA-E), solu&ccedil;&atilde;o que n&atilde;o se harmoniza com o entendimento vinculante posteriormente fixado pelo STJ.
+
+Diante da orienta&ccedil;&atilde;o firmada em recurso repetitivo, imp&otilde;e-se o exerc&iacute;cio do ju&iacute;zo de retrata&ccedil;&atilde;o previsto no art. 1.030, II, do CPC, para adequar o ac&oacute;rd&atilde;o ao precedente obrigat&oacute;rio.
+
+Assim, deve-se reconhecer a incid&ecirc;ncia da taxa SELIC, de forma exclusiva, englobando corre&ccedil;&atilde;o monet&aacute;ria e juros de mora at&eacute; a entrada em vigor da Lei n&ordm; 14.905/2024, a partir de quando passam a incidir a taxa legal prevista no art. 406, &sect;1&ordm;, do C&oacute;digo Civil e a corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA, conforme a nova sistem&aacute;tica legal.
+
+IV. DISPOSITIVO E TESE
+
+Ju&iacute;zo de retrata&ccedil;&atilde;o exercido, para adequar o ac&oacute;rd&atilde;o ao entendimento firmado pelo Superior Tribunal de Justi&ccedil;a no Tema 1368, determinando a incid&ecirc;ncia da taxa SELIC como &iacute;ndice &uacute;nico de corre&ccedil;&atilde;o monet&aacute;ria e juros morat&oacute;rios at&eacute; a entrada em vigor da Lei n&ordm; 14.905/2024, e, a partir de ent&atilde;o, a aplica&ccedil;&atilde;o da taxa legal prevista no art. 406, &sect;1&ordm;, do C&oacute;digo Civil, cumulada com corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA.
+
+Tese de julgamento:
+
+Nos termos do Tema 1368 do STJ, a taxa SELIC constitui a taxa legal aplic&aacute;vel &agrave;s d&iacute;vidas civis com fundamento no art. 406 do C&oacute;digo Civil, antes da entrada em vigor da Lei n&ordm; 14.905/2024, englobando simultaneamente juros de mora e corre&ccedil;&atilde;o monet&aacute;ria, vedada sua cumula&ccedil;&atilde;o com outros &iacute;ndices.
+
+Ap&oacute;s a entrada em vigor da Lei n&ordm; 14.905/2024, aplica-se a nova sistem&aacute;tica do art. 406 do C&oacute;digo Civil, com incid&ecirc;ncia da taxa legal resultante da dedu&ccedil;&atilde;o prevista no &sect;1&ordm; do dispositivo e corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA.
+
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 2&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0842519-41.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. RESPONSABILIDADE CIVIL. TRANSPORTE COLETIVO. QUEDA DE PASSAGEIRA DURANTE DESEMBARQUE. DANOS MORAIS. JUÍZO DE RETRATAÇÃO. TEMA 1368/STJ. APLICAÇÃO DA TAXA SELIC. ADEQUAÇÃO DO ACÓRDÃO.
+
+I. CASO EM EXAME
+
+Trata-se de apelações interpostas por Viação Campo Grande Ltda., Consórcio Guaicurus e Jackelliny Teodoro de Oliveira contra sentença proferida
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. RESPONSABILIDADE CIVIL. TRANSPORTE COLETIVO. QUEDA DE PASSAGEIRA DURANTE DESEMBARQUE. DANOS MORAIS. JUÍZO DE RETRATAÇÃO. TEMA 1368/STJ. APLICAÇÃO DA TAXA SELIC. ADEQUAÇÃO DO ACÓRDÃO.
+
+I. CASO EM EXAME
+
+Trata-se de apelações interpostas por Viação Campo Grande Ltda., Consórcio Guaicurus e Jackelliny Teodoro de Oliveira contra sentença proferida pelo Juízo da 6ª Vara Cível da Comarca de Campo Grande, que julgou parcialmente procedente ação de indenização por danos morais decorrentes de queda da autora ao desembarcar de ônibus do transporte coletivo.
+
+A sentença condenou os réus, solidariamente, ao pagamento de R$ 5.000,00 a título de danos morais, com atualização monetária pelo IPCA-IBGE desde a sentença e juros de mora de 1% ao mês a partir do evento danoso, nos termos da Súmula 54 do STJ, até 27/08/2024, e, a partir de 28/08/2024, pela taxa SELIC.
+
+Os réus sustentaram, em síntese, culpa exclusiva da autora, inexistência de conduta ilícita do motorista e ausência de <em>dano</em> <em>moral</em> indenizável, requerendo subsidiariamente a redução do quantum indenizatório ou o reconhecimento de culpa concorrente.
+
+Após o julgamento das apelações por esta Câmara, a Vice-Presidência do Tribunal determinou o retorno dos autos para eventual juízo de retratação, em razão da tese firmada pelo Superior Tribunal de Justiça no Tema 1368, relativa à interpretação do art. 406 do Código Civil quanto aos juros de mora em obrigações civis.
+
+II. QUESTÃO EM DISCUSSÃO
+
+A questão em discussão consiste em verificar se o acórdão anteriormente proferido deve ser adequado à tese firmada no Tema 1368 do STJ, no que se refere à forma de incidência dos juros moratórios e da correção monetária nas condenações de natureza civil.
+
+III. RAZÕES DE DECIDIR
+
+O Superior Tribunal de Justiça, ao julgar o Tema 1368 dos recursos repetitivos, fixou a tese de que a taxa SELIC constitui a taxa legal de juros moratórios aplicável às dívidas civis, conforme interpretação do art. 406 do Código Civil, antes da entrada em vigor da Lei nº 14.905/2024.
+
+A Corte Superior estabeleceu que a SELIC engloba simultaneamente juros de mora e correção monetária, razão pela qual não admite cumulação com outros índices de atualização.
+
+No caso concreto, o acórdão anteriormente proferido por esta Câmara determinou a aplicação de juros moratórios pela taxa SELIC descontado o índice de correção monetária (IPCA-E), solução que não se harmoniza com o entendimento vinculante posteriormente fixado pelo STJ.
+
+Diante da orientação firmada em recurso repetitivo, impõe-se o exercício do juízo de retratação previsto no art. 1.030, II, do CPC, para adequar o acórdão ao precedente obrigatório.
+
+Assim, deve-se reconhecer a incidência da taxa SELIC, de forma exclusiva, englobando correção monetária e juros de mora até a entrada em vigor da Lei nº 14.905/2024, a partir de quando passam a incidir a taxa legal prevista no art. 406, §1º, do Código Civil e a correção monetária pelo IPCA, conforme a nova sistemática legal.
+
+IV. DISPOSITIVO E TESE
+
+Juízo de retratação exercido, para adequar o acórdão ao entendimento firmado pelo Superior Tribunal de Justiça no Tema 1368, determinando a incidência da taxa SELIC como índice único de correção monetária e juros moratórios até a entrada em vigor da Lei nº 14.905/2024, e, a partir de então, a aplicação da taxa legal prevista no art. 406, §1º, do Código Civil, cumulada com correção monetária pelo IPCA.
+
+Tese de julgamento:
+
+Nos termos do Tema 1368 do STJ, a taxa SELIC constitui a taxa legal aplicável às dívidas civis com fundamento no art. 406 do Código Civil, antes da entrada em vigor da Lei nº 14.905/2024, englobando simultaneamente juros de mora e correção monetária, vedada sua cumulação com outros índices.
+
+Após a entrada em vigor da Lei nº 14.905/2024, aplica-se a nova sistemática do art. 406 do Código Civil, com incidência da taxa legal resultante da dedução prevista no §1º do dispositivo e correção monetária pelo IPCA.
+
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 2ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>147&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875873" cdForo="0" >
+										0800841-36.2021.8.12.0027
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875873" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875873);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875873" style="display: none;" >
+	<div id="textAreaDados_1875873" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. AGRAVO INTERNO EM APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Iacute;VIDA C/C REPARA&Ccedil;&Atilde;O DE DANOS MORAIS. SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA QUANTO AO DANO MORAL. RELA&Ccedil;&Atilde;O JUR&Iacute;DICA MOTIVADORA DECLARADA INEXISTENTE. NEGATIVA&Ccedil;&Atilde;O INDEVIDA. DANO MORAL IN RE IPSA. ALEGA&Ccedil;&Atilde;O DE ANOTA&Ccedil;&Atilde;O PREEXISTENTE N&Atilde;O COMPROVADA. RECURSO PROVIDO. SENTEN&Ccedil;A PARCIALMENTE REFORMADA. CONDENA&Ccedil;&Atilde;O DOS R&Eacute;US AO PAGAMENTO DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. Constatado que o &uacute;nico apontamento existente em nome da recorrente &eacute; o discutido nos presentes autos, cuja rela&ccedil;&atilde;o jur&iacute;dica motivadora foi declarada inexistente pela senten&ccedil;a apelada, deve-se reformar a senten&ccedil;a para condenar os r&eacute;us ao pagamento de indeniza&ccedil;&atilde;o por danos morais, os quais s&atilde;o presumidos na hip&oacute;tese.  <br><br>(<b>TJMS</b>. Agravo Interno C&iacute;vel n. 0800841-36.2021.8.12.0027,&nbsp; Bataypor&atilde;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(63 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Batayporã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800841362021812002750000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. AGRAVO INTERNO EM APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA C/C REPARAÇÃO DE DANOS MORAIS. SENTENÇA DE IMPROCEDÊNCIA QUANTO AO <em>DANO</em> <em>MORAL</em>. RELAÇÃO JURÍDICA MOTIVADORA DECLARADA INEXISTENTE. NEGATIVAÇÃO INDEVIDA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. ALEGAÇÃO DE ANOTAÇÃO PREEXISTENTE NÃO COMPROVADA. RECURSO PROVIDO. SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. AGRAVO INTERNO EM APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA C/C REPARAÇÃO DE DANOS MORAIS. SENTENÇA DE IMPROCEDÊNCIA QUANTO AO <em>DANO</em> <em>MORAL</em>. RELAÇÃO JURÍDICA MOTIVADORA DECLARADA INEXISTENTE. NEGATIVAÇÃO INDEVIDA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. ALEGAÇÃO DE ANOTAÇÃO PREEXISTENTE NÃO COMPROVADA. RECURSO PROVIDO. SENTENÇA PARCIALMENTE REFORMADA. CONDENAÇÃO DOS RÉUS AO PAGAMENTO DE INDENIZAÇÃO POR DANOS MORAIS. Constatado que o único apontamento existente em nome da recorrente é o discutido nos presentes autos, cuja relação jurídica motivadora foi declarada inexistente pela sentença apelada, deve-se reformar a sentença para condenar os réus ao pagamento de indenização por danos morais, os quais são presumidos na hipótese.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>148&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875875" cdForo="0" >
+										0801207-58.2023.8.12.0010
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875875" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875875);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875875" style="display: none;" >
+	<div id="textAreaDados_1875875" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE RESCIS&Atilde;O CONTRATUAL C/C BUSCA E APREENS&Atilde;O &ndash; INADIMPLEMENTO DE OBRIGA&Ccedil;&Atilde;O POSITIVA, L&Iacute;QUIDA E COM TERMO CERTO &ndash; MORA EX RE &ndash;  DESNECESSIDADE DE INTERPELA&Ccedil;&Atilde;O PR&Eacute;VIA &ndash;  CITA&Ccedil;&Atilde;O V&Aacute;LIDA COMO INTERPELA&Ccedil;&Atilde;O JUDICIAL &ndash;  DANOS MORAIS &Agrave; PESSOA JUR&Iacute;DICA &ndash; N&Atilde;O CONFIGURA&Ccedil;&Atilde;O &ndash; NECESSIDADE DE PROVA DE ABALO &Agrave; HONRA OBJETIVA &ndash; MERO INADIMPLEMENTO CONTRATUAL &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO
+Em se tratando de obriga&ccedil;&atilde;o positiva, l&iacute;quida e com termo de vencimento certo, a mora do devedor &eacute; ex re, constituindo-se de pleno direito a partir do inadimplemento, nos termos do art. 397, caput, do C&oacute;digo Civil, sendo desnecess&aacute;ria a interpela&ccedil;&atilde;o pr&eacute;via para este fim.
+A exig&ecirc;ncia de interpela&ccedil;&atilde;o judicial para a resolu&ccedil;&atilde;o de contrato com cl&aacute;usula resolutiva t&aacute;cita (art. 474 do CC) &eacute; suprida pela cita&ccedil;&atilde;o v&aacute;lida no bojo da pr&oacute;pria a&ccedil;&atilde;o de resolu&ccedil;&atilde;o contratual. O ato citat&oacute;rio, por ser a forma mais solene de convoca&ccedil;&atilde;o do devedor ao processo, cumpre a finalidade de notific&aacute;-lo da inten&ccedil;&atilde;o do credor de extinguir o v&iacute;nculo contratual, afastando a tese de aus&ecirc;ncia de pressuposto processual e privilegiando a primazia do julgamento de m&eacute;rito.
+O dano moral para a pessoa jur&iacute;dica n&atilde;o &eacute; presumido (in re ipsa), exigindo a comprova&ccedil;&atilde;o de efetivo abalo &agrave; sua honra objetiva, ou seja, &agrave; sua imagem, credibilidade e reputa&ccedil;&atilde;o perante o mercado.
+A alega&ccedil;&atilde;o de dificuldades financeiras internas, como a necessidade de demitir funcion&aacute;rios em decorr&ecirc;ncia do inadimplemento contratual da outra parte, por si s&oacute;, n&atilde;o configura dano moral, pois se insere na esfera do preju&iacute;zo patrimonial e do risco da atividade empresarial, n&atilde;o demonstrando m&aacute;cula externa ao bom nome da empresa.
+Recurso conhecido e parcialmente provido para reformar a senten&ccedil;a apenas no cap&iacute;tulo que concedeu a indeniza&ccedil;&atilde;o por danos morais, com a consequente readequa&ccedil;&atilde;o dos &ocirc;nus sucumbenciais. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801207-58.2023.8.12.0010,&nbsp; F&aacute;tima do Sul,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(50 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Busca e Apreensão
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Fátima do Sul
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESCISÃO CONTRATUAL C/C BUSCA E APREENSÃO – INADIMPLEMENTO DE OBRIGAÇÃO POSITIVA, LÍQUIDA E COM TERMO CERTO – MORA EX RE –  DESNECESSIDADE DE INTERPELAÇÃO PRÉVIA –  CITAÇÃO VÁLIDA COMO INTERPELAÇÃO JUDICIAL –  DANOS MORAIS À PESSOA JURÍDICA – NÃO CONFIGURAÇÃO – NECESSIDADE DE PROVA DE ABALO À HONRA OBJETIVA – MERO INADIMPLEMENTO CONTRATUAL – RECURSO CONHECIDO E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE RESCISÃO CONTRATUAL C/C BUSCA E APREENSÃO – INADIMPLEMENTO DE OBRIGAÇÃO POSITIVA, LÍQUIDA E COM TERMO CERTO – MORA EX RE –  DESNECESSIDADE DE INTERPELAÇÃO PRÉVIA –  CITAÇÃO VÁLIDA COMO INTERPELAÇÃO JUDICIAL –  DANOS MORAIS À PESSOA JURÍDICA – NÃO CONFIGURAÇÃO – NECESSIDADE DE PROVA DE ABALO À HONRA OBJETIVA – MERO INADIMPLEMENTO CONTRATUAL – RECURSO CONHECIDO E PARCIALMENTE PROVIDO
+Em se tratando de obrigação positiva, líquida e com termo de vencimento certo, a mora do devedor é ex re, constituindo-se de pleno direito a partir do inadimplemento, nos termos do art. 397, caput, do Código Civil, sendo desnecessária a interpelação prévia para este fim.
+A exigência de interpelação judicial para a resolução de contrato com cláusula resolutiva tácita (art. 474 do CC) é suprida pela citação válida no bojo da própria ação de resolução contratual. O ato citatório, por ser a forma mais solene de convocação do devedor ao processo, cumpre a finalidade de notificá-lo da intenção do credor de extinguir o vínculo contratual, afastando a tese de ausência de pressuposto processual e privilegiando a primazia do julgamento de mérito.
+O <em>dano</em> <em>moral</em> para a pessoa jurídica não é presumido (in re ipsa), exigindo a comprovação de efetivo abalo à sua honra objetiva, ou seja, à sua imagem, credibilidade e reputação perante o mercado.
+A alegação de dificuldades financeiras internas, como a necessidade de demitir funcionários em decorrência do inadimplemento contratual da outra parte, por si só, não configura <em>dano</em> <em>moral</em>, pois se insere na esfera do prejuízo patrimonial e do risco da atividade empresarial, não demonstrando mácula externa ao bom nome da empresa.
+Recurso conhecido e parcialmente provido para reformar a sentença apenas no capítulo que concedeu a indenização por danos morais, com a consequente readequação dos ônus sucumbenciais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>149&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875876" cdForo="0" >
+										0800014-03.2023.8.12.0044
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875876" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875876);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875876" style="display: none;" >
+	<div id="textAreaDados_1875876" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR. APELA&Ccedil;&Atilde;O C&Iacute;VEL. INSCRI&Ccedil;&Atilde;O EM CADASTRO DE PROTE&Ccedil;&Atilde;O AO CR&Eacute;DITO. NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA POR MEIO ELETR&Ocirc;NICO. VALIDADE. COMPROVA&Ccedil;&Atilde;O DE ENVIO E ENTREGA. ILICITUDE DA INSCRI&Ccedil;&Atilde;O N&Atilde;O CONFIGURADA. DANO MORAL AFASTADO. RECURSO PROVIDO.
+I. Caso em exame
+1. Apela&ccedil;&atilde;o c&iacute;vel interposta por Boa Vista Servi&ccedil;os S.A. contra senten&ccedil;a proferida pela Vara &Uacute;nica da Comarca de Sete Quedas/MS, que julgou parcialmente procedente a&ccedil;&atilde;o declarat&oacute;ria cumulada com pedido indenizat&oacute;rio, declarou il&iacute;cita a inscri&ccedil;&atilde;o do nome de Marlene Portilho no cadastro SCPC por aus&ecirc;ncia de pr&eacute;via notifica&ccedil;&atilde;o (art. 43, &sect;2&ordm;, CDC), determinou a exclus&atilde;o do registro e condenou a apelante ao pagamento de R$ 5.000,00 (cinco mil reais) a t&iacute;tulo de indeniza&ccedil;&atilde;o por danos morais.
+II. Quest&atilde;o em discuss&atilde;o
+2. A quest&atilde;o em discuss&atilde;o consiste em saber: (i) se a notifica&ccedil;&atilde;o pr&eacute;via ao consumidor, exigida pelo art. 43, &sect;2&ordm;, do C&oacute;digo de Defesa do Consumidor, para a abertura de cadastro ou registro em banco de dados, pode ser realizada por meio eletr&ocirc;nico; e (ii) se a Boa Vista Servi&ccedil;os S.A. comprovou o envio e a efetiva entrega de tal comunica&ccedil;&atilde;o &agrave; apelada antes da publica&ccedil;&atilde;o da inscri&ccedil;&atilde;o restritiva.
+III. Raz&otilde;es de decidir
+3. O art. 43, &sect;2&ordm;, do CDC estabelece que a abertura de cadastro, ficha, registro e dados pessoais e de consumo dever&aacute; ser comunicada &quot;por escrito&quot; ao consumidor, quando n&atilde;o solicitada por ele. A norma n&atilde;o circunscreve o meio de comunica&ccedil;&atilde;o &agrave; via postal, sendo compat&iacute;vel com formatos eletr&ocirc;nicos que preservem o conte&uacute;do escrito e permitam a comprova&ccedil;&atilde;o do envio e do recebimento.
+4. A mat&eacute;ria foi definitivamente pacificada pela 2&ordf; Se&ccedil;&atilde;o do STJ, ao fixar, no julgamento do Tema 1.315 dos recursos repetitivos (j. 05/03/2026), tese vinculante nos seguintes termos: a comunica&ccedil;&atilde;o eletr&ocirc;nica ao consumidor acerca da abertura de cadastro ou registro em banco de dados &eacute; v&aacute;lida, para fins do art. 43, &sect;2&ordm;, do CDC, desde que comprovados o envio da notifica&ccedil;&atilde;o e a respectiva entrega ao destinat&aacute;rio. Esse entendimento j&aacute; havia sido antecipado pelas turmas de direito privado do STJ (REsp 2.063.145/RS, 4&ordf; Turma, j. 14/03/2024; REsp 2.092.539/RS, 3&ordf; Turma, j. 17/09/2024).
+5. No &acirc;mbito do TJMS, a quest&atilde;o foi uniformizada pelo julgamento do IRDR n&ordm; 0835488-67.2023.8.12.0001 (Se&ccedil;&atilde;o Especial C&iacute;vel, j. 29/11/2024, p. 02/12/2024), cujo ac&oacute;rd&atilde;o fixou tese vinculante com os seguintes termos: &quot;A notifica&ccedil;&atilde;o pr&eacute;via do consumidor acerca do registro do seu nome no cadastro de inadimplentes, nos termos do artigo 43, &sect;2&ordm;, do CDC, pode ser realizada por meio eletr&ocirc;nico desde que devidamente comprovados o envio e a entrega da notifica&ccedil;&atilde;o, realizados por e-mail, mensagem de texto de celular (SMS) ou aplicativo de mensagens WhatsApp, dispensada a prova da leitura.&quot; Esse precedente vincula todas as c&acirc;maras c&iacute;veis do tribunal, incluindo esta 1&ordf; C&acirc;mara C&iacute;vel.
+6. Aplicando essas premissas ao caso concreto, verifica-se que a apelante comprovou, por meio de Relat&oacute;rio de Envio de E-Mail Registrado (fl. 142/144), que a notifica&ccedil;&atilde;o foi enviada ao endere&ccedil;o eletr&ocirc;nico marlene_portilho@hotmail.com &ndash; informado pela empresa credora (Energisa Mato Grosso do Sul - DI) ao cadastrar o apontamento &ndash; em 03/07/2020, com confirma&ccedil;&atilde;o de entrega no mesmo dia, &agrave;s 07h01. A publica&ccedil;&atilde;o da inscri&ccedil;&atilde;o restritiva somente ocorreu em 18/08/2020, ou seja, quarenta e seis dias ap&oacute;s a comunica&ccedil;&atilde;o eletr&ocirc;nica. Presentes, portanto, os requisitos de anterioridade e comprova&ccedil;&atilde;o de envio e entrega, nos termos da tese vinculante do IRDR e do Tema 1.315/STJ.
+7. Configurada a regularidade da notifica&ccedil;&atilde;o pr&eacute;via, afasta-se a ilicitude da inscri&ccedil;&atilde;o. Sem ato il&iacute;cito imput&aacute;vel &agrave; apelante, n&atilde;o h&aacute; nexo causal apto a sustentar a condena&ccedil;&atilde;o por danos morais. A indeniza&ccedil;&atilde;o in re ipsa pressup&otilde;e inscri&ccedil;&atilde;o indevida, o que n&atilde;o se verifica no caso.
+IV. Dispositivo e tese
+8. Recurso provido para reformar a senten&ccedil;a e julgar improcedente a pretens&atilde;o declarat&oacute;ria e indenizat&oacute;ria, invertendo-se a sucumb&ecirc;ncia, ressalvada a suspens&atilde;o da exigibilidade caso mantida a gratuidade de justi&ccedil;a da apelada (art. 98, &sect;3&ordm;, do CPC).
+Tese de julgamento: A notifica&ccedil;&atilde;o pr&eacute;via do consumidor acerca da inscri&ccedil;&atilde;o de seu nome em cadastro de prote&ccedil;&atilde;o ao cr&eacute;dito, nos termos do art. 43, &sect;2&ordm;, do CDC, pode ser realizada por meio eletr&ocirc;nico &ndash; e-mail, mensagem de texto (SMS) ou aplicativo de mensagens &ndash; desde que comprovados o envio e a efetiva entrega da comunica&ccedil;&atilde;o ao destinat&aacute;rio, sendo dispensada a prova da leitura; configurada a notifica&ccedil;&atilde;o v&aacute;lida e pr&eacute;via, a inscri&ccedil;&atilde;o &eacute; l&iacute;cita e n&atilde;o gera dano moral indeniz&aacute;vel.
+_______________________________________________
+Dispositivos relevantes citados: CDC (Lei n&ordm; 8.078/1990), art. 43, &sect;2&ordm;; CDC, art. 14; CF/1988, art. 5&ordm;, XXXII; CPC (Lei n&ordm; 13.105/2015), arts. 85, &sect;&sect;2&ordm;, 10 e 11; 98, &sect;3&ordm;; 373; 932, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, 2&ordf; Se&ccedil;&atilde;o, Tema 1.315 (REsp 2.171.003, REsp 2.171.177 e REsp 2.175.268/RS), Rel. Min. Nancy Andrighi, j. 05/03/2026; STJ, REsp 2.063.145/RS, Rel. Min. Maria Isabel Gallotti, 4&ordf; Turma, j. 14/03/2024 (Informativo 808); STJ, REsp 2.092.539/RS, Rel. Min. Marco Aur&eacute;lio Bellizze, 3&ordf; Turma, j. 17/09/2024, DJe 26/09/2024; TJMS, IRDR n&ordm; 0835488-67.2023.8.12.0001, Se&ccedil;&atilde;o Especial C&iacute;vel, j. 07/11/2024, p. 02/12/2024.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800014-03.2023.8.12.0044,&nbsp; Sete Quedas,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Branco Pucci, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Branco Pucci
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sete Quedas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. INSCRIÇÃO EM CADASTRO DE PROTEÇÃO AO CRÉDITO. NOTIFICAÇÃO PRÉVIA POR MEIO ELETRÔNICO. VALIDADE. COMPROVAÇÃO DE ENVIO E ENTREGA. ILICITUDE DA INSCRIÇÃO NÃO CONFIGURADA. <em>DANO</em> <em>MORAL</em> AFASTADO. RECURSO PROVIDO.
+I. Caso em exame
+1. Apelação cível interposta por Boa Vista Serviços S.A. contra sentença proferida pela Vara Única da Comarca de Sete
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR. APELAÇÃO CÍVEL. INSCRIÇÃO EM CADASTRO DE PROTEÇÃO AO CRÉDITO. NOTIFICAÇÃO PRÉVIA POR MEIO ELETRÔNICO. VALIDADE. COMPROVAÇÃO DE ENVIO E ENTREGA. ILICITUDE DA INSCRIÇÃO NÃO CONFIGURADA. <em>DANO</em> <em>MORAL</em> AFASTADO. RECURSO PROVIDO.
+I. Caso em exame
+1. Apelação cível interposta por Boa Vista Serviços S.A. contra sentença proferida pela Vara Única da Comarca de Sete Quedas/MS, que julgou parcialmente procedente ação declaratória cumulada com pedido indenizatório, declarou ilícita a inscrição do nome de Marlene Portilho no cadastro SCPC por ausência de prévia notificação (art. 43, §2º, CDC), determinou a exclusão do registro e condenou a apelante ao pagamento de R$ 5.000,00 (cinco mil reais) a título de indenização por danos morais.
+II. Questão em discussão
+2. A questão em discussão consiste em saber: (i) se a notificação prévia ao consumidor, exigida pelo art. 43, §2º, do Código de Defesa do Consumidor, para a abertura de cadastro ou registro em banco de dados, pode ser realizada por meio eletrônico; e (ii) se a Boa Vista Serviços S.A. comprovou o envio e a efetiva entrega de tal comunicação à apelada antes da publicação da inscrição restritiva.
+III. Razões de decidir
+3. O art. 43, §2º, do CDC estabelece que a abertura de cadastro, ficha, registro e dados pessoais e de consumo deverá ser comunicada "por escrito" ao consumidor, quando não solicitada por ele. A norma não circunscreve o meio de comunicação à via postal, sendo compatível com formatos eletrônicos que preservem o conteúdo escrito e permitam a comprovação do envio e do recebimento.
+4. A matéria foi definitivamente pacificada pela 2ª Seção do STJ, ao fixar, no julgamento do Tema 1.315 dos recursos repetitivos (j. 05/03/2026), tese vinculante nos seguintes termos: a comunicação eletrônica ao consumidor acerca da abertura de cadastro ou registro em banco de dados é válida, para fins do art. 43, §2º, do CDC, desde que comprovados o envio da notificação e a respectiva entrega ao destinatário. Esse entendimento já havia sido antecipado pelas turmas de direito privado do STJ (REsp 2.063.145/RS, 4ª Turma, j. 14/03/2024; REsp 2.092.539/RS, 3ª Turma, j. 17/09/2024).
+5. No âmbito do TJMS, a questão foi uniformizada pelo julgamento do IRDR nº 0835488-67.2023.8.12.0001 (Seção Especial Cível, j. 29/11/2024, p. 02/12/2024), cujo acórdão fixou tese vinculante com os seguintes termos: "A notificação prévia do consumidor acerca do registro do seu nome no cadastro de inadimplentes, nos termos do artigo 43, §2º, do CDC, pode ser realizada por meio eletrônico desde que devidamente comprovados o envio e a entrega da notificação, realizados por e-mail, mensagem de texto de celular (SMS) ou aplicativo de mensagens WhatsApp, dispensada a prova da leitura." Esse precedente vincula todas as câmaras cíveis do tribunal, incluindo esta 1ª Câmara Cível.
+6. Aplicando essas premissas ao caso concreto, verifica-se que a apelante comprovou, por meio de Relatório de Envio de E-Mail Registrado (fl. 142/144), que a notificação foi enviada ao endereço eletrônico marlene_portilho@hotmail.com – informado pela empresa credora (Energisa Mato Grosso do Sul - DI) ao cadastrar o apontamento – em 03/07/2020, com confirmação de entrega no mesmo dia, às 07h01. A publicação da inscrição restritiva somente ocorreu em 18/08/2020, ou seja, quarenta e seis dias após a comunicação eletrônica. Presentes, portanto, os requisitos de anterioridade e comprovação de envio e entrega, nos termos da tese vinculante do IRDR e do Tema 1.315/STJ.
+7. Configurada a regularidade da notificação prévia, afasta-se a ilicitude da inscrição. Sem ato ilícito imputável à apelante, não há nexo causal apto a sustentar a condenação por danos morais. A indenização in re ipsa pressupõe inscrição indevida, o que não se verifica no caso.
+IV. Dispositivo e tese
+8. Recurso provido para reformar a sentença e julgar improcedente a pretensão declaratória e indenizatória, invertendo-se a sucumbência, ressalvada a suspensão da exigibilidade caso mantida a gratuidade de justiça da apelada (art. 98, §3º, do CPC).
+Tese de julgamento: A notificação prévia do consumidor acerca da inscrição de seu nome em cadastro de proteção ao crédito, nos termos do art. 43, §2º, do CDC, pode ser realizada por meio eletrônico – e-mail, mensagem de texto (SMS) ou aplicativo de mensagens – desde que comprovados o envio e a efetiva entrega da comunicação ao destinatário, sendo dispensada a prova da leitura; configurada a notificação válida e prévia, a inscrição é lícita e não gera <em>dano</em> <em>moral</em> indenizável.
+_______________________________________________
+Dispositivos relevantes citados: CDC (Lei nº 8.078/1990), art. 43, §2º; CDC, art. 14; CF/1988, art. 5º, XXXII; CPC (Lei nº 13.105/2015), arts. 85, §§2º, 10 e 11; 98, §3º; 373; 932, IV.
+Jurisprudência relevante citada: STJ, 2ª Seção, Tema 1.315 (REsp 2.171.003, REsp 2.171.177 e REsp 2.175.268/RS), Rel. Min. Nancy Andrighi, j. 05/03/2026; STJ, REsp 2.063.145/RS, Rel. Min. Maria Isabel Gallotti, 4ª Turma, j. 14/03/2024 (Informativo 808); STJ, REsp 2.092.539/RS, Rel. Min. Marco Aurélio Bellizze, 3ª Turma, j. 17/09/2024, DJe 26/09/2024; TJMS, IRDR nº 0835488-67.2023.8.12.0001, Seção Especial Cível, j. 07/11/2024, p. 02/12/2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>150&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875877" cdForo="0" >
+										1420662-19.2025.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875877" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875877);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875877" style="display: none;" >
+	<div id="textAreaDados_1875877" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR. PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. PLANO DE SA&Uacute;DE COLETIVO. TRANSTORNO DO ESPECTRO AUTISTA N&Iacute;VEL 3. TRATAMENTO MULTIDISCIPLINAR. COPARTICIPA&Ccedil;&Atilde;O. COBRAN&Ccedil;A QUE SUPERA EXPRESSIVAMENTE O VALOR DA MENSALIDADE. FATOR RESTRITOR SEVERO DE ACESSO &Agrave; SA&Uacute;DE. LIMITA&Ccedil;&Atilde;O DO VALOR MENSAL. TUTELA DE URG&Ecirc;NCIA. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+
+
+
+
+
+
+
+IV. DISPOSITIVO E TESE
+
+Tese de julgamento:
+
+
+
+Dispositivos relevantes citados: CPC, arts. 297, 300, 1.003, &sect; 5&ordm;, 1.015, I, e 1.016; Lei n&ordm; 9.656/1998, art. 16, VIII; Lei n&ordm; 12.764/2012, art. 3&ordm;, III; Lei n&ordm; 13.146/2015, art. 18; Resolu&ccedil;&atilde;o CONSU n&ordm; 8/1998; RN-ANS n&ordm; 465/2022, art. 19, II, &quot;b&quot;.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp n&ordm; 1.510.697/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 3&ordf; Turma, j. 09.06.2015, DJe 15.06.2015; STJ, REsp n&ordm; 1.848.372/SP, Rel. Min. Luis Felipe Salom&atilde;o, 4&ordf; Turma, j. 02.02.2021, DJe 11.03.2021; STJ, REsp n&ordm; 2.001.108/MT, Rel. Min. Nancy Andrighi, 3&ordf; Turma, j. 03.10.2023, DJe 09.10.2023; STJ, AgInt nos EDcl no REsp n&ordm; 2.045.203/SP, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 3&ordf; Turma, j. 22.04.2024, DJe 25.04.2024; STJ, AgInt no AREsp n&ordm; 1.695.118/MG, Rel. Min. Ricardo Villas B&ocirc;as Cueva, 3&ordf; Turma, j. 03.04.2023, DJe 13.04.2023; STJ, AREsp n&ordm; 2.829.402/MT, Rel. Min. Daniela Teixeira, 3&ordf; Turma, j. 18.08.2025, DJEN 22.08.2025; TJMS, Agravo de Instrumento n&ordm; 1414151-39.2024.8.12.0000, Rel. Juiz F&aacute;bio Possik Salamene, 1&ordf; C&acirc;mara C&iacute;vel, j. 31.10.2024; TJMS, Agravo de Instrumento n&ordm; 1419229-77.2025.8.12.0000, Rel. Juiz F&aacute;bio Possik Salamene, 3&ordf; C&acirc;mara C&iacute;vel, j. 19.12.2025.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1420662-19.2025.8.12.0000,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Branco Pucci, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Serviços de Saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Branco Pucci
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. PLANO DE SAÚDE COLETIVO. TRANSTORNO DO ESPECTRO AUTISTA NÍVEL 3. TRATAMENTO MULTIDISCIPLINAR. COPARTICIPAÇÃO. COBRANÇA QUE SUPERA EXPRESSIVAMENTE O VALOR DA MENSALIDADE. FATOR RESTRITOR SEVERO DE ACESSO À SAÚDE. LIMITAÇÃO DO VALOR MENSAL. TUTELA DE URGÊNCIA. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+
+II. QUESTÃO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR. PROCESSUAL CIVIL. AGRAVO DE INSTRUMENTO. PLANO DE SAÚDE COLETIVO. TRANSTORNO DO ESPECTRO AUTISTA NÍVEL 3. TRATAMENTO MULTIDISCIPLINAR. COPARTICIPAÇÃO. COBRANÇA QUE SUPERA EXPRESSIVAMENTE O VALOR DA MENSALIDADE. FATOR RESTRITOR SEVERO DE ACESSO À SAÚDE. LIMITAÇÃO DO VALOR MENSAL. TUTELA DE URGÊNCIA. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+
+II. QUESTÃO EM DISCUSSÃO
+
+III. RAZÕES DE DECIDIR
+
+
+
+
+
+
+
+
+IV. DISPOSITIVO E TESE
+
+Tese de julgamento:
+
+
+
+Dispositivos relevantes citados: CPC, arts. 297, 300, 1.003, § 5º, 1.015, I, e 1.016; Lei nº 9.656/1998, art. 16, VIII; Lei nº 12.764/2012, art. 3º, III; Lei nº 13.146/2015, art. 18; Resolução CONSU nº 8/1998; RN-ANS nº 465/2022, art. 19, II, "b".
+Jurisprudência relevante citada: STJ, REsp nº 1.510.697/SP, Rel. Min. Ricardo Villas Bôas Cueva, 3ª Turma, j. 09.06.2015, DJe 15.06.2015; STJ, REsp nº 1.848.372/SP, Rel. Min. Luis Felipe Salomão, 4ª Turma, j. 02.02.2021, DJe 11.03.2021; STJ, REsp nº 2.001.108/MT, Rel. Min. Nancy Andrighi, 3ª Turma, j. 03.10.2023, DJe 09.10.2023; STJ, AgInt nos EDcl no REsp nº 2.045.203/SP, Rel. Min. Ricardo Villas Bôas Cueva, 3ª Turma, j. 22.04.2024, DJe 25.04.2024; STJ, AgInt no AREsp nº 1.695.118/MG, Rel. Min. Ricardo Villas Bôas Cueva, 3ª Turma, j. 03.04.2023, DJe 13.04.2023; STJ, AREsp nº 2.829.402/MT, Rel. Min. Daniela Teixeira, 3ª Turma, j. 18.08.2025, DJEN 22.08.2025; TJMS, Agravo de Instrumento nº 1414151-39.2024.8.12.0000, Rel. Juiz Fábio Possik Salamene, 1ª Câmara Cível, j. 31.10.2024; TJMS, Agravo de Instrumento nº 1419229-77.2025.8.12.0000, Rel. Juiz Fábio Possik Salamene, 3ª Câmara Cível, j. 19.12.2025.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>151&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875880" cdForo="0" >
+										0807921-24.2024.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875880" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875880);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875880" style="display: none;" >
+	<div id="textAreaDados_1875880" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. RESPONSABILIDADE DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA. DANOS MORAIS CONFIGURADOS. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. MAJORA&Ccedil;&Atilde;O DE HONOR&Aacute;RIOS. DESPROVIMENTO.
+
+I. CASO EM EXAME
+
+Trata-se de apela&ccedil;&atilde;o interposta contra senten&ccedil;a que reconheceu a ocorr&ecirc;ncia de descontos indevidos em conta banc&aacute;ria de pessoa idosa, aposentada, com renda mensal de um sal&aacute;rio m&iacute;nimo.
+A institui&ccedil;&atilde;o financeira r&eacute;, respons&aacute;vel pela gest&atilde;o da conta, permitiu a realiza&ccedil;&atilde;o de d&eacute;bitos n&atilde;o autorizados, gerando preju&iacute;zo &agrave; parte autora.
+A senten&ccedil;a condenou a parte r&eacute; ao pagamento de indeniza&ccedil;&atilde;o por danos morais.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+A controv&eacute;rsia consiste em verificar:
+a) a exist&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o banc&aacute;rio;
+b) a configura&ccedil;&atilde;o de dano moral decorrente de descontos indevidos em conta de pessoa hipervulner&aacute;vel;
+c) a adequa&ccedil;&atilde;o do valor da indeniza&ccedil;&atilde;o fixada.
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+Restou evidenciado que a institui&ccedil;&atilde;o financeira falhou no dever de seguran&ccedil;a ao permitir descontos indevidos na conta da autora.
+A responsabilidade do banco &eacute; objetiva, nos termos do C&oacute;digo de Defesa do Consumidor, respondendo pelos danos causados por defeitos na presta&ccedil;&atilde;o do servi&ccedil;o.
+A condi&ccedil;&atilde;o da autora &ndash; idosa e benefici&aacute;ria de renda m&iacute;nima &ndash; agrava os efeitos do il&iacute;cito, tornando relevante o impacto dos descontos, ainda que de pequeno valor nominal.
+O dano moral, no caso, decorre da indevida subtra&ccedil;&atilde;o de valores essenciais &agrave; subsist&ecirc;ncia, sendo desnecess&aacute;ria prova de preju&iacute;zo concreto (dano in re ipsa).
+A indeniza&ccedil;&atilde;o fixada mostra-se adequada, atendendo aos princ&iacute;pios da razoabilidade e proporcionalidade, al&eacute;m de cumprir fun&ccedil;&atilde;o compensat&oacute;ria e pedag&oacute;gica.
+Diante do desprovimento do recurso, imp&otilde;e-se a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios, conforme art. 85, &sect;11, do CPC.
+
+IV. DISPOSITIVO E TESE
+
+Recurso desprovido.
+
+Tese de julgamento:
+
+A institui&ccedil;&atilde;o financeira responde objetivamente por descontos indevidos realizados em conta banc&aacute;ria, especialmente quando falha na seguran&ccedil;a do servi&ccedil;o prestado.
+A realiza&ccedil;&atilde;o de d&eacute;bitos n&atilde;o autorizados em benef&iacute;cio previdenci&aacute;rio de pessoa idosa e de baixa renda configura dano moral in re ipsa, diante do impacto direto na subsist&ecirc;ncia do consumidor.
+O valor da indeniza&ccedil;&atilde;o por danos morais deve observar as circunst&acirc;ncias do caso concreto, incluindo a condi&ccedil;&atilde;o de hipervulnerabilidade da v&iacute;tima e a fun&ccedil;&atilde;o pedag&oacute;gica da condena&ccedil;&atilde;o.
+O desprovimento do recurso enseja a majora&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios, nos termos do art. 85, &sect;11, do CPC. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0807921-24.2024.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. RESPONSABILIDADE DA INSTITUIÇÃO FINANCEIRA. DANOS MORAIS CONFIGURADOS. MANUTENÇÃO DA SENTENÇA. MAJORAÇÃO DE HONORÁRIOS. DESPROVIMENTO.
+
+I. CASO EM EXAME
+
+Trata-se de apelação interposta contra sentença que reconheceu a ocorrência de descontos indevidos em conta bancária de pessoa idosa,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO. RESPONSABILIDADE DA INSTITUIÇÃO FINANCEIRA. DANOS MORAIS CONFIGURADOS. MANUTENÇÃO DA SENTENÇA. MAJORAÇÃO DE HONORÁRIOS. DESPROVIMENTO.
+
+I. CASO EM EXAME
+
+Trata-se de apelação interposta contra sentença que reconheceu a ocorrência de descontos indevidos em conta bancária de pessoa idosa, aposentada, com renda mensal de um salário mínimo.
+A instituição financeira ré, responsável pela gestão da conta, permitiu a realização de débitos não autorizados, gerando prejuízo à parte autora.
+A sentença condenou a parte ré ao pagamento de indenização por danos morais.
+
+II. QUESTÃO EM DISCUSSÃO
+
+A controvérsia consiste em verificar:
+a) a existência de falha na prestação do serviço bancário;
+b) a configuração de <em>dano</em> <em>moral</em> decorrente de descontos indevidos em conta de pessoa hipervulnerável;
+c) a adequação do valor da indenização fixada.
+
+III. RAZÕES DE DECIDIR
+
+Restou evidenciado que a instituição financeira falhou no dever de segurança ao permitir descontos indevidos na conta da autora.
+A responsabilidade do banco é objetiva, nos termos do Código de Defesa do Consumidor, respondendo pelos danos causados por defeitos na prestação do serviço.
+A condição da autora – idosa e beneficiária de renda mínima – agrava os efeitos do ilícito, tornando relevante o impacto dos descontos, ainda que de pequeno valor nominal.
+O <em>dano</em> <em>moral</em>, no caso, decorre da indevida subtração de valores essenciais à subsistência, sendo desnecessária prova de prejuízo concreto (<em>dano</em> in re ipsa).
+A indenização fixada mostra-se adequada, atendendo aos princípios da razoabilidade e proporcionalidade, além de cumprir função compensatória e pedagógica.
+Diante do desprovimento do recurso, impõe-se a majoração dos honorários advocatícios, conforme art. 85, §11, do CPC.
+
+IV. DISPOSITIVO E TESE
+
+Recurso desprovido.
+
+Tese de julgamento:
+
+A instituição financeira responde objetivamente por descontos indevidos realizados em conta bancária, especialmente quando falha na segurança do serviço prestado.
+A realização de débitos não autorizados em benefício previdenciário de pessoa idosa e de baixa renda configura <em>dano</em> <em>moral</em> in re ipsa, diante do impacto direto na subsistência do consumidor.
+O valor da indenização por danos morais deve observar as circunstâncias do caso concreto, incluindo a condição de hipervulnerabilidade da vítima e a função pedagógica da condenação.
+O desprovimento do recurso enseja a majoração dos honorários advocatícios, nos termos do art. 85, §11, do CPC.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>152&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875909" cdForo="0" >
+										0862080-51.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875909" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875909);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875909" style="display: none;" >
+	<div id="textAreaDados_1875909" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C DANOS MORAIS &ndash; C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash; CANCELAMENTO UNILATERAL DO CONTRATO SEM NOTIFICA&Ccedil;&Atilde;O DO CONSUMIDOR &ndash; RECUSA NO PAGAMENTO DO PR&Ecirc;MIO &ndash; DEFEITO NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O  &ndash; DANO MORAL CONFIGURADO &ndash; QUANTUM INDENIZAT&Oacute;RIO ARBITRADO EM R$ 3.000,00 &ndash;CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA DESDE A CITA&Ccedil;&Atilde;O COM INCID&Ecirc;NCIA DA TAXA SELIC AT&Eacute; IN&Iacute;CIO DA VIG&Ecirc;NCIA DA LEI 14.905/2024 &ndash; JUROS DE MORA DEVIDOS A PARTIR DO ABITRAMENTO PELA TAXA SELIC, DEDUZIDO O IPCA &ndash; SENTEN&Ccedil;A REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O cancelamento unilateral e indevido do contrato de seguro, em raz&atilde;o da aus&ecirc;ncia de pagamento do pr&ecirc;mio, sem notifica&ccedil;&atilde;o pr&eacute;via da seguradora, gera danos de ordem moral, em raz&atilde;o da quebra da tranquilidade financeira e da paz que o segurado buscou por meio do contrato.
+O cancelamento unilateral de seguro e sem notifica&ccedil;&atilde;o pr&eacute;via ao consumidor gera expectativa de cobertura, configurando dano moral a recusa indevida em cumprir a cobertura aven&ccedil;ada, considerando que o contrato de seguro visa exatamente proteger a tranquilidade financeira e a paz do contratante diante de eventos de elevado estresse, como se verifica no caso de desemprego involunt&aacute;rio, constituem fatos suficientes para causar desequil&iacute;brio do bem-estar e sofrimento psicol&oacute;gico relevante, ensejador de dano moral e n&atilde;o mero aborrecimento.
+Quantum indenizat&oacute;rio arbitrado em R$ 3.000,00, com fundamento nos princ&iacute;pios da proporcionalidade e razoabilidade, visando desestimular condutas reincidentes al&eacute;m de reparar o dano experimentado consumidor.
+Recurso conhecido e parcialmente provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0862080-51.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 10/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(33 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE OBRIGAÇÃO DE FAZER C/C DANOS MORAIS – CÓDIGO DE DEFESA DO CONSUMIDOR – CANCELAMENTO UNILATERAL DO CONTRATO SEM NOTIFICAÇÃO DO CONSUMIDOR – RECUSA NO PAGAMENTO DO PRÊMIO – DEFEITO NA PRESTAÇÃO DO SERVIÇO  – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM INDENIZATÓRIO ARBITRADO EM R$ 3.000,00 –CORREÇÃO MONETÁRIA DESDE A CITAÇÃO COM INCIDÊNCIA DA TAXA SELIC
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE OBRIGAÇÃO DE FAZER C/C DANOS MORAIS – CÓDIGO DE DEFESA DO CONSUMIDOR – CANCELAMENTO UNILATERAL DO CONTRATO SEM NOTIFICAÇÃO DO CONSUMIDOR – RECUSA NO PAGAMENTO DO PRÊMIO – DEFEITO NA PRESTAÇÃO DO SERVIÇO  – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM INDENIZATÓRIO ARBITRADO EM R$ 3.000,00 –CORREÇÃO MONETÁRIA DESDE A CITAÇÃO COM INCIDÊNCIA DA TAXA SELIC ATÉ INÍCIO DA VIGÊNCIA DA LEI 14.905/2024 – JUROS DE MORA DEVIDOS A PARTIR DO ABITRAMENTO PELA TAXA SELIC, DEDUZIDO O IPCA – SENTENÇA REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O cancelamento unilateral e indevido do contrato de seguro, em razão da ausência de pagamento do prêmio, sem notificação prévia da seguradora, gera danos de ordem <em>moral</em>, em razão da quebra da tranquilidade financeira e da paz que o segurado buscou por meio do contrato.
+O cancelamento unilateral de seguro e sem notificação prévia ao consumidor gera expectativa de cobertura, configurando <em>dano</em> <em>moral</em> a recusa indevida em cumprir a cobertura avençada, considerando que o contrato de seguro visa exatamente proteger a tranquilidade financeira e a paz do contratante diante de eventos de elevado estresse, como se verifica no caso de desemprego involuntário, constituem fatos suficientes para causar desequilíbrio do bem-estar e sofrimento psicológico relevante, ensejador de <em>dano</em> <em>moral</em> e não mero aborrecimento.
+Quantum indenizatório arbitrado em R$ 3.000,00, com fundamento nos princípios da proporcionalidade e razoabilidade, visando desestimular condutas reincidentes além de reparar o <em>dano</em> experimentado consumidor.
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>153&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875915" cdForo="0" >
+										0804196-58.2024.8.12.0800
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875915" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875915);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875915" style="display: none;" >
+	<div id="textAreaDados_1875915" class="mensagemSemFormatacao" >
+		DIREITO PENAL E PROCESSUAL PENAL. APELA&Ccedil;&Atilde;O CRIMINAL. ESTELIONATO. CRIME CONTINUADO. V&Iacute;TIMAS IDOSAS. FRAUDE MEDIANTE EMPR&Eacute;STIMOS CONSIGNADOS PARA INSTALA&Ccedil;&Atilde;O DE PLACAS SOLARES. MATERIALIDADE E AUTORIA COMPROVADAS. DOSIMETRIA. PENA-BASE. CULPABILIDADE E ANTECEDENTES. REINCID&Ecirc;NCIA. CAUSA DE AUMENTO DO ART. 171, &sect; 4&ordm;, DO CP. MANUTEN&Ccedil;&Atilde;O. INEXIGIBILIDADE DE PROVA ESPEC&Iacute;FICA DA VULNERABILIDADE. CRIME CONTINUADO CONFIGURADO. SUBSTITUI&Ccedil;&Atilde;O DA PENA E SURSIS. INVIABILIDADE. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. AUS&Ecirc;NCIA DE INDICA&Ccedil;&Atilde;O DE VALOR NA DEN&Uacute;NCIA. AFASTAMENTO DE OF&Iacute;CIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Apela&ccedil;&atilde;o criminal interposta contra senten&ccedil;a que julgou parcialmente procedente a pretens&atilde;o punitiva estatal, condenando o r&eacute;u pela pr&aacute;tica de dezesseis crimes de estelionato contra v&iacute;timas idosas, em continuidade delitiva, em raz&atilde;o de fraude consistente na indu&ccedil;&atilde;o das v&iacute;timas &agrave; contrata&ccedil;&atilde;o de empr&eacute;stimos consignados para suposta instala&ccedil;&atilde;o de placas solares, servi&ccedil;o jamais prestado, fixando pena privativa de liberdade em regime fechado, al&eacute;m de indeniza&ccedil;&atilde;o por danos morais.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2) H&aacute; oito quest&otilde;es em discuss&atilde;o: (i) definir se est&atilde;o comprovadas a materialidade e a autoria delitivas; (ii) estabelecer se &eacute; cab&iacute;vel a absolvi&ccedil;&atilde;o por aus&ecirc;ncia de fraude ou vantagem il&iacute;cita; (iii) determinar se a pena-base deve ser reduzida ao m&iacute;nimo legal; (iv) definir se deve ser afastada a agravante da reincid&ecirc;ncia; (v) estabelecer a incid&ecirc;ncia da causa de aumento do art. 171, &sect; 4&ordm;, do C&oacute;digo Penal; (vi) analisar a configura&ccedil;&atilde;o do crime continuado; (vii) verificar a possibilidade de substitui&ccedil;&atilde;o da pena privativa de liberdade ou concess&atilde;o de sursis; e (viii) determinar a legalidade da fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais.
+III. RAZ&Otilde;ES DE DECIDIR
+3) A prova documental e testemunhal demonstra de forma segura a materialidade e a autoria dos delitos, especialmente pelos boletins de ocorr&ecirc;ncia, extratos banc&aacute;rios e depoimentos convergentes das v&iacute;timas e testemunhas.
+4) Os relatos das v&iacute;timas idosas s&atilde;o coerentes, detalhados e confirmados por outros elementos probat&oacute;rios, revelando fraude consistente no aproveitamento da baixa instru&ccedil;&atilde;o e vulnerabilidade econ&ocirc;mica.
+5) A culpabilidade do agente se mostra exacerbada, pois a conduta ultrapassa o tipo penal ao impor &agrave;s v&iacute;timas descontos permanentes em benef&iacute;cios previdenci&aacute;rios.
+6) Os maus antecedentes est&atilde;o devidamente comprovados por condena&ccedil;&otilde;es transitadas em julgado, legitimando a exaspera&ccedil;&atilde;o da pena-base.
+7) A reincid&ecirc;ncia se configura, pois n&atilde;o transcorreu o prazo quinquenal entre a extin&ccedil;&atilde;o da pena anterior e a pr&aacute;tica dos novos delitos.
+8) A causa de aumento do art. 171, &sect; 4&ordm;, do C&oacute;digo Penal incide de forma objetiva, bastando que o crime seja cometido contra idoso, sendo prescind&iacute;vel a prova de explora&ccedil;&atilde;o consciente da vulnerabilidade.
+9) O crime continuado resta caracterizado pela pluralidade de condutas, identidade de crimes e semelhan&ccedil;a de tempo, lugar e modo de execu&ccedil;&atilde;o.
+10) A substitui&ccedil;&atilde;o da pena privativa de liberdade e a concess&atilde;o do sursis s&atilde;o invi&aacute;veis diante da reincid&ecirc;ncia, da pena aplicada e das circunst&acirc;ncias judiciais desfavor&aacute;veis.
+11) A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais exige pedido expresso com indica&ccedil;&atilde;o do valor na den&uacute;ncia, o que n&atilde;o ocorreu, impondo seu afastamento de of&iacute;cio.
+IV. DISPOSITIVO E TESE
+12) Recurso desprovido, com afastamento de of&iacute;cio da indeniza&ccedil;&atilde;o por danos morais.
+
+Tese de julgamento:
+1. A palavra da v&iacute;tima idosa, quando coerente e amparada por prova documental, &eacute; suficiente para a condena&ccedil;&atilde;o por estelionato.
+2. Configura-se a reincid&ecirc;ncia quando o novo delito &eacute; praticado antes do transcurso do prazo quinquenal previsto no art. 64, I, do C&oacute;digo Penal.
+3. A causa de aumento do art. 171, &sect; 4&ordm;, do C&oacute;digo Penal possui natureza objetiva e independe da comprova&ccedil;&atilde;o do dolo espec&iacute;fico de explora&ccedil;&atilde;o da vulnerabilidade.
+4. A continuidade delitiva se configura quando presentes pluralidade de condutas, crimes da mesma esp&eacute;cie e modus operandi semelhante.
+5. A fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o m&iacute;nima por danos morais na senten&ccedil;a penal condenat&oacute;ria exige pedido expresso e indica&ccedil;&atilde;o do valor na den&uacute;ncia.
+
+Dispositivos relevantes citados: CP, arts. 59, 63, 64, I, 71, caput, 171, &sect; 4&ordm;; CPP, arts. 156 e 387, IV.
+Jurisprud&ecirc;ncia relevante citada: STJ, REsp 1.986.672/SC, Rel. Min. Ribeiro Dantas, Terceira Se&ccedil;&atilde;o, j. 08.11.2023; TJSP, Apela&ccedil;&atilde;o Criminal n&ordm; 0003370-42.2018.8.26.0297, Rel. J. E. S. Bittencourt Rodrigues, j. 01.07.2024; TJMS, ACr n&ordm; 0002672-07.2019.8.12.0001, Rel. Des. Luiz Claudio Bonassini da Silva, j. 29.04.2024.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0804196-58.2024.8.12.0800,&nbsp; Dois Irm&atilde;os do Buriti,&nbsp; 3&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. Zaloar Murat Martins de Souza, j: 10/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(28 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Estelionato
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Zaloar Murat Martins de Souza
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dois Irmãos do Buriti
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. ESTELIONATO. CRIME CONTINUADO. VÍTIMAS IDOSAS. FRAUDE MEDIANTE EMPRÉSTIMOS CONSIGNADOS PARA INSTALAÇÃO DE PLACAS SOLARES. MATERIALIDADE E AUTORIA COMPROVADAS. DOSIMETRIA. PENA-BASE. CULPABILIDADE E ANTECEDENTES. REINCIDÊNCIA. CAUSA DE AUMENTO DO ART. 171, § 4º, DO CP. MANUTENÇÃO. INEXIGIBILIDADE DE PROVA ESPECÍFICA DA VULNERABILIDADE. CRIME
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO PENAL E PROCESSUAL PENAL. APELAÇÃO CRIMINAL. ESTELIONATO. CRIME CONTINUADO. VÍTIMAS IDOSAS. FRAUDE MEDIANTE EMPRÉSTIMOS CONSIGNADOS PARA INSTALAÇÃO DE PLACAS SOLARES. MATERIALIDADE E AUTORIA COMPROVADAS. DOSIMETRIA. PENA-BASE. CULPABILIDADE E ANTECEDENTES. REINCIDÊNCIA. CAUSA DE AUMENTO DO ART. 171, § 4º, DO CP. MANUTENÇÃO. INEXIGIBILIDADE DE PROVA ESPECÍFICA DA VULNERABILIDADE. CRIME CONTINUADO CONFIGURADO. SUBSTITUIÇÃO DA PENA E SURSIS. INVIABILIDADE. INDENIZAÇÃO POR DANOS MORAIS. AUSÊNCIA DE INDICAÇÃO DE VALOR NA DENÚNCIA. AFASTAMENTO DE OFÍCIO. RECURSO DESPROVIDO.
+I. CASO EM EXAME
+1) Apelação criminal interposta contra sentença que julgou parcialmente procedente a pretensão punitiva estatal, condenando o réu pela prática de dezesseis crimes de estelionato contra vítimas idosas, em continuidade delitiva, em razão de fraude consistente na indução das vítimas à contratação de empréstimos consignados para suposta instalação de placas solares, serviço jamais prestado, fixando pena privativa de liberdade em regime fechado, além de indenização por danos morais.
+II. QUESTÃO EM DISCUSSÃO
+2) Há oito questões em discussão: (i) definir se estão comprovadas a materialidade e a autoria delitivas; (ii) estabelecer se é cabível a absolvição por ausência de fraude ou vantagem ilícita; (iii) determinar se a pena-base deve ser reduzida ao mínimo legal; (iv) definir se deve ser afastada a agravante da reincidência; (v) estabelecer a incidência da causa de aumento do art. 171, § 4º, do Código Penal; (vi) analisar a configuração do crime continuado; (vii) verificar a possibilidade de substituição da pena privativa de liberdade ou concessão de sursis; e (viii) determinar a legalidade da fixação de indenização por danos morais.
+III. RAZÕES DE DECIDIR
+3) A prova documental e testemunhal demonstra de forma segura a materialidade e a autoria dos delitos, especialmente pelos boletins de ocorrência, extratos bancários e depoimentos convergentes das vítimas e testemunhas.
+4) Os relatos das vítimas idosas são coerentes, detalhados e confirmados por outros elementos probatórios, revelando fraude consistente no aproveitamento da baixa instrução e vulnerabilidade econômica.
+5) A culpabilidade do agente se mostra exacerbada, pois a conduta ultrapassa o tipo penal ao impor às vítimas descontos permanentes em benefícios previdenciários.
+6) Os maus antecedentes estão devidamente comprovados por condenações transitadas em julgado, legitimando a exasperação da pena-base.
+7) A reincidência se configura, pois não transcorreu o prazo quinquenal entre a extinção da pena anterior e a prática dos novos delitos.
+8) A causa de aumento do art. 171, § 4º, do Código Penal incide de forma objetiva, bastando que o crime seja cometido contra idoso, sendo prescindível a prova de exploração consciente da vulnerabilidade.
+9) O crime continuado resta caracterizado pela pluralidade de condutas, identidade de crimes e semelhança de tempo, lugar e modo de execução.
+10) A substituição da pena privativa de liberdade e a concessão do sursis são inviáveis diante da reincidência, da pena aplicada e das circunstâncias judiciais desfavoráveis.
+11) A fixação de indenização por danos morais exige pedido expresso com indicação do valor na denúncia, o que não ocorreu, impondo seu afastamento de ofício.
+IV. DISPOSITIVO E TESE
+12) Recurso desprovido, com afastamento de ofício da indenização por danos morais.
+
+Tese de julgamento:
+1. A palavra da vítima idosa, quando coerente e amparada por prova documental, é suficiente para a condenação por estelionato.
+2. Configura-se a reincidência quando o novo delito é praticado antes do transcurso do prazo quinquenal previsto no art. 64, I, do Código Penal.
+3. A causa de aumento do art. 171, § 4º, do Código Penal possui natureza objetiva e independe da comprovação do dolo específico de exploração da vulnerabilidade.
+4. A continuidade delitiva se configura quando presentes pluralidade de condutas, crimes da mesma espécie e modus operandi semelhante.
+5. A fixação de indenização mínima por danos morais na sentença penal condenatória exige pedido expresso e indicação do valor na denúncia.
+
+Dispositivos relevantes citados: CP, arts. 59, 63, 64, I, 71, caput, 171, § 4º; CPP, arts. 156 e 387, IV.
+Jurisprudência relevante citada: STJ, REsp 1.986.672/SC, Rel. Min. Ribeiro Dantas, Terceira Seção, j. 08.11.2023; TJSP, Apelação Criminal nº 0003370-42.2018.8.26.0297, Rel. J. E. S. Bittencourt Rodrigues, j. 01.07.2024; TJMS, ACr nº 0002672-07.2019.8.12.0001, Rel. Des. Luiz Claudio Bonassini da Silva, j. 29.04.2024.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>154&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875928" cdForo="0" >
+										1401001-20.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875928" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875928);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875928" style="display: none;" >
+	<div id="textAreaDados_1875928" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; TUTELA DE URG&Ecirc;NCIA INDEFERIDA NA ORIGEM &ndash; SUSPENS&Atilde;O DE DESCONTOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL (RMC) &ndash; ALEGA&Ccedil;&Atilde;O DE V&Iacute;CIO DE CONSENTIMENTO E FALTA DE INFORMA&Ccedil;&Atilde;O &ndash; AUS&Ecirc;NCIA DE PROBABILIDADE DO DIREITO &ndash; NECESSIDADE DE DILA&Ccedil;&Atilde;O PROBAT&Oacute;RIA &ndash; PERIGO DE DANO N&Atilde;O CONFIGURADO &ndash; DESCONTOS QUE SE PERPETUAM NO TEMPO (DESDE 2020) &ndash; DECIS&Atilde;O MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+I - A concess&atilde;o da tutela antecipada exige a presen&ccedil;a concomitante da probabilidade do direito e do perigo de dano ou risco ao resultado &uacute;til do processo (art. 300, caput, do CPC).
+II - A alega&ccedil;&atilde;o de que a consumidora pretendia contratar empr&eacute;stimo consignado tradicional, e n&atilde;o cart&atilde;o de cr&eacute;dito (RMC), demanda dila&ccedil;&atilde;o probat&oacute;ria sob o crivo do contradit&oacute;rio. Em sede de cogni&ccedil;&atilde;o sum&aacute;ria, inexistindo prova inequ&iacute;voca do v&iacute;cio de consentimento ou da falha no dever de informa&ccedil;&atilde;o, n&atilde;o se mostra prudente a suspens&atilde;o imediata dos descontos de contrato cuja exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica e proveito econ&ocirc;mico n&atilde;o s&atilde;o negados.
+III - O periculum in mora resta mitigado quando se verifica que os descontos questionados v&ecirc;m sendo realizados h&aacute; longo per&iacute;odo (desde o ano de 2020) sem insurg&ecirc;ncia oportuna, o que afasta a natureza de urg&ecirc;ncia contempor&acirc;nea ao pedido.
+IV - Orienta&ccedil;&atilde;o jurisprudencial desta Corte no sentido de que a longevidade dos descontos e a necessidade de instru&ccedil;&atilde;o processual para aferi&ccedil;&atilde;o de v&iacute;cios de vontade impedem a antecipa&ccedil;&atilde;o dos efeitos da tutela.
+V - Recurso conhecido e desprovido. <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1401001-20.2026.8.12.0000,&nbsp; Navira&iacute;,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 10/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(12 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Liminar
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Naviraí
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – TUTELA DE URGÊNCIA INDEFERIDA NA ORIGEM – SUSPENSÃO DE DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC) – ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO E FALTA DE INFORMAÇÃO – AUSÊNCIA DE PROBABILIDADE DO DIREITO – NECESSIDADE DE DILAÇÃO PROBATÓRIA – PERIGO DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – AÇÃO DE OBRIGAÇÃO DE FAZER C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – TUTELA DE URGÊNCIA INDEFERIDA NA ORIGEM – SUSPENSÃO DE DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL (RMC) – ALEGAÇÃO DE VÍCIO DE CONSENTIMENTO E FALTA DE INFORMAÇÃO – AUSÊNCIA DE PROBABILIDADE DO DIREITO – NECESSIDADE DE DILAÇÃO PROBATÓRIA – PERIGO DE <em>DANO</em> NÃO CONFIGURADO – DESCONTOS QUE SE PERPETUAM NO TEMPO (DESDE 2020) – DECISÃO MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+I - A concessão da tutela antecipada exige a presença concomitante da probabilidade do direito e do perigo de <em>dano</em> ou risco ao resultado útil do processo (art. 300, caput, do CPC).
+II - A alegação de que a consumidora pretendia contratar empréstimo consignado tradicional, e não cartão de crédito (RMC), demanda dilação probatória sob o crivo do contraditório. Em sede de cognição sumária, inexistindo prova inequívoca do vício de consentimento ou da falha no dever de informação, não se mostra prudente a suspensão imediata dos descontos de contrato cuja existência da relação jurídica e proveito econômico não são negados.
+III - O periculum in mora resta mitigado quando se verifica que os descontos questionados vêm sendo realizados há longo período (desde o ano de 2020) sem insurgência oportuna, o que afasta a natureza de urgência contemporânea ao pedido.
+IV - Orientação jurisprudencial desta Corte no sentido de que a longevidade dos descontos e a necessidade de instrução processual para aferição de vícios de vontade impedem a antecipação dos efeitos da tutela.
+V - Recurso conhecido e desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>155&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875945" cdForo="0" >
+										1401297-42.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875945" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875945);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875945" style="display: none;" >
+	<div id="textAreaDados_1875945" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E DO CONSUMIDOR &ndash; PLANO DE SA&Uacute;DE &ndash; AGRAVO DE INSTRUMENTO &ndash; TUTELA DE URG&Ecirc;NCIA &ndash; COPARTICIPA&Ccedil;&Atilde;O &ndash; TRATAMENTO MULTIDISCIPLINAR &ndash; TRANSTORNO DO ESPECTRO AUTISTA (TEA) &ndash; LIMITA&Ccedil;&Atilde;O &ndash; MANUTEN&Ccedil;&Atilde;O &ndash; RECURSO DESPROVIDO
+
+I. CASO EM EXAME
+Trata-se de agravo de instrumento interposto por operadora de plano de sa&uacute;de contra decis&atilde;o que, em a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer cumulada com restitui&ccedil;&atilde;o de valores, deferiu tutela de urg&ecirc;ncia para limitar a cobran&ccedil;a de coparticipa&ccedil;&atilde;o relativa a tratamento multidisciplinar de menor diagnosticado com Transtorno do Espectro Autista (TEA).
+A decis&atilde;o agravada fixou como par&acirc;metro m&aacute;ximo de coparticipa&ccedil;&atilde;o valor equivalente &agrave; mensalidade do plano, a fim de viabilizar a continuidade das terapias prescritas.
+A agravante sustenta a legalidade da coparticipa&ccedil;&atilde;o, a aus&ecirc;ncia dos requisitos do art. 300 do CPC e risco de desequil&iacute;brio econ&ocirc;mico-financeiro do contrato.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+Discute-se se est&atilde;o presentes os requisitos para manuten&ccedil;&atilde;o da tutela de urg&ecirc;ncia que limitou a cobran&ccedil;a de coparticipa&ccedil;&atilde;o em plano de sa&uacute;de, quando os valores exigidos inviabilizam o acesso de crian&ccedil;a com TEA ao tratamento multidisciplinar prescrito.
+III. RAZ&Otilde;ES DE DECIDIR
+Nos termos do art. 300 do CPC, a concess&atilde;o da tutela de urg&ecirc;ncia exige probabilidade do direito e perigo de dano.
+A coparticipa&ccedil;&atilde;o &eacute; admitida pelo art. 16, VIII, da Lei n&ordm; 9.656/1998, sendo mecanismo leg&iacute;timo de regula&ccedil;&atilde;o contratual, desde que n&atilde;o se converta em obst&aacute;culo ao acesso do consumidor ao tratamento de sa&uacute;de.
+A jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a reconhece a validade da coparticipa&ccedil;&atilde;o, mas condiciona sua aplica&ccedil;&atilde;o &agrave; aus&ecirc;ncia de inviabiliza&ccedil;&atilde;o do tratamento m&eacute;dico necess&aacute;rio.
+No caso concreto, verifica-se que:
+o benefici&aacute;rio &eacute; crian&ccedil;a de tr&ecirc;s anos diagnosticada com TEA n&iacute;vel 3;
+h&aacute; prescri&ccedil;&atilde;o de tratamento intensivo e multidisciplinar;
+a mensalidade do plano &eacute; significativamente inferior aos valores cobrados a t&iacute;tulo de coparticipa&ccedil;&atilde;o, que superam substancialmente esse montante.
+Tal circunst&acirc;ncia evidencia, em ju&iacute;zo de cogni&ccedil;&atilde;o sum&aacute;ria, desproporcionalidade na cobran&ccedil;a, com potencial de inviabilizar a continuidade do tratamento, caracterizando probabilidade do direito.
+O perigo de dano tamb&eacute;m se mostra presente, diante do risco de preju&iacute;zo irrevers&iacute;vel ao desenvolvimento neuropsicomotor da crian&ccedil;a, especialmente em fase cr&iacute;tica de interven&ccedil;&atilde;o precoce.
+Incidem, ainda, os princ&iacute;pios da prote&ccedil;&atilde;o integral e da prioridade absoluta da crian&ccedil;a e do adolescente (CF, art. 227; ECA, arts. 1&ordm; e 3&ordm;), que refor&ccedil;am a necessidade de assegurar o acesso efetivo ao tratamento de sa&uacute;de.
+A limita&ccedil;&atilde;o da coparticipa&ccedil;&atilde;o, nesse contexto, n&atilde;o implica supress&atilde;o do modelo contratual, mas medida excepcional para evitar desequil&iacute;brio material e garantir a fun&ccedil;&atilde;o social do contrato.
+Inexiste perigo de irreversibilidade, pois eventual reforma da decis&atilde;o ensejar&aacute; apenas efeitos patrimoniais, pass&iacute;veis de compensa&ccedil;&atilde;o.
+IV. DISPOSITIVO E TESE
+Recurso desprovido.
+
+Tese de julgamento:
+
+A cl&aacute;usula de coparticipa&ccedil;&atilde;o em plano de sa&uacute;de &eacute; v&aacute;lida, nos termos do art. 16, VIII, da Lei n&ordm; 9.656/1998, desde que n&atilde;o inviabilize o acesso do benefici&aacute;rio ao tratamento m&eacute;dico necess&aacute;rio.
+&Eacute; cab&iacute;vel, em sede de tutela de urg&ecirc;ncia, a limita&ccedil;&atilde;o da coparticipa&ccedil;&atilde;o quando os valores cobrados se mostram desproporcionais e aptos a impedir a continuidade de tratamento essencial, especialmente em se tratando de crian&ccedil;a com Transtorno do Espectro Autista.
+A prote&ccedil;&atilde;o integral e a prioridade absoluta da crian&ccedil;a e do adolescente autorizam a interven&ccedil;&atilde;o judicial para assegurar o acesso efetivo ao tratamento de sa&uacute;de, ainda que implique restri&ccedil;&atilde;o tempor&aacute;ria &agrave; din&acirc;mica contratual.
+
+
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 2&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator. <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1401297-42.2026.8.12.0000,&nbsp; Parana&iacute;ba,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(8 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Planos de saúde
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR – PLANO DE SAÚDE – AGRAVO DE INSTRUMENTO – TUTELA DE URGÊNCIA – COPARTICIPAÇÃO – TRATAMENTO MULTIDISCIPLINAR – TRANSTORNO DO ESPECTRO AUTISTA (TEA) – LIMITAÇÃO – MANUTENÇÃO – RECURSO DESPROVIDO
+
+I. CASO EM EXAME
+Trata-se de agravo de instrumento interposto por operadora de plano de saúde contra decisão que, em ação de obrigação de fazer cumulada com restituição de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E DO CONSUMIDOR – PLANO DE SAÚDE – AGRAVO DE INSTRUMENTO – TUTELA DE URGÊNCIA – COPARTICIPAÇÃO – TRATAMENTO MULTIDISCIPLINAR – TRANSTORNO DO ESPECTRO AUTISTA (TEA) – LIMITAÇÃO – MANUTENÇÃO – RECURSO DESPROVIDO
+
+I. CASO EM EXAME
+Trata-se de agravo de instrumento interposto por operadora de plano de saúde contra decisão que, em ação de obrigação de fazer cumulada com restituição de valores, deferiu tutela de urgência para limitar a cobrança de coparticipação relativa a tratamento multidisciplinar de menor diagnosticado com Transtorno do Espectro Autista (TEA).
+A decisão agravada fixou como parâmetro máximo de coparticipação valor equivalente à mensalidade do plano, a fim de viabilizar a continuidade das terapias prescritas.
+A agravante sustenta a legalidade da coparticipação, a ausência dos requisitos do art. 300 do CPC e risco de desequilíbrio econômico-financeiro do contrato.
+II. QUESTÃO EM DISCUSSÃO
+Discute-se se estão presentes os requisitos para manutenção da tutela de urgência que limitou a cobrança de coparticipação em plano de saúde, quando os valores exigidos inviabilizam o acesso de criança com TEA ao tratamento multidisciplinar prescrito.
+III. RAZÕES DE DECIDIR
+Nos termos do art. 300 do CPC, a concessão da tutela de urgência exige probabilidade do direito e perigo de <em>dano</em>.
+A coparticipação é admitida pelo art. 16, VIII, da Lei nº 9.656/1998, sendo mecanismo legítimo de regulação contratual, desde que não se converta em obstáculo ao acesso do consumidor ao tratamento de saúde.
+A jurisprudência do Superior Tribunal de Justiça reconhece a validade da coparticipação, mas condiciona sua aplicação à ausência de inviabilização do tratamento médico necessário.
+No caso concreto, verifica-se que:
+o beneficiário é criança de três anos diagnosticada com TEA nível 3;
+há prescrição de tratamento intensivo e multidisciplinar;
+a mensalidade do plano é significativamente inferior aos valores cobrados a título de coparticipação, que superam substancialmente esse montante.
+Tal circunstância evidencia, em juízo de cognição sumária, desproporcionalidade na cobrança, com potencial de inviabilizar a continuidade do tratamento, caracterizando probabilidade do direito.
+O perigo de <em>dano</em> também se mostra presente, diante do risco de prejuízo irreversível ao desenvolvimento neuropsicomotor da criança, especialmente em fase crítica de intervenção precoce.
+Incidem, ainda, os princípios da proteção integral e da prioridade absoluta da criança e do adolescente (CF, art. 227; ECA, arts. 1º e 3º), que reforçam a necessidade de assegurar o acesso efetivo ao tratamento de saúde.
+A limitação da coparticipação, nesse contexto, não implica supressão do modelo contratual, mas medida excepcional para evitar desequilíbrio material e garantir a função social do contrato.
+Inexiste perigo de irreversibilidade, pois eventual reforma da decisão ensejará apenas efeitos patrimoniais, passíveis de compensação.
+IV. DISPOSITIVO E TESE
+Recurso desprovido.
+
+Tese de julgamento:
+
+A cláusula de coparticipação em plano de saúde é válida, nos termos do art. 16, VIII, da Lei nº 9.656/1998, desde que não inviabilize o acesso do beneficiário ao tratamento médico necessário.
+É cabível, em sede de tutela de urgência, a limitação da coparticipação quando os valores cobrados se mostram desproporcionais e aptos a impedir a continuidade de tratamento essencial, especialmente em se tratando de criança com Transtorno do Espectro Autista.
+A proteção integral e a prioridade absoluta da criança e do adolescente autorizam a intervenção judicial para assegurar o acesso efetivo ao tratamento de saúde, ainda que implique restrição temporária à dinâmica contratual.
+
+
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 2ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>156&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875952" cdForo="0" >
+										0808128-72.2024.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875952" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875952);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875952" style="display: none;" >
+	<div id="textAreaDados_1875952" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash;  A&Ccedil;&Atilde;O DE COBRAN&Ccedil;A C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash;  PRELIMINAR CONTRARRECURSAL DE AUS&Ecirc;NCIA DE DIALETICIDADE &ndash; AFASTADA &ndash; M&Eacute;RITO &ndash; PEDIDO RECONVENCIONAL &ndash; AUS&Ecirc;NCIA DE RECOLHIMENTO DAS CUSTAS INICIAIS &ndash; IMPOSSIBILIDADE DE APRECIA&Ccedil;&Atilde;O &ndash; PRESTA&Ccedil;&Atilde;O DE SERVI&Ccedil;OS DE PINTURA NO IM&Oacute;VEL DA INSTITUI&Ccedil;&Atilde;O BANC&Aacute;RIA &ndash; AUS&Ecirc;NCIA DE PAGAMENTO PELOS SERVI&Ccedil;OS &ndash; ALEGA&Ccedil;&Atilde;O DE COMPENSA&Ccedil;&Atilde;O ADMINISTRATIVA DE D&Iacute;VIDA ENTRE AS PARTES &ndash; IMPOSSIBILIDADE &ndash; ATO IL&Iacute;CITO CONFIGURADO &ndash; DANOS MORAIS &ndash; DEVIDOS &ndash; SENTEN&Ccedil;A MANTIDA &ndash;  RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I - N&atilde;o h&aacute; ofensa ao princ&iacute;pio da&nbsp;dialeticidade, porquanto se verifica que as raz&otilde;es da pe&ccedil;a recursal s&atilde;o suficientes para atacar minimamente os fundamentos da decis&atilde;o recorrida. Preliminar contrarrecursal afastada.
+II - Nos termos do caput do art. 292 do CPC, deve constar o valor da causa na reconven&ccedil;&atilde;o, impondo-se ainda o recolhimento das custas iniciais. Ausente o&nbsp;recolhimento, mesmo ap&oacute;s a intima&ccedil;&atilde;o da parte para faz&ecirc;-lo, a consequ&ecirc;ncia &eacute; a extin&ccedil;&atilde;o do processo sem resolu&ccedil;&atilde;o de m&eacute;rito, por aus&ecirc;ncia de pressuposto processual de constitui&ccedil;&atilde;o e de desenvolvimento v&aacute;lido e regular, com fulcro no art. 485, IV, do CPC.
+III - &Eacute; il&iacute;cita a reten&ccedil;&atilde;o de valores creditados em conta banc&aacute;ria a t&iacute;tulo de remunera&ccedil;&atilde;o oriunda de presta&ccedil;&atilde;o de servi&ccedil;os de pintura no im&oacute;vel da institui&ccedil;&atilde;o financeira, para&nbsp;compensa&ccedil;&atilde;o de d&iacute;vida banc&aacute;ria, sem autoriza&ccedil;&atilde;o expressa e espec&iacute;fica do consumidor.
+IV - Assim, se o banco ret&eacute;m indevidamente valor da conta banc&aacute;ria do correntista, dever&aacute; efetuar a restitui&ccedil;&atilde;o daquilo que foi arrecadado ao arrepio da Lei.
+V - A reten&ccedil;&atilde;o indevida de valores em conta banc&aacute;ria configura ato il&iacute;cito apto a justificar a pretens&atilde;o de condena&ccedil;&atilde;o ao pagamento de indeniza&ccedil;&atilde;o por danos morais.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0808128-72.2024.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DE COBRANÇA C/C INDENIZAÇÃO POR DANOS MORAIS –  PRELIMINAR CONTRARRECURSAL DE AUSÊNCIA DE DIALETICIDADE – AFASTADA – MÉRITO – PEDIDO RECONVENCIONAL – AUSÊNCIA DE RECOLHIMENTO DAS CUSTAS INICIAIS – IMPOSSIBILIDADE DE APRECIAÇÃO – PRESTAÇÃO DE SERVIÇOS DE PINTURA NO IMÓVEL DA INSTITUIÇÃO BANCÁRIA – AUSÊNCIA DE PAGAMENTO PELOS SERVIÇOS – ALEGAÇÃO DE COMPENSAÇÃO ADMINISTRATIVA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DE COBRANÇA C/C INDENIZAÇÃO POR DANOS MORAIS –  PRELIMINAR CONTRARRECURSAL DE AUSÊNCIA DE DIALETICIDADE – AFASTADA – MÉRITO – PEDIDO RECONVENCIONAL – AUSÊNCIA DE RECOLHIMENTO DAS CUSTAS INICIAIS – IMPOSSIBILIDADE DE APRECIAÇÃO – PRESTAÇÃO DE SERVIÇOS DE PINTURA NO IMÓVEL DA INSTITUIÇÃO BANCÁRIA – AUSÊNCIA DE PAGAMENTO PELOS SERVIÇOS – ALEGAÇÃO DE COMPENSAÇÃO ADMINISTRATIVA DE DÍVIDA ENTRE AS PARTES – IMPOSSIBILIDADE – ATO ILÍCITO CONFIGURADO – DANOS MORAIS – DEVIDOS – SENTENÇA MANTIDA –  RECURSO CONHECIDO E NÃO PROVIDO.
+I - Não há ofensa ao princípio da dialeticidade, porquanto se verifica que as razões da peça recursal são suficientes para atacar minimamente os fundamentos da decisão recorrida. Preliminar contrarrecursal afastada.
+II - Nos termos do caput do art. 292 do CPC, deve constar o valor da causa na reconvenção, impondo-se ainda o recolhimento das custas iniciais. Ausente o recolhimento, mesmo após a intimação da parte para fazê-lo, a consequência é a extinção do processo sem resolução de mérito, por ausência de pressuposto processual de constituição e de desenvolvimento válido e regular, com fulcro no art. 485, IV, do CPC.
+III - É ilícita a retenção de valores creditados em conta bancária a título de remuneração oriunda de prestação de serviços de pintura no imóvel da instituição financeira, para compensação de dívida bancária, sem autorização expressa e específica do consumidor.
+IV - Assim, se o banco retém indevidamente valor da conta bancária do correntista, deverá efetuar a restituição daquilo que foi arrecadado ao arrepio da Lei.
+V - A retenção indevida de valores em conta bancária configura ato ilícito apto a justificar a pretensão de condenação ao pagamento de indenização por danos morais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>157&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875958" cdForo="0" >
+										0856094-19.2023.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875958" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875958);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875958" style="display: none;" >
+	<div id="textAreaDados_1875958" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO BANC&Aacute;RIO &ndash; AUS&Ecirc;NCIA  DOS V&Iacute;CIOS DISPOSTOS NO ART. 1.022 DO CPC &ndash;  MULTA PREVISTA NO &sect; 2&ordm; DO ART. 1.026 DO CPC &ndash; EMBARGOS REJEITADOS COM APLICA&Ccedil;&Atilde;O DE MULTA.
+I - N&atilde;o padece de v&iacute;cio a decis&atilde;o apenas porque, sob a &oacute;tica particular do pr&oacute;prio interessado a respeito da valora&ccedil;&atilde;o jur&iacute;dica dos fatos e das provas, a solu&ccedil;&atilde;o haveria de ter sido diferente daquela adotada pelo Estado-Juiz, porquanto a rediscuss&atilde;o do m&eacute;rito de decisum via aclarat&oacute;rios n&atilde;o encontra amparo na legisla&ccedil;&atilde;o processual vigente.  Ademais, o Tribunal n&atilde;o fica obrigado a examinar todas as min&uacute;cias e possibilidades abstratas invocadas pela defesa, desde que decida sob fundamentos suficientes para sustentar a manifesta&ccedil;&atilde;o jurisdicional.
+II - Mesmo na hip&oacute;tese de prequestionamento da mat&eacute;ria, a irresigna&ccedil;&atilde;o apresentada a exame deve encontrar abrigo em uma das hip&oacute;teses do artigo 1.022 do C&oacute;digo de Processo Civil. O prequestionamento pressup&otilde;e debate e decis&atilde;o quanto &agrave; mat&eacute;ria, de sorte que a manifesta&ccedil;&atilde;o expressa sobre normativo &eacute; prescind&iacute;vel.
+III - Diante do manifesto prop&oacute;sito protelat&oacute;rio dos presentes embargos, com mero intuito de rediscuss&atilde;o que quest&atilde;o j&aacute; trazida &agrave; aprecia&ccedil;&atilde;o deste &Oacute;rg&atilde;o Colegiado, imp&otilde;e-se a aplica&ccedil;&atilde;o da multa prevista no &sect;2&ordm;, do art. 1.026 do CPC ao caso.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0856094-19.2023.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									856094192023812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL EM AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – AUSÊNCIA  DOS VÍCIOS DISPOSTOS NO ART. 1.022 DO CPC –  MULTA PREVISTA NO § 2º DO ART. 1.026 DO CPC – EMBARGOS REJEITADOS COM APLICAÇÃO DE MULTA.
+I - Não padece de vício a decisão apenas porque, sob a ótica particular do próprio interessado a respeito da valoração jurídica dos fatos e das provas, a solução haveria
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL EM AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – AUSÊNCIA  DOS VÍCIOS DISPOSTOS NO ART. 1.022 DO CPC –  MULTA PREVISTA NO § 2º DO ART. 1.026 DO CPC – EMBARGOS REJEITADOS COM APLICAÇÃO DE MULTA.
+I - Não padece de vício a decisão apenas porque, sob a ótica particular do próprio interessado a respeito da valoração jurídica dos fatos e das provas, a solução haveria de ter sido diferente daquela adotada pelo Estado-Juiz, porquanto a rediscussão do mérito de decisum via aclaratórios não encontra amparo na legislação processual vigente.  Ademais, o Tribunal não fica obrigado a examinar todas as minúcias e possibilidades abstratas invocadas pela defesa, desde que decida sob fundamentos suficientes para sustentar a manifestação jurisdicional.
+II - Mesmo na hipótese de prequestionamento da matéria, a irresignação apresentada a exame deve encontrar abrigo em uma das hipóteses do artigo 1.022 do Código de Processo Civil. O prequestionamento pressupõe debate e decisão quanto à matéria, de sorte que a manifestação expressa sobre normativo é prescindível.
+III - Diante do manifesto propósito protelatório dos presentes embargos, com mero intuito de rediscussão que questão já trazida à apreciação deste Órgão Colegiado, impõe-se a aplicação da multa prevista no §2º, do art. 1.026 do CPC ao caso.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>158&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875974" cdForo="0" >
+										0807567-96.2024.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875974" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875974);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875974" style="display: none;" >
+	<div id="textAreaDados_1875974" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. PROMESSA DE COMPRA E VENDA DE IM&Oacute;VEL. JUROS DE OBRA. COBRAN&Ccedil;A AP&Oacute;S ENTREGA DAS CHAVES. ILEGALIDADE. NEGATIVA&Ccedil;&Atilde;O INDEVIDA. DANO MORAL IN RE IPSA. PROVIMENTO DO RECURSO.
+
+I. CASO EM EXAME
+
+Trata-se de apela&ccedil;&atilde;o interposta contra senten&ccedil;a que julgou improcedentes os pedidos em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de d&eacute;bito c/c indeniza&ccedil;&atilde;o por danos morais ajuizada em face de Residencial Cuiab&aacute; Incorporadora SPE.
+
+O autor alega que, embora a obra tenha sido conclu&iacute;da em 13/11/2023, com expedi&ccedil;&atilde;o do habite-se em 04/03/2024 e entrega das chaves em 05/03/2024, continuaram sendo cobrados juros de obra (taxa de evolu&ccedil;&atilde;o de obra), culminando em sua negativa&ccedil;&atilde;o.
+
+Requereu a declara&ccedil;&atilde;o de inexigibilidade dos valores cobrados ap&oacute;s a entrega do im&oacute;vel, bem como indeniza&ccedil;&atilde;o por danos morais.
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+A controv&eacute;rsia consiste em definir:
+
+a) se &eacute; leg&iacute;tima a cobran&ccedil;a de juros de obra ap&oacute;s a conclus&atilde;o da constru&ccedil;&atilde;o e entrega das chaves ao adquirente;
+b) se a negativa&ccedil;&atilde;o decorrente de tais cobran&ccedil;as enseja indeniza&ccedil;&atilde;o por danos morais.
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+A taxa de evolu&ccedil;&atilde;o de obra tem natureza de encargo incidente durante a fase de constru&ccedil;&atilde;o, destinada a remunerar o agente financeiro at&eacute; a entrega do im&oacute;vel.
+
+Encerrada a obra e entregue a unidade ao adquirente, inicia-se a fase de amortiza&ccedil;&atilde;o do financiamento, cessando a exigibilidade dos juros de obra.
+
+A jurisprud&ecirc;ncia do Superior Tribunal de Justi&ccedil;a (Tema 996) consolidou o entendimento de que &eacute; il&iacute;cita a cobran&ccedil;a de juros de obra ap&oacute;s a entrega das chaves.
+
+No caso concreto, restou comprovado que a cobran&ccedil;a perdurou ap&oacute;s a entrega do im&oacute;vel, o que evidencia sua ilegalidade.
+
+A transfer&ecirc;ncia ao consumidor de encargos decorrentes de eventual demora da incorporadora na regulariza&ccedil;&atilde;o do empreendimento junto ao agente financeiro configura pr&aacute;tica abusiva.
+
+A negativa&ccedil;&atilde;o do nome do autor fundada em d&eacute;bito inexig&iacute;vel configura ato il&iacute;cito e enseja dano moral in re ipsa, dispensando prova do preju&iacute;zo.
+
+O valor da indeniza&ccedil;&atilde;o deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, cumprindo fun&ccedil;&atilde;o compensat&oacute;ria e pedag&oacute;gica, sendo adequado o montante de R$ 5.000,00 no caso concreto.
+
+IV. DISPOSITIVO E TESE
+
+Recurso provido.
+
+Tese de julgamento:
+
+&Eacute; indevida a cobran&ccedil;a de juros de obra (taxa de evolu&ccedil;&atilde;o de obra) ap&oacute;s a conclus&atilde;o da constru&ccedil;&atilde;o e a entrega das chaves ao adquirente, momento em que se encerra a fase de constru&ccedil;&atilde;o e se inicia a amortiza&ccedil;&atilde;o do financiamento.
+
+A negativa&ccedil;&atilde;o do nome do consumidor fundada em d&eacute;bito decorrente de cobran&ccedil;a indevida configura dano moral in re ipsa, sendo devida indeniza&ccedil;&atilde;o, a ser fixada conforme os princ&iacute;pios da razoabilidade e proporcionalidade.
+
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 2&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0807567-96.2024.8.12.0002,&nbsp; Dourados,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(63 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. JUROS DE OBRA. COBRANÇA APÓS ENTREGA DAS CHAVES. ILEGALIDADE. NEGATIVAÇÃO INDEVIDA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. PROVIMENTO DO RECURSO.
+
+I. CASO EM EXAME
+
+Trata-se de apelação interposta contra sentença que julgou improcedentes os pedidos em ação declaratória de inexistência de débito c/c
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. PROMESSA DE COMPRA E VENDA DE IMÓVEL. JUROS DE OBRA. COBRANÇA APÓS ENTREGA DAS CHAVES. ILEGALIDADE. NEGATIVAÇÃO INDEVIDA. <em>DANO</em> <em>MORAL</em> IN RE IPSA. PROVIMENTO DO RECURSO.
+
+I. CASO EM EXAME
+
+Trata-se de apelação interposta contra sentença que julgou improcedentes os pedidos em ação declaratória de inexistência de débito c/c indenização por danos morais ajuizada em face de Residencial Cuiabá Incorporadora SPE.
+
+O autor alega que, embora a obra tenha sido concluída em 13/11/2023, com expedição do habite-se em 04/03/2024 e entrega das chaves em 05/03/2024, continuaram sendo cobrados juros de obra (taxa de evolução de obra), culminando em sua negativação.
+
+Requereu a declaração de inexigibilidade dos valores cobrados após a entrega do imóvel, bem como indenização por danos morais.
+
+II. QUESTÃO EM DISCUSSÃO
+
+A controvérsia consiste em definir:
+
+a) se é legítima a cobrança de juros de obra após a conclusão da construção e entrega das chaves ao adquirente;
+b) se a negativação decorrente de tais cobranças enseja indenização por danos morais.
+
+III. RAZÕES DE DECIDIR
+
+A taxa de evolução de obra tem natureza de encargo incidente durante a fase de construção, destinada a remunerar o agente financeiro até a entrega do imóvel.
+
+Encerrada a obra e entregue a unidade ao adquirente, inicia-se a fase de amortização do financiamento, cessando a exigibilidade dos juros de obra.
+
+A jurisprudência do Superior Tribunal de Justiça (Tema 996) consolidou o entendimento de que é ilícita a cobrança de juros de obra após a entrega das chaves.
+
+No caso concreto, restou comprovado que a cobrança perdurou após a entrega do imóvel, o que evidencia sua ilegalidade.
+
+A transferência ao consumidor de encargos decorrentes de eventual demora da incorporadora na regularização do empreendimento junto ao agente financeiro configura prática abusiva.
+
+A negativação do nome do autor fundada em débito inexigível configura ato ilícito e enseja <em>dano</em> <em>moral</em> in re ipsa, dispensando prova do prejuízo.
+
+O valor da indenização deve observar os princípios da razoabilidade e proporcionalidade, cumprindo função compensatória e pedagógica, sendo adequado o montante de R$ 5.000,00 no caso concreto.
+
+IV. DISPOSITIVO E TESE
+
+Recurso provido.
+
+Tese de julgamento:
+
+É indevida a cobrança de juros de obra (taxa de evolução de obra) após a conclusão da construção e a entrega das chaves ao adquirente, momento em que se encerra a fase de construção e se inicia a amortização do financiamento.
+
+A negativação do nome do consumidor fundada em débito decorrente de cobrança indevida configura <em>dano</em> <em>moral</em> in re ipsa, sendo devida indenização, a ser fixada conforme os princípios da razoabilidade e proporcionalidade.
+
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 2ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>159&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875975" cdForo="0" >
+										0816155-61.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875975" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875975);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875975" style="display: none;" >
+	<div id="textAreaDados_1875975" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL EM A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO BANC&Aacute;RIO &ndash; AUS&Ecirc;NCIA  DOS V&Iacute;CIOS DISPOSTOS NO ART. 1.022 DO CPC &ndash;  MULTA PREVISTA NO &sect; 2&ordm; DO ART. 1.026 DO CPC &ndash; EMBARGOS REJEITADOS COM APLICA&Ccedil;&Atilde;O DE MULTA.
+I - N&atilde;o padece de v&iacute;cio a decis&atilde;o apenas porque, sob a &oacute;tica particular do pr&oacute;prio interessado a respeito da valora&ccedil;&atilde;o jur&iacute;dica dos fatos e das provas, a solu&ccedil;&atilde;o haveria de ter sido diferente daquela adotada pelo Estado-Juiz, porquanto a rediscuss&atilde;o do m&eacute;rito de decisum via aclarat&oacute;rios n&atilde;o encontra amparo na legisla&ccedil;&atilde;o processual vigente.  Ademais, o Tribunal n&atilde;o fica obrigado a examinar todas as min&uacute;cias e possibilidades abstratas invocadas pela defesa, desde que decida sob fundamentos suficientes para sustentar a manifesta&ccedil;&atilde;o jurisdicional.
+II - Mesmo na hip&oacute;tese de prequestionamento da mat&eacute;ria, a irresigna&ccedil;&atilde;o apresentada a exame deve encontrar abrigo em uma das hip&oacute;teses do artigo 1.022 do C&oacute;digo de Processo Civil. O prequestionamento pressup&otilde;e debate e decis&atilde;o quanto &agrave; mat&eacute;ria, de sorte que a manifesta&ccedil;&atilde;o expressa sobre normativo &eacute; prescind&iacute;vel.
+III - Diante do manifesto prop&oacute;sito protelat&oacute;rio dos presentes embargos, com mero intuito de rediscuss&atilde;o que quest&atilde;o j&aacute; trazida &agrave; aprecia&ccedil;&atilde;o deste &Oacute;rg&atilde;o Colegiado, imp&otilde;e-se a aplica&ccedil;&atilde;o da multa prevista no &sect;2&ordm;, do art. 1.026 do CPC ao caso.  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0816155-61.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									816155612025812000150000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL EM AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – AUSÊNCIA  DOS VÍCIOS DISPOSTOS NO ART. 1.022 DO CPC –  MULTA PREVISTA NO § 2º DO ART. 1.026 DO CPC – EMBARGOS REJEITADOS COM APLICAÇÃO DE MULTA.
+I - Não padece de vício a decisão apenas porque, sob a ótica particular do próprio interessado a respeito da valoração jurídica dos fatos e das provas, a solução haveria
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL EM AÇÃO REVISIONAL DE CONTRATO BANCÁRIO – AUSÊNCIA  DOS VÍCIOS DISPOSTOS NO ART. 1.022 DO CPC –  MULTA PREVISTA NO § 2º DO ART. 1.026 DO CPC – EMBARGOS REJEITADOS COM APLICAÇÃO DE MULTA.
+I - Não padece de vício a decisão apenas porque, sob a ótica particular do próprio interessado a respeito da valoração jurídica dos fatos e das provas, a solução haveria de ter sido diferente daquela adotada pelo Estado-Juiz, porquanto a rediscussão do mérito de decisum via aclaratórios não encontra amparo na legislação processual vigente.  Ademais, o Tribunal não fica obrigado a examinar todas as minúcias e possibilidades abstratas invocadas pela defesa, desde que decida sob fundamentos suficientes para sustentar a manifestação jurisdicional.
+II - Mesmo na hipótese de prequestionamento da matéria, a irresignação apresentada a exame deve encontrar abrigo em uma das hipóteses do artigo 1.022 do Código de Processo Civil. O prequestionamento pressupõe debate e decisão quanto à matéria, de sorte que a manifestação expressa sobre normativo é prescindível.
+III - Diante do manifesto propósito protelatório dos presentes embargos, com mero intuito de rediscussão que questão já trazida à apreciação deste Órgão Colegiado, impõe-se a aplicação da multa prevista no §2º, do art. 1.026 do CPC ao caso.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>160&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875984" cdForo="0" >
+										0851382-49.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875984" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875984);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875984" style="display: none;" >
+	<div id="textAreaDados_1875984" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Iacute;VIDA &ndash; PRELIMINAR DE LITISCONS&Oacute;RCIO PASSIVO NECESS&Aacute;RIO &ndash; AFASTADA &ndash; M&Eacute;RITO &ndash; COBRAN&Ccedil;A E NEGATIVA&Ccedil;&Atilde;O INDEVIDAS &ndash; ACORDO EXTRAJUDICIAL E QUITA&Ccedil;&Atilde;O COMPROVADOS &ndash; DEVOLU&Ccedil;&Atilde;O EM DOBRO &ndash; AUS&Ecirc;NCIA DE PAGAMENTO EFETIVO DO VALOR INDEVIDO &ndash; DANO MORAL IN RE IPSA &ndash; DEVIDO &ndash; VALOR ALTERADO &ndash; RECURSO DA INSTITUI&Ccedil;&Atilde;O DE ENSINO CONHECIDO E N&Atilde;O PROVIDO &ndash; RECURSO DA AUTORA CONHECIDO E PARCIALMENTE PROVIDO.
+A controv&eacute;rsia delineada nos autos n&atilde;o diz respeito &agrave;s regras do Fundo de Financiamento Estudantil (FIES), tampouco &agrave; validade das portarias do MEC ou do FNDE. O objeto da lide se restringe &agrave; rela&ccedil;&atilde;o jur&iacute;dica firmada exclusivamente entre a aluna e a faculdade, consistente na alegada cobran&ccedil;a indevida e negativa&ccedil;&atilde;o de valores residuais que j&aacute; teriam sido objeto de acordo extrajudicial e quita&ccedil;&atilde;o entre as partes, no caso, entre autora e r&eacute;.
+A prova documental que instruiu a inicial, qual seja, o acordo entabulado entre as partes, &eacute; inequ&iacute;voca ao prever expressamente em sua cl&aacute;usula 8.9 a plena e total quita&ccedil;&atilde;o aos valores negociados, de modo que a cobran&ccedil;a e negativa&ccedil;&atilde;o posteriores foram indevidos.
+O art. 42, par&aacute;grafo &uacute;nico, do C&oacute;digo de Defesa do Consumidor estabelece que: &quot;O consumidor cobrado em quantia indevida tem direito &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, por valor igual ao dobro do que pagou em excesso, acrescido de corre&ccedil;&atilde;o monet&aacute;ria e juros legais, salvo hip&oacute;tese de engano justific&aacute;vel&quot;.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+Recurso da institui&ccedil;&atilde;o de ensino conhecido e n&atilde;o provido. Recurso da parte autora conhecido e parcialmente provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0851382-49.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(48 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA – PRELIMINAR DE LITISCONSÓRCIO PASSIVO NECESSÁRIO – AFASTADA – MÉRITO – COBRANÇA E NEGATIVAÇÃO INDEVIDAS – ACORDO EXTRAJUDICIAL E QUITAÇÃO COMPROVADOS – DEVOLUÇÃO EM DOBRO – AUSÊNCIA DE PAGAMENTO EFETIVO DO VALOR INDEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEVIDO – VALOR ALTERADO – RECURSO DA INSTITUIÇÃO DE ENSINO CONHECIDO E
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÍVIDA – PRELIMINAR DE LITISCONSÓRCIO PASSIVO NECESSÁRIO – AFASTADA – MÉRITO – COBRANÇA E NEGATIVAÇÃO INDEVIDAS – ACORDO EXTRAJUDICIAL E QUITAÇÃO COMPROVADOS – DEVOLUÇÃO EM DOBRO – AUSÊNCIA DE PAGAMENTO EFETIVO DO VALOR INDEVIDO – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEVIDO – VALOR ALTERADO – RECURSO DA INSTITUIÇÃO DE ENSINO CONHECIDO E NÃO PROVIDO – RECURSO DA AUTORA CONHECIDO E PARCIALMENTE PROVIDO.
+A controvérsia delineada nos autos não diz respeito às regras do Fundo de Financiamento Estudantil (FIES), tampouco à validade das portarias do MEC ou do FNDE. O objeto da lide se restringe à relação jurídica firmada exclusivamente entre a aluna e a faculdade, consistente na alegada cobrança indevida e negativação de valores residuais que já teriam sido objeto de acordo extrajudicial e quitação entre as partes, no caso, entre autora e ré.
+A prova documental que instruiu a inicial, qual seja, o acordo entabulado entre as partes, é inequívoca ao prever expressamente em sua cláusula 8.9 a plena e total quitação aos valores negociados, de modo que a cobrança e negativação posteriores foram indevidos.
+O art. 42, parágrafo único, do Código de Defesa do Consumidor estabelece que: "O consumidor cobrado em quantia indevida tem direito à repetição do indébito, por valor igual ao dobro do que pagou em excesso, acrescido de correção monetária e juros legais, salvo hipótese de engano justificável".
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+Recurso da instituição de ensino conhecido e não provido. Recurso da parte autora conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>161&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876006" cdForo="0" >
+										0869541-40.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876006" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876006);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876006" style="display: none;" >
+	<div id="textAreaDados_1876006" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Otilde;ES C&Iacute;VEIS. A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANO MORAL COM PEDIDO DE TUTELA DE URG&Ecirc;NCIA. RECURSO DO R&Eacute;U N&Atilde;O CONHECIDO. INOVA&Ccedil;&Atilde;O RECURSAL. RECURSO DA AUTORA CONHECIDO E N&Atilde;O PROVIDO. VALOR DA INDENIZA&Ccedil;&Atilde;O MANTIDO.
+I. CASO EM EXAME: Apela&ccedil;&otilde;es interpostas por Bradesco Administradora de Cons&oacute;rcios Ltda. e S&ocirc;nia M&aacute;rcia de Lira Ramos contra senten&ccedil;a que, em a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer c/c indeniza&ccedil;&atilde;o por danos morais, julgou parcialmente procedentes os pedidos. Determinou-se a libera&ccedil;&atilde;o de cartas de cr&eacute;dito relativas a cotas de cons&oacute;rcio contempladas, sem exig&ecirc;ncia de garantias adicionais, bem como o pagamento de indeniza&ccedil;&atilde;o por danos morais fixada em R$ 3.000,00. O r&eacute;u sustenta a legitimidade da exig&ecirc;ncia de garantias e aus&ecirc;ncia de dano moral; a autora pleiteia a majora&ccedil;&atilde;o da indeniza&ccedil;&atilde;o.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O: H&aacute; duas quest&otilde;es centrais: i) verificar a admissibilidade do recurso do r&eacute;u diante da alega&ccedil;&atilde;o de inova&ccedil;&atilde;o recursal; ii) analisar a adequa&ccedil;&atilde;o do valor fixado a t&iacute;tulo de danos morais, &agrave; luz dos princ&iacute;pios da proporcionalidade e razoabilidade.
+III. RAZ&Otilde;ES DE DECIDIR: A) Configura inova&ccedil;&atilde;o recursal a apresenta&ccedil;&atilde;o, apenas em grau de apela&ccedil;&atilde;o, de teses defensivas n&atilde;o deduzidas na contesta&ccedil;&atilde;o, em viola&ccedil;&atilde;o aos princ&iacute;pios do contradit&oacute;rio e da ampla defesa. No caso, o r&eacute;u deixou de enfrentar especificamente os fatos narrados na inicial e passou a apresentar fundamentos novos apenas em sede recursal (an&aacute;lise de cr&eacute;dito, crit&eacute;rios sigilosos e aus&ecirc;ncia de dano moral), o que impede o conhecimento do recurso. A recusa imotivada na libera&ccedil;&atilde;o de carta de cr&eacute;dito, sem indica&ccedil;&atilde;o de crit&eacute;rios objetivos, caracteriza falha na presta&ccedil;&atilde;o do servi&ccedil;o e conduta abusiva, apta a ensejar repara&ccedil;&atilde;o por dano moral. B) A fixa&ccedil;&atilde;o do dano moral deve observar os princ&iacute;pios da proporcionalidade e razoabilidade, atendendo &agrave;s fun&ccedil;&otilde;es compensat&oacute;ria e pedag&oacute;gica, considerando as circunst&acirc;ncias do caso concreto. No caso, o valor de R$ 3.000,00 mostra-se adequado &agrave; extens&atilde;o do dano, &agrave;s condi&ccedil;&otilde;es das partes e &agrave; finalidade da indeniza&ccedil;&atilde;o, n&atilde;o comportando majora&ccedil;&atilde;o.
+IV. DISPOSITIVO E TESE: Recurso do r&eacute;u n&atilde;o conhecido. Recurso da autora conhecido e desprovido.
+TESE DE JULGAMENTO: 1) &Eacute; vedada a inova&ccedil;&atilde;o recursal, n&atilde;o se conhecendo de alega&ccedil;&otilde;es suscitadas apenas em grau de apela&ccedil;&atilde;o, sem pr&eacute;via submiss&atilde;o ao contradit&oacute;rio na inst&acirc;ncia de origem. 2) O valor da indeniza&ccedil;&atilde;o por danos morais deve ser fixado com base nos princ&iacute;pios da proporcionalidade e razoabilidade, sendo mantido quando adequado &agrave;s circunst&acirc;ncias do caso concreto. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0869541-40.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(33 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS. AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em> COM PEDIDO DE TUTELA DE URGÊNCIA. RECURSO DO RÉU NÃO CONHECIDO. INOVAÇÃO RECURSAL. RECURSO DA AUTORA CONHECIDO E NÃO PROVIDO. VALOR DA INDENIZAÇÃO MANTIDO.
+I. CASO EM EXAME: Apelações interpostas por Bradesco Administradora de Consórcios Ltda. e Sônia Márcia de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÕES CÍVEIS. AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR <em>DANO</em> <em>MORAL</em> COM PEDIDO DE TUTELA DE URGÊNCIA. RECURSO DO RÉU NÃO CONHECIDO. INOVAÇÃO RECURSAL. RECURSO DA AUTORA CONHECIDO E NÃO PROVIDO. VALOR DA INDENIZAÇÃO MANTIDO.
+I. CASO EM EXAME: Apelações interpostas por Bradesco Administradora de Consórcios Ltda. e Sônia Márcia de Lira Ramos contra sentença que, em ação de obrigação de fazer c/c indenização por danos morais, julgou parcialmente procedentes os pedidos. Determinou-se a liberação de cartas de crédito relativas a cotas de consórcio contempladas, sem exigência de garantias adicionais, bem como o pagamento de indenização por danos morais fixada em R$ 3.000,00. O réu sustenta a legitimidade da exigência de garantias e ausência de <em>dano</em> <em>moral</em>; a autora pleiteia a majoração da indenização.
+II. QUESTÃO EM DISCUSSÃO: Há duas questões centrais: i) verificar a admissibilidade do recurso do réu diante da alegação de inovação recursal; ii) analisar a adequação do valor fixado a título de danos morais, à luz dos princípios da proporcionalidade e razoabilidade.
+III. RAZÕES DE DECIDIR: A) Configura inovação recursal a apresentação, apenas em grau de apelação, de teses defensivas não deduzidas na contestação, em violação aos princípios do contraditório e da ampla defesa. No caso, o réu deixou de enfrentar especificamente os fatos narrados na inicial e passou a apresentar fundamentos novos apenas em sede recursal (análise de crédito, critérios sigilosos e ausência de <em>dano</em> <em>moral</em>), o que impede o conhecimento do recurso. A recusa imotivada na liberação de carta de crédito, sem indicação de critérios objetivos, caracteriza falha na prestação do serviço e conduta abusiva, apta a ensejar reparação por <em>dano</em> <em>moral</em>. B) A fixação do <em>dano</em> <em>moral</em> deve observar os princípios da proporcionalidade e razoabilidade, atendendo às funções compensatória e pedagógica, considerando as circunstâncias do caso concreto. No caso, o valor de R$ 3.000,00 mostra-se adequado à extensão do <em>dano</em>, às condições das partes e à finalidade da indenização, não comportando majoração.
+IV. DISPOSITIVO E TESE: Recurso do réu não conhecido. Recurso da autora conhecido e desprovido.
+TESE DE JULGAMENTO: 1) É vedada a inovação recursal, não se conhecendo de alegações suscitadas apenas em grau de apelação, sem prévia submissão ao contraditório na instância de origem. 2) O valor da indenização por danos morais deve ser fixado com base nos princípios da proporcionalidade e razoabilidade, sendo mantido quando adequado às circunstâncias do caso concreto.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>162&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876016" cdForo="0" >
+										0807956-29.2021.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876016" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876016);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876016" style="display: none;" >
+	<div id="textAreaDados_1876016" class="mensagemSemFormatacao" >
+
+APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; EMPR&Eacute;STIMO CONSIGNADO &ndash; ASSINATURA FALSIFICADA &ndash; PER&Iacute;CIA GRAFOT&Eacute;CNICA &ndash; INEXIST&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; RESPONSABILIDADE OBJETIVA DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; S&Uacute;MULA 479/STJ &ndash; DANO MORAL IN RE IPSA &ndash; CONFIGURA&Ccedil;&Atilde;O &ndash; REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO &ndash; PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; CORRE&Ccedil;&Atilde;O MONET&Aacute;RIA &ndash; IPCA &ndash; ADEQUA&Ccedil;&Atilde;O &Agrave; LEI N&ordm; 14.905/2024 &ndash; RECURSO PARCIALMENTE PROVIDO.
+
+CASO EM EXAME
+Apela&ccedil;&atilde;o C&iacute;vel interposta por Banco Bradesco S.A. contra senten&ccedil;a que, em a&ccedil;&atilde;o declarat&oacute;ria de inexist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica, reconheceu a nulidade de contrato de empr&eacute;stimo consignado, determinou a cessa&ccedil;&atilde;o dos descontos em benef&iacute;cio previdenci&aacute;rio, condenou &agrave; restitui&ccedil;&atilde;o simples dos valores descontados e ao pagamento de indeniza&ccedil;&atilde;o por danos morais no valor de R$ 8.000,00.
+
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+Discute-se:
+(i) a validade da contrata&ccedil;&atilde;o do empr&eacute;stimo consignado;
+(ii) a responsabilidade da institui&ccedil;&atilde;o financeira por descontos indevidos;
+(iii) a configura&ccedil;&atilde;o e o valor dos danos morais;
+(iv) o &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria aplic&aacute;vel &agrave; condena&ccedil;&atilde;o.
+
+RAZ&Otilde;ES DE DECIDIR
+
+A per&iacute;cia grafot&eacute;cnica concluiu pela inautenticidade da assinatura constante do contrato, evidenciando a inexist&ecirc;ncia de contrata&ccedil;&atilde;o v&aacute;lida.
+A institui&ccedil;&atilde;o financeira responde objetivamente pelos danos decorrentes de fraudes praticadas no &acirc;mbito de suas opera&ccedil;&otilde;es (fortuito interno), nos termos da S&uacute;mula 479 do STJ.
+Os descontos indevidos em benef&iacute;cio previdenci&aacute;rio caracterizam falha na presta&ccedil;&atilde;o do servi&ccedil;o e ensejam repara&ccedil;&atilde;o, independentemente de prova de culpa.
+O dano moral, na hip&oacute;tese, &eacute; in re ipsa, decorrente da pr&oacute;pria ilegalidade dos descontos em verba de natureza alimentar, sendo desnecess&aacute;ria a comprova&ccedil;&atilde;o de preju&iacute;zo concreto.
+O valor fixado a t&iacute;tulo de indeniza&ccedil;&atilde;o deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, sendo cab&iacute;vel a redu&ccedil;&atilde;o quando excessivo em rela&ccedil;&atilde;o &agrave;s circunst&acirc;ncias do caso concreto.
+A corre&ccedil;&atilde;o monet&aacute;ria da indeniza&ccedil;&atilde;o por danos morais deve observar o IPCA, conforme art. 389 do C&oacute;digo Civil, com a reda&ccedil;&atilde;o dada pela Lei n&ordm; 14.905/2024, incidindo a partir do arbitramento, e juros morat&oacute;rios desde o evento danoso, com observ&acirc;ncia da sistem&aacute;tica da Selic ap&oacute;s a vig&ecirc;ncia da referida lei.
+
+DISPOSITIVO
+Recurso conhecido e parcialmente provido, para reduzir o valor da indeniza&ccedil;&atilde;o por danos morais para R$ 2.500,00 e adequar o &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria para o IPCA, mantidos os demais termos da senten&ccedil;a.
+
+TESE
+A comprova&ccedil;&atilde;o da falsidade da assinatura em contrato de empr&eacute;stimo consignado afasta a exist&ecirc;ncia de rela&ccedil;&atilde;o jur&iacute;dica, ensejando a nulidade dos descontos e a responsabiliza&ccedil;&atilde;o objetiva da institui&ccedil;&atilde;o financeira, sendo devida a indeniza&ccedil;&atilde;o por dano moral in re ipsa, admitindo-se a redu&ccedil;&atilde;o do quantum quando excessivo, bem como a aplica&ccedil;&atilde;o do IPCA como &iacute;ndice de corre&ccedil;&atilde;o monet&aacute;ria, nos termos do art. 389 do C&oacute;digo Civil. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0807956-29.2021.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(36 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>
+APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – ASSINATURA FALSIFICADA – PERÍCIA GRAFOTÉCNICA – INEXISTÊNCIA DE CONTRATAÇÃO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – SÚMULA 479/STJ – <em>DANO</em> <em>MORAL</em> IN RE IPSA – CONFIGURAÇÃO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>
+APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – EMPRÉSTIMO CONSIGNADO – ASSINATURA FALSIFICADA – PERÍCIA GRAFOTÉCNICA – INEXISTÊNCIA DE CONTRATAÇÃO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE OBJETIVA DA INSTITUIÇÃO FINANCEIRA – SÚMULA 479/STJ – <em>DANO</em> <em>MORAL</em> IN RE IPSA – CONFIGURAÇÃO – REDUÇÃO DO QUANTUM INDENIZATÓRIO – PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – CORREÇÃO MONETÁRIA – IPCA – ADEQUAÇÃO À LEI Nº 14.905/2024 – RECURSO PARCIALMENTE PROVIDO.
+
+CASO EM EXAME
+Apelação Cível interposta por Banco Bradesco S.A. contra sentença que, em ação declaratória de inexistência de relação jurídica, reconheceu a nulidade de contrato de empréstimo consignado, determinou a cessação dos descontos em benefício previdenciário, condenou à restituição simples dos valores descontados e ao pagamento de indenização por danos morais no valor de R$ 8.000,00.
+
+QUESTÃO EM DISCUSSÃO
+Discute-se:
+(i) a validade da contratação do empréstimo consignado;
+(ii) a responsabilidade da instituição financeira por descontos indevidos;
+(iii) a configuração e o valor dos danos morais;
+(iv) o índice de correção monetária aplicável à condenação.
+
+RAZÕES DE DECIDIR
+
+A perícia grafotécnica concluiu pela inautenticidade da assinatura constante do contrato, evidenciando a inexistência de contratação válida.
+A instituição financeira responde objetivamente pelos danos decorrentes de fraudes praticadas no âmbito de suas operações (fortuito interno), nos termos da Súmula 479 do STJ.
+Os descontos indevidos em benefício previdenciário caracterizam falha na prestação do serviço e ensejam reparação, independentemente de prova de culpa.
+O <em>dano</em> <em>moral</em>, na hipótese, é in re ipsa, decorrente da própria ilegalidade dos descontos em verba de natureza alimentar, sendo desnecessária a comprovação de prejuízo concreto.
+O valor fixado a título de indenização deve observar os princípios da razoabilidade e proporcionalidade, sendo cabível a redução quando excessivo em relação às circunstâncias do caso concreto.
+A correção monetária da indenização por danos morais deve observar o IPCA, conforme art. 389 do Código Civil, com a redação dada pela Lei nº 14.905/2024, incidindo a partir do arbitramento, e juros moratórios desde o evento danoso, com observância da sistemática da Selic após a vigência da referida lei.
+
+DISPOSITIVO
+Recurso conhecido e parcialmente provido, para reduzir o valor da indenização por danos morais para R$ 2.500,00 e adequar o índice de correção monetária para o IPCA, mantidos os demais termos da sentença.
+
+TESE
+A comprovação da falsidade da assinatura em contrato de empréstimo consignado afasta a existência de relação jurídica, ensejando a nulidade dos descontos e a responsabilização objetiva da instituição financeira, sendo devida a indenização por <em>dano</em> <em>moral</em> in re ipsa, admitindo-se a redução do quantum quando excessivo, bem como a aplicação do IPCA como índice de correção monetária, nos termos do art. 389 do Código Civil.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>163&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876018" cdForo="0" >
+										0931187-51.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876018" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876018);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876018" style="display: none;" >
+	<div id="textAreaDados_1876018" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O CRIMINAL &ndash; APROPRIA&Ccedil;&Atilde;O IND&Eacute;BITA EM RAZ&Atilde;O DA PROFISS&Atilde;O &ndash; PLEITO ABSOLUT&Oacute;RIO SOB ALEGA&Ccedil;&Atilde;O DE ATIPICIDADE DA CONDUTA &ndash; IMPOSSIBILIDADE &ndash; CONDENA&Ccedil;&Atilde;O MANTIDA &ndash; INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS PRESERVADA &ndash; DESNECESSIDADE DE INSTRU&Ccedil;&Atilde;O ESPEC&Iacute;FICA &ndash; RECURSO N&Atilde;O PROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o Criminal n. 0931187-51.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara Criminal, Relator (a):&nbsp; Des. Waldir Marques, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(19 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Criminal / Apropriação indébita
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Waldir Marques
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Criminal
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa1876018" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												APELAÇÃO CRIMINAL – APROPRIAÇÃO INDÉBITA EM RAZÃO DA PROFISSÃO – PLEITO ABSOLUTÓRIO SOB ALEGAÇÃO DE ATIPICIDADE DA CONDUTA – IMPOSSIBILIDADE – CONDENAÇÃO MANTIDA – INDENIZAÇÃO POR DANOS MORAIS PRESERVADA – DESNECESSIDADE DE INSTRUÇÃO ESPECÍFICA – RECURSO NÃO PROVIDO.
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>164&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876024" cdForo="0" >
+										0800749-66.2024.8.12.0055
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876024" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876024);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876024" style="display: none;" >
+	<div id="textAreaDados_1876024" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O ANULAT&Oacute;RIA DE CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL COM INEXIST&Ecirc;NCIA DE D&Eacute;BITOS C/C RESTITUI&Ccedil;&Atilde;O DE VALORES EM DOBRO E DANOS MORAIS &ndash; JULGAMENTO PROCEDENTE &ndash; RECURSO DA PARTE REQUERIDA &ndash; REGULARIDADE DA CONTRATA&Ccedil;&Atilde;O N&Atilde;O DEMONSTRADA &ndash; DESCONTOS INDEVIDOS &ndash; DANOS MORAIS CARACTERIZADOS &ndash; RESTITUI&Ccedil;&Atilde;O EM DOBRO DEVIDA &ndash; QUANTOS INDENIZAT&Oacute;RIO &ndash; NECESSIDADE DE ADEQUA&Ccedil;&Atilde;O &ndash; VALORES MINORADOS A FIM DE ATENDER AOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800749-66.2024.8.12.0055,&nbsp; Sonora,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Amaury da Silva Kuklinski, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(42 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Amaury da Silva Kuklinski
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Sonora
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO ANULATÓRIA DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL COM INEXISTÊNCIA DE DÉBITOS C/C RESTITUIÇÃO DE VALORES EM DOBRO E DANOS MORAIS – JULGAMENTO PROCEDENTE – RECURSO DA PARTE REQUERIDA – REGULARIDADE DA CONTRATAÇÃO NÃO DEMONSTRADA – DESCONTOS INDEVIDOS – DANOS MORAIS CARACTERIZADOS – RESTITUIÇÃO EM DOBRO DEVIDA – QUANTOS INDENIZATÓRIO – NECESSIDADE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO ANULATÓRIA DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL COM INEXISTÊNCIA DE DÉBITOS C/C RESTITUIÇÃO DE VALORES EM DOBRO E DANOS MORAIS – JULGAMENTO PROCEDENTE – RECURSO DA PARTE REQUERIDA – REGULARIDADE DA CONTRATAÇÃO NÃO DEMONSTRADA – DESCONTOS INDEVIDOS – DANOS MORAIS CARACTERIZADOS – RESTITUIÇÃO EM DOBRO DEVIDA – QUANTOS INDENIZATÓRIO – NECESSIDADE DE ADEQUAÇÃO – VALORES MINORADOS A FIM DE ATENDER AOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>165&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876035" cdForo="0" >
+										0867344-15.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876035" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876035);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876035" style="display: none;" >
+	<div id="textAreaDados_1876035" class="mensagemSemFormatacao" >
+		A&Ccedil;&Atilde;O DE RESTITUI&Ccedil;&Atilde;O DE DESCONTOS INDEVIDOS C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS - RETEN&Ccedil;&Atilde;O INTEGRAL DE SAL&Aacute;RIO PARA COBERTURA DE SALDO DEVEDOR DE CHEQUE ESPECIAL &ndash; D&Eacute;BITO PRET&Eacute;RITO &ndash; DESCABIMENTO &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DE SERVI&Ccedil;O &ndash; M&Iacute;NIMO EXISTENCIAL &ndash; RECOMPOSI&Ccedil;&Atilde;O DO SALDO DEVIDO NA FORMA SIMPLES &ndash; DANO MORAL CONFIGURADO &ndash; QUANTUM FIXADO EM ATEN&Ccedil;&Atilde;O &Agrave; PROPORCIONALIDADE E RAZOABILIDADE &ndash; RECURSO CONHECIDO E PROVIDO &ndash; SENTEN&Ccedil;A REFORMADA.
+Ainda que seja poss&iacute;vel desconto de parcelas livremente pactuadas entre as partes em conta corrente, n&atilde;o pode a institui&ccedil;&atilde;o financeira, em aut&ecirc;ntica autotutela de seus interesses, reter a integralidade de verba salarial depositada em conta de seu cliente para cobrir saldo negativo de limite de cheque especial, d&iacute;vida esta pret&eacute;rita. Evidente, pois, a conduta irregular do banco r&eacute;u, que retirou da conta da parte autora valores da qual era deposit&aacute;rio, para adimplir d&eacute;bitos pret&eacute;ritos. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0867344-15.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 10/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(34 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AÇÃO DE RESTITUIÇÃO DE DESCONTOS INDEVIDOS C/C INDENIZAÇÃO POR DANOS MORAIS - RETENÇÃO INTEGRAL DE SALÁRIO PARA COBERTURA DE SALDO DEVEDOR DE CHEQUE ESPECIAL – DÉBITO PRETÉRITO – DESCABIMENTO – FALHA NA PRESTAÇÃO DE SERVIÇO – MÍNIMO EXISTENCIAL – RECOMPOSIÇÃO DO SALDO DEVIDO NA FORMA SIMPLES – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM FIXADO EM ATENÇÃO À PROPORCIONALIDADE E RAZOABILIDADE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AÇÃO DE RESTITUIÇÃO DE DESCONTOS INDEVIDOS C/C INDENIZAÇÃO POR DANOS MORAIS - RETENÇÃO INTEGRAL DE SALÁRIO PARA COBERTURA DE SALDO DEVEDOR DE CHEQUE ESPECIAL – DÉBITO PRETÉRITO – DESCABIMENTO – FALHA NA PRESTAÇÃO DE SERVIÇO – MÍNIMO EXISTENCIAL – RECOMPOSIÇÃO DO SALDO DEVIDO NA FORMA SIMPLES – <em>DANO</em> <em>MORAL</em> CONFIGURADO – QUANTUM FIXADO EM ATENÇÃO À PROPORCIONALIDADE E RAZOABILIDADE – RECURSO CONHECIDO E PROVIDO – SENTENÇA REFORMADA.
+Ainda que seja possível desconto de parcelas livremente pactuadas entre as partes em conta corrente, não pode a instituição financeira, em autêntica autotutela de seus interesses, reter a integralidade de verba salarial depositada em conta de seu cliente para cobrir saldo negativo de limite de cheque especial, dívida esta pretérita. Evidente, pois, a conduta irregular do banco réu, que retirou da conta da parte autora valores da qual era depositário, para adimplir débitos pretéritos.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>166&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876040" cdForo="0" >
+										0813828-46.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876040" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876040);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876040" style="display: none;" >
+	<div id="textAreaDados_1876040" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL DA REQUERIDA &ndash;  A&Ccedil;&Atilde;O DE BUSCA E APREENS&Atilde;O &ndash; PEDIDO DE REVIS&Atilde;O DO CONTRATO &ndash;  JUROS REMUNERAT&Oacute;RIOS &ndash; PERCENTUAL POUCO SUPERIOR &Agrave; M&Eacute;DIA DE MERCADO - ABUSIVIDADE N&Atilde;O CONFIGURADA &ndash; CAPITALIZA&Ccedil;&Atilde;O CONTRATADA - POSSIBILIDADE DE COBRAN&Ccedil;A - SEGURO - VENDA CASADA N&Atilde;O CONFIGURADA &ndash; TARIFA DE REGISTRO E IOF - POSSIBILIDADE DE REPASSE - RECURSO CONHECIDO E DESPROVIDO.
+I - N&atilde;o h&aacute; abusividade nos juros remunerat&oacute;rios simplesmente por excederem a taxa m&eacute;dia de mercado. Hip&oacute;tese em que a taxa contratada &eacute; inferior &agrave; m&eacute;dia de mercado.
+II &ndash; N&atilde;o configurada a venda casada deve ser reconhecida a higidez da contrata&ccedil;&atilde;o de seguro.
+IV &ndash; Consoante precedentes de observ&acirc;ncia obrigat&oacute;ria, &eacute; poss&iacute;vel a inclus&atilde;o dos encargos do contrato no valor total do financiamento. Abusividade n&atilde;o configurada.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0813828-46.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL DA REQUERIDA –  AÇÃO DE BUSCA E APREENSÃO – PEDIDO DE REVISÃO DO CONTRATO –  JUROS REMUNERATÓRIOS – PERCENTUAL POUCO SUPERIOR À MÉDIA DE MERCADO - ABUSIVIDADE NÃO CONFIGURADA – CAPITALIZAÇÃO CONTRATADA - POSSIBILIDADE DE COBRANÇA - SEGURO - VENDA CASADA NÃO CONFIGURADA – TARIFA DE REGISTRO E IOF - POSSIBILIDADE DE REPASSE - RECURSO CONHECIDO E DESPROVIDO.
+I - Não há abusividade
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL DA REQUERIDA –  AÇÃO DE BUSCA E APREENSÃO – PEDIDO DE REVISÃO DO CONTRATO –  JUROS REMUNERATÓRIOS – PERCENTUAL POUCO SUPERIOR À MÉDIA DE MERCADO - ABUSIVIDADE NÃO CONFIGURADA – CAPITALIZAÇÃO CONTRATADA - POSSIBILIDADE DE COBRANÇA - SEGURO - VENDA CASADA NÃO CONFIGURADA – TARIFA DE REGISTRO E IOF - POSSIBILIDADE DE REPASSE - RECURSO CONHECIDO E DESPROVIDO.
+I - Não há abusividade nos juros remuneratórios simplesmente por excederem a taxa média de mercado. Hipótese em que a taxa contratada é inferior à média de mercado.
+II – Não configurada a venda casada deve ser reconhecida a higidez da contratação de seguro.
+IV – Consoante precedentes de observância obrigatória, é possível a inclusão dos encargos do contrato no valor total do financiamento. Abusividade não configurada.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>167&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876041" cdForo="0" >
+										0843530-13.2020.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876041" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876041);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876041" style="display: none;" >
+	<div id="textAreaDados_1876041" class="mensagemSemFormatacao" >
+		RECURSO DE APELA&Ccedil;&Atilde;O EM A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O C/C COMINAT&Oacute;RIA - TRANSFER&Ecirc;NCIA POSSE VE&Iacute;CULO COM ALIENA&Ccedil;&Atilde;O FIDUCI&Aacute;RIA &ndash; ALEGA&Ccedil;&Atilde;O DE REFINANCIAMENTO DO BEM SEM O CONSENTIMENTO DO DEVEDOR &ndash; AUS&Ecirc;NCIA DE ANU&Ecirc;NCIA DO CREDOR QUANTO &Agrave; TRANSFER&Ecirc;NCIA DO CONTRATO DE FINANCIAMENTO &ndash; DESCABIMENTO DE INVERS&Atilde;O DO &Ocirc;NUS DA PROVA - AUS&Ecirc;NCIA DE VEROSSIMILHAN&Ccedil;A DAS ALEGA&Ccedil;&Otilde;ES &ndash; SENTEN&Ccedil;A DE IMPROCED&Ecirc;NCIA MANTIDA &ndash;  RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I - A concord&acirc;ncia do credor fiduci&aacute;rio, corr&eacute;u, se afigurava imprescind&iacute;vel, pois o mesmo celebrou o contrato com certa pessoa e a altera&ccedil;&atilde;o de seu devedor pode ser prejudicial aos seus interesses. Neste contexto, a pr&oacute;pria aliena&ccedil;&atilde;o do bem m&oacute;vel a um terceiro, no caso o primeiro r&eacute;u, dependeria da anu&ecirc;ncia do credor fiduci&aacute;rio (segundo r&eacute;u), para que, inclusive, pudessem ser realizados os tr&acirc;mites administrativos da transfer&ecirc;ncia do ve&iacute;culo.
+II - O pedido de deferimento da  invers&atilde;o do &ocirc;nus da prova, a fim de garantir a defesa do consumidor, poder&aacute; ser deferido desde que se demonstre a verossimilhan&ccedil;a das alega&ccedil;&otilde;es do demandante, a teor do que disp&otilde;e o inc. VIII do art. 6&ordm; do CDC.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0843530-13.2020.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(2 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO EM AÇÃO DE INDENIZAÇÃO C/C COMINATÓRIA - TRANSFERÊNCIA POSSE VEÍCULO COM ALIENAÇÃO FIDUCIÁRIA – ALEGAÇÃO DE REFINANCIAMENTO DO BEM SEM O CONSENTIMENTO DO DEVEDOR – AUSÊNCIA DE ANUÊNCIA DO CREDOR QUANTO À TRANSFERÊNCIA DO CONTRATO DE FINANCIAMENTO – DESCABIMENTO DE INVERSÃO DO ÔNUS DA PROVA - AUSÊNCIA DE VEROSSIMILHANÇA DAS ALEGAÇÕES – SENTENÇA DE IMPROCEDÊNCIA MANTIDA –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>RECURSO DE APELAÇÃO EM AÇÃO DE INDENIZAÇÃO C/C COMINATÓRIA - TRANSFERÊNCIA POSSE VEÍCULO COM ALIENAÇÃO FIDUCIÁRIA – ALEGAÇÃO DE REFINANCIAMENTO DO BEM SEM O CONSENTIMENTO DO DEVEDOR – AUSÊNCIA DE ANUÊNCIA DO CREDOR QUANTO À TRANSFERÊNCIA DO CONTRATO DE FINANCIAMENTO – DESCABIMENTO DE INVERSÃO DO ÔNUS DA PROVA - AUSÊNCIA DE VEROSSIMILHANÇA DAS ALEGAÇÕES – SENTENÇA DE IMPROCEDÊNCIA MANTIDA –  RECURSO CONHECIDO E NÃO PROVIDO.
+I - A concordância do credor fiduciário, corréu, se afigurava imprescindível, pois o mesmo celebrou o contrato com certa pessoa e a alteração de seu devedor pode ser prejudicial aos seus interesses. Neste contexto, a própria alienação do bem móvel a um terceiro, no caso o primeiro réu, dependeria da anuência do credor fiduciário (segundo réu), para que, inclusive, pudessem ser realizados os trâmites administrativos da transferência do veículo.
+II - O pedido de deferimento da  inversão do ônus da prova, a fim de garantir a defesa do consumidor, poderá ser deferido desde que se demonstre a verossimilhança das alegações do demandante, a teor do que dispõe o inc. VIII do art. 6º do CDC.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>168&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876042" cdForo="0" >
+										0815809-13.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876042" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876042);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876042" style="display: none;" >
+	<div id="textAreaDados_1876042" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. ALEGA&Ccedil;&Atilde;O DE CERCEAMENTO DE DEFESA. REJEI&Ccedil;&Atilde;O. ESPECIFICA&Ccedil;&Atilde;O PROVAS OPORTUNIZADA. IN&Eacute;RCIA DOS AUTORES. CONCESSION&Aacute;RIA DE ENERGIA EL&Eacute;TRICA. DIVERG&Ecirc;NCIA CADASTRAL NA NUMERA&Ccedil;&Atilde;O DO MEDIDOR. SUBSTITUI&Ccedil;&Atilde;O DO EQUIPAMENTO E REGULARIZA&Ccedil;&Atilde;O DO CADASTRO NO CURSO DO PROCESSO. PERDA SUPERVENIENTE DO OBJETO DA OBRIGA&Ccedil;&Atilde;O DE FAZER. AUS&Ecirc;NCIA DE PROVA DE COBRAN&Ccedil;A INDEVIDA. INEXIST&Ecirc;NCIA DE DANO MORAL. SUCUMB&Ecirc;NCIA M&Iacute;NIMA DA R&Eacute;. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+III. RAZ&Otilde;ES DE DECIDIR
+
+
+
+
+
+
+
+IV. DISPOSITIVO E TESE
+
+Tese de julgamento:
+
+
+
+
+15)
+Reconhecida a perda superveniente do objeto apenas quanto &agrave; obriga&ccedil;&atilde;o de fazer, e sendo m&iacute;nima a sucumb&ecirc;ncia da concession&aacute;ria, os autores devem suportar integralmente os &ocirc;nus sucumbenciais.
+Dispositivos relevantes citados: CF/1988, art. 37, &sect;6&ordm;; CDC, arts. 2&ordm;, 3&ordm;, 6&ordm;, VIII, 14 e 22; CPC, arts. 86, par&aacute;grafo &uacute;nico, 98, &sect;3&ordm;, 371 e 493.
+Jurisprud&ecirc;ncia relevante citada: STJ, AgInt no REsp 1.920.967/SP, Rel. Min. Marco Aur&eacute;lio Bellizze, 3&ordf; Turma, j. 03.05.2021; STJ, AgInt no AREsp 1.382.885/SP, Rel. Min. Francisco Falc&atilde;o, 4&ordf; Turma, j. 26.04.2021.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0815809-13.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Branco Pucci, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Branco Pucci
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. ALEGAÇÃO DE CERCEAMENTO DE DEFESA. REJEIÇÃO. ESPECIFICAÇÃO PROVAS OPORTUNIZADA. INÉRCIA DOS AUTORES. CONCESSIONÁRIA DE ENERGIA ELÉTRICA. DIVERGÊNCIA CADASTRAL NA NUMERAÇÃO DO MEDIDOR. SUBSTITUIÇÃO DO EQUIPAMENTO E REGULARIZAÇÃO DO CADASTRO NO CURSO DO PROCESSO. PERDA SUPERVENIENTE DO OBJETO DA OBRIGAÇÃO DE FAZER. AUSÊNCIA DE PROVA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. ALEGAÇÃO DE CERCEAMENTO DE DEFESA. REJEIÇÃO. ESPECIFICAÇÃO PROVAS OPORTUNIZADA. INÉRCIA DOS AUTORES. CONCESSIONÁRIA DE ENERGIA ELÉTRICA. DIVERGÊNCIA CADASTRAL NA NUMERAÇÃO DO MEDIDOR. SUBSTITUIÇÃO DO EQUIPAMENTO E REGULARIZAÇÃO DO CADASTRO NO CURSO DO PROCESSO. PERDA SUPERVENIENTE DO OBJETO DA OBRIGAÇÃO DE FAZER. AUSÊNCIA DE PROVA DE COBRANÇA INDEVIDA. INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em>. SUCUMBÊNCIA MÍNIMA DA RÉ. RECURSO PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+
+II. QUESTÃO EM DISCUSSÃO
+
+III. RAZÕES DE DECIDIR
+
+
+
+
+
+
+
+IV. DISPOSITIVO E TESE
+
+Tese de julgamento:
+
+
+
+
+15)
+Reconhecida a perda superveniente do objeto apenas quanto à obrigação de fazer, e sendo mínima a sucumbência da concessionária, os autores devem suportar integralmente os ônus sucumbenciais.
+Dispositivos relevantes citados: CF/1988, art. 37, §6º; CDC, arts. 2º, 3º, 6º, VIII, 14 e 22; CPC, arts. 86, parágrafo único, 98, §3º, 371 e 493.
+Jurisprudência relevante citada: STJ, AgInt no REsp 1.920.967/SP, Rel. Min. Marco Aurélio Bellizze, 3ª Turma, j. 03.05.2021; STJ, AgInt no AREsp 1.382.885/SP, Rel. Min. Francisco Falcão, 4ª Turma, j. 26.04.2021.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>169&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876044" cdForo="0" >
+										0809447-60.2023.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876044" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876044);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876044" style="display: none;" >
+	<div id="textAreaDados_1876044" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIGIBILIDADE DE D&Iacute;VIDA C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; PRELIMINAR CONTRARRECURSAL &ndash; OFENSA AO PRINC&Iacute;PIO DA DIALETICIDADE &ndash; AFASTADA &ndash; M&Eacute;RITO &ndash; PARTE AUTORA QUE N&Atilde;O RECONHECE CONTRATO CELEBRADO EM SEU NOME &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA &ndash;  DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; DANOS MORAIS &ndash; N&Atilde;O CONFIGURADOS &ndash; RECURSO DA AUTORA CONHECIDO E  N&Atilde;O PROVIDO.
+I  - Se o  recurso de apela&ccedil;&atilde;o devolve de maneira suficiente a mat&eacute;ria impugnada, permitindo sua compreens&atilde;o pela parte recorrida e tamb&eacute;m pelo julgador, consignando sua irresigna&ccedil;&atilde;o, com o objetivo de reforma do julgado de primeira inst&acirc;ncia, n&atilde;o merece ser acolhida a preliminar de ofensa ao princ&iacute;pio da dialeticidade recursal.
+II - Para a configura&ccedil;&atilde;o do dano moral h&aacute; de existir uma consequ&ecirc;ncia grave em virtude do ato que, em tese, tenha violado o direito da personalidade, provocando dor, sofrimento, abalo psicol&oacute;gico ou humilha&ccedil;&atilde;o consider&aacute;veis &agrave; pessoa, e n&atilde;o quaisquer dissabores da vida.&nbsp; em sua conta corrente. N&atilde;o restou demonstrado, no caso concreto, o alegado abalo moral capaz de ensejar repara&ccedil;&atilde;o indenizat&oacute;ria o fato de ter sido descontado valores de seu benef&iacute;cio previdenci&aacute;rio. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0809447-60.2023.8.12.0002,&nbsp; Dourados,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(18 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÍVIDA C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR CONTRARRECURSAL – OFENSA AO PRINCÍPIO DA DIALETICIDADE – AFASTADA – MÉRITO – PARTE AUTORA QUE NÃO RECONHECE CONTRATO CELEBRADO EM SEU NOME – CONTRATAÇÃO NÃO COMPROVADA –  DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – DANOS MORAIS – NÃO CONFIGURADOS – RECURSO DA AUTORA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÍVIDA C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR CONTRARRECURSAL – OFENSA AO PRINCÍPIO DA DIALETICIDADE – AFASTADA – MÉRITO – PARTE AUTORA QUE NÃO RECONHECE CONTRATO CELEBRADO EM SEU NOME – CONTRATAÇÃO NÃO COMPROVADA –  DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – DANOS MORAIS – NÃO CONFIGURADOS – RECURSO DA AUTORA CONHECIDO E  NÃO PROVIDO.
+I  - Se o  recurso de apelação devolve de maneira suficiente a matéria impugnada, permitindo sua compreensão pela parte recorrida e também pelo julgador, consignando sua irresignação, com o objetivo de reforma do julgado de primeira instância, não merece ser acolhida a preliminar de ofensa ao princípio da dialeticidade recursal.
+II - Para a configuração do <em>dano</em> <em>moral</em> há de existir uma consequência grave em virtude do ato que, em tese, tenha violado o direito da personalidade, provocando dor, sofrimento, abalo psicológico ou humilhação consideráveis à pessoa, e não quaisquer dissabores da vida.  em sua conta corrente. Não restou demonstrado, no caso concreto, o alegado abalo <em>moral</em> capaz de ensejar reparação indenizatória o fato de ter sido descontado valores de seu benefício previdenciário.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>170&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876045" cdForo="0" >
+										0849240-38.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876045" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876045);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876045" style="display: none;" >
+	<div id="textAreaDados_1876045" class="mensagemSemFormatacao" >
+
+APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; CONS&Oacute;RCIO &ndash; CONTEMPLA&Ccedil;&Atilde;O &ndash; NEGATIVA DE LIBERA&Ccedil;&Atilde;O DE CARTA DE CR&Eacute;DITO &ndash; AN&Aacute;LISE DE CAPACIDADE FINANCEIRA &ndash; PREVIS&Atilde;O CONTRATUAL E LEGAL &ndash; EXIG&Ecirc;NCIA DE GARANTIAS &ndash; LEGITIMIDADE &ndash; AUS&Ecirc;NCIA DE ABUSIVIDADE &ndash; INEXIST&Ecirc;NCIA DE DANO MORAL &ndash; REFORMA DA SENTEN&Ccedil;A &ndash; RECURSO PROVIDO.
+
+CASO EM EXAME
+Apela&ccedil;&atilde;o C&iacute;vel interposta por XS5 Administradora de Cons&oacute;rcios S.A contra senten&ccedil;a que, em a&ccedil;&atilde;o de obriga&ccedil;&atilde;o de fazer c/c indeniza&ccedil;&atilde;o por danos morais, declarou abusiva a negativa de libera&ccedil;&atilde;o de carta de cr&eacute;dito ap&oacute;s contempla&ccedil;&atilde;o, determinando sua libera&ccedil;&atilde;o e condenando a administradora ao pagamento de indeniza&ccedil;&atilde;o por danos morais.
+
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+(i) Verificar a legalidade da exig&ecirc;ncia de an&aacute;lise de cr&eacute;dito e de garantias para libera&ccedil;&atilde;o da carta de cr&eacute;dito ap&oacute;s a contempla&ccedil;&atilde;o;
+(ii) Apurar a ocorr&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o apta a ensejar dano moral.
+
+RAZ&Otilde;ES DE DECIDIR
+
+A rela&ccedil;&atilde;o contratual de cons&oacute;rcio admite a exig&ecirc;ncia de comprova&ccedil;&atilde;o da capacidade financeira do consorciado contemplado, bem como a apresenta&ccedil;&atilde;o de garantias, nos termos da Lei n. 11.795/2008 e do contrato firmado entre as partes.
+
+A contempla&ccedil;&atilde;o n&atilde;o implica libera&ccedil;&atilde;o autom&aacute;tica da carta de cr&eacute;dito, estando condicionada ao atendimento das exig&ecirc;ncias contratuais e legais, especialmente quanto &agrave; an&aacute;lise de risco e &agrave; prote&ccedil;&atilde;o do grupo consorcial.
+
+A exig&ecirc;ncia de garantias complementares e a verifica&ccedil;&atilde;o da capacidade econ&ocirc;mico-financeira do consorciado constituem exerc&iacute;cio regular de direito da administradora, n&atilde;o configurando pr&aacute;tica abusiva.
+
+Inexistente demonstra&ccedil;&atilde;o de cumprimento, pelo consorciado, dos requisitos exigidos para libera&ccedil;&atilde;o do cr&eacute;dito, n&atilde;o h&aacute; que se reconhecer falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+
+Ausente ato il&iacute;cito, afasta-se o dever de indenizar, n&atilde;o se configurando dano moral indeniz&aacute;vel.
+
+DISPOSITIVO
+Recurso conhecido e provido para reformar a senten&ccedil;a e julgar improcedentes os pedidos iniciais.
+
+TESE
+A administradora de cons&oacute;rcio pode condicionar a libera&ccedil;&atilde;o da carta de cr&eacute;dito, mesmo ap&oacute;s a contempla&ccedil;&atilde;o, &agrave; an&aacute;lise da capacidade financeira do consorciado e &agrave; apresenta&ccedil;&atilde;o de garantias, desde que previstas contratual e legalmente, n&atilde;o configurando tal exig&ecirc;ncia pr&aacute;tica abusiva nem gerando, por si s&oacute;, dano moral. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0849240-38.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>
+APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS – CONSÓRCIO – CONTEMPLAÇÃO – NEGATIVA DE LIBERAÇÃO DE CARTA DE CRÉDITO – ANÁLISE DE CAPACIDADE FINANCEIRA – PREVISÃO CONTRATUAL E LEGAL – EXIGÊNCIA DE GARANTIAS – LEGITIMIDADE – AUSÊNCIA DE ABUSIVIDADE – INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em> – REFORMA DA SENTENÇA – RECURSO PROVIDO.
+
+CASO EM EXAME
+Apelação
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>
+APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C INDENIZAÇÃO POR DANOS MORAIS – CONSÓRCIO – CONTEMPLAÇÃO – NEGATIVA DE LIBERAÇÃO DE CARTA DE CRÉDITO – ANÁLISE DE CAPACIDADE FINANCEIRA – PREVISÃO CONTRATUAL E LEGAL – EXIGÊNCIA DE GARANTIAS – LEGITIMIDADE – AUSÊNCIA DE ABUSIVIDADE – INEXISTÊNCIA DE <em>DANO</em> <em>MORAL</em> – REFORMA DA SENTENÇA – RECURSO PROVIDO.
+
+CASO EM EXAME
+Apelação Cível interposta por XS5 Administradora de Consórcios S.A contra sentença que, em ação de obrigação de fazer c/c indenização por danos morais, declarou abusiva a negativa de liberação de carta de crédito após contemplação, determinando sua liberação e condenando a administradora ao pagamento de indenização por danos morais.
+
+QUESTÃO EM DISCUSSÃO
+(i) Verificar a legalidade da exigência de análise de crédito e de garantias para liberação da carta de crédito após a contemplação;
+(ii) Apurar a ocorrência de falha na prestação do serviço apta a ensejar <em>dano</em> <em>moral</em>.
+
+RAZÕES DE DECIDIR
+
+A relação contratual de consórcio admite a exigência de comprovação da capacidade financeira do consorciado contemplado, bem como a apresentação de garantias, nos termos da Lei n. 11.795/2008 e do contrato firmado entre as partes.
+
+A contemplação não implica liberação automática da carta de crédito, estando condicionada ao atendimento das exigências contratuais e legais, especialmente quanto à análise de risco e à proteção do grupo consorcial.
+
+A exigência de garantias complementares e a verificação da capacidade econômico-financeira do consorciado constituem exercício regular de direito da administradora, não configurando prática abusiva.
+
+Inexistente demonstração de cumprimento, pelo consorciado, dos requisitos exigidos para liberação do crédito, não há que se reconhecer falha na prestação do serviço.
+
+Ausente ato ilícito, afasta-se o dever de indenizar, não se configurando <em>dano</em> <em>moral</em> indenizável.
+
+DISPOSITIVO
+Recurso conhecido e provido para reformar a sentença e julgar improcedentes os pedidos iniciais.
+
+TESE
+A administradora de consórcio pode condicionar a liberação da carta de crédito, mesmo após a contemplação, à análise da capacidade financeira do consorciado e à apresentação de garantias, desde que previstas contratual e legalmente, não configurando tal exigência prática abusiva nem gerando, por si só, <em>dano</em> <em>moral</em>.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>171&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876046" cdForo="0" >
+										0856537-33.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876046" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876046);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876046" style="display: none;" >
+	<div id="textAreaDados_1876046" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS E MATERIAIS &ndash; RELA&Ccedil;&Atilde;O DE CONSUMO &ndash; RECUSA INDEVIDA DE TRANSA&Ccedil;&Atilde;O COM CART&Atilde;O &ndash; CONSTRANGIMENTO EM ESTABELECIMENTO COMERCIAL &ndash; FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O &ndash; DANO MORAL CONFIGURADO &ndash; PRELIMINAR DE ILEGITIMIDADE PASSIVA &ndash; MAT&Eacute;RIA J&Aacute; DECIDIDA EM SANEADOR &ndash; PRECLUS&Atilde;O &ndash; REDU&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; MANUTEN&Ccedil;&Atilde;O DO PERCENTUAL &ndash; MAJORA&Ccedil;&Atilde;O EM GRAU RECURSAL &ndash; RECURSO DA AUTORA DESPROVIDO &ndash; RECURSO DA R&Eacute; PARCIALMENTE PROVIDO.
+
+CASO EM EXAME
+
+Apela&ccedil;&otilde;es c&iacute;veis interpostas por Lucimara da Silva Lopes Macena e Atacad&atilde;o S.A contra senten&ccedil;a que julgou parcialmente procedente a&ccedil;&atilde;o indenizat&oacute;ria, condenando a r&eacute; ao ressarcimento de dano material e ao pagamento de indeniza&ccedil;&atilde;o por dano moral no valor de R$ 5.000,00, decorrente de recusa indevida de pagamento com cart&atilde;o em estabelecimento comercial.
+
+A autora pretende a majora&ccedil;&atilde;o da indeniza&ccedil;&atilde;o para R$ 15.000,00 e a eleva&ccedil;&atilde;o dos honor&aacute;rios advocat&iacute;cios. A r&eacute;, por sua vez, sustenta ilegitimidade passiva, inexist&ecirc;ncia de dano moral ou, subsidiariamente, redu&ccedil;&atilde;o do valor indenizat&oacute;rio.
+
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+3. As quest&otilde;es controvertidas consistem em: (i) verificar a possibilidade de conhecimento da preliminar de ilegitimidade passiva arguida em apela&ccedil;&atilde;o; (ii) examinar a ocorr&ecirc;ncia de falha na presta&ccedil;&atilde;o do servi&ccedil;o apta a ensejar indeniza&ccedil;&atilde;o por dano moral; e (iii) definir a adequa&ccedil;&atilde;o do valor fixado a t&iacute;tulo de indeniza&ccedil;&atilde;o e da verba honor&aacute;ria.
+
+RAZ&Otilde;ES DE DECIDIR
+4. A preliminar de ilegitimidade passiva n&atilde;o merece conhecimento, porquanto a mat&eacute;ria foi expressamente apreciada e rejeitada na decis&atilde;o saneadora, sem interposi&ccedil;&atilde;o de recurso, operando-se a preclus&atilde;o (art. 507 do CPC).
+5. Comprovado nos autos que houve d&eacute;bito do valor na conta da consumidora e recusa da compra no estabelecimento comercial, sem esclarecimento do motivo da negativa, evidencia-se falha na presta&ccedil;&atilde;o do servi&ccedil;o.
+6. A recusa indevida de pagamento em estabelecimento comercial, expondo o consumidor a constrangimento perante terceiros, caracteriza dano moral indeniz&aacute;vel, nos termos do art. 14 do C&oacute;digo de Defesa do Consumidor.
+7. Todavia, consideradas as circunst&acirc;ncias do caso concreto e os princ&iacute;pios da razoabilidade e proporcionalidade, o valor arbitrado em primeiro grau mostra-se elevado, devendo ser reduzido para R$ 2.500,00, montante suficiente para compensar o abalo sofrido e cumprir a fun&ccedil;&atilde;o pedag&oacute;gica da condena&ccedil;&atilde;o.
+8. Quanto aos honor&aacute;rios advocat&iacute;cios, a fixa&ccedil;&atilde;o em 10% do valor da condena&ccedil;&atilde;o mostra-se adequada aos crit&eacute;rios do art. 85, &sect;2&ordm;, do CPC, n&atilde;o havendo raz&atilde;o para majora&ccedil;&atilde;o na forma pretendida pela autora.
+9. Em raz&atilde;o do julgamento do recurso, aplica-se a majora&ccedil;&atilde;o recursal prevista no art. 85, &sect;11, do CPC.
+
+DISPOSITIVO
+10. Recurso de Lucimara da Silva Lopes Macena conhecido e desprovido.
+11. Recurso de Atacad&atilde;o S.A conhecido e parcialmente provido para reduzir o valor da indeniza&ccedil;&atilde;o por danos morais para R$ 2.500,00, mantidos os demais termos da senten&ccedil;a.
+12. Honor&aacute;rios advocat&iacute;cios majorados para 15% sobre o valor da condena&ccedil;&atilde;o.
+
+TESE
+13. A recusa indevida de pagamento com cart&atilde;o em estabelecimento comercial, quando comprovado o d&eacute;bito do valor ou aus&ecirc;ncia de justificativa para a negativa da opera&ccedil;&atilde;o, configura falha na presta&ccedil;&atilde;o do servi&ccedil;o e enseja indeniza&ccedil;&atilde;o por dano moral, sendo poss&iacute;vel a revis&atilde;o do quantum indenizat&oacute;rio quando se mostrar desproporcional &agrave;s circunst&acirc;ncias do caso concreto.
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 2&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade negaram provimento ao recurso da autora e  deram parcial provimento ao recurso da r&eacute;, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0856537-33.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(47 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E MATERIAIS – RELAÇÃO DE CONSUMO – RECUSA INDEVIDA DE TRANSAÇÃO COM CARTÃO – CONSTRANGIMENTO EM ESTABELECIMENTO COMERCIAL – FALHA NA PRESTAÇÃO DO SERVIÇO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – PRELIMINAR DE ILEGITIMIDADE PASSIVA – MATÉRIA JÁ DECIDIDA EM SANEADOR – PRECLUSÃO – REDUÇÃO DO QUANTUM INDENIZATÓRIO – HONORÁRIOS ADVOCATÍCIOS –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS E MATERIAIS – RELAÇÃO DE CONSUMO – RECUSA INDEVIDA DE TRANSAÇÃO COM CARTÃO – CONSTRANGIMENTO EM ESTABELECIMENTO COMERCIAL – FALHA NA PRESTAÇÃO DO SERVIÇO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – PRELIMINAR DE ILEGITIMIDADE PASSIVA – MATÉRIA JÁ DECIDIDA EM SANEADOR – PRECLUSÃO – REDUÇÃO DO QUANTUM INDENIZATÓRIO – HONORÁRIOS ADVOCATÍCIOS – MANUTENÇÃO DO PERCENTUAL – MAJORAÇÃO EM GRAU RECURSAL – RECURSO DA AUTORA DESPROVIDO – RECURSO DA RÉ PARCIALMENTE PROVIDO.
+
+CASO EM EXAME
+
+Apelações cíveis interpostas por Lucimara da Silva Lopes Macena e Atacadão S.A contra sentença que julgou parcialmente procedente ação indenizatória, condenando a ré ao ressarcimento de <em>dano</em> material e ao pagamento de indenização por <em>dano</em> <em>moral</em> no valor de R$ 5.000,00, decorrente de recusa indevida de pagamento com cartão em estabelecimento comercial.
+
+A autora pretende a majoração da indenização para R$ 15.000,00 e a elevação dos honorários advocatícios. A ré, por sua vez, sustenta ilegitimidade passiva, inexistência de <em>dano</em> <em>moral</em> ou, subsidiariamente, redução do valor indenizatório.
+
+QUESTÃO EM DISCUSSÃO
+3. As questões controvertidas consistem em: (i) verificar a possibilidade de conhecimento da preliminar de ilegitimidade passiva arguida em apelação; (ii) examinar a ocorrência de falha na prestação do serviço apta a ensejar indenização por <em>dano</em> <em>moral</em>; e (iii) definir a adequação do valor fixado a título de indenização e da verba honorária.
+
+RAZÕES DE DECIDIR
+4. A preliminar de ilegitimidade passiva não merece conhecimento, porquanto a matéria foi expressamente apreciada e rejeitada na decisão saneadora, sem interposição de recurso, operando-se a preclusão (art. 507 do CPC).
+5. Comprovado nos autos que houve débito do valor na conta da consumidora e recusa da compra no estabelecimento comercial, sem esclarecimento do motivo da negativa, evidencia-se falha na prestação do serviço.
+6. A recusa indevida de pagamento em estabelecimento comercial, expondo o consumidor a constrangimento perante terceiros, caracteriza <em>dano</em> <em>moral</em> indenizável, nos termos do art. 14 do Código de Defesa do Consumidor.
+7. Todavia, consideradas as circunstâncias do caso concreto e os princípios da razoabilidade e proporcionalidade, o valor arbitrado em primeiro grau mostra-se elevado, devendo ser reduzido para R$ 2.500,00, montante suficiente para compensar o abalo sofrido e cumprir a função pedagógica da condenação.
+8. Quanto aos honorários advocatícios, a fixação em 10% do valor da condenação mostra-se adequada aos critérios do art. 85, §2º, do CPC, não havendo razão para majoração na forma pretendida pela autora.
+9. Em razão do julgamento do recurso, aplica-se a majoração recursal prevista no art. 85, §11, do CPC.
+
+DISPOSITIVO
+10. Recurso de Lucimara da Silva Lopes Macena conhecido e desprovido.
+11. Recurso de Atacadão S.A conhecido e parcialmente provido para reduzir o valor da indenização por danos morais para R$ 2.500,00, mantidos os demais termos da sentença.
+12. Honorários advocatícios majorados para 15% sobre o valor da condenação.
+
+TESE
+13. A recusa indevida de pagamento com cartão em estabelecimento comercial, quando comprovado o débito do valor ou ausência de justificativa para a negativa da operação, configura falha na prestação do serviço e enseja indenização por <em>dano</em> <em>moral</em>, sendo possível a revisão do quantum indenizatório quando se mostrar desproporcional às circunstâncias do caso concreto.
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 2ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade negaram provimento ao recurso da autora e  deram parcial provimento ao recurso da ré, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>172&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876047" cdForo="0" >
+										0800078-35.2021.8.12.0027
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876047" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876047);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876047" style="display: none;" >
+	<div id="textAreaDados_1876047" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash;  A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash;  DESCONTOS DE VALOR A T&Iacute;TULO DE SEGURO &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA &ndash; DESCONTOS INDEVIDOS &ndash; RESTITUI&Ccedil;&Atilde;O DOS VALORES EM DOBRO &ndash; JUROS DE MORA INCIDENTES A PARTIR DE CADA DESCONTO INDEVIDO &ndash; DANO MORAL &ndash; N&Atilde;O CONFIGURADO &ndash; MAJORA&Ccedil;&Atilde;O INDEVIDA &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS - TEMA 1076 DO STJ &ndash; RECURSO  CONHECIDO E PARCIALMENTE PROVIDO.
+I &ndash;  N&atilde;o havendo demonstra&ccedil;&atilde;o de ofensa aos direitos da personalidade do autor, deve ser afastada a pretens&atilde;o recursal de majora&ccedil;&atilde;o da indeniza&ccedil;&atilde;o por danos morais.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800078-35.2021.8.12.0027,&nbsp; Bataypor&atilde;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(33 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Batayporã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS –  DESCONTOS DE VALOR A TÍTULO DE SEGURO – CONTRATAÇÃO NÃO COMPROVADA – DESCONTOS INDEVIDOS – RESTITUIÇÃO DOS VALORES EM DOBRO – JUROS DE MORA INCIDENTES A PARTIR DE CADA DESCONTO INDEVIDO – <em>DANO</em> <em>MORAL</em> – NÃO CONFIGURADO – MAJORAÇÃO INDEVIDA – HONORÁRIOS ADVOCATÍCIOS - TEMA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL –  AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS –  DESCONTOS DE VALOR A TÍTULO DE SEGURO – CONTRATAÇÃO NÃO COMPROVADA – DESCONTOS INDEVIDOS – RESTITUIÇÃO DOS VALORES EM DOBRO – JUROS DE MORA INCIDENTES A PARTIR DE CADA DESCONTO INDEVIDO – <em>DANO</em> <em>MORAL</em> – NÃO CONFIGURADO – MAJORAÇÃO INDEVIDA – HONORÁRIOS ADVOCATÍCIOS - TEMA 1076 DO STJ – RECURSO  CONHECIDO E PARCIALMENTE PROVIDO.
+I –  Não havendo demonstração de ofensa aos direitos da personalidade do autor, deve ser afastada a pretensão recursal de majoração da indenização por danos morais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>173&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876048" cdForo="0" >
+										0802270-56.2025.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876048" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876048);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876048" style="display: none;" >
+	<div id="textAreaDados_1876048" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL DA PARTE AUTORA EM A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL C/C INEXIST&Ecirc;NCIA DE D&Eacute;BITO, RESTITUI&Ccedil;&Atilde;O DE VALORES E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; PRELIMINAR CONTRARRECURSAL DE OFENSA AO PRINC&Iacute;PIO DA DIALETICIDADE  REJEITADA &ndash; M&Eacute;RITO &ndash; ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O DO CR&Eacute;DITO POR MEIO DE CART&Atilde;O DE CR&Eacute;DITO &ndash; PRODUTO DE SAQUE COM O CART&Atilde;O DEPOSITADO EM CONTA CORRENTE DE TITULARIDADE DA PARTE AUTORA &ndash; N&Atilde;O UTILIZA&Ccedil;&Atilde;O DO CART&Atilde;O DE CR&Eacute;DITO PARA COMPRAS &ndash; OCORR&Ecirc;NCIA DE ERRO SUBSTANCIAL &ndash; V&Iacute;CIO DE CONSENTIMENTO &ndash; POSSIBILIDADE, TODAVIA, DE APROVEITAMENTO DO NEG&Oacute;CIO JUR&Iacute;DICO &ndash; CONVERS&Atilde;O DO CONTRATO EM M&Uacute;TUO COM CONSIGNA&Ccedil;&Atilde;O EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; DANOS MORAIS &ndash; INOCORR&Ecirc;NCIA &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I - N&atilde;o h&aacute; ofensa ao princ&iacute;pio da&nbsp;dialeticidade, se as raz&otilde;es da pe&ccedil;a recursal s&atilde;o suficientes para atacar minimamente os fundamentos da decis&atilde;o atacada.
+II - Havendo prova de que a parte autora se beneficiou do produto do mutuo banc&aacute;rio, por&eacute;m sem a utiliza&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito para compras a prazo, resta evidente a ocorr&ecirc;ncia de indu&ccedil;&atilde;o do cliente a erro, impondo-se a declara&ccedil;&atilde;o de nulidade do contrato e a determina&ccedil;&atilde;o de sua convers&atilde;o para a modalidade de empr&eacute;stimo consignado em benef&iacute;cio previdenci&aacute;rio, com a aplica&ccedil;&atilde;o das taxas de juros m&eacute;dia do mercado aferidas pelo BACEN na data da contrata&ccedil;&atilde;o.
+III - Considerando que a parte  autora se beneficiou do valor disponibilizado em sua conta banc&aacute;ria, afiguram-se leg&iacute;timos os descontos efetuados pela institui&ccedil;&atilde;o financeira r&eacute;, uma vez que agiu no exerc&iacute;cio regular de seu direito, n&atilde;o havendo que se falar em ato il&iacute;cito e, por consequ&ecirc;ncia, no dever de indenizar os danos morais.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802270-56.2025.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL DA PARTE AUTORA EM AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL C/C INEXISTÊNCIA DE DÉBITO, RESTITUIÇÃO DE VALORES E INDENIZAÇÃO POR DANOS MORAIS – PRELIMINAR CONTRARRECURSAL DE OFENSA AO PRINCÍPIO DA DIALETICIDADE  REJEITADA – MÉRITO – ALEGAÇÃO DE AUSÊNCIA DE CONTRATAÇÃO DO CRÉDITO POR MEIO DE CARTÃO DE CRÉDITO – PRODUTO DE SAQUE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL DA PARTE AUTORA EM AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL C/C INEXISTÊNCIA DE DÉBITO, RESTITUIÇÃO DE VALORES E INDENIZAÇÃO POR DANOS MORAIS – PRELIMINAR CONTRARRECURSAL DE OFENSA AO PRINCÍPIO DA DIALETICIDADE  REJEITADA – MÉRITO – ALEGAÇÃO DE AUSÊNCIA DE CONTRATAÇÃO DO CRÉDITO POR MEIO DE CARTÃO DE CRÉDITO – PRODUTO DE SAQUE COM O CARTÃO DEPOSITADO EM CONTA CORRENTE DE TITULARIDADE DA PARTE AUTORA – NÃO UTILIZAÇÃO DO CARTÃO DE CRÉDITO PARA COMPRAS – OCORRÊNCIA DE ERRO SUBSTANCIAL – VÍCIO DE CONSENTIMENTO – POSSIBILIDADE, TODAVIA, DE APROVEITAMENTO DO NEGÓCIO JURÍDICO – CONVERSÃO DO CONTRATO EM MÚTUO COM CONSIGNAÇÃO EM BENEFÍCIO PREVIDENCIÁRIO – DANOS MORAIS – INOCORRÊNCIA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I - Não há ofensa ao princípio da dialeticidade, se as razões da peça recursal são suficientes para atacar minimamente os fundamentos da decisão atacada.
+II - Havendo prova de que a parte autora se beneficiou do produto do mutuo bancário, porém sem a utilização do cartão de crédito para compras a prazo, resta evidente a ocorrência de indução do cliente a erro, impondo-se a declaração de nulidade do contrato e a determinação de sua conversão para a modalidade de empréstimo consignado em benefício previdenciário, com a aplicação das taxas de juros média do mercado aferidas pelo BACEN na data da contratação.
+III - Considerando que a parte  autora se beneficiou do valor disponibilizado em sua conta bancária, afiguram-se legítimos os descontos efetuados pela instituição financeira ré, uma vez que agiu no exercício regular de seu direito, não havendo que se falar em ato ilícito e, por consequência, no dever de indenizar os danos morais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>174&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876049" cdForo="0" >
+										0843377-43.2021.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876049" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876049);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876049" style="display: none;" >
+	<div id="textAreaDados_1876049" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; RECURSO DA PARTE AUTORA &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIGIBILIDADE DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E DANOS MORAIS &ndash; PARTE AUTORA QUE N&Atilde;O RECONHECE  CONTRATOS  QUE MOTIVARAM  DESCONTOS DE PARCELAS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; N&Atilde;O REALIZA&Ccedil;&Atilde;O DE PROVA PERICIAL GRAFOT&Eacute;CNICA &ndash; DOCUMENTOS QUE EVIDENCIAM A CONTRATA&Ccedil;&Atilde;O &ndash; DISPONIBILIZA&Ccedil;&Atilde;O DOS PRODUTOS DOS M&Uacute;TUOS EM CONTA CORRENTE  &ndash;  CUMPRIMENTO PELO R&Eacute;U DO &Ocirc;NUS DA PROVA &ndash; REGULARIDADE DOS D&Eacute;BITOS &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I - Hip&oacute;tese em que os elementos dos autos evidenciam que a autora firmou os contratos de&nbsp;empr&eacute;stimo&nbsp;consignados questionados, elidindo a alega&ccedil;&atilde;o de&nbsp;fraude&nbsp;na contrata&ccedil;&atilde;o. Evidenciada a licitude da origem das d&iacute;vidas, persiste a responsabilidade da mutu&aacute;ria por seu pagamento.
+II - Demonstrado nos autos que os produtos dos empr&eacute;stimos ditos nulos foram disponibilizados &agrave; parte autora,  n&atilde;o h&aacute; como considerar v&aacute;lida a justificativa apontada de que n&atilde;o firmou o contrato, tampouco de que n&atilde;o se beneficiara de qualquer quantia.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0843377-43.2021.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – RECURSO DA PARTE AUTORA – AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – PARTE AUTORA QUE NÃO RECONHECE  CONTRATOS  QUE MOTIVARAM  DESCONTOS DE PARCELAS EM BENEFÍCIO PREVIDENCIÁRIO – NÃO REALIZAÇÃO DE PROVA PERICIAL GRAFOTÉCNICA – DOCUMENTOS QUE EVIDENCIAM A CONTRATAÇÃO – DISPONIBILIZAÇÃO DOS PRODUTOS DOS MÚTUOS EM CONTA CORRENTE  –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – RECURSO DA PARTE AUTORA – AÇÃO DECLARATÓRIA DE INEXIGIBILIDADE DE DÉBITO C/C REPETIÇÃO DE INDÉBITO E DANOS MORAIS – PARTE AUTORA QUE NÃO RECONHECE  CONTRATOS  QUE MOTIVARAM  DESCONTOS DE PARCELAS EM BENEFÍCIO PREVIDENCIÁRIO – NÃO REALIZAÇÃO DE PROVA PERICIAL GRAFOTÉCNICA – DOCUMENTOS QUE EVIDENCIAM A CONTRATAÇÃO – DISPONIBILIZAÇÃO DOS PRODUTOS DOS MÚTUOS EM CONTA CORRENTE  –  CUMPRIMENTO PELO RÉU DO ÔNUS DA PROVA – REGULARIDADE DOS DÉBITOS – RECURSO CONHECIDO E NÃO PROVIDO.
+I - Hipótese em que os elementos dos autos evidenciam que a autora firmou os contratos de empréstimo consignados questionados, elidindo a alegação de fraude na contratação. Evidenciada a licitude da origem das dívidas, persiste a responsabilidade da mutuária por seu pagamento.
+II - Demonstrado nos autos que os produtos dos empréstimos ditos nulos foram disponibilizados à parte autora,  não há como considerar válida a justificativa apontada de que não firmou o contrato, tampouco de que não se beneficiara de qualquer quantia.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>175&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876054" cdForo="0" >
+										1404806-78.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876054" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876054);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876054" style="display: none;" >
+	<div id="textAreaDados_1876054" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; DECIS&Atilde;O QUE DECLINOU COMPET&Ecirc;NCIA AO JUIZADO ESPECIAL DA FAZENDA P&Uacute;BLICA &ndash; REGRA DE COMPET&Ecirc;NCIA ABSOLUTA - A&Ccedil;&Atilde;O INDIVIDUAL DE INDENIZA&Ccedil;&Atilde;O PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANIT&Aacute;RIO &ndash; QUEST&Atilde;O AMBIENTAL TRATADA T&Atilde;O SOMENTE DE MANEIRA REFLEXA &ndash; PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SAL&Aacute;RIOS M&Iacute;NIMOS - PREVAL&Ecirc;NCIA COMPET&Ecirc;NCIA DO JUIZADO ESPECIAL DA FAZENDA P&Uacute;BLICA &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO &ndash; DECIS&Atilde;O MANTIDA.
+Recai sobre o Juizado Especial da Fazenda P&uacute;blica a compet&ecirc;ncia para processar e julgar pedido de dano moral individual ocasionado por suposta les&atilde;o ambiental provocada pelo Munic&iacute;pio, consistente em destina&ccedil;&atilde;o err&ocirc;nea dada a aterro sanit&aacute;rio.
+A suposta les&atilde;o ambiental deve ser tratada t&atilde;o somente de maneira reflexa, pois o dano ambiental pode afetar, simultaneamente, o bem jur&iacute;dico ambiental e outros interesses jur&iacute;dicos individuais. Na hip&oacute;tese de dano individual, a decis&atilde;o que vier a ser prolatada afetar&aacute; exclusivamente a esfera de interesse das partes envolvidas.
+O STJ possui entendimento consolidado &ndash; expressamente reafirmado no IAC 10, com efeito vinculante nos termos do art. 927 do CPC &ndash; no sentido de que a compet&ecirc;ncia dos Juizados Especiais da Fazenda P&uacute;blica, onde instalados, &eacute; absoluta, e que os crit&eacute;rios de afastamento dessa compet&ecirc;ncia s&atilde;o apenas os expressamente previstos na lei, n&atilde;o comportando amplia&ccedil;&atilde;o por interpreta&ccedil;&atilde;o judicial, revelando-se irrelevante a complexidade da prova.
+No caso concreto, o valor da causa &eacute; de R$ 25.000,00, soma inferior ao limite de sessenta sal&aacute;rios m&iacute;nimos atualmente vigente; a demanda n&atilde;o se enquadra em qualquer das exce&ccedil;&otilde;es do &sect; 1&ordm; do art. 2&ordm; da Lei n. 12.153/2009 &ndash; porquanto n&atilde;o se trata de mandado de seguran&ccedil;a, desapropria&ccedil;&atilde;o, divis&atilde;o e demarca&ccedil;&atilde;o, a&ccedil;&atilde;o popular, improbidade administrativa, execu&ccedil;&atilde;o fiscal ou demanda sobre bens im&oacute;veis, pelo que consubstanciada a compet&ecirc;ncia absoluta dos Juizados Especiais da Fazenda P&uacute;blica.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1404806-78.2026.8.12.0000,&nbsp; Juizado Especial Central de Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 10/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(19 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Dano Ambiental
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DECISÃO QUE DECLINOU COMPETÊNCIA AO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – REGRA DE COMPETÊNCIA ABSOLUTA - AÇÃO INDIVIDUAL DE INDENIZAÇÃO PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANITÁRIO – QUESTÃO AMBIENTAL TRATADA TÃO SOMENTE DE MANEIRA REFLEXA – PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SALÁRIOS MÍNIMOS - PREVALÊNCIA COMPETÊNCIA DO JUIZADO ESPECIAL
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DECISÃO QUE DECLINOU COMPETÊNCIA AO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – REGRA DE COMPETÊNCIA ABSOLUTA - AÇÃO INDIVIDUAL DE INDENIZAÇÃO PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANITÁRIO – QUESTÃO AMBIENTAL TRATADA TÃO SOMENTE DE MANEIRA REFLEXA – PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SALÁRIOS MÍNIMOS - PREVALÊNCIA COMPETÊNCIA DO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – RECURSO CONHECIDO E NÃO PROVIDO – DECISÃO MANTIDA.
+Recai sobre o Juizado Especial da Fazenda Pública a competência para processar e julgar pedido de <em>dano</em> <em>moral</em> individual ocasionado por suposta lesão ambiental provocada pelo Município, consistente em destinação errônea dada a aterro sanitário.
+A suposta lesão ambiental deve ser tratada tão somente de maneira reflexa, pois o <em>dano</em> ambiental pode afetar, simultaneamente, o bem jurídico ambiental e outros interesses jurídicos individuais. Na hipótese de <em>dano</em> individual, a decisão que vier a ser prolatada afetará exclusivamente a esfera de interesse das partes envolvidas.
+O STJ possui entendimento consolidado – expressamente reafirmado no IAC 10, com efeito vinculante nos termos do art. 927 do CPC – no sentido de que a competência dos Juizados Especiais da Fazenda Pública, onde instalados, é absoluta, e que os critérios de afastamento dessa competência são apenas os expressamente previstos na lei, não comportando ampliação por interpretação judicial, revelando-se irrelevante a complexidade da prova.
+No caso concreto, o valor da causa é de R$ 25.000,00, soma inferior ao limite de sessenta salários mínimos atualmente vigente; a demanda não se enquadra em qualquer das exceções do § 1º do art. 2º da Lei n. 12.153/2009 – porquanto não se trata de mandado de segurança, desapropriação, divisão e demarcação, ação popular, improbidade administrativa, execução fiscal ou demanda sobre bens imóveis, pelo que consubstanciada a competência absoluta dos Juizados Especiais da Fazenda Pública.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>176&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876056" cdForo="0" >
+										1405073-50.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876056" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876056);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876056" style="display: none;" >
+	<div id="textAreaDados_1876056" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; DECIS&Atilde;O QUE DECLINOU COMPET&Ecirc;NCIA AO JUIZADO ESPECIAL DA FAZENDA P&Uacute;BLICA &ndash; REGRA DE COMPET&Ecirc;NCIA ABSOLUTA - A&Ccedil;&Atilde;O INDIVIDUAL DE INDENIZA&Ccedil;&Atilde;O PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANIT&Aacute;RIO &ndash; QUEST&Atilde;O AMBIENTAL TRATADA T&Atilde;O SOMENTE DE MANEIRA REFLEXA &ndash; PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SAL&Aacute;RIOS M&Iacute;NIMOS - PREVAL&Ecirc;NCIA COMPET&Ecirc;NCIA DO JUIZADO ESPECIAL DA FAZENDA P&Uacute;BLICA &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO &ndash; DECIS&Atilde;O MANTIDA.
+Recai sobre o Juizado Especial da Fazenda P&uacute;blica a compet&ecirc;ncia para processar e julgar pedido de dano moral individual ocasionado por suposta les&atilde;o ambiental provocada pelo Munic&iacute;pio, consistente em destina&ccedil;&atilde;o err&ocirc;nea dada a aterro sanit&aacute;rio.
+A suposta les&atilde;o ambiental deve ser tratada t&atilde;o somente de maneira reflexa, pois o dano ambiental pode afetar, simultaneamente, o bem jur&iacute;dico ambiental e outros interesses jur&iacute;dicos individuais. Na hip&oacute;tese de dano individual, a decis&atilde;o que vier a ser prolatada afetar&aacute; exclusivamente a esfera de interesse das partes envolvidas.
+O STJ possui entendimento consolidado &ndash; expressamente reafirmado no IAC 10, com efeito vinculante nos termos do art. 927 do CPC &ndash; no sentido de que a compet&ecirc;ncia dos Juizados Especiais da Fazenda P&uacute;blica, onde instalados, &eacute; absoluta, e que os crit&eacute;rios de afastamento dessa compet&ecirc;ncia s&atilde;o apenas os expressamente previstos na lei, n&atilde;o comportando amplia&ccedil;&atilde;o por interpreta&ccedil;&atilde;o judicial, revelando-se irrelevante a complexidade da prova.
+No caso concreto, o valor da causa &eacute; de R$ 25.000,00, soma inferior ao limite de sessenta sal&aacute;rios m&iacute;nimos atualmente vigente; a demanda n&atilde;o se enquadra em qualquer das exce&ccedil;&otilde;es do &sect; 1&ordm; do art. 2&ordm; da Lei n. 12.153/2009 &ndash; porquanto n&atilde;o se trata de mandado de seguran&ccedil;a, desapropria&ccedil;&atilde;o, divis&atilde;o e demarca&ccedil;&atilde;o, a&ccedil;&atilde;o popular, improbidade administrativa, execu&ccedil;&atilde;o fiscal ou demanda sobre bens im&oacute;veis, pelo que consubstanciada a compet&ecirc;ncia absoluta dos Juizados Especiais da Fazenda P&uacute;blica.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1405073-50.2026.8.12.0000,&nbsp; Juizado Especial Central de Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 10/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(19 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Dano Ambiental
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DECISÃO QUE DECLINOU COMPETÊNCIA AO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – REGRA DE COMPETÊNCIA ABSOLUTA - AÇÃO INDIVIDUAL DE INDENIZAÇÃO PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANITÁRIO – QUESTÃO AMBIENTAL TRATADA TÃO SOMENTE DE MANEIRA REFLEXA – PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SALÁRIOS MÍNIMOS - PREVALÊNCIA COMPETÊNCIA DO JUIZADO ESPECIAL
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DECISÃO QUE DECLINOU COMPETÊNCIA AO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – REGRA DE COMPETÊNCIA ABSOLUTA - AÇÃO INDIVIDUAL DE INDENIZAÇÃO PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANITÁRIO – QUESTÃO AMBIENTAL TRATADA TÃO SOMENTE DE MANEIRA REFLEXA – PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SALÁRIOS MÍNIMOS - PREVALÊNCIA COMPETÊNCIA DO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – RECURSO CONHECIDO E NÃO PROVIDO – DECISÃO MANTIDA.
+Recai sobre o Juizado Especial da Fazenda Pública a competência para processar e julgar pedido de <em>dano</em> <em>moral</em> individual ocasionado por suposta lesão ambiental provocada pelo Município, consistente em destinação errônea dada a aterro sanitário.
+A suposta lesão ambiental deve ser tratada tão somente de maneira reflexa, pois o <em>dano</em> ambiental pode afetar, simultaneamente, o bem jurídico ambiental e outros interesses jurídicos individuais. Na hipótese de <em>dano</em> individual, a decisão que vier a ser prolatada afetará exclusivamente a esfera de interesse das partes envolvidas.
+O STJ possui entendimento consolidado – expressamente reafirmado no IAC 10, com efeito vinculante nos termos do art. 927 do CPC – no sentido de que a competência dos Juizados Especiais da Fazenda Pública, onde instalados, é absoluta, e que os critérios de afastamento dessa competência são apenas os expressamente previstos na lei, não comportando ampliação por interpretação judicial, revelando-se irrelevante a complexidade da prova.
+No caso concreto, o valor da causa é de R$ 25.000,00, soma inferior ao limite de sessenta salários mínimos atualmente vigente; a demanda não se enquadra em qualquer das exceções do § 1º do art. 2º da Lei n. 12.153/2009 – porquanto não se trata de mandado de segurança, desapropriação, divisão e demarcação, ação popular, improbidade administrativa, execução fiscal ou demanda sobre bens imóveis, pelo que consubstanciada a competência absoluta dos Juizados Especiais da Fazenda Pública.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>177&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876060" cdForo="0" >
+										0800650-58.2025.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876060" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876060);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876060" style="display: none;" >
+	<div id="textAreaDados_1876060" class="mensagemSemFormatacao" >
+		EMBARGOS DE DECLARA&Ccedil;&Atilde;O EM APELA&Ccedil;&Atilde;O C&Iacute;VEL - ALEGA&Ccedil;&Atilde;O DE OMISS&Atilde;O - N&Iacute;TIDA PRETENS&Atilde;O DE REDISCUSS&Atilde;O DE MAT&Eacute;RIA DEVIDAMENTE APRECIADA NO AC&Oacute;RD&Atilde;O RECORRIDO - DECISUM MANTIDO - PREQUESTIONAMENTO - DESNECESSIDADE DE MANIFESTA&Ccedil;&Atilde;O EXPRESSA - EMBARGOS DECLARAT&Oacute;RIOS REJEITADOS.
+A mera inconformidade com o resultado da demanda n&atilde;o autoriza a revis&atilde;o de tema satisfatoriamente debatido e devidamente fundamentado.
+Eventual discord&acirc;ncia da parte quanto ao resultado do julgamento deve ser objeto de recurso apropriado, n&atilde;o lhe servindo a via estreita dos embargos de declara&ccedil;&atilde;o para modific&aacute;-lo, de modo a prevalecer teses pessoais.
+Mesmo para fins de prequestionamento, a oposi&ccedil;&atilde;o de embargos pressup&otilde;e a exist&ecirc;ncia de algum dos v&iacute;cios do art. 1.022 do CPC, sendo desnecess&aacute;rio que o julgador se manifeste sobre todos os dispositivos legais apontados pelas partes como violados.
+Segundo disp&otilde;e o art. 1.025, do CPC, a mat&eacute;ria ventilada pela parte embargante encontra-se automaticamente prequestionada para fins de interposi&ccedil;&atilde;o de recursos &agrave;s inst&acirc;ncias superiores.
+Embargos rejeitados.
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, rejeitaram os embargos, nos termos do voto do Relator..  <br><br>(<b>TJMS</b>. Embargos de Declara&ccedil;&atilde;o C&iacute;vel n. 0800650-58.2025.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Embargos de Declaração Cível / Defeito, nulidade ou anulação
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									800650582025812002450000
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL - ALEGAÇÃO DE OMISSÃO - NÍTIDA PRETENSÃO DE REDISCUSSÃO DE MATÉRIA DEVIDAMENTE APRECIADA NO ACÓRDÃO RECORRIDO - DECISUM MANTIDO - PREQUESTIONAMENTO - DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA - EMBARGOS DECLARATÓRIOS REJEITADOS.
+A mera inconformidade com o resultado da demanda não autoriza a revisão de tema satisfatoriamente debatido e devidamente
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>EMBARGOS DE DECLARAÇÃO EM APELAÇÃO CÍVEL - ALEGAÇÃO DE OMISSÃO - NÍTIDA PRETENSÃO DE REDISCUSSÃO DE MATÉRIA DEVIDAMENTE APRECIADA NO ACÓRDÃO RECORRIDO - DECISUM MANTIDO - PREQUESTIONAMENTO - DESNECESSIDADE DE MANIFESTAÇÃO EXPRESSA - EMBARGOS DECLARATÓRIOS REJEITADOS.
+A mera inconformidade com o resultado da demanda não autoriza a revisão de tema satisfatoriamente debatido e devidamente fundamentado.
+Eventual discordância da parte quanto ao resultado do julgamento deve ser objeto de recurso apropriado, não lhe servindo a via estreita dos embargos de declaração para modificá-lo, de modo a prevalecer teses pessoais.
+Mesmo para fins de prequestionamento, a oposição de embargos pressupõe a existência de algum dos vícios do art. 1.022 do CPC, sendo desnecessário que o julgador se manifeste sobre todos os dispositivos legais apontados pelas partes como violados.
+Segundo dispõe o art. 1.025, do CPC, a matéria ventilada pela parte embargante encontra-se automaticamente prequestionada para fins de interposição de recursos às instâncias superiores.
+Embargos rejeitados.
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, rejeitaram os embargos, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>178&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876065" cdForo="0" >
+										0801111-31.2024.8.12.0035
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876065" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876065);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876065" style="display: none;" >
+	<div id="textAreaDados_1876065" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR  DANOS MORAIS &ndash; INSCRI&Ccedil;&Atilde;O EM &Oacute;RG&Atilde;OS DE PROTE&Ccedil;&Atilde;O AO CR&Eacute;DITO &ndash;  NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA AO CADASTRO &ndash; EVIDENCIADO O CUMPRIMENTO DA EXIG&Ecirc;NCIA LEGAL PREVISTA NO ARTIGO 43, &sect; 2&ordm;, DO C&Oacute;DIGO DE DEFESA DO CONSUMIDOR &ndash;  APLICA&Ccedil;&Atilde;O DA TESE JUR&Iacute;DICA FIXADA NO JULGAMENTO DO IRDR N. 0835488-67.2023.8.12.0001 &ndash; NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA ELETR&Ocirc;NICA &ndash; CORRESPOND&Ecirc;NCIA E SMS &ndash; SENTEN&Ccedil;A MANTIDA &ndash; RECURSO CONHECIDO E DESPROVIDO.
+
+Como a finalidade da legisla&ccedil;&atilde;o consumerista foi alcan&ccedil;ada, tendo sido a parte autora previamente notificada sobre a d&iacute;vida antes de sua disponibiliza&ccedil;&atilde;o, n&atilde;o h&aacute; que se falar em dano moral, tampouco na exclus&atilde;o da inser&ccedil;&atilde;o de seu nome em cadastro de inadimplentes, eis que leg&iacute;tima. Senten&ccedil;a de improced&ecirc;ncia mantida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801111-31.2024.8.12.0035,&nbsp; Iguatemi,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(10 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Iguatemi
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR  DANOS MORAIS – INSCRIÇÃO EM ÓRGÃOS DE PROTEÇÃO AO CRÉDITO –  NOTIFICAÇÃO PRÉVIA AO CADASTRO – EVIDENCIADO O CUMPRIMENTO DA EXIGÊNCIA LEGAL PREVISTA NO ARTIGO 43, § 2º, DO CÓDIGO DE DEFESA DO CONSUMIDOR –  APLICAÇÃO DA TESE JURÍDICA FIXADA NO JULGAMENTO DO IRDR N. 0835488-67.2023.8.12.0001 – NOTIFICAÇÃO PRÉVIA ELETRÔNICA – CORRESPONDÊNCIA E SMS – SENTENÇA
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE INDENIZAÇÃO POR  DANOS MORAIS – INSCRIÇÃO EM ÓRGÃOS DE PROTEÇÃO AO CRÉDITO –  NOTIFICAÇÃO PRÉVIA AO CADASTRO – EVIDENCIADO O CUMPRIMENTO DA EXIGÊNCIA LEGAL PREVISTA NO ARTIGO 43, § 2º, DO CÓDIGO DE DEFESA DO CONSUMIDOR –  APLICAÇÃO DA TESE JURÍDICA FIXADA NO JULGAMENTO DO IRDR N. 0835488-67.2023.8.12.0001 – NOTIFICAÇÃO PRÉVIA ELETRÔNICA – CORRESPONDÊNCIA E SMS – SENTENÇA MANTIDA – RECURSO CONHECIDO E DESPROVIDO.
+
+Como a finalidade da legislação consumerista foi alcançada, tendo sido a parte autora previamente notificada sobre a dívida antes de sua disponibilização, não há que se falar em <em>dano</em> <em>moral</em>, tampouco na exclusão da inserção de seu nome em cadastro de inadimplentes, eis que legítima. Sentença de improcedência mantida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>179&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876066" cdForo="0" >
+										0800157-25.2023.8.12.0033
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876066" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876066);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876066" style="display: none;" >
+	<div id="textAreaDados_1876066" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE NULIDADE DE CONTRATO DE CART&Atilde;O DE CR&Eacute;DITO COM RESERVA DE MARGEM CONSIGN&Aacute;VEL C/C INEXIST&Ecirc;NCIA DE D&Eacute;BITO, RESTITUI&Ccedil;&Atilde;O DE VALORES E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; PRELIMINAR RECURSAL DE NULIDADE DA SENTEN&Ccedil;A POR CERCEAMENTO DE DEFESA &ndash; AFASTADA &ndash; M&Eacute;RITO &ndash; ALEGA&Ccedil;&Atilde;O DE AUS&Ecirc;NCIA DE CONTRATA&Ccedil;&Atilde;O DO CR&Eacute;DITO POR MEIO DE CART&Atilde;O &ndash; PRODUTO DE SAQUE COM O CART&Atilde;O DEPOSITADO EM CONTA CORRENTE DE TITULARIDADE DA PARTE AUTORA &ndash; N&Atilde;O UTILIZA&Ccedil;&Atilde;O DO CART&Atilde;O DE CR&Eacute;DITO PARA COMPRAS &ndash; OCORR&Ecirc;NCIA DE ERRO SUBSTANCIAL &ndash; V&Iacute;CIO DE CONSENTIMENTO &ndash; POSSIBILIDADE, TODAVIA, DE APROVEITAMENTO DO NEG&Oacute;CIO JUR&Iacute;DICO &ndash; CONVERS&Atilde;O DO CONTRATO EM M&Uacute;TUO COM CONSIGNA&Ccedil;&Atilde;O EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; DANOS MORAIS &ndash; INOCORR&Ecirc;NCIA &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I -  O indeferimento de produ&ccedil;&atilde;o de prova desnecess&aacute;ria ao deslinde da demanda n&atilde;o acarreta&nbsp;cerceamento&nbsp;do direito de&nbsp;defesa.
+II - Havendo prova de que a parte autora se beneficiou do produto do m&uacute;tuo banc&aacute;rio, por&eacute;m sem a utiliza&ccedil;&atilde;o do cart&atilde;o de cr&eacute;dito para compras a prazo, resta evidente a ocorr&ecirc;ncia de indu&ccedil;&atilde;o do cliente a erro, impondo-se a declara&ccedil;&atilde;o de nulidade do contrato e a determina&ccedil;&atilde;o de sua convers&atilde;o para a modalidade de empr&eacute;stimo consignado em benef&iacute;cio previdenci&aacute;rio, com a aplica&ccedil;&atilde;o das taxas de juros m&eacute;dia do mercado aferidas pelo BACEN na data da contrata&ccedil;&atilde;o.
+III - Considerando que a parte autora se beneficiou do valor disponibilizado em sua conta banc&aacute;ria, afiguram-se leg&iacute;timos os descontos efetuados pela institui&ccedil;&atilde;o financeira r&eacute;, uma vez que agiu no exerc&iacute;cio regular de seu direito, n&atilde;o havendo que se falar em ato il&iacute;cito e, por consequ&ecirc;ncia, no dever de indenizar os danos morais.   <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800157-25.2023.8.12.0033,&nbsp; Eldorado,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Contratos Bancários
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Eldorado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL C/C INEXISTÊNCIA DE DÉBITO, RESTITUIÇÃO DE VALORES E INDENIZAÇÃO POR DANOS MORAIS – PRELIMINAR RECURSAL DE NULIDADE DA SENTENÇA POR CERCEAMENTO DE DEFESA – AFASTADA – MÉRITO – ALEGAÇÃO DE AUSÊNCIA DE CONTRATAÇÃO DO CRÉDITO POR MEIO DE CARTÃO – PRODUTO DE SAQUE COM O CARTÃO DEPOSITADO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE NULIDADE DE CONTRATO DE CARTÃO DE CRÉDITO COM RESERVA DE MARGEM CONSIGNÁVEL C/C INEXISTÊNCIA DE DÉBITO, RESTITUIÇÃO DE VALORES E INDENIZAÇÃO POR DANOS MORAIS – PRELIMINAR RECURSAL DE NULIDADE DA SENTENÇA POR CERCEAMENTO DE DEFESA – AFASTADA – MÉRITO – ALEGAÇÃO DE AUSÊNCIA DE CONTRATAÇÃO DO CRÉDITO POR MEIO DE CARTÃO – PRODUTO DE SAQUE COM O CARTÃO DEPOSITADO EM CONTA CORRENTE DE TITULARIDADE DA PARTE AUTORA – NÃO UTILIZAÇÃO DO CARTÃO DE CRÉDITO PARA COMPRAS – OCORRÊNCIA DE ERRO SUBSTANCIAL – VÍCIO DE CONSENTIMENTO – POSSIBILIDADE, TODAVIA, DE APROVEITAMENTO DO NEGÓCIO JURÍDICO – CONVERSÃO DO CONTRATO EM MÚTUO COM CONSIGNAÇÃO EM BENEFÍCIO PREVIDENCIÁRIO – DANOS MORAIS – INOCORRÊNCIA – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I -  O indeferimento de produção de prova desnecessária ao deslinde da demanda não acarreta cerceamento do direito de defesa.
+II - Havendo prova de que a parte autora se beneficiou do produto do mútuo bancário, porém sem a utilização do cartão de crédito para compras a prazo, resta evidente a ocorrência de indução do cliente a erro, impondo-se a declaração de nulidade do contrato e a determinação de sua conversão para a modalidade de empréstimo consignado em benefício previdenciário, com a aplicação das taxas de juros média do mercado aferidas pelo BACEN na data da contratação.
+III - Considerando que a parte autora se beneficiou do valor disponibilizado em sua conta bancária, afiguram-se legítimos os descontos efetuados pela instituição financeira ré, uma vez que agiu no exercício regular de seu direito, não havendo que se falar em ato ilícito e, por consequência, no dever de indenizar os danos morais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>180&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876069" cdForo="0" >
+										1405159-21.2026.8.12.0000
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876069" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876069);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876069" style="display: none;" >
+	<div id="textAreaDados_1876069" class="mensagemSemFormatacao" >
+		AGRAVO DE INSTRUMENTO &ndash; DECIS&Atilde;O QUE DECLINOU COMPET&Ecirc;NCIA AO JUIZADO ESPECIAL DA FAZENDA P&Uacute;BLICA &ndash; REGRA DE COMPET&Ecirc;NCIA ABSOLUTA - A&Ccedil;&Atilde;O INDIVIDUAL DE INDENIZA&Ccedil;&Atilde;O PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANIT&Aacute;RIO &ndash; QUEST&Atilde;O AMBIENTAL TRATADA T&Atilde;O SOMENTE DE MANEIRA REFLEXA &ndash; PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SAL&Aacute;RIOS M&Iacute;NIMOS - PREVAL&Ecirc;NCIA COMPET&Ecirc;NCIA DO JUIZADO ESPECIAL DA FAZENDA P&Uacute;BLICA &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO &ndash; DECIS&Atilde;O MANTIDA.
+Recai sobre o Juizado Especial da Fazenda P&uacute;blica a compet&ecirc;ncia para processar e julgar pedido de dano moral individual ocasionado por suposta les&atilde;o ambiental provocada pelo Munic&iacute;pio, consistente em destina&ccedil;&atilde;o err&ocirc;nea dada a aterro sanit&aacute;rio.
+A suposta les&atilde;o ambiental deve ser tratada t&atilde;o somente de maneira reflexa, pois o dano ambiental pode afetar, simultaneamente, o bem jur&iacute;dico ambiental e outros interesses jur&iacute;dicos individuais. Na hip&oacute;tese de dano individual, a decis&atilde;o que vier a ser prolatada afetar&aacute; exclusivamente a esfera de interesse das partes envolvidas.
+O STJ possui entendimento consolidado &ndash; expressamente reafirmado no IAC 10, com efeito vinculante nos termos do art. 927 do CPC &ndash; no sentido de que a compet&ecirc;ncia dos Juizados Especiais da Fazenda P&uacute;blica, onde instalados, &eacute; absoluta, e que os crit&eacute;rios de afastamento dessa compet&ecirc;ncia s&atilde;o apenas os expressamente previstos na lei, n&atilde;o comportando amplia&ccedil;&atilde;o por interpreta&ccedil;&atilde;o judicial, revelando-se irrelevante a complexidade da prova.
+No caso concreto, o valor da causa &eacute; de R$ 25.000,00, soma inferior ao limite de sessenta sal&aacute;rios m&iacute;nimos atualmente vigente; a demanda n&atilde;o se enquadra em qualquer das exce&ccedil;&otilde;es do &sect; 1&ordm; do art. 2&ordm; da Lei n. 12.153/2009 &ndash; porquanto n&atilde;o se trata de mandado de seguran&ccedil;a, desapropria&ccedil;&atilde;o, divis&atilde;o e demarca&ccedil;&atilde;o, a&ccedil;&atilde;o popular, improbidade administrativa, execu&ccedil;&atilde;o fiscal ou demanda sobre bens im&oacute;veis, pelo que consubstanciada a compet&ecirc;ncia absoluta dos Juizados Especiais da Fazenda P&uacute;blica.  <br><br>(<b>TJMS</b>. Agravo de Instrumento n. 1405159-21.2026.8.12.0000,&nbsp; Campo Grande,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Ju&iacute;za Denize de Barros Dodero, j: 10/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(19 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo de Instrumento / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juíza Denize de Barros Dodero
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									10/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DECISÃO QUE DECLINOU COMPETÊNCIA AO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – REGRA DE COMPETÊNCIA ABSOLUTA - AÇÃO INDIVIDUAL DE INDENIZAÇÃO PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANITÁRIO – QUESTÃO AMBIENTAL TRATADA TÃO SOMENTE DE MANEIRA REFLEXA – PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SALÁRIOS MÍNIMOS - PREVALÊNCIA COMPETÊNCIA DO JUIZADO ESPECIAL
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>AGRAVO DE INSTRUMENTO – DECISÃO QUE DECLINOU COMPETÊNCIA AO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – REGRA DE COMPETÊNCIA ABSOLUTA - AÇÃO INDIVIDUAL DE INDENIZAÇÃO PELOS DANOS MORAIS CAUSADOS POR IRREGULARIDADES EM ATERRO SANITÁRIO – QUESTÃO AMBIENTAL TRATADA TÃO SOMENTE DE MANEIRA REFLEXA – PROVA PERICIAL -  VALOR DA CAUSA INFERIOR A 60 SALÁRIOS MÍNIMOS - PREVALÊNCIA COMPETÊNCIA DO JUIZADO ESPECIAL DA FAZENDA PÚBLICA – RECURSO CONHECIDO E NÃO PROVIDO – DECISÃO MANTIDA.
+Recai sobre o Juizado Especial da Fazenda Pública a competência para processar e julgar pedido de <em>dano</em> <em>moral</em> individual ocasionado por suposta lesão ambiental provocada pelo Município, consistente em destinação errônea dada a aterro sanitário.
+A suposta lesão ambiental deve ser tratada tão somente de maneira reflexa, pois o <em>dano</em> ambiental pode afetar, simultaneamente, o bem jurídico ambiental e outros interesses jurídicos individuais. Na hipótese de <em>dano</em> individual, a decisão que vier a ser prolatada afetará exclusivamente a esfera de interesse das partes envolvidas.
+O STJ possui entendimento consolidado – expressamente reafirmado no IAC 10, com efeito vinculante nos termos do art. 927 do CPC – no sentido de que a competência dos Juizados Especiais da Fazenda Pública, onde instalados, é absoluta, e que os critérios de afastamento dessa competência são apenas os expressamente previstos na lei, não comportando ampliação por interpretação judicial, revelando-se irrelevante a complexidade da prova.
+No caso concreto, o valor da causa é de R$ 25.000,00, soma inferior ao limite de sessenta salários mínimos atualmente vigente; a demanda não se enquadra em qualquer das exceções do § 1º do art. 2º da Lei n. 12.153/2009 – porquanto não se trata de mandado de segurança, desapropriação, divisão e demarcação, ação popular, improbidade administrativa, execução fiscal ou demanda sobre bens imóveis, pelo que consubstanciada a competência absoluta dos Juizados Especiais da Fazenda Pública.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>181&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876076" cdForo="0" >
+										0800999-03.2025.8.12.0011
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876076" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876076);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876076" style="display: none;" >
+	<div id="textAreaDados_1876076" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; RECURSO DA PARTE AUTORA &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO, COM PEDIDO DE TUTELA PROVIS&Oacute;RIA DE URG&Ecirc;NCIA &ndash;  COMPRAS REALIZADAS COM CART&Atilde;O DE CR&Eacute;DITO - V&Iacute;TIMA DO GOLPE QUE CONFIRMOU OS LAN&Ccedil;AMENTOS PELO  APLICATIVO DO BANCO AP&Oacute;S CONTATO DE TERCEIRO  FRAUDADOR     &ndash; FATO IMPREVIS&Iacute;VEL QUE FOGE DO DEVER DE FISCALIZA&Ccedil;&Atilde;O E DE SEGURAN&Ccedil;A DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; FORTUITO EXTERNO &ndash; NEXO CAUSAL ROMPIDO &ndash; INC&Uacute;RIA DO CONSUMIDOR &ndash; CULPA EXCLUSIVA DE TERCEIRO E DA V&Iacute;TIMA &ndash; DEVER DE INDENIZAR N&Atilde;O CARACTERIZADO &ndash; PREQUESTIONAMENTO DE ARTIGOS DE LEI &ndash; DESNECESSIDADE &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+I -  Considerando que a autora reconhece que   seguiu as instru&ccedil;&otilde;es do fraudador atrav&eacute;s de contrato telef&ocirc;nico e confirmou os lan&ccedil;amentos das compras perante o aplicativo do banco, caracterizou-se a ocorr&ecirc;ncia de fato imprevis&iacute;vel que foge ao dever de fiscaliza&ccedil;&atilde;o e de seguran&ccedil;a da institui&ccedil;&atilde;o financeira, tratando-se, portanto, de caso fortuito externo, alheio &agrave; atividade ou ao servi&ccedil;o prestado &agrave; consumidora, rompendo o nexo de causalidade, em virtude de excludente de responsabilidade fundada na culpa exclusiva de terceiro.
+II - N&atilde;o h&aacute; como atribuir responsabilidade civil &agrave; institui&ccedil;&atilde;o financeira quando o preju&iacute;zo experimentado pelo consumidor se d&aacute; por sua exclusiva culpa, tendo em vista que n&atilde;o agiu prudentemente ao analisar fatos que, por si, fogem &agrave; normalidade, sendo pass&iacute;veis de gerar desconfian&ccedil;a.
+III - Se a quest&atilde;o foi suficientemente debatida, n&atilde;o se faz necess&aacute;ria a expressa manifesta&ccedil;&atilde;o sobre os dispositivos legais mencionados pela parte.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800999-03.2025.8.12.0011,&nbsp; Coxim,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(4 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Coxim
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – RECURSO DA PARTE AUTORA – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO, COM PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA –  COMPRAS REALIZADAS COM CARTÃO DE CRÉDITO - VÍTIMA DO GOLPE QUE CONFIRMOU OS LANÇAMENTOS PELO  APLICATIVO DO BANCO APÓS CONTATO DE TERCEIRO  FRAUDADOR     – FATO IMPREVISÍVEL QUE FOGE DO DEVER DE FISCALIZAÇÃO E DE SEGURANÇA DA INSTITUIÇÃO FINANCEIRA – FORTUITO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – RECURSO DA PARTE AUTORA – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO, COM PEDIDO DE TUTELA PROVISÓRIA DE URGÊNCIA –  COMPRAS REALIZADAS COM CARTÃO DE CRÉDITO - VÍTIMA DO GOLPE QUE CONFIRMOU OS LANÇAMENTOS PELO  APLICATIVO DO BANCO APÓS CONTATO DE TERCEIRO  FRAUDADOR     – FATO IMPREVISÍVEL QUE FOGE DO DEVER DE FISCALIZAÇÃO E DE SEGURANÇA DA INSTITUIÇÃO FINANCEIRA – FORTUITO EXTERNO – NEXO CAUSAL ROMPIDO – INCÚRIA DO CONSUMIDOR – CULPA EXCLUSIVA DE TERCEIRO E DA VÍTIMA – DEVER DE INDENIZAR NÃO CARACTERIZADO – PREQUESTIONAMENTO DE ARTIGOS DE LEI – DESNECESSIDADE – RECURSO CONHECIDO E NÃO PROVIDO.
+I -  Considerando que a autora reconhece que   seguiu as instruções do fraudador através de contrato telefônico e confirmou os lançamentos das compras perante o aplicativo do banco, caracterizou-se a ocorrência de fato imprevisível que foge ao dever de fiscalização e de segurança da instituição financeira, tratando-se, portanto, de caso fortuito externo, alheio à atividade ou ao serviço prestado à consumidora, rompendo o nexo de causalidade, em virtude de excludente de responsabilidade fundada na culpa exclusiva de terceiro.
+II - Não há como atribuir responsabilidade civil à instituição financeira quando o prejuízo experimentado pelo consumidor se dá por sua exclusiva culpa, tendo em vista que não agiu prudentemente ao analisar fatos que, por si, fogem à normalidade, sendo passíveis de gerar desconfiança.
+III - Se a questão foi suficientemente debatida, não se faz necessária a expressa manifestação sobre os dispositivos legais mencionados pela parte.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>182&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876078" cdForo="0" >
+										0840983-97.2020.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876078" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876078);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876078" style="display: none;" >
+	<div id="textAreaDados_1876078" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; RESPONSABILIDADE CIVIL &ndash; DANOS MORAIS &ndash; REDU&Ccedil;&Atilde;O DO QUANTUM &ndash; DANOS EST&Eacute;TICOS &ndash; POSSIBILIDADE DE CUMULA&Ccedil;&Atilde;O &ndash; PENS&Atilde;O VITAL&Iacute;CIA &ndash; AUS&Ecirc;NCIA DE INCAPACIDADE LABORATIVA &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA
+
+CASO EM EXAME
+
+Apela&ccedil;&otilde;es c&iacute;veis interpostas contra senten&ccedil;a que julgou parcialmente procedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, est&eacute;ticos e materiais decorrentes de acidente de tr&acirc;nsito, condenando o r&eacute;u ao pagamento de indeniza&ccedil;&otilde;es e rejeitando o pedido de pens&atilde;o mensal vital&iacute;cia.
+
+QUEST&Atilde;O EM DISCUSS&Atilde;O
+
+Discute-se:
+(i) a adequa&ccedil;&atilde;o do valor arbitrado a t&iacute;tulo de danos morais;
+(ii) a possibilidade de cumula&ccedil;&atilde;o entre danos morais e danos est&eacute;ticos;
+(iii) a exist&ecirc;ncia de incapacidade laborativa apta a justificar o pagamento de pens&atilde;o vital&iacute;cia.
+
+RAZ&Otilde;ES DE DECIDIR
+Responsabilidade civil:
+Comprovada a culpa do r&eacute;u pelo acidente, ao invadir via preferencial sem a devida cautela, configurando ato il&iacute;cito indeniz&aacute;vel nos termos dos arts. 186 e 927 do C&oacute;digo Civil.
+Danos morais:
+Caracterizados in re ipsa, diante da gravidade das les&otilde;es sofridas (politrauma, fratura exposta e procedimento cir&uacute;rgico), sendo devida a indeniza&ccedil;&atilde;o. Contudo, o valor arbitrado na origem (R$ 10.000,00) mostra-se elevado diante das circunst&acirc;ncias do caso e da capacidade econ&ocirc;mica das partes, impondo-se a redu&ccedil;&atilde;o para R$ 5.000,00, em observ&acirc;ncia aos princ&iacute;pios da razoabilidade e proporcionalidade.
+Danos est&eacute;ticos:
+Poss&iacute;vel a cumula&ccedil;&atilde;o com danos morais, conforme entendimento consolidado do STJ (S&uacute;mula 387). No caso, comprovada a exist&ecirc;ncia de cicatrizes decorrentes do acidente, sendo adequada a manuten&ccedil;&atilde;o do valor fixado em R$ 3.000,00.
+Pens&atilde;o vital&iacute;cia:
+Invi&aacute;vel a concess&atilde;o, pois o laudo pericial concluiu pela inexist&ecirc;ncia de incapacidade ou redu&ccedil;&atilde;o da capacidade laborativa, n&atilde;o sendo infirmado pelo conjunto probat&oacute;rio. Ausente requisito do art. 950 do C&oacute;digo Civil.
+Conclus&atilde;o:
+Recurso do r&eacute;u parcialmente provido apenas para reduzir o valor dos danos morais. Recurso do autor desprovido.
+DISPOSITIVO
+
+Recurso de F&eacute;lix Melgarejo conhecido e parcialmente provido para reduzir a indeniza&ccedil;&atilde;o por danos morais para R$ 5.000,00.
+Recurso de Higo Leme da Silva da Hora conhecido e desprovido.
+
+TESE
+
+(i) &Eacute; devida a indeniza&ccedil;&atilde;o por danos morais decorrentes de acidente de tr&acirc;nsito, podendo seu valor ser reduzido quando excessivo, &agrave; luz dos princ&iacute;pios da razoabilidade e proporcionalidade;
+(ii) &Eacute; l&iacute;cita a cumula&ccedil;&atilde;o de danos morais e est&eacute;ticos, quando aut&ocirc;nomos;
+(iii) A pens&atilde;o vital&iacute;cia exige comprova&ccedil;&atilde;o de incapacidade ou redu&ccedil;&atilde;o da capacidade laborativa, n&atilde;o sendo devida na sua aus&ecirc;ncia.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0840983-97.2020.8.12.0001,&nbsp; Campo Grande,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 12/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(32 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									12/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – RESPONSABILIDADE CIVIL – DANOS MORAIS – REDUÇÃO DO QUANTUM – DANOS ESTÉTICOS – POSSIBILIDADE DE CUMULAÇÃO – PENSÃO VITALÍCIA – AUSÊNCIA DE INCAPACIDADE LABORATIVA – SENTENÇA PARCIALMENTE REFORMADA
+
+CASO EM EXAME
+
+Apelações cíveis interpostas contra sentença que julgou parcialmente procedente ação de indenização por danos morais,
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DE INDENIZAÇÃO – ACIDENTE DE TRÂNSITO – RESPONSABILIDADE CIVIL – DANOS MORAIS – REDUÇÃO DO QUANTUM – DANOS ESTÉTICOS – POSSIBILIDADE DE CUMULAÇÃO – PENSÃO VITALÍCIA – AUSÊNCIA DE INCAPACIDADE LABORATIVA – SENTENÇA PARCIALMENTE REFORMADA
+
+CASO EM EXAME
+
+Apelações cíveis interpostas contra sentença que julgou parcialmente procedente ação de indenização por danos morais, estéticos e materiais decorrentes de acidente de trânsito, condenando o réu ao pagamento de indenizações e rejeitando o pedido de pensão mensal vitalícia.
+
+QUESTÃO EM DISCUSSÃO
+
+Discute-se:
+(i) a adequação do valor arbitrado a título de danos morais;
+(ii) a possibilidade de cumulação entre danos morais e danos estéticos;
+(iii) a existência de incapacidade laborativa apta a justificar o pagamento de pensão vitalícia.
+
+RAZÕES DE DECIDIR
+Responsabilidade civil:
+Comprovada a culpa do réu pelo acidente, ao invadir via preferencial sem a devida cautela, configurando ato ilícito indenizável nos termos dos arts. 186 e 927 do Código Civil.
+Danos morais:
+Caracterizados in re ipsa, diante da gravidade das lesões sofridas (politrauma, fratura exposta e procedimento cirúrgico), sendo devida a indenização. Contudo, o valor arbitrado na origem (R$ 10.000,00) mostra-se elevado diante das circunstâncias do caso e da capacidade econômica das partes, impondo-se a redução para R$ 5.000,00, em observância aos princípios da razoabilidade e proporcionalidade.
+Danos estéticos:
+Possível a cumulação com danos morais, conforme entendimento consolidado do STJ (Súmula 387). No caso, comprovada a existência de cicatrizes decorrentes do acidente, sendo adequada a manutenção do valor fixado em R$ 3.000,00.
+Pensão vitalícia:
+Inviável a concessão, pois o laudo pericial concluiu pela inexistência de incapacidade ou redução da capacidade laborativa, não sendo infirmado pelo conjunto probatório. Ausente requisito do art. 950 do Código Civil.
+Conclusão:
+Recurso do réu parcialmente provido apenas para reduzir o valor dos danos morais. Recurso do autor desprovido.
+DISPOSITIVO
+
+Recurso de Félix Melgarejo conhecido e parcialmente provido para reduzir a indenização por danos morais para R$ 5.000,00.
+Recurso de Higo Leme da Silva da Hora conhecido e desprovido.
+
+TESE
+
+(i) É devida a indenização por danos morais decorrentes de acidente de trânsito, podendo seu valor ser reduzido quando excessivo, à luz dos princípios da razoabilidade e proporcionalidade;
+(ii) É lícita a cumulação de danos morais e estéticos, quando autônomos;
+(iii) A pensão vitalícia exige comprovação de incapacidade ou redução da capacidade laborativa, não sendo devida na sua ausência.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>183&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876083" cdForo="0" >
+										0837191-38.2020.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876083" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876083);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876083" style="display: none;" >
+	<div id="textAreaDados_1876083" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O REGRESSIVA DE RESSARCIMENTO &ndash; M&Eacute;RITO &ndash; CONTRATO DE SEGURO &ndash; DESCARGAS EL&Eacute;TRICAS &ndash; ALTERA&Ccedil;&Atilde;O DE TENS&Atilde;O &ndash; RESPONSABILIDADE CIVIL DA CONCESSION&Aacute;RIA DE ENERGIA EL&Eacute;TRICA &ndash; RESSARCIMENTO DOS VALORES DESPENDIDOS PELA SEGURADORA EM VIRTUDE DO SINISTRO &ndash; DEVIDO &ndash;   RECURSO  CONHECIDO E DESPROVIDO.
+I - A responsabilidade ressarcit&oacute;ria da concession&aacute;ria requerida, na qualidade de prestadora de servi&ccedil;o p&uacute;blico, &eacute; objetiva e decorre do &sect; 6&ordm; do art. 37 da CF/88, sendo, por isso, desnecess&aacute;ria a demonstra&ccedil;&atilde;o de culpa ou dolo, basta que se verifique o ato il&iacute;cito e o nexo causal.
+II - A prova de que os danos no equipamento do segurado da parte autora decorreram de oscila&ccedil;&atilde;o na rede el&eacute;trica administrada pela requerida, como alegado na inicial, confere respaldo &agrave; pretens&atilde;o regressiva da seguradora.
+  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0837191-38.2020.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Marco Andr&eacute; Nogueira Hanson, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(15 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Marco André Nogueira Hanson
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REGRESSIVA DE RESSARCIMENTO – MÉRITO – CONTRATO DE SEGURO – DESCARGAS ELÉTRICAS – ALTERAÇÃO DE TENSÃO – RESPONSABILIDADE CIVIL DA CONCESSIONÁRIA DE ENERGIA ELÉTRICA – RESSARCIMENTO DOS VALORES DESPENDIDOS PELA SEGURADORA EM VIRTUDE DO SINISTRO – DEVIDO –   RECURSO  CONHECIDO E DESPROVIDO.
+I - A responsabilidade ressarcitória da concessionária requerida, na qualidade de
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REGRESSIVA DE RESSARCIMENTO – MÉRITO – CONTRATO DE SEGURO – DESCARGAS ELÉTRICAS – ALTERAÇÃO DE TENSÃO – RESPONSABILIDADE CIVIL DA CONCESSIONÁRIA DE ENERGIA ELÉTRICA – RESSARCIMENTO DOS VALORES DESPENDIDOS PELA SEGURADORA EM VIRTUDE DO SINISTRO – DEVIDO –   RECURSO  CONHECIDO E DESPROVIDO.
+I - A responsabilidade ressarcitória da concessionária requerida, na qualidade de prestadora de serviço público, é objetiva e decorre do § 6º do art. 37 da CF/88, sendo, por isso, desnecessária a demonstração de culpa ou dolo, basta que se verifique o ato ilícito e o nexo causal.
+II - A prova de que os danos no equipamento do segurado da parte autora decorreram de oscilação na rede elétrica administrada pela requerida, como alegado na inicial, confere respaldo à pretensão regressiva da seguradora.
+
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>184&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876094" cdForo="0" >
+										0802078-30.2024.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876094" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876094);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876094" style="display: none;" >
+	<div id="textAreaDados_1876094" class="mensagemSemFormatacao" >
+		Apelante	: Jair Pereira da Silva.
+Advogada	: Taiz Cristina Pereira da Silva Xavier (OAB: 17532/MS).
+Advogada	: Daiane de Oliveira Elias (OAB: 30371/MS).
+Apelado	: Luiz Gustavo Ferreira Lopes.
+Advogada	: Vanessa Gouveia Barbosa (OAB: 22379/MS).
+Advogado	: Marcos Ant&ocirc;nio Moreira Ferraz (OAB: 11390/MS).
+EMENTA &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O REPARAT&Oacute;RIA DE DANOS &ndash; ACIDENTE DE TR&Acirc;NSITO &ndash; PRELIMINAR EM CONTRARRAZ&Otilde;ES &ndash; OFENSA AO PRINC&Iacute;PIO DA DIALETICIDADE &ndash; AFASTADA &ndash; M&Eacute;RITO &ndash; MANOBRA DE MARCHA &Agrave; R&Eacute; PARA SA&Iacute;DA DE GARAGEM &ndash; CULPA EXCLUSIVA DO R&Eacute;U MANTIDA &ndash; DANOS MATERIAIS &ndash; OR&Ccedil;AMENTO &Uacute;NICO &ndash; VALIDADE &ndash; DEVER DE REPARAR MANTIDO &ndash; DANO EST&Eacute;TICO &ndash; REQUISITOS &ndash; DEFORMIDADE PERMANENTE E SIGNIFICATIVA &ndash; AUS&Ecirc;NCIA DE PROVA ROBUSTA &ndash; CONDENA&Ccedil;&Atilde;O AFASTADA &ndash; DANO MORAL &ndash; QUANTUM INDENIZAT&Oacute;RIO &ndash; OBSERV&Acirc;NCIA DOS PRINC&Iacute;PIOS DA RAZOABILIDADE E PROPORCIONALIDADE &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Rejeita-se a preliminar de aus&ecirc;ncia de dialeticidade, pois o recurso est&aacute; devidamente fundamentado.
+Mant&eacute;m-se o reconhecimento da culpa exclusiva do r&eacute;u que, ao realizar manobra de marcha a r&eacute; de forma imprudente, viola seu dever de cuidado excepcional (art. 34, CTB) e intercepta a trajet&oacute;ria de ve&iacute;culo que trafega na via preferencial.
+A apresenta&ccedil;&atilde;o de um &uacute;nico or&ccedil;amento, desde que n&atilde;o se mostre manifestamente inid&ocirc;neo, &eacute; prova suficiente para a demonstra&ccedil;&atilde;o dos danos materiais, mormente quando a parte adversa, limita-se a contesta-lo genericamente.
+O dano est&eacute;tico, para sua configura&ccedil;&atilde;o, demanda prova de uma altera&ccedil;&atilde;o morfol&oacute;gica permanente que cause um efetivo afeiamento na v&iacute;tima. Meras cicatrizes, cuja relev&acirc;ncia e impacto n&atilde;o s&atilde;o cabalmente demonstrados, n&atilde;o autorizam a condena&ccedil;&atilde;o.
+Deve ser mantido o valor da indeniza&ccedil;&atilde;o por danos morais (R$ 10.000,00) quando este se mostra condizente com a gravidade da les&atilde;o sofrida, o abalo psicol&oacute;gico decorrente e os par&acirc;metros adotados pela jurisprud&ecirc;ncia em casos an&aacute;logos, atendendo &agrave; dupla finalidade compensat&oacute;ria e pedag&oacute;gica da medida, sem implicar enriquecimento il&iacute;cito.
+ Recurso conhecido e parcialmente provido para, unicamente, afastar a condena&ccedil;&atilde;o do apelante ao pagamento de danos est&eacute;ticos.
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, deram parcial provimento ao recurso, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0802078-30.2024.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(22 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Acidente de Trânsito
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Apelante	: Jair Pereira da Silva.
+Advogada	: Taiz Cristina Pereira da Silva Xavier (OAB: 17532/MS).
+Advogada	: Daiane de Oliveira Elias (OAB: 30371/MS).
+Apelado	: Luiz Gustavo Ferreira Lopes.
+Advogada	: Vanessa Gouveia Barbosa (OAB: 22379/MS).
+Advogado	: Marcos Antônio Moreira Ferraz (OAB: 11390/MS).
+EMENTA – APELAÇÃO CÍVEL – AÇÃO REPARATÓRIA DE DANOS – ACIDENTE DE TRÂNSITO –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Apelante	: Jair Pereira da Silva.
+Advogada	: Taiz Cristina Pereira da Silva Xavier (OAB: 17532/MS).
+Advogada	: Daiane de Oliveira Elias (OAB: 30371/MS).
+Apelado	: Luiz Gustavo Ferreira Lopes.
+Advogada	: Vanessa Gouveia Barbosa (OAB: 22379/MS).
+Advogado	: Marcos Antônio Moreira Ferraz (OAB: 11390/MS).
+EMENTA – APELAÇÃO CÍVEL – AÇÃO REPARATÓRIA DE DANOS – ACIDENTE DE TRÂNSITO – PRELIMINAR EM CONTRARRAZÕES – OFENSA AO PRINCÍPIO DA DIALETICIDADE – AFASTADA – MÉRITO – MANOBRA DE MARCHA À RÉ PARA SAÍDA DE GARAGEM – CULPA EXCLUSIVA DO RÉU MANTIDA – DANOS MATERIAIS – ORÇAMENTO ÚNICO – VALIDADE – DEVER DE REPARAR MANTIDO – <em>DANO</em> ESTÉTICO – REQUISITOS – DEFORMIDADE PERMANENTE E SIGNIFICATIVA – AUSÊNCIA DE PROVA ROBUSTA – CONDENAÇÃO AFASTADA – <em>DANO</em> <em>MORAL</em> – QUANTUM INDENIZATÓRIO – OBSERVÂNCIA DOS PRINCÍPIOS DA RAZOABILIDADE E PROPORCIONALIDADE – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Rejeita-se a preliminar de ausência de dialeticidade, pois o recurso está devidamente fundamentado.
+Mantém-se o reconhecimento da culpa exclusiva do réu que, ao realizar manobra de marcha a ré de forma imprudente, viola seu dever de cuidado excepcional (art. 34, CTB) e intercepta a trajetória de veículo que trafega na via preferencial.
+A apresentação de um único orçamento, desde que não se mostre manifestamente inidôneo, é prova suficiente para a demonstração dos danos materiais, mormente quando a parte adversa, limita-se a contesta-lo genericamente.
+O <em>dano</em> estético, para sua configuração, demanda prova de uma alteração morfológica permanente que cause um efetivo afeiamento na vítima. Meras cicatrizes, cuja relevância e impacto não são cabalmente demonstrados, não autorizam a condenação.
+Deve ser mantido o valor da indenização por danos morais (R$ 10.000,00) quando este se mostra condizente com a gravidade da lesão sofrida, o abalo psicológico decorrente e os parâmetros adotados pela jurisprudência em casos análogos, atendendo à dupla finalidade compensatória e pedagógica da medida, sem implicar enriquecimento ilícito.
+ Recurso conhecido e parcialmente provido para, unicamente, afastar a condenação do apelante ao pagamento de danos estéticos.
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, deram parcial provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>185&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876102" cdForo="0" >
+										0808837-98.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876102" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876102);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876102" style="display: none;" >
+	<div id="textAreaDados_1876102" class="mensagemSemFormatacao" >
+		DIREITO EMPRESARIAL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL DOS REQUERIDOS. DISSOLU&Ccedil;&Atilde;O PARCIAL DE SOCIEDADE LIMITADA. APURA&Ccedil;&Atilde;O DE HAVERES. BALAN&Ccedil;O DE DETERMINA&Ccedil;&Atilde;O. DEP&Oacute;SITO DE PARCELA INCONTROVERSA COM BASE NO VALOR NOMINAL DAS QUOTAS. MITIGA&Ccedil;&Atilde;O DO PACTA SUNT SERVANDA. RECURSO DESPROVIDO.
+O balan&ccedil;o de determina&ccedil;&atilde;o constitui o crit&eacute;rio mais adequado para apura&ccedil;&atilde;o de haveres em caso de dissenso, pois reflete o valor patrimonial real da sociedade mediante avalia&ccedil;&atilde;o de ativos e passivos a pre&ccedil;o de mercado, conforme orienta&ccedil;&atilde;o do STJ.
+A integraliza&ccedil;&atilde;o do capital social mediante bens im&oacute;veis refor&ccedil;a a necessidade de avalia&ccedil;&atilde;o patrimonial atualizada, justificando a ado&ccedil;&atilde;o do crit&eacute;rio legal em detrimento do contratual.
+O art. 604, &sect;1&ordm;, do CPC autoriza o dep&oacute;sito da parcela incontroversa, sendo esta corretamente identificada como o valor nominal das quotas integralizadas pelos s&oacute;cios retirantes.
+A participa&ccedil;&atilde;o societ&aacute;ria traduz fra&ccedil;&atilde;o do capital social, de modo que o valor integralizado pelos s&oacute;cios constitui quantia certa e incontroversa.
+A cl&aacute;usula contratual que prev&ecirc; pagamento em 30 presta&ccedil;&otilde;es anuais indexadas em arrobas de boi pode ser mitigada por excessiva onerosidade, &agrave; luz da boa-f&eacute; objetiva, fun&ccedil;&atilde;o social do contrato e veda&ccedil;&atilde;o ao enriquecimento sem causa.
+A aus&ecirc;ncia de comprova&ccedil;&atilde;o de incapacidade financeira da sociedade afasta a pretens&atilde;o de afastar ou substituir o dep&oacute;sito determinado judicialmente.
+Recurso conhecido e desprovido.
+EMENTA. DIREITO EMPRESARIAL E PROCESSUAL CIVIL. RECURSO ADESIVO DOS AUTORES. DISSOLU&Ccedil;&Atilde;O PARCIAL DE SOCIEDADE LIMITADA. HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS. CONCORD&Acirc;NCIA DOS REQUERIDOS COM A DISSOLU&Ccedil;&Atilde;O DA SOCIEDADE. AUS&Ecirc;NCIA DE LITIGIOSIDADE NA PRIMEIRA FASE. HONOR&Aacute;RIOS N&Atilde;O DEVIDOS. ART. 601, &sect;1&ordm; DO CPC. RECURSO ADESIVO DESPROVIDO.
+A diverg&ecirc;ncia sobre crit&eacute;rios de apura&ccedil;&atilde;o de haveres configura exerc&iacute;cio regular do direito de defesa, n&atilde;o caracterizando litig&acirc;ncia de m&aacute;-f&eacute;.
+A concord&acirc;ncia expressa das partes quanto &agrave; dissolu&ccedil;&atilde;o parcial atrai a aplica&ccedil;&atilde;o do art. 603, &sect;1&ordm;, do CPC, afastando a condena&ccedil;&atilde;o em honor&aacute;rios sucumbenciais, ainda que haja controv&eacute;rsia na fase de liquida&ccedil;&atilde;o.
+Recurso conhecido e desprovido.
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, negaram provimento aos recursos, nos termos do voto do Relator..  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0808837-98.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(3 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Dissolução
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO EMPRESARIAL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL DOS REQUERIDOS. DISSOLUÇÃO PARCIAL DE SOCIEDADE LIMITADA. APURAÇÃO DE HAVERES. BALANÇO DE DETERMINAÇÃO. DEPÓSITO DE PARCELA INCONTROVERSA COM BASE NO VALOR NOMINAL DAS QUOTAS. MITIGAÇÃO DO PACTA SUNT SERVANDA. RECURSO DESPROVIDO.
+O balanço de determinação constitui o critério mais adequado para apuração de haveres em caso de dissenso, pois
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO EMPRESARIAL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL DOS REQUERIDOS. DISSOLUÇÃO PARCIAL DE SOCIEDADE LIMITADA. APURAÇÃO DE HAVERES. BALANÇO DE DETERMINAÇÃO. DEPÓSITO DE PARCELA INCONTROVERSA COM BASE NO VALOR NOMINAL DAS QUOTAS. MITIGAÇÃO DO PACTA SUNT SERVANDA. RECURSO DESPROVIDO.
+O balanço de determinação constitui o critério mais adequado para apuração de haveres em caso de dissenso, pois reflete o valor patrimonial real da sociedade mediante avaliação de ativos e passivos a preço de mercado, conforme orientação do STJ.
+A integralização do capital social mediante bens imóveis reforça a necessidade de avaliação patrimonial atualizada, justificando a adoção do critério legal em detrimento do contratual.
+O art. 604, §1º, do CPC autoriza o depósito da parcela incontroversa, sendo esta corretamente identificada como o valor nominal das quotas integralizadas pelos sócios retirantes.
+A participação societária traduz fração do capital social, de modo que o valor integralizado pelos sócios constitui quantia certa e incontroversa.
+A cláusula contratual que prevê pagamento em 30 prestações anuais indexadas em arrobas de boi pode ser mitigada por excessiva onerosidade, à luz da boa-fé objetiva, função social do contrato e vedação ao enriquecimento sem causa.
+A ausência de comprovação de incapacidade financeira da sociedade afasta a pretensão de afastar ou substituir o depósito determinado judicialmente.
+Recurso conhecido e desprovido.
+EMENTA. DIREITO EMPRESARIAL E PROCESSUAL CIVIL. RECURSO ADESIVO DOS AUTORES. DISSOLUÇÃO PARCIAL DE SOCIEDADE LIMITADA. HONORÁRIOS ADVOCATÍCIOS. CONCORDÂNCIA DOS REQUERIDOS COM A DISSOLUÇÃO DA SOCIEDADE. AUSÊNCIA DE LITIGIOSIDADE NA PRIMEIRA FASE. HONORÁRIOS NÃO DEVIDOS. ART. 601, §1º DO CPC. RECURSO ADESIVO DESPROVIDO.
+A divergência sobre critérios de apuração de haveres configura exercício regular do direito de defesa, não caracterizando litigância de má-fé.
+A concordância expressa das partes quanto à dissolução parcial atrai a aplicação do art. 603, §1º, do CPC, afastando a condenação em honorários sucumbenciais, ainda que haja controvérsia na fase de liquidação.
+Recurso conhecido e desprovido.
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, negaram provimento aos recursos, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>186&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876103" cdForo="0" >
+										0808466-37.2024.8.12.0021
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876103" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876103);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876103" style="display: none;" >
+	<div id="textAreaDados_1876103" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; DESCONTOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; CONTRATA&Ccedil;&Atilde;O N&Atilde;O COMPROVADA &ndash; DESCONTOS INDEVIDOS &ndash; VALOR DA INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS &ndash; MAJORA&Ccedil;&Atilde;O DO QUANTUM &ndash; HONOR&Aacute;RIOS SUCUMBENCIAIS &ndash; QUANTUM MAJORADO PARA 15% SOBRE O VALOR DA CONDENA&Ccedil;&Atilde;O &ndash;  SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apela&ccedil;&atilde;o interposta pela parte autora contra senten&ccedil;a que julgou parcialmente procedentes os pedidos formulados em A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de D&eacute;bito c/c Indeniza&ccedil;&atilde;o por Danos Materiais e Morais.
+II. HIP&Oacute;TESE EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a justeza do valor da indeniza&ccedil;&atilde;o por danos morais; e, b) o valor dos honor&aacute;rios sucumbenciais.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Segundo o m&eacute;todo bif&aacute;sico de fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, na primeira etapa, deve-se estabelecer um valor b&aacute;sico, &agrave; luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jur&iacute;dico lesado; e, na segunda etapa, devem ser consideradas as circunst&acirc;ncias do caso, para a fixa&ccedil;&atilde;o definitiva do valor da indeniza&ccedil;&atilde;o, atendendo-se, assim, a determina&ccedil;&atilde;o legal de arbitramento equitativo pelo Juiz.
+4. Considerando-se o referido grupo de precedentes, e levando-se em conta a condi&ccedil;&atilde;o financeira das partes, a finalidade educativa e preventiva da condena&ccedil;&atilde;o, a razo&aacute;vel gravidade do dano, reputa-se adequado majorar o valor da indeniza&ccedil;&atilde;o por danos morais para R$ 5.000,00, montante que se afigura adequado e proporcional &agrave;s especificidades do caso em an&aacute;lise.
+5. Segundo o art. 85, &sect; 2&ordm;, do CPC, os honor&aacute;rios ser&atilde;o fixados entre o m&iacute;nimo de dez e o m&aacute;ximo de vinte por cento sobre o valor da condena&ccedil;&atilde;o, do proveito econ&ocirc;mico obtido ou, n&atilde;o sendo poss&iacute;vel mensur&aacute;-lo, sobre o valor atualizado da causa, atendidos: &quot;I - o grau de zelo do profissional; II - o lugar de presta&ccedil;&atilde;o do servi&ccedil;o; III - a natureza e a import&acirc;ncia da causa; IV - o trabalho realizado pelo advogado e o tempo exigido para o seu servi&ccedil;o&quot;. No caso, esses par&acirc;metros n&atilde;o foram na senten&ccedil;a, devendo ser majorado o percentual para 15% do valor da condena&ccedil;&atilde;o.
+IV. DISPOSITIVO
+5. Apela&ccedil;&atilde;o C&iacute;vel conhecida e parcialmente provida.    <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0808466-37.2024.8.12.0021,&nbsp; Tr&ecirc;s Lagoas,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(39 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Três Lagoas
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – CONTRATAÇÃO NÃO COMPROVADA – DESCONTOS INDEVIDOS – VALOR DA INDENIZAÇÃO POR DANOS MORAIS – MAJORAÇÃO DO QUANTUM – HONORÁRIOS SUCUMBENCIAIS – QUANTUM MAJORADO PARA 15% SOBRE O VALOR DA CONDENAÇÃO –  SENTENÇA PARCIALMENTE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO – CONTRATAÇÃO NÃO COMPROVADA – DESCONTOS INDEVIDOS – VALOR DA INDENIZAÇÃO POR DANOS MORAIS – MAJORAÇÃO DO QUANTUM – HONORÁRIOS SUCUMBENCIAIS – QUANTUM MAJORADO PARA 15% SOBRE O VALOR DA CONDENAÇÃO –  SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Apelação interposta pela parte autora contra sentença que julgou parcialmente procedentes os pedidos formulados em Ação Declaratória de Inexistência de Débito c/c Indenização por Danos Materiais e Morais.
+II. HIPÓTESE EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a justeza do valor da indenização por danos morais; e, b) o valor dos honorários sucumbenciais.
+III. RAZÕES DE DECIDIR
+3. Segundo o método bifásico de fixação de indenização por danos morais, na primeira etapa, deve-se estabelecer um valor básico, à luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jurídico lesado; e, na segunda etapa, devem ser consideradas as circunstâncias do caso, para a fixação definitiva do valor da indenização, atendendo-se, assim, a determinação legal de arbitramento equitativo pelo Juiz.
+4. Considerando-se o referido grupo de precedentes, e levando-se em conta a condição financeira das partes, a finalidade educativa e preventiva da condenação, a razoável gravidade do <em>dano</em>, reputa-se adequado majorar o valor da indenização por danos morais para R$ 5.000,00, montante que se afigura adequado e proporcional às especificidades do caso em análise.
+5. Segundo o art. 85, § 2º, do CPC, os honorários serão fixados entre o mínimo de dez e o máximo de vinte por cento sobre o valor da condenação, do proveito econômico obtido ou, não sendo possível mensurá-lo, sobre o valor atualizado da causa, atendidos: "I - o grau de zelo do profissional; II - o lugar de prestação do serviço; III - a natureza e a importância da causa; IV - o trabalho realizado pelo advogado e o tempo exigido para o seu serviço". No caso, esses parâmetros não foram na sentença, devendo ser majorado o percentual para 15% do valor da condenação.
+IV. DISPOSITIVO
+5. Apelação Cível conhecida e parcialmente provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>187&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876106" cdForo="0" >
+										0803246-09.2020.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876106" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876106);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876106" style="display: none;" >
+	<div id="textAreaDados_1876106" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DE INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS - RESPONSABILIDADE CIVIL OBJETIVA - CONCESSION&Aacute;RIA DE SERVI&Ccedil;O P&Uacute;BLICO - ESTA&Ccedil;&Atilde;O DE TRATAMENTO DE ESGOTO - MAU CHEIRO - DANO AMBIENTAL E &Agrave; SA&Uacute;DE DOS MORADORES - DANO MORAL CONFIGURADO - INDENIZA&Ccedil;&Atilde;O DEVIDA - SENTEN&Ccedil;A REFORMADA - RECURSO CONHECIDO E PROVIDO.
+A responsabilidade civil das concession&aacute;rias de servi&ccedil;o p&uacute;blico &eacute; objetiva, nos termos do art. 37, &sect; 6&ordm;, da CF e do art. 14 do CDC, sendo suficiente a comprova&ccedil;&atilde;o do dano e do nexo causal entre a atividade prestada e o preju&iacute;zo sofrido pelo consumidor.
+O Laudo pericial judicial demonstra que a ETE opera sem Licen&ccedil;a de Opera&ccedil;&atilde;o, com falhas t&eacute;cnicas como aus&ecirc;ncia de veda&ccedil;&atilde;o adequada e de cortina arb&oacute;rea, o que contribui significativamente para a emiss&atilde;o de odores, afetando o meio ambiente urbano e os moradores da regi&atilde;o.
+A falha na presta&ccedil;&atilde;o do servi&ccedil;o restou caracterizada, sendo comprovado que o odor &eacute; percept&iacute;vel, inc&ocirc;modo e favorece a prolifera&ccedil;&atilde;o de insetos, impactando negativamente a sa&uacute;de e o cotidiano dos residentes.
+O dano moral &eacute; configurado quando h&aacute; les&atilde;o relevante a direitos da personalidade, como a dignidade e a integridade psicof&iacute;sica, sendo o conv&iacute;vio prolongado com odor insalubre, baratas e desconforto ps&iacute;quico circunst&acirc;ncia que ultrapassa o mero aborrecimento.
+A condi&ccedil;&atilde;o social da autora, residente em &aacute;rea popular e sem alternativa de moradia, n&atilde;o afasta a responsabilidade da concession&aacute;ria, que deve prestar servi&ccedil;o adequado, eficiente e em conformidade com normas ambientais.
+A indeniza&ccedil;&atilde;o por danos morais deve cumprir fun&ccedil;&atilde;o compensat&oacute;ria e pedag&oacute;gica, sem ensejar enriquecimento sem causa, sendo razo&aacute;vel o arbitramento em R$ 2.000,00 (dois mil reais), com corre&ccedil;&atilde;o monet&aacute;ria pelo IPCA a partir do arbitramento (S&uacute;mula 362/STJ) e juros morat&oacute;rios de 1% ao m&ecirc;s desde a cita&ccedil;&atilde;o (S&uacute;mula 54/STJ).
+Recurso conhecido e provido.
+
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803246-09.2020.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(38 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Prestação de Serviços
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL - AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS - RESPONSABILIDADE CIVIL OBJETIVA - CONCESSIONÁRIA DE SERVIÇO PÚBLICO - ESTAÇÃO DE TRATAMENTO DE ESGOTO - MAU CHEIRO - <em>DANO</em> AMBIENTAL E À SAÚDE DOS MORADORES - <em>DANO</em> <em>MORAL</em> CONFIGURADO - INDENIZAÇÃO DEVIDA - SENTENÇA REFORMADA - RECURSO CONHECIDO E PROVIDO.
+A responsabilidade civil das concessionárias de serviço
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL - AÇÃO DE INDENIZAÇÃO POR DANOS MORAIS - RESPONSABILIDADE CIVIL OBJETIVA - CONCESSIONÁRIA DE SERVIÇO PÚBLICO - ESTAÇÃO DE TRATAMENTO DE ESGOTO - MAU CHEIRO - <em>DANO</em> AMBIENTAL E À SAÚDE DOS MORADORES - <em>DANO</em> <em>MORAL</em> CONFIGURADO - INDENIZAÇÃO DEVIDA - SENTENÇA REFORMADA - RECURSO CONHECIDO E PROVIDO.
+A responsabilidade civil das concessionárias de serviço público é objetiva, nos termos do art. 37, § 6º, da CF e do art. 14 do CDC, sendo suficiente a comprovação do <em>dano</em> e do nexo causal entre a atividade prestada e o prejuízo sofrido pelo consumidor.
+O Laudo pericial judicial demonstra que a ETE opera sem Licença de Operação, com falhas técnicas como ausência de vedação adequada e de cortina arbórea, o que contribui significativamente para a emissão de odores, afetando o meio ambiente urbano e os moradores da região.
+A falha na prestação do serviço restou caracterizada, sendo comprovado que o odor é perceptível, incômodo e favorece a proliferação de insetos, impactando negativamente a saúde e o cotidiano dos residentes.
+O <em>dano</em> <em>moral</em> é configurado quando há lesão relevante a direitos da personalidade, como a dignidade e a integridade psicofísica, sendo o convívio prolongado com odor insalubre, baratas e desconforto psíquico circunstância que ultrapassa o mero aborrecimento.
+A condição social da autora, residente em área popular e sem alternativa de moradia, não afasta a responsabilidade da concessionária, que deve prestar serviço adequado, eficiente e em conformidade com normas ambientais.
+A indenização por danos morais deve cumprir função compensatória e pedagógica, sem ensejar enriquecimento sem causa, sendo razoável o arbitramento em R$ 2.000,00 (dois mil reais), com correção monetária pelo IPCA a partir do arbitramento (Súmula 362/STJ) e juros moratórios de 1% ao mês desde a citação (Súmula 54/STJ).
+Recurso conhecido e provido.
+
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, deram provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>188&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876140" cdForo="0" >
+										0820664-35.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876140" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876140);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876140" style="display: none;" >
+	<div id="textAreaDados_1876140" class="mensagemSemFormatacao" >
+		Recurso da r&eacute; Centro de Estudos dos Benef&iacute;cios dos Aposentados e Pensionistas - Cebap
+EMENTA &ndash; PROCESSUAL CIVIL E CONSUMIDOR &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C.C. INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS C.C. REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; DESCONTOS&nbsp;EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO -  AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DA CONTRATA&Ccedil;&Atilde;O &ndash; DESCONTOS INDEVIDOS &ndash; RESTITUI&Ccedil;&Atilde;O DE IND&Eacute;BITO EM DOBRO - AUS&Ecirc;NCIA DE ENGANO JUSTIFIC&Aacute;VEL - DANO MORAL PRESUMIDO &ndash; QUANTUM INDENIZAT&Oacute;RIO &ndash; PROPORCIONAL AO CASO - RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Recurso de Apela&ccedil;&atilde;o interposto pela parte r&eacute; contra senten&ccedil;a de parcial proced&ecirc;ncia proferida em A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de D&eacute;bito c.c Indeniza&ccedil;&atilde;o por Danos Materiais e Morais c.c. Repeti&ccedil;&atilde;o de Ind&eacute;bito na qual se discute os descontos desconhecidos em seu benef&iacute;cio previdenci&aacute;rio.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discute-se no presente recurso: a) a ocorr&ecirc;ncia, ou n&atilde;o, de danos morais na esp&eacute;cie; b) o quantum indenizat&oacute;rio dos danos morais; e c) a restitui&ccedil;&atilde;o em dobro dos valores.
+III. RAZ&Otilde;ES DE DECIDIR
+3.  O par&aacute;grafo &uacute;nico, do art. 42, da Lei n&ordm; 8.078, de 11/09/1990 (C&oacute;digo de Defesa do Consumidor) disp&otilde;e que o consumidor cobrado em quantia indevida tem direito &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito, por valor igual ao dobro do que pagou em excesso, acrescido de corre&ccedil;&atilde;o monet&aacute;ria e juros legais, salvo hip&oacute;tese de &quot;engano justific&aacute;vel&quot;, o que n&atilde;o restou caracterizado nos autos.
+4. Inexistente contrato formalizado entre as partes, s&atilde;o indevidos os descontos mensais efetuados em conta banc&aacute;ria, o que d&aacute; ensejo &agrave; condena&ccedil;&atilde;o por dano moral in re ipsa. Precedentes do STJ.&nbsp;
+5. Segundo o m&eacute;todo bif&aacute;sico de fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, na primeira etapa, deve-se estabelecer um valor b&aacute;sico, &agrave; luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jur&iacute;dico lesado; e, na segunda etapa, devem ser consideradas as circunst&acirc;ncias do caso, para a fixa&ccedil;&atilde;o definitiva do valor da indeniza&ccedil;&atilde;o, atendendo-se, assim, a determina&ccedil;&atilde;o legal de arbitramento equitativo pelo Juiz.
+6. Considerando-se o referido grupo de precedentes, e levando-se em conta a condi&ccedil;&atilde;o financeira das partes, a finalidade educativa e preventiva da condena&ccedil;&atilde;o, a razo&aacute;vel gravidade do dano, e sobretudo a quantidade de descontos e o seu valor mensal, reputo que &eacute; o caso de manter o valor fixado na senten&ccedil;a (R$ 4.000,00), a qual se mostra proporcional e adequada para o caso versando.
+IV. DISPOSITIVO
+7. Apela&ccedil;&atilde;o conhecida e desprovida.
+
+Recurso do consumidor
+EMENTA &ndash; PROCESSUAL CIVIL E CONSUMIDOR &ndash; APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C.C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS C.C. REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO &ndash; DESCONTOS&nbsp;EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO -  AUS&Ecirc;NCIA DE COMPROVA&Ccedil;&Atilde;O DA CONTRATA&Ccedil;&Atilde;O &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO  &ndash; DANO MORAL PRESUMIDO &ndash; QUANTUM INDENIZAT&Oacute;RIO &ndash; PROPORCIONAL AO CASO - TERMO INICIAL DOS JUROS DE MORA &ndash; EVENTO DANOSO - ADEQUA&Ccedil;&Atilde;O - HONOR&Aacute;RIOS SUCUMBENCIAIS &ndash; MAJORADOS -  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Recurso de Apela&ccedil;&atilde;o interposto pela parte autora contra senten&ccedil;a de parcial proced&ecirc;ncia proferida em A&ccedil;&atilde;o Declarat&oacute;ria de Inexist&ecirc;ncia de D&eacute;bito c.c Indeniza&ccedil;&atilde;o por Danos Materiais e Morais c.c. Repeti&ccedil;&atilde;o de Ind&eacute;bito na qual se discute os descontos desconhecidos em seu benef&iacute;cio previdenci&aacute;rio.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O
+2. Discutem-se nos presentes recursos: a) o quantum indenizat&oacute;rio dos danos morais; b) o termo inicial dos juros de mora; e c) o valor dos honor&aacute;rios advocat&iacute;cios.
+III. RAZ&Otilde;ES DE DECIDIR
+3. Segundo o m&eacute;todo bif&aacute;sico de fixa&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais, na primeira etapa, deve-se estabelecer um valor b&aacute;sico, &agrave; luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jur&iacute;dico lesado; e, na segunda etapa, devem ser consideradas as circunst&acirc;ncias do caso, para a fixa&ccedil;&atilde;o definitiva do valor da indeniza&ccedil;&atilde;o, atendendo-se, assim, a determina&ccedil;&atilde;o legal de arbitramento equitativo pelo Juiz.
+4. Considerando-se o referido grupo de precedentes, e levando-se em conta a condi&ccedil;&atilde;o financeira das partes, a finalidade educativa e preventiva da condena&ccedil;&atilde;o, a razo&aacute;vel gravidade do dano, e sobretudo a quantidade de descontos e o seu valor mensal, reputo que &eacute; o caso de manter o valor fixado na senten&ccedil;a (R$ 4.000,00), a qual se mostra proporcional e adequada para o caso versando.
+5.Por intelig&ecirc;ncia do Enunciado n&ordm; 54 /STJ, os juros morat&oacute;rios devem incidir desde o evento danoso, em caso de responsabilidade civil extracontratual.
+6. Segundo o art. 85, &sect; 2&ordm;, do CPC, os honor&aacute;rios ser&atilde;o fixados entre o m&iacute;nimo de dez e o m&aacute;ximo de vinte por cento sobre o valor da condena&ccedil;&atilde;o, do proveito econ&ocirc;mico obtido ou, n&atilde;o sendo poss&iacute;vel mensur&aacute;-lo, sobre o valor atualizado da causa, atendidos: &quot;I - o grau de zelo do profissional; II - o lugar de presta&ccedil;&atilde;o do servi&ccedil;o; III - a natureza e a import&acirc;ncia da causa; IV - o trabalho realizado pelo advogado e o tempo exigido para o seu servi&ccedil;o&quot;. No caso, em decorr&ecirc;ncia da reforma da senten&ccedil;a quanto aos danos morais, o valor dos honor&aacute;rios sofrer&aacute; impacto, raz&atilde;o pela qual o percentual deve ser mantido. No caso, esses par&acirc;metros n&atilde;o foram na senten&ccedil;a, devendo ser majorado o percentual para 17% do valor da condena&ccedil;&atilde;o.
+IV. DISPOSITIVO
+7. Apela&ccedil;&atilde;o da parte autora conhecida e parcialmente provida. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0820664-35.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Paulo Alberto de Oliveira, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(57 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Paulo Alberto de Oliveira
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>Recurso da ré Centro de Estudos dos Benefícios dos Aposentados e Pensionistas - Cebap
+EMENTA – PROCESSUAL CIVIL E CONSUMIDOR – APELAÇÃO CÍVEL - AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C. INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS C.C. REPETIÇÃO DE INDÉBITO – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO -  AUSÊNCIA DE COMPROVAÇÃO DA CONTRATAÇÃO – DESCONTOS INDEVIDOS – RESTITUIÇÃO DE INDÉBITO EM
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>Recurso da ré Centro de Estudos dos Benefícios dos Aposentados e Pensionistas - Cebap
+EMENTA – PROCESSUAL CIVIL E CONSUMIDOR – APELAÇÃO CÍVEL - AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C. INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS C.C. REPETIÇÃO DE INDÉBITO – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO -  AUSÊNCIA DE COMPROVAÇÃO DA CONTRATAÇÃO – DESCONTOS INDEVIDOS – RESTITUIÇÃO DE INDÉBITO EM DOBRO - AUSÊNCIA DE ENGANO JUSTIFICÁVEL - <em>DANO</em> <em>MORAL</em> PRESUMIDO – QUANTUM INDENIZATÓRIO – PROPORCIONAL AO CASO - RECURSO CONHECIDO E DESPROVIDO.
+I. CASO EM EXAME
+1. Recurso de Apelação interposto pela parte ré contra sentença de parcial procedência proferida em Ação Declaratória de Inexistência de Débito c.c Indenização por Danos Materiais e Morais c.c. Repetição de Indébito na qual se discute os descontos desconhecidos em seu benefício previdenciário.
+II. QUESTÃO EM DISCUSSÃO
+2. Discute-se no presente recurso: a) a ocorrência, ou não, de danos morais na espécie; b) o quantum indenizatório dos danos morais; e c) a restituição em dobro dos valores.
+III. RAZÕES DE DECIDIR
+3.  O parágrafo único, do art. 42, da Lei nº 8.078, de 11/09/1990 (Código de Defesa do Consumidor) dispõe que o consumidor cobrado em quantia indevida tem direito à repetição do indébito, por valor igual ao dobro do que pagou em excesso, acrescido de correção monetária e juros legais, salvo hipótese de "engano justificável", o que não restou caracterizado nos autos.
+4. Inexistente contrato formalizado entre as partes, são indevidos os descontos mensais efetuados em conta bancária, o que dá ensejo à condenação por <em>dano</em> <em>moral</em> in re ipsa. Precedentes do STJ. 
+5. Segundo o método bifásico de fixação de indenização por danos morais, na primeira etapa, deve-se estabelecer um valor básico, à luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jurídico lesado; e, na segunda etapa, devem ser consideradas as circunstâncias do caso, para a fixação definitiva do valor da indenização, atendendo-se, assim, a determinação legal de arbitramento equitativo pelo Juiz.
+6. Considerando-se o referido grupo de precedentes, e levando-se em conta a condição financeira das partes, a finalidade educativa e preventiva da condenação, a razoável gravidade do <em>dano</em>, e sobretudo a quantidade de descontos e o seu valor mensal, reputo que é o caso de manter o valor fixado na sentença (R$ 4.000,00), a qual se mostra proporcional e adequada para o caso versando.
+IV. DISPOSITIVO
+7. Apelação conhecida e desprovida.
+
+Recurso do consumidor
+EMENTA – PROCESSUAL CIVIL E CONSUMIDOR – APELAÇÃO CÍVEL - AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C.C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS C.C. REPETIÇÃO DE INDÉBITO – DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO -  AUSÊNCIA DE COMPROVAÇÃO DA CONTRATAÇÃO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO  – <em>DANO</em> <em>MORAL</em> PRESUMIDO – QUANTUM INDENIZATÓRIO – PROPORCIONAL AO CASO - TERMO INICIAL DOS JUROS DE MORA – EVENTO DANOSO - ADEQUAÇÃO - HONORÁRIOS SUCUMBENCIAIS – MAJORADOS -  RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+I. CASO EM EXAME
+1. Recurso de Apelação interposto pela parte autora contra sentença de parcial procedência proferida em Ação Declaratória de Inexistência de Débito c.c Indenização por Danos Materiais e Morais c.c. Repetição de Indébito na qual se discute os descontos desconhecidos em seu benefício previdenciário.
+II. QUESTÃO EM DISCUSSÃO
+2. Discutem-se nos presentes recursos: a) o quantum indenizatório dos danos morais; b) o termo inicial dos juros de mora; e c) o valor dos honorários advocatícios.
+III. RAZÕES DE DECIDIR
+3. Segundo o método bifásico de fixação de indenização por danos morais, na primeira etapa, deve-se estabelecer um valor básico, à luz de um grupo de precedentes jurisprudenciais que apreciaram casos semelhantes, conforme o interesse jurídico lesado; e, na segunda etapa, devem ser consideradas as circunstâncias do caso, para a fixação definitiva do valor da indenização, atendendo-se, assim, a determinação legal de arbitramento equitativo pelo Juiz.
+4. Considerando-se o referido grupo de precedentes, e levando-se em conta a condição financeira das partes, a finalidade educativa e preventiva da condenação, a razoável gravidade do <em>dano</em>, e sobretudo a quantidade de descontos e o seu valor mensal, reputo que é o caso de manter o valor fixado na sentença (R$ 4.000,00), a qual se mostra proporcional e adequada para o caso versando.
+5.Por inteligência do Enunciado nº 54 /STJ, os juros moratórios devem incidir desde o evento danoso, em caso de responsabilidade civil extracontratual.
+6. Segundo o art. 85, § 2º, do CPC, os honorários serão fixados entre o mínimo de dez e o máximo de vinte por cento sobre o valor da condenação, do proveito econômico obtido ou, não sendo possível mensurá-lo, sobre o valor atualizado da causa, atendidos: "I - o grau de zelo do profissional; II - o lugar de prestação do serviço; III - a natureza e a importância da causa; IV - o trabalho realizado pelo advogado e o tempo exigido para o seu serviço". No caso, em decorrência da reforma da sentença quanto aos danos morais, o valor dos honorários sofrerá impacto, razão pela qual o percentual deve ser mantido. No caso, esses parâmetros não foram na sentença, devendo ser majorado o percentual para 17% do valor da condenação.
+IV. DISPOSITIVO
+7. Apelação da parte autora conhecida e parcialmente provida.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>189&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876149" cdForo="0" >
+										0803524-85.2025.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876149" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876149);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876149" style="display: none;" >
+	<div id="textAreaDados_1876149" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE PROCEDIMENTO COMUM &ndash; SEGURO &ndash; NEGATIVA DE COBERTURA &ndash; REVELIA DA REQUERIDA &ndash; SENTEN&Ccedil;A DE PARCIAL PROCED&Ecirc;NCIA &ndash; RECURSO DA AUTORA &ndash; PLEITO DE CONDENA&Ccedil;&Atilde;O EM DANOS MORAIS &ndash; CABIMENTO &ndash; RECUSA INDEVIDA QUE ULTRAPASSA O MERO ABORRECIMENTO &ndash; DEVER DE INDENIZAR CONFIGURADO &ndash; QUANTUM INDENIZAT&Oacute;RIO FIXADO EM R$ 5.000,00 &ndash; RECURSO CONHECIDO E PROVIDO.
+A recusa indevida ou injustificada do pagamento de indeniza&ccedil;&atilde;o securit&aacute;ria por parte da seguradora, especialmente diante da sua revelia no processo, agrava a situa&ccedil;&atilde;o de afli&ccedil;&atilde;o psicol&oacute;gica da segurada e ultrapassa o mero dissabor cotidiano, configurando dano moral pass&iacute;vel de indeniza&ccedil;&atilde;o.
+O valor da indeniza&ccedil;&atilde;o por danos morais deve ser fixado em patamar que, al&eacute;m de proporcionar &agrave; v&iacute;tima uma satisfa&ccedil;&atilde;o capaz de atenuar seu sofrimento, sirva como medida pedag&oacute;gica e punitiva &agrave; ofensora, observados os princ&iacute;pios da razoabilidade e da proporcionalidade.
+Recurso conhecido e provido para reformar a senten&ccedil;a e condenar a r&eacute; ao pagamento de danos morais. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0803524-85.2025.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(25 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Seguro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE PROCEDIMENTO COMUM – SEGURO – NEGATIVA DE COBERTURA – REVELIA DA REQUERIDA – SENTENÇA DE PARCIAL PROCEDÊNCIA – RECURSO DA AUTORA – PLEITO DE CONDENAÇÃO EM DANOS MORAIS – CABIMENTO – RECUSA INDEVIDA QUE ULTRAPASSA O MERO ABORRECIMENTO – DEVER DE INDENIZAR CONFIGURADO – QUANTUM INDENIZATÓRIO FIXADO EM R$ 5.000,00 – RECURSO CONHECIDO E PROVIDO.
+A recusa indevida ou
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE PROCEDIMENTO COMUM – SEGURO – NEGATIVA DE COBERTURA – REVELIA DA REQUERIDA – SENTENÇA DE PARCIAL PROCEDÊNCIA – RECURSO DA AUTORA – PLEITO DE CONDENAÇÃO EM DANOS MORAIS – CABIMENTO – RECUSA INDEVIDA QUE ULTRAPASSA O MERO ABORRECIMENTO – DEVER DE INDENIZAR CONFIGURADO – QUANTUM INDENIZATÓRIO FIXADO EM R$ 5.000,00 – RECURSO CONHECIDO E PROVIDO.
+A recusa indevida ou injustificada do pagamento de indenização securitária por parte da seguradora, especialmente diante da sua revelia no processo, agrava a situação de aflição psicológica da segurada e ultrapassa o mero dissabor cotidiano, configurando <em>dano</em> <em>moral</em> passível de indenização.
+O valor da indenização por danos morais deve ser fixado em patamar que, além de proporcionar à vítima uma satisfação capaz de atenuar seu sofrimento, sirva como medida pedagógica e punitiva à ofensora, observados os princípios da razoabilidade e da proporcionalidade.
+Recurso conhecido e provido para reformar a sentença e condenar a ré ao pagamento de danos morais.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>190&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876150" cdForo="0" >
+										0824881-29.2022.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876150" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876150);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876150" style="display: none;" >
+	<div id="textAreaDados_1876150" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DE RESCIS&Atilde;O CONTRATUAL - PRESTA&Ccedil;&Atilde;O DE SERVI&Ccedil;OS EDUCACIONAIS (AUTOESCOLA) - FALHA NA PRESTA&Ccedil;&Atilde;O DO SERVI&Ccedil;O - PERDAS E DANOS DECORRENTES DE NOVA CONTRATA&Ccedil;&Atilde;O - CUMULA&Ccedil;&Atilde;O COM A RESTITUI&Ccedil;&Atilde;O INTEGRAL DOS VALORES PAGOS - IMPOSSIBILIDADE, SOB PENA DE BIS IN IDEM E ENRIQUECIMENTO SEM CAUSA - DANO MORAL - PRETENS&Atilde;O DE MAJORA&Ccedil;&Atilde;O DO QUANTUM INDENIZAT&Oacute;RIO - VALOR ARBITRADO EM PRIMEIRO GRAU QUE SE MOSTRA RAZO&Aacute;VEL E PROPORCIONAL - SENTEN&Ccedil;A MANTIDA - RECURSO DESPROVIDO. A restitui&ccedil;&atilde;o integral do valor pago pelo servi&ccedil;o n&atilde;o prestado tem por finalidade recompor o patrim&ocirc;nio da consumidora e restabelecer o status quo ante. A cumula&ccedil;&atilde;o da restitui&ccedil;&atilde;o com indeniza&ccedil;&atilde;o correspondente ao custo de novo contrato configura bis in idem e enseja enriquecimento sem causa, vedado pelo ordenamento jur&iacute;dico. O valor da indeniza&ccedil;&atilde;o por danos morais deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, considerando a extens&atilde;o do dano e o car&aacute;ter compensat&oacute;rio e pedag&oacute;gico. O quantum fixado em R$ 5.000,00 mostra-se adequado, n&atilde;o sendo irris&oacute;rio nem excessivo, al&eacute;m de compat&iacute;vel com precedentes da Corte.  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0824881-29.2022.8.12.0001,&nbsp; Campo Grande,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(11 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Rescisão do contrato e devolução do dinheiro
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL - AÇÃO DE RESCISÃO CONTRATUAL - PRESTAÇÃO DE SERVIÇOS EDUCACIONAIS (AUTOESCOLA) - FALHA NA PRESTAÇÃO DO SERVIÇO - PERDAS E DANOS DECORRENTES DE NOVA CONTRATAÇÃO - CUMULAÇÃO COM A RESTITUIÇÃO INTEGRAL DOS VALORES PAGOS - IMPOSSIBILIDADE, SOB PENA DE BIS IN IDEM E ENRIQUECIMENTO SEM CAUSA - <em>DANO</em> <em>MORAL</em> - PRETENSÃO DE MAJORAÇÃO DO QUANTUM INDENIZATÓRIO - VALOR
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL - AÇÃO DE RESCISÃO CONTRATUAL - PRESTAÇÃO DE SERVIÇOS EDUCACIONAIS (AUTOESCOLA) - FALHA NA PRESTAÇÃO DO SERVIÇO - PERDAS E DANOS DECORRENTES DE NOVA CONTRATAÇÃO - CUMULAÇÃO COM A RESTITUIÇÃO INTEGRAL DOS VALORES PAGOS - IMPOSSIBILIDADE, SOB PENA DE BIS IN IDEM E ENRIQUECIMENTO SEM CAUSA - <em>DANO</em> <em>MORAL</em> - PRETENSÃO DE MAJORAÇÃO DO QUANTUM INDENIZATÓRIO - VALOR ARBITRADO EM PRIMEIRO GRAU QUE SE MOSTRA RAZOÁVEL E PROPORCIONAL - SENTENÇA MANTIDA - RECURSO DESPROVIDO. A restituição integral do valor pago pelo serviço não prestado tem por finalidade recompor o patrimônio da consumidora e restabelecer o status quo ante. A cumulação da restituição com indenização correspondente ao custo de novo contrato configura bis in idem e enseja enriquecimento sem causa, vedado pelo ordenamento jurídico. O valor da indenização por danos morais deve observar os princípios da razoabilidade e proporcionalidade, considerando a extensão do <em>dano</em> e o caráter compensatório e pedagógico. O quantum fixado em R$ 5.000,00 mostra-se adequado, não sendo irrisório nem excessivo, além de compatível com precedentes da Corte.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>191&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876156" cdForo="0" >
+										0800438-34.2025.8.12.0025
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876156" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876156);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876156" style="display: none;" >
+	<div id="textAreaDados_1876156" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O REVISIONAL DE CONTRATO &ndash; TAXA DE JUROS &ndash;  JUROS REMUNERAT&Oacute;RIOS  &ndash; CERCA DE CINCO VEZES ACIMA DA TAXA M&Eacute;DIA DE MERCADO DO BANCO CENTRAL DO BRASIL &ndash; ABUSIVIDADE &ndash; DEVOLU&Ccedil;&Atilde;O SIMPLES &ndash; JUROS DE MORA CONTADO DA DATA DA CITA&Ccedil;&Atilde;O &ndash; DANOS MORAIS INEXISTENTES  &ndash; SENTEN&Ccedil;A PARCIALMENTE REFORMADA &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Nos termos da orienta&ccedil;&atilde;o jurisprudencial do STJ, n&atilde;o ser&aacute; considerada abusiva a taxa dos&nbsp;juros&nbsp;remunerat&oacute;rios&nbsp;contratada quando ela for at&eacute; tr&ecirc;s superior &agrave; taxa de&nbsp;juros&nbsp;m&eacute;dia&nbsp;praticada pelo&nbsp;mercado, divulgada pelo Banco Central do Brasil, para o tipo espec&iacute;fico de contrato, na &eacute;poca de sua celebra&ccedil;&atilde;o, o que n&atilde;o &eacute; o caso dos autos, em que os juros cobrados s&atilde;o mais que cinco vezes superior &agrave; referida taxa.
+O valor a ser restitu&iacute;do dever&aacute; ser corrigido monetariamente pelo IGP-M/FGV desde a data de cada desembolso a maior e os juros de mora dever&atilde;o ser de 1% ao m&ecirc;s (12% ao ano) a contar da data da cita&ccedil;&atilde;o (art. 240 do CPC), considerando n&atilde;o ser aplic&aacute;vel a S&uacute;mula n&ordm; 54 do STJ, visto que n&atilde;o estamos diante de responsabilidade extracontratual.
+Como n&atilde;o restou comprovado nos autos que agiu o banco com evidente m&aacute;-f&eacute;, a restitui&ccedil;&atilde;o deve se dar na forma simples.
+A cobran&ccedil;a de encargos abusivos, por si s&oacute;, n&atilde;o configura dano moral, sendo necess&aacute;ria demonstra&ccedil;&atilde;o de les&atilde;o a direitos da personalidade. Nesse contexto, inexistente prova de abalo moral relevante, afasta-se o dever de indenizar.
+Recurso conhecido e parcialmente provido.
+
+                              A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, deram parcial provimento ao recurso, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800438-34.2025.8.12.0025,&nbsp; Bandeirantes,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Empréstimo consignado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Bandeirantes
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO – TAXA DE JUROS –  JUROS REMUNERATÓRIOS  – CERCA DE CINCO VEZES ACIMA DA TAXA MÉDIA DE MERCADO DO BANCO CENTRAL DO BRASIL – ABUSIVIDADE – DEVOLUÇÃO SIMPLES – JUROS DE MORA CONTADO DA DATA DA CITAÇÃO – DANOS MORAIS INEXISTENTES  – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Nos termos da orientação jurisprudencial do
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO REVISIONAL DE CONTRATO – TAXA DE JUROS –  JUROS REMUNERATÓRIOS  – CERCA DE CINCO VEZES ACIMA DA TAXA MÉDIA DE MERCADO DO BANCO CENTRAL DO BRASIL – ABUSIVIDADE – DEVOLUÇÃO SIMPLES – JUROS DE MORA CONTADO DA DATA DA CITAÇÃO – DANOS MORAIS INEXISTENTES  – SENTENÇA PARCIALMENTE REFORMADA – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+Nos termos da orientação jurisprudencial do STJ, não será considerada abusiva a taxa dos juros remuneratórios contratada quando ela for até três superior à taxa de juros média praticada pelo mercado, divulgada pelo Banco Central do Brasil, para o tipo específico de contrato, na época de sua celebração, o que não é o caso dos autos, em que os juros cobrados são mais que cinco vezes superior à referida taxa.
+O valor a ser restituído deverá ser corrigido monetariamente pelo IGP-M/FGV desde a data de cada desembolso a maior e os juros de mora deverão ser de 1% ao mês (12% ao ano) a contar da data da citação (art. 240 do CPC), considerando não ser aplicável a Súmula nº 54 do STJ, visto que não estamos diante de responsabilidade extracontratual.
+Como não restou comprovado nos autos que agiu o banco com evidente má-fé, a restituição deve se dar na forma simples.
+A cobrança de encargos abusivos, por si só, não configura <em>dano</em> <em>moral</em>, sendo necessária demonstração de lesão a direitos da personalidade. Nesse contexto, inexistente prova de abalo <em>moral</em> relevante, afasta-se o dever de indenizar.
+Recurso conhecido e parcialmente provido.
+
+                              A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, deram parcial provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>192&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876157" cdForo="0" >
+										0800604-22.2023.8.12.0030
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876157" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876157);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876157" style="display: none;" >
+	<div id="textAreaDados_1876157" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPARA&Ccedil;&Atilde;O DE DANOS &ndash; SISTEMA DE INFORMA&Ccedil;&Otilde;ES DE CR&Eacute;DITO DO BANCO CENTRAL &ndash; SCR &ndash; STJ &ndash; NATUREZA RESTRITIVA DE CR&Eacute;DITO &ndash; MANUTEN&Ccedil;&Atilde;O DA INSCRI&Ccedil;&Atilde;O &ndash; D&Iacute;VIDA PAGA &ndash; DANO MORAL &ndash; OCORR&Ecirc;NCIA &ndash; RESPONSABILIDADE DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; QUANTUM INDENIZAT&Oacute;RIO &ndash; PRINC&Iacute;PIOS DA PROPORCIONALIDADE E RAZOABILIDADE &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O SCR possui natureza de cadastro restritivo de cr&eacute;dito, pois suas informa&ccedil;&otilde;es influenciam diretamente a concess&atilde;o de cr&eacute;dito pelas institui&ccedil;&otilde;es financeiras, conforme entendimento consolidado do STJ..
+A institui&ccedil;&atilde;o financeira deve promover a exclus&atilde;o ou atualiza&ccedil;&atilde;o dos dados no prazo razo&aacute;vel, aplicando-se por analogia o prazo de 5 dias &uacute;teis previsto no art. 43, &sect;3&ordm;, do CDC.
+A manuten&ccedil;&atilde;o do registro negativo ap&oacute;s a quita&ccedil;&atilde;o do d&eacute;bito configura abuso de direito e ato il&iacute;cito, nos termos do art. 187 do C&oacute;digo Civil.
+A inscri&ccedil;&atilde;o ou manuten&ccedil;&atilde;o indevida em cadastro restritivo gera dano moral presumido (in re ipsa), por violar a honra objetiva e a credibilidade do consumidor no mercado.
+O valor da indeniza&ccedil;&atilde;o deve observar os princ&iacute;pios da razoabilidade e proporcionalidade, evitando enriquecimento sem causa e assegurando fun&ccedil;&atilde;o pedag&oacute;gica, sendo adequado o montante de R$ 3.500,00 no caso concreto.
+Recurso conhecido e parcialmente provido.
+
+A C &Oacute; R D &Atilde; O <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800604-22.2023.8.12.0030,&nbsp; Brasil&acirc;ndia,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(21 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Brasilândia
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO DE DANOS – SISTEMA DE INFORMAÇÕES DE CRÉDITO DO BANCO CENTRAL – SCR – STJ – NATUREZA RESTRITIVA DE CRÉDITO – MANUTENÇÃO DA INSCRIÇÃO – DÍVIDA PAGA – <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA – RESPONSABILIDADE DA INSTITUIÇÃO FINANCEIRA – QUANTUM INDENIZATÓRIO – PRINCÍPIOS DA PROPORCIONALIDADE E RAZOABILIDADE – RECURSO
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPARAÇÃO DE DANOS – SISTEMA DE INFORMAÇÕES DE CRÉDITO DO BANCO CENTRAL – SCR – STJ – NATUREZA RESTRITIVA DE CRÉDITO – MANUTENÇÃO DA INSCRIÇÃO – DÍVIDA PAGA – <em>DANO</em> <em>MORAL</em> – OCORRÊNCIA – RESPONSABILIDADE DA INSTITUIÇÃO FINANCEIRA – QUANTUM INDENIZATÓRIO – PRINCÍPIOS DA PROPORCIONALIDADE E RAZOABILIDADE – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O SCR possui natureza de cadastro restritivo de crédito, pois suas informações influenciam diretamente a concessão de crédito pelas instituições financeiras, conforme entendimento consolidado do STJ..
+A instituição financeira deve promover a exclusão ou atualização dos dados no prazo razoável, aplicando-se por analogia o prazo de 5 dias úteis previsto no art. 43, §3º, do CDC.
+A manutenção do registro negativo após a quitação do débito configura abuso de direito e ato ilícito, nos termos do art. 187 do Código Civil.
+A inscrição ou manutenção indevida em cadastro restritivo gera <em>dano</em> <em>moral</em> presumido (in re ipsa), por violar a honra objetiva e a credibilidade do consumidor no mercado.
+O valor da indenização deve observar os princípios da razoabilidade e proporcionalidade, evitando enriquecimento sem causa e assegurando função pedagógica, sendo adequado o montante de R$ 3.500,00 no caso concreto.
+Recurso conhecido e parcialmente provido.
+
+A C Ó R D Ã O
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>193&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876165" cdForo="0" >
+										0805221-75.2024.8.12.0002
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876165" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876165);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876165" style="display: none;" >
+	<div id="textAreaDados_1876165" class="mensagemSemFormatacao" >
+		DIREITO CIVIL E PROCESSUAL CIVIL. APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. IMPUGNA&Ccedil;&Atilde;O &Agrave; JUSTI&Ccedil;A GRATUITA. REJEITADA. M&Eacute;RITO. NEGATIVA&Ccedil;&Atilde;O. INADIMPL&Ecirc;NCIA COMPROVADA. EXERC&Iacute;CIO REGULAR DE DIREITO. AUS&Ecirc;NCIA DE ATO IL&Iacute;CITO. MANUTEN&Ccedil;&Atilde;O DA SENTEN&Ccedil;A. RECURSO DESPROVIDO.
+O &ocirc;nus de comprovar a aus&ecirc;ncia dos pressupostos da justi&ccedil;a gratuita incumbe ao impugnante, que deve apresentar prova id&ocirc;nea da capacidade financeira da parte benefici&aacute;ria, o que n&atilde;o ocorreu no caso. Impugna&ccedil;&atilde;o &agrave; justi&ccedil;a gratuita rejeitada.
+A rela&ccedil;&atilde;o contratual entre as partes e a inadimpl&ecirc;ncia da apelante s&atilde;o incontroversas, sendo inclusive reconhecida a exist&ecirc;ncia do d&eacute;bito. A prova documental demonstra a exist&ecirc;ncia de parcelas inadimplidas, inclusive com pagamento parcial e aus&ecirc;ncia de quita&ccedil;&atilde;o de encargos, al&eacute;m de outras presta&ccedil;&otilde;es em aberto. Dessa maneira, a inscri&ccedil;&atilde;o do nome do devedor em cadastros de inadimplentes constituiu exerc&iacute;cio regular de direito do credor, nos termos do art. 188, I, do C&oacute;digo Civil, posto existente d&iacute;vida leg&iacute;tima e exig&iacute;vel.
+A configura&ccedil;&atilde;o do dano moral exige a pr&aacute;tica de ato il&iacute;cito, inexistente quando a negativa&ccedil;&atilde;o decorre de inadimplemento contratual comprovado. A jurisprud&ecirc;ncia afasta a responsabilidade civil em hip&oacute;teses de inscri&ccedil;&atilde;o regular fundada em d&eacute;bito existente e n&atilde;o quitado.
+Recurso conhecido e desprovido.
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0805221-75.2024.8.12.0002,&nbsp; Dourados,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Dourados
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS. IMPUGNAÇÃO À JUSTIÇA GRATUITA. REJEITADA. MÉRITO. NEGATIVAÇÃO. INADIMPLÊNCIA COMPROVADA. EXERCÍCIO REGULAR DE DIREITO. AUSÊNCIA DE ATO ILÍCITO. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+O ônus de comprovar a ausência dos pressupostos da justiça gratuita incumbe ao
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CIVIL E PROCESSUAL CIVIL. APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C INDENIZAÇÃO POR DANOS MORAIS. IMPUGNAÇÃO À JUSTIÇA GRATUITA. REJEITADA. MÉRITO. NEGATIVAÇÃO. INADIMPLÊNCIA COMPROVADA. EXERCÍCIO REGULAR DE DIREITO. AUSÊNCIA DE ATO ILÍCITO. MANUTENÇÃO DA SENTENÇA. RECURSO DESPROVIDO.
+O ônus de comprovar a ausência dos pressupostos da justiça gratuita incumbe ao impugnante, que deve apresentar prova idônea da capacidade financeira da parte beneficiária, o que não ocorreu no caso. Impugnação à justiça gratuita rejeitada.
+A relação contratual entre as partes e a inadimplência da apelante são incontroversas, sendo inclusive reconhecida a existência do débito. A prova documental demonstra a existência de parcelas inadimplidas, inclusive com pagamento parcial e ausência de quitação de encargos, além de outras prestações em aberto. Dessa maneira, a inscrição do nome do devedor em cadastros de inadimplentes constituiu exercício regular de direito do credor, nos termos do art. 188, I, do Código Civil, posto existente dívida legítima e exigível.
+A configuração do <em>dano</em> <em>moral</em> exige a prática de ato ilícito, inexistente quando a negativação decorre de inadimplemento contratual comprovado. A jurisprudência afasta a responsabilidade civil em hipóteses de inscrição regular fundada em débito existente e não quitado.
+Recurso conhecido e desprovido.
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>194&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1876169" cdForo="0" >
+										0805000-11.2023.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1876169" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1876169);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1876169" style="display: none;" >
+	<div id="textAreaDados_1876169" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA &ndash; RESPONSABILIDADE CIVIL DO ESTADO &ndash; SISTEMA PRISIONAL &ndash; SUPERLOTA&Ccedil;&Atilde;O CARCER&Aacute;RIA &ndash; DANO MORAL &ndash; TEMA 365/STF &ndash; INEXIST&Ecirc;NCIA DE DANO PRESUMIDO (IN RE IPSA) &ndash; NECESSIDADE DE COMPROVA&Ccedil;&Atilde;O CONCRETA E INDIVIDUALIZADA &ndash; IMPROCED&Ecirc;NCIA MANTIDA &ndash; RECURSO CONHECIDO DESPROVIDO.
+Considerando que os elementos de provas contidos nos autos permitiram ao Magistrado julgar o processo, n&atilde;o se vislumbra o alegado cerceamento de defesa no julgamento antecipado da lide. Preliminar de nulidade por cerceamento de defesa rejeitada.
+A Constitui&ccedil;&atilde;o Federal, em seu art. 37, &sect; 6&ordm;, adota a responsabilidade civil objetiva do Estado, exigindo a demonstra&ccedil;&atilde;o do ato il&iacute;cito, do dano e do nexo causal, ainda que prescind&iacute;vel a prova de culpa.
+O Supremo Tribunal Federal, no julgamento do RE 580.252/MS (Tema 365), fixa tese no sentido de que o Estado responde por danos, inclusive morais, comprovadamente causados aos detentos em raz&atilde;o da falta ou insufici&ecirc;ncia das condi&ccedil;&otilde;es legais de encarceramento, afastando a presun&ccedil;&atilde;o autom&aacute;tica do dano.
+O Superior Tribunal de Justi&ccedil;a interpreta o Tema 365 no sentido de que alega&ccedil;&otilde;es gen&eacute;ricas sobre superlota&ccedil;&atilde;o e precariedade do sistema prisional n&atilde;o s&atilde;o suficientes para ensejar indeniza&ccedil;&atilde;o, exigindo prova concreta e individualizada do abalo moral, entendimento reafirmado no AgInt no AREsp 1.906.225/SP.
+No caso concreto, as provas indicam que, embora existente superlota&ccedil;&atilde;o, os internos t&ecirc;m acesso &agrave; sa&uacute;de, alimenta&ccedil;&atilde;o e atividades externas, como banho de sol, n&atilde;o se evidenciando priva&ccedil;&atilde;o de direitos b&aacute;sicos da execu&ccedil;&atilde;o penal.
+As alega&ccedil;&otilde;es do apelante limitam-se a descri&ccedil;&otilde;es gen&eacute;ricas das condi&ccedil;&otilde;es do c&aacute;rcere, sem demonstra&ccedil;&atilde;o de circunst&acirc;ncias extremas ou de preju&iacute;zo espec&iacute;fico e individualizado que configure dano moral indeniz&aacute;vel.
+Consta dos autos registro de investimentos e destina&ccedil;&atilde;o de verbas &agrave; pol&iacute;tica penitenci&aacute;ria estadual, evidenciando medidas voltadas &agrave; melhoria das condi&ccedil;&otilde;es carcer&aacute;rias.
+A jurisprud&ecirc;ncia deste Tribunal de Justi&ccedil;a, em conson&acirc;ncia com o STF e o STJ, afasta o reconhecimento de dano moral presumido em hip&oacute;teses an&aacute;logas envolvendo o estabelecimento penal de Corumb&aacute;, exigindo prova concreta do dano.
+Senten&ccedil;a mantida.
+Recurso conhecido e desprovido.
+
+A C &Oacute; R D &Atilde; O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sess&atilde;o permanente e virtual, os(as) magistrados(as) do(a) 5&ordf; C&acirc;mara C&iacute;vel do Tribunal de Justi&ccedil;a de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decis&atilde;o: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator.. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0805000-11.2023.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Luiz Ant&ocirc;nio Cavassa de Almeida, j: 13/04/2026, p:&nbsp; 14/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(77 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Obrigação de Fazer / Não Fazer
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Luiz Antônio Cavassa de Almeida
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									14/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA – RESPONSABILIDADE CIVIL DO ESTADO – SISTEMA PRISIONAL – SUPERLOTAÇÃO CARCERÁRIA – <em>DANO</em> <em>MORAL</em> – TEMA 365/STF – INEXISTÊNCIA DE <em>DANO</em> PRESUMIDO (IN RE IPSA) – NECESSIDADE DE COMPROVAÇÃO CONCRETA E INDIVIDUALIZADA – IMPROCEDÊNCIA MANTIDA – RECURSO CONHECIDO DESPROVIDO.
+Considerando que os elementos de provas
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – PRELIMINAR DE CERCEAMENTO DE DEFESA REJEITADA – RESPONSABILIDADE CIVIL DO ESTADO – SISTEMA PRISIONAL – SUPERLOTAÇÃO CARCERÁRIA – <em>DANO</em> <em>MORAL</em> – TEMA 365/STF – INEXISTÊNCIA DE <em>DANO</em> PRESUMIDO (IN RE IPSA) – NECESSIDADE DE COMPROVAÇÃO CONCRETA E INDIVIDUALIZADA – IMPROCEDÊNCIA MANTIDA – RECURSO CONHECIDO DESPROVIDO.
+Considerando que os elementos de provas contidos nos autos permitiram ao Magistrado julgar o processo, não se vislumbra o alegado cerceamento de defesa no julgamento antecipado da lide. Preliminar de nulidade por cerceamento de defesa rejeitada.
+A Constituição Federal, em seu art. 37, § 6º, adota a responsabilidade civil objetiva do Estado, exigindo a demonstração do ato ilícito, do <em>dano</em> e do nexo causal, ainda que prescindível a prova de culpa.
+O Supremo Tribunal Federal, no julgamento do RE 580.252/MS (Tema 365), fixa tese no sentido de que o Estado responde por danos, inclusive morais, comprovadamente causados aos detentos em razão da falta ou insuficiência das condições legais de encarceramento, afastando a presunção automática do <em>dano</em>.
+O Superior Tribunal de Justiça interpreta o Tema 365 no sentido de que alegações genéricas sobre superlotação e precariedade do sistema prisional não são suficientes para ensejar indenização, exigindo prova concreta e individualizada do abalo <em>moral</em>, entendimento reafirmado no AgInt no AREsp 1.906.225/SP.
+No caso concreto, as provas indicam que, embora existente superlotação, os internos têm acesso à saúde, alimentação e atividades externas, como banho de sol, não se evidenciando privação de direitos básicos da execução penal.
+As alegações do apelante limitam-se a descrições genéricas das condições do cárcere, sem demonstração de circunstâncias extremas ou de prejuízo específico e individualizado que configure <em>dano</em> <em>moral</em> indenizável.
+Consta dos autos registro de investimentos e destinação de verbas à política penitenciária estadual, evidenciando medidas voltadas à melhoria das condições carcerárias.
+A jurisprudência deste Tribunal de Justiça, em consonância com o STF e o STJ, afasta o reconhecimento de <em>dano</em> <em>moral</em> presumido em hipóteses análogas envolvendo o estabelecimento penal de Corumbá, exigindo prova concreta do <em>dano</em>.
+Sentença mantida.
+Recurso conhecido e desprovido.
+
+A C Ó R D Ã O
+
+Vistos, relatados e discutidos estes autos, ACORDAM, em sessão permanente e virtual, os(as) magistrados(as) do(a) 5ª Câmara Cível do Tribunal de Justiça de Mato Grosso do Sul, na conformidade da ata de julgamentos, a seguinte decisão: Por unanimidade, negaram provimento ao recurso, nos termos do voto do Relator..
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>195&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875202" cdForo="0" >
+										0801622-74.2024.8.12.0020
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875202" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875202);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875202" style="display: none;" >
+	<div id="textAreaDados_1875202" class="mensagemSemFormatacao" >
+		DIREITO DO CONSUMIDOR &ndash; AGRAVO INTERNO &ndash; DESCONTOS INDEVIDOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO &ndash; RESPONSABILIDADE SOLID&Aacute;RIA &ndash; LEGITIMIDADE PASSIVA DO BANCO &ndash; DANO MORAL CONFIGURADO &ndash; REPETI&Ccedil;&Atilde;O DO IND&Eacute;BITO EM DOBRO &ndash; DECIS&Atilde;O MONOCR&Aacute;TICA MANTIDA &ndash; RECURSO DESPROVIDO. I. CASO EM EXAME: Agravo interno interposto contra decis&atilde;o monocr&aacute;tica que deu provimento &agrave; apela&ccedil;&atilde;o para reconhecer a legitimidade passiva do banco, condenar solidariamente as r&eacute;s &agrave; repeti&ccedil;&atilde;o do ind&eacute;bito em dobro e ao pagamento de danos morais no valor de R$ 1.500,00 por descontos n&atilde;o autorizados em benef&iacute;cio previdenci&aacute;rio. II. QUEST&Atilde;O EM DISCUSS&Atilde;O: Definir a legitimidade passiva do banco, a ocorr&ecirc;ncia de dano moral decorrente de desconto indevido e o termo inicial dos juros de mora. III. RAZ&Otilde;ES DE DECIDIR: Institui&ccedil;&otilde;es integrantes da cadeia de consumo respondem solidariamente pelos danos ao consumidor. Desconto indevido em benef&iacute;cio previdenci&aacute;rio configura falha na presta&ccedil;&atilde;o do servi&ccedil;o e gera dano moral. Juros de mora, em responsabilidade extracontratual, incidem a partir do evento danoso. IV. DISPOSITIVO E TESE: Agravo interno desprovido. TESE DE JULGAMENTO: 1) A institui&ccedil;&atilde;o financeira que viabiliza descontos em conta banc&aacute;ria responde solidariamente por cobran&ccedil;as indevidas decorrentes de contrata&ccedil;&atilde;o n&atilde;o comprovada. 2) O desconto indevido em benef&iacute;cio previdenci&aacute;rio caracteriza dano moral indeniz&aacute;vel, ainda que de pequeno valor. <br><br>(<b>TJMS</b>. Agravo Interno C&iacute;vel n. 0801622-74.2024.8.12.0020,&nbsp; Rio Brilhante,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 09/04/2026, p:&nbsp; 13/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(17 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Agravo Interno Cível / Descontos dos benefícios
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Rio Brilhante
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									09/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Outros números:
+									</strong>
+									801622742024812002050002
+								</td>
+							</tr>
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – AGRAVO INTERNO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE SOLIDÁRIA – LEGITIMIDADE PASSIVA DO BANCO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – REPETIÇÃO DO INDÉBITO EM DOBRO – DECISÃO MONOCRÁTICA MANTIDA – RECURSO DESPROVIDO. I. CASO EM EXAME: Agravo interno interposto contra decisão monocrática que deu provimento à apelação para reconhecer a
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO DO CONSUMIDOR – AGRAVO INTERNO – DESCONTOS INDEVIDOS EM BENEFÍCIO PREVIDENCIÁRIO – RESPONSABILIDADE SOLIDÁRIA – LEGITIMIDADE PASSIVA DO BANCO – <em>DANO</em> <em>MORAL</em> CONFIGURADO – REPETIÇÃO DO INDÉBITO EM DOBRO – DECISÃO MONOCRÁTICA MANTIDA – RECURSO DESPROVIDO. I. CASO EM EXAME: Agravo interno interposto contra decisão monocrática que deu provimento à apelação para reconhecer a legitimidade passiva do banco, condenar solidariamente as rés à repetição do indébito em dobro e ao pagamento de danos morais no valor de R$ 1.500,00 por descontos não autorizados em benefício previdenciário. II. QUESTÃO EM DISCUSSÃO: Definir a legitimidade passiva do banco, a ocorrência de <em>dano</em> <em>moral</em> decorrente de desconto indevido e o termo inicial dos juros de mora. III. RAZÕES DE DECIDIR: Instituições integrantes da cadeia de consumo respondem solidariamente pelos danos ao consumidor. Desconto indevido em benefício previdenciário configura falha na prestação do serviço e gera <em>dano</em> <em>moral</em>. Juros de mora, em responsabilidade extracontratual, incidem a partir do evento danoso. IV. DISPOSITIVO E TESE: Agravo interno desprovido. TESE DE JULGAMENTO: 1) A instituição financeira que viabiliza descontos em conta bancária responde solidariamente por cobranças indevidas decorrentes de contratação não comprovada. 2) O desconto indevido em benefício previdenciário caracteriza <em>dano</em> <em>moral</em> indenizável, ainda que de pequeno valor.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>196&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875211" cdForo="0" >
+										0851678-71.2024.8.12.0001
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875211" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875211);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875211" style="display: none;" >
+	<div id="textAreaDados_1875211" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL. A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA C/C REPETI&Ccedil;&Atilde;O DE IND&Eacute;BITO E INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. DESCONTOS EM BENEF&Iacute;CIO PREVIDENCI&Aacute;RIO. SINDICATO. PRELIMINAR DE SUSPENS&Atilde;O DO FEITO. INVESTIGA&Ccedil;&Otilde;ES DECORRENTES DA DENOMINADA &quot;OPERA&Ccedil;&Atilde;O SEM DESCONTO&quot; E SUPOSTA ADPF EM TR&Acirc;MITE PERANTE O SUPREMO TRIBUNAL FEDERAL. AUS&Ecirc;NCIA DE PREJUDICIALIDADE EXTERNA.  INEXIST&Ecirc;NCIA DE DETERMINA&Ccedil;&Atilde;O DE SOBRESTAMENTO. REJEI&Ccedil;&Atilde;O. M&Eacute;RITO. NEGATIVA DE CONTRATA&Ccedil;&Atilde;O. &Ocirc;NUS DA R&Eacute; (ART. 373, II, DO CPC). DOCUMENTA&Ccedil;&Atilde;O INSUFICIENTE PARA COMPROVAR A AUTENTICIDADE DA ASSINATURA ELETR&Ocirc;NICA E A REGULARIDADE DA ADES&Atilde;O. INEXIST&Ecirc;NCIA DE RELA&Ccedil;&Atilde;O JUR&Iacute;DICA. PERDA DO OBJETO. CANCELAMENTO POSTERIOR DA FILIA&Ccedil;&Atilde;O. IRRELEV&Acirc;NCIA. SUBSIST&Ecirc;NCIA DO INTERESSE PROCESSUAL. RESTITUI&Ccedil;&Atilde;O DOS VALORES. DEVOLU&Ccedil;&Atilde;O NA FORMA SIMPLES. COBRAN&Ccedil;A INDEVIDA. AUS&Ecirc;NCIA DE CAUSA JUR&Iacute;DICA PARA A RETEN&Ccedil;&Atilde;O. MANUTEN&Ccedil;&Atilde;O. DANOS MORAIS.  DESCONTOS REITERADOS INCIDENTES SOBRE VERBA DE NATUREZA ALIMENTAR. SITUA&Ccedil;&Atilde;O QUE ULTRAPASSA MERO ABORRECIMENTO. INDENIZA&Ccedil;&Atilde;O FIXADA EM R$ 3.000,00. RAZOABILIDADE E PROPORCIONALIDADE. RECURSO DESPROVIDO
+A preliminar de suspens&atilde;o do feito n&atilde;o merece acolhimento, pois a controv&eacute;rsia &eacute; de natureza individual e n&atilde;o depende do desfecho de investiga&ccedil;&otilde;es administrativas ou de a&ccedil;&atilde;o de controle concentrado, inexistindo determina&ccedil;&atilde;o de sobrestamento com efeito vinculante.
+No m&eacute;rito, competia &agrave; r&eacute; comprovar a regularidade da contrata&ccedil;&atilde;o e a autenticidade da assinatura eletr&ocirc;nica, &ocirc;nus do qual n&atilde;o se desincumbiu, impondo-se a manuten&ccedil;&atilde;o da declara&ccedil;&atilde;o de inexist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica.
+O cancelamento posterior da filia&ccedil;&atilde;o n&atilde;o acarreta perda do objeto, pois subsiste controv&eacute;rsia quanto &agrave; legalidade dos descontos j&aacute; realizados e aos seus efeitos patrimoniais.
+Reconhecida a cobran&ccedil;a indevida, correta a restitui&ccedil;&atilde;o na forma simples, diante da aus&ecirc;ncia de causa jur&iacute;dica apta a legitimar a reten&ccedil;&atilde;o dos valores.
+Por fim, os descontos reiterados sobre benef&iacute;cio previdenci&aacute;rio de natureza alimentar ultrapassam o mero aborrecimento, configurando dano moral indeniz&aacute;vel, sendo adequado o valor fixado na origem.
+Recurso desprovido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0851678-71.2024.8.12.0001,&nbsp; Campo Grande,&nbsp; 3&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Juiz F&aacute;bio Possik Salamene, j: 09/04/2026, p:&nbsp; 13/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(39 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Desconto em Folha de Pagamento/Benefício Previdenciário
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Juiz Fábio Possik Salamene
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Campo Grande
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									3ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									09/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS. DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO. SINDICATO. PRELIMINAR DE SUSPENSÃO DO FEITO. INVESTIGAÇÕES DECORRENTES DA DENOMINADA "OPERAÇÃO SEM DESCONTO" E SUPOSTA ADPF EM TRÂMITE PERANTE O SUPREMO TRIBUNAL FEDERAL. AUSÊNCIA DE PREJUDICIALIDADE EXTERNA.  INEXISTÊNCIA DE
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL. AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE RELAÇÃO JURÍDICA C/C REPETIÇÃO DE INDÉBITO E INDENIZAÇÃO POR DANOS MORAIS. DESCONTOS EM BENEFÍCIO PREVIDENCIÁRIO. SINDICATO. PRELIMINAR DE SUSPENSÃO DO FEITO. INVESTIGAÇÕES DECORRENTES DA DENOMINADA "OPERAÇÃO SEM DESCONTO" E SUPOSTA ADPF EM TRÂMITE PERANTE O SUPREMO TRIBUNAL FEDERAL. AUSÊNCIA DE PREJUDICIALIDADE EXTERNA.  INEXISTÊNCIA DE DETERMINAÇÃO DE SOBRESTAMENTO. REJEIÇÃO. MÉRITO. NEGATIVA DE CONTRATAÇÃO. ÔNUS DA RÉ (ART. 373, II, DO CPC). DOCUMENTAÇÃO INSUFICIENTE PARA COMPROVAR A AUTENTICIDADE DA ASSINATURA ELETRÔNICA E A REGULARIDADE DA ADESÃO. INEXISTÊNCIA DE RELAÇÃO JURÍDICA. PERDA DO OBJETO. CANCELAMENTO POSTERIOR DA FILIAÇÃO. IRRELEVÂNCIA. SUBSISTÊNCIA DO INTERESSE PROCESSUAL. RESTITUIÇÃO DOS VALORES. DEVOLUÇÃO NA FORMA SIMPLES. COBRANÇA INDEVIDA. AUSÊNCIA DE CAUSA JURÍDICA PARA A RETENÇÃO. MANUTENÇÃO. DANOS MORAIS.  DESCONTOS REITERADOS INCIDENTES SOBRE VERBA DE NATUREZA ALIMENTAR. SITUAÇÃO QUE ULTRAPASSA MERO ABORRECIMENTO. INDENIZAÇÃO FIXADA EM R$ 3.000,00. RAZOABILIDADE E PROPORCIONALIDADE. RECURSO DESPROVIDO
+A preliminar de suspensão do feito não merece acolhimento, pois a controvérsia é de natureza individual e não depende do desfecho de investigações administrativas ou de ação de controle concentrado, inexistindo determinação de sobrestamento com efeito vinculante.
+No mérito, competia à ré comprovar a regularidade da contratação e a autenticidade da assinatura eletrônica, ônus do qual não se desincumbiu, impondo-se a manutenção da declaração de inexistência da relação jurídica.
+O cancelamento posterior da filiação não acarreta perda do objeto, pois subsiste controvérsia quanto à legalidade dos descontos já realizados e aos seus efeitos patrimoniais.
+Reconhecida a cobrança indevida, correta a restituição na forma simples, diante da ausência de causa jurídica apta a legitimar a retenção dos valores.
+Por fim, os descontos reiterados sobre benefício previdenciário de natureza alimentar ultrapassam o mero aborrecimento, configurando <em>dano</em> <em>moral</em> indenizável, sendo adequado o valor fixado na origem.
+Recurso desprovido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>197&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875213" cdForo="0" >
+										0800588-18.2021.8.12.0037
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875213" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875213);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875213" style="display: none;" >
+	<div id="textAreaDados_1875213" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Otilde;ES C&Iacute;VEIS &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA D&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash;  RELA&Ccedil;&Atilde;O JUR&Iacute;DICA &ndash; N&Atilde;O COMPROVADA &ndash; REALIZA&Ccedil;&Atilde;O DE PER&Iacute;CIA GRAFOT&Eacute;CNICA &ndash;  DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; VALOR ALTERADO &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO PARCIALMENTE. RECURSO DA PARTE R&Eacute; CONHECIDO E N&Atilde;O PROVIDO.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+A rela&ccedil;&atilde;o jur&iacute;dica vincula os sujeitos de direito em decorr&ecirc;ncia dos fatos jur&iacute;dicos suficientemente comprovados, que s&atilde;o a causa da instaura&ccedil;&atilde;o, da modifica&ccedil;&atilde;o ou da extin&ccedil;&atilde;o de obriga&ccedil;&otilde;es. Especificamente no contrato de m&uacute;tuo ou de empr&eacute;stimo, a tradi&ccedil;&atilde;o da coisa mutuada &eacute; suficiente para se concluir pela exist&ecirc;ncia da rela&ccedil;&atilde;o jur&iacute;dica, cujos efeitos devem operar regulamente, nos termos do art. 586 do C&oacute;digo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso da parte autora conhecido e provido parcialmente. Recurso da parte r&eacute; conhecido e n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800588-18.2021.8.12.0037,&nbsp; Itapor&atilde;,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 09/04/2026, p:&nbsp; 13/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(24 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Pagamento Indevido
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Itaporã
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									09/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS –  RELAÇÃO JURÍDICA – NÃO COMPROVADA – REALIZAÇÃO DE PERÍCIA GRAFOTÉCNICA –  <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR ALTERADO – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÕES CÍVEIS – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS –  RELAÇÃO JURÍDICA – NÃO COMPROVADA – REALIZAÇÃO DE PERÍCIA GRAFOTÉCNICA –  <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR ALTERADO – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO DA PARTE AUTORA CONHECIDO E PROVIDO PARCIALMENTE. RECURSO DA PARTE RÉ CONHECIDO E NÃO PROVIDO.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+A relação jurídica vincula os sujeitos de direito em decorrência dos fatos jurídicos suficientemente comprovados, que são a causa da instauração, da modificação ou da extinção de obrigações. Especificamente no contrato de mútuo ou de empréstimo, a tradição da coisa mutuada é suficiente para se concluir pela existência da relação jurídica, cujos efeitos devem operar regulamente, nos termos do art. 586 do Código Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso da parte autora conhecido e provido parcialmente. Recurso da parte ré conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>198&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875214" cdForo="0" >
+										0800452-21.2025.8.12.0024
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875214" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875214);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875214" style="display: none;" >
+	<div id="textAreaDados_1875214" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DE OBRIGA&Ccedil;&Atilde;O DE FAZER C/C TUTELA ANTECIPADA DE URG&Ecirc;NCIA C/C MULTA ASTREINTE C/C DANOS MORAIS &ndash; INSCRI&Ccedil;&Atilde;O NO SISTEMA DE INFORMA&Ccedil;&Otilde;ES DE CR&Eacute;DITOS DO BACEN (SCR) &ndash; NATUREZA DE CADASTRO RESTRITIVO &ndash; INDEVIDA &ndash; NOTIFICA&Ccedil;&Atilde;O PR&Eacute;VIA &ndash; OBRIGA&Ccedil;&Atilde;O DA INSTITUI&Ccedil;&Atilde;O FINANCEIRA &ndash; N&Atilde;O COMPROVADA &ndash; DANO MORAL IN RE IPSA &ndash; N&Atilde;O DEMONSTRADO &ndash; INDEVIDO &ndash; INSCRI&Ccedil;&Atilde;O PREEXISTENTE &ndash; S&Uacute;MULA 385 DO STJ &ndash; FLEXIBILIZA&Ccedil;&Atilde;O &ndash; CAB&Iacute;VEL &ndash; RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O Superior Tribunal de Justi&ccedil;a tem entendimento consolidado de que o Sistema de Informa&ccedil;&otilde;es de Cr&eacute;ditos do Bacen (SCR), embora n&atilde;o se confunda com os cadastros de inadimplentes &ndash; como o Servi&ccedil;o de Prote&ccedil;&atilde;o ao Cr&eacute;dito - SPC e o Serasa &ndash; tem indiscut&iacute;vel car&aacute;ter restritivo de cr&eacute;dito.
+Al&eacute;m disso, justamente por se distinguir dos cadastros de inadimplentes, &eacute; que a obriga&ccedil;&atilde;o de notifica&ccedil;&atilde;o pr&eacute;via ao devedor n&atilde;o incumbe ao Banco Central do Brasil, mas, sim, &agrave;s institui&ccedil;&otilde;es financeiras.
+O Superior Tribunal de Justi&ccedil;a admite a flexibiliza&ccedil;&atilde;o da orienta&ccedil;&atilde;o contida na s&uacute;mula 385/STJ para reconhecer o dano moral decorrente da inscri&ccedil;&atilde;o indevida do nome do consumidor em cadastro restritivo, ainda que n&atilde;o tenha havido o tr&acirc;nsito em julgado das outras demandas em que se apontava a irregularidade das anota&ccedil;&otilde;es preexistentes, desde que haja nos autos elementos aptos a demonstrar a verossimilhan&ccedil;a das alega&ccedil;&otilde;es. Precedentes. (AgInt no AREsp n. 2.163.040/RJ, relatora Ministra Nancy Andrighi, Terceira Turma, julgado em 5/12/2022, Dje de 7/12/2022.)
+S&atilde;o inviol&aacute;veis a intimidade, a vida privada, a honra e a imagem das pessoas, assegurado o direito a indeniza&ccedil;&atilde;o pelo dano material ou moral decorrente de sua viola&ccedil;&atilde;o, nos termos do art. 5&ordm;, inc. X, da Constitui&ccedil;&atilde;o Federal. Caracteriza-se o dano moral in re ipsa a inscri&ccedil;&atilde;o ou a manuten&ccedil;&atilde;o indevida do consumidor em cadastro de prote&ccedil;&atilde;o ao cr&eacute;dito, por ofensa aos direitos da personalidade, consoante o art. 12 do C&oacute;digo Civil. O valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto. Jurisprud&ecirc;ncia dominante do Superior Tribunal de Justi&ccedil;a. (STJ: Recursos Especiais n&ordm; 1.062.336/RS e 1.061.134/RS (recurso repetitivo) (Temas 37, 40 e 41) e Recurso Especial n&ordm; 1.444.469/DF (recurso repetitivo) (Tema 806); S&uacute;mula n&ordm; 385).
+Recurso conhecido e parcialmente provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800452-21.2025.8.12.0024,&nbsp; Aparecida do Taboado,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 09/04/2026, p:&nbsp; 13/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(38 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Inclusão Indevida em Cadastro de Inadimplentes
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Aparecida do Taboado
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									09/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C TUTELA ANTECIPADA DE URGÊNCIA C/C MULTA ASTREINTE C/C DANOS MORAIS – INSCRIÇÃO NO SISTEMA DE INFORMAÇÕES DE CRÉDITOS DO BACEN (SCR) – NATUREZA DE CADASTRO RESTRITIVO – INDEVIDA – NOTIFICAÇÃO PRÉVIA – OBRIGAÇÃO DA INSTITUIÇÃO FINANCEIRA – NÃO COMPROVADA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – NÃO DEMONSTRADO – INDEVIDO – INSCRIÇÃO PREEXISTENTE –
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DE OBRIGAÇÃO DE FAZER C/C TUTELA ANTECIPADA DE URGÊNCIA C/C MULTA ASTREINTE C/C DANOS MORAIS – INSCRIÇÃO NO SISTEMA DE INFORMAÇÕES DE CRÉDITOS DO BACEN (SCR) – NATUREZA DE CADASTRO RESTRITIVO – INDEVIDA – NOTIFICAÇÃO PRÉVIA – OBRIGAÇÃO DA INSTITUIÇÃO FINANCEIRA – NÃO COMPROVADA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – NÃO DEMONSTRADO – INDEVIDO – INSCRIÇÃO PREEXISTENTE – SÚMULA 385 DO STJ – FLEXIBILIZAÇÃO – CABÍVEL – RECURSO CONHECIDO E PARCIALMENTE PROVIDO.
+O Superior Tribunal de Justiça tem entendimento consolidado de que o Sistema de Informações de Créditos do Bacen (SCR), embora não se confunda com os cadastros de inadimplentes – como o Serviço de Proteção ao Crédito - SPC e o Serasa – tem indiscutível caráter restritivo de crédito.
+Além disso, justamente por se distinguir dos cadastros de inadimplentes, é que a obrigação de notificação prévia ao devedor não incumbe ao Banco Central do Brasil, mas, sim, às instituições financeiras.
+O Superior Tribunal de Justiça admite a flexibilização da orientação contida na súmula 385/STJ para reconhecer o <em>dano</em> <em>moral</em> decorrente da inscrição indevida do nome do consumidor em cadastro restritivo, ainda que não tenha havido o trânsito em julgado das outras demandas em que se apontava a irregularidade das anotações preexistentes, desde que haja nos autos elementos aptos a demonstrar a verossimilhança das alegações. Precedentes. (AgInt no AREsp n. 2.163.040/RJ, relatora Ministra Nancy Andrighi, Terceira Turma, julgado em 5/12/2022, Dje de 7/12/2022.)
+São invioláveis a intimidade, a vida privada, a honra e a imagem das pessoas, assegurado o direito a indenização pelo <em>dano</em> material ou <em>moral</em> decorrente de sua violação, nos termos do art. 5º, inc. X, da Constituição Federal. Caracteriza-se o <em>dano</em> <em>moral</em> in re ipsa a inscrição ou a manutenção indevida do consumidor em cadastro de proteção ao crédito, por ofensa aos direitos da personalidade, consoante o art. 12 do Código Civil. O valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto. Jurisprudência dominante do Superior Tribunal de Justiça. (STJ: Recursos Especiais nº 1.062.336/RS e 1.061.134/RS (recurso repetitivo) (Temas 37, 40 e 41) e Recurso Especial nº 1.444.469/DF (recurso repetitivo) (Tema 806); Súmula nº 385).
+Recurso conhecido e parcialmente provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>199&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875215" cdForo="0" >
+										0801015-33.2025.8.12.0018
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875215" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875215);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875215" style="display: none;" >
+	<div id="textAreaDados_1875215" class="mensagemSemFormatacao" >
+		APELA&Ccedil;&Atilde;O C&Iacute;VEL &ndash; A&Ccedil;&Atilde;O DECLARAT&Oacute;RIA DE INEXIST&Ecirc;NCIA DE D&Eacute;BITO C/C REPETI&Ccedil;&Atilde;O IND&Eacute;BITO C/C INDENIZA&Ccedil;&Atilde;O POR DANOS MATERIAIS E MORAIS &ndash; PRELIMINAR &ndash; DIALETICIDADE &ndash; AFASTADA &ndash; DANO MORAL IN RE IPSA &ndash; DEMONSTRADO &ndash; DEVIDO &ndash; VALOR MANTIDO &ndash; HONOR&Aacute;RIOS ADVOCAT&Iacute;CIOS &ndash; MANTIDOS &ndash; ATUALIZA&Ccedil;&Atilde;O MONET&Aacute;RIA E MORA NO PAGAMENTO &ndash; &Iacute;NDICES &ndash; MAT&Eacute;RIA DE ORDEM P&Uacute;BLICA &ndash; APLICA&Ccedil;&Atilde;O DA TAXA SELIC AT&Eacute; A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENT&Atilde;O, INCID&Ecirc;NCIA DAS ALTERA&Ccedil;&Otilde;ES DO C&Oacute;DIGO CIVIL &ndash; RECURSO CONHECIDO E N&Atilde;O PROVIDO.
+Os recursos previstos no C&oacute;digo de Processo Civil reclamam dialeticidade. Para tanto, as raz&otilde;es recursais devem se desincumbir do &ocirc;nus de expor fatos ou fundamentos espec&iacute;ficos que justifiquem a integra&ccedil;&atilde;o, a reforma ou a anula&ccedil;&atilde;o da decis&atilde;o, da senten&ccedil;a ou do ac&oacute;rd&atilde;o recorrido, sem preju&iacute;zo do pedido de nova decis&atilde;o. Enfim, deve haver impugna&ccedil;&atilde;o espec&iacute;fica, pertinente e atual, sem a qual os recursos s&atilde;o inadmiss&iacute;veis e, por isso, n&atilde;o devem ser conhecidos, nos termos do art. 932, inc. III, do C&oacute;digo de Processo Civil.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que o C&oacute;digo de Defesa do Consumidor &eacute; aplic&aacute;vel &agrave;s institui&ccedil;&otilde;es financeiras, nos termos do enunciado da S&uacute;mula n&ordm; 297 (STF: ADI n&ordm; 2.591).
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispens&aacute;vel a demonstra&ccedil;&atilde;o de dor ou sofrimento, uma vez que intr&iacute;nseca &agrave; pr&oacute;pria conduta. E o valor da condena&ccedil;&atilde;o deve se afastar do irris&oacute;rio ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARA&Uacute;JO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justi&ccedil;a, nos julgamentos dos Recursos Especiais n&ordm; 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixa&ccedil;&atilde;o dos honor&aacute;rios por aprecia&ccedil;&atilde;o equitativa n&atilde;o &eacute; permitida quando os valores da condena&ccedil;&atilde;o ou da causa, ou o proveito econ&ocirc;mico da demanda, forem elevados. &Eacute; obrigat&oacute;ria, nesses casos, a observ&acirc;ncia dos percentuais previstos nos par&aacute;grafos 2&ordm; ou 3&ordm; do artigo 85 do C&oacute;digo de Processo Civil (CPC) &ndash; a depender da presen&ccedil;a da Fazenda P&uacute;blica na lide &ndash;, os quais ser&atilde;o subsequentemente calculados sobre o valor: (a) da condena&ccedil;&atilde;o; ou (b) do proveito econ&ocirc;mico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honor&aacute;rios por equidade quando, havendo ou n&atilde;o condena&ccedil;&atilde;o: (a) o proveito econ&ocirc;mico obtido pelo vencedor for inestim&aacute;vel ou irris&oacute;rio; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justi&ccedil;a tem jurisprud&ecirc;ncia dominante no sentido de que a aplica&ccedil;&atilde;o de juros e corre&ccedil;&atilde;o monet&aacute;ria pode ser alegada na inst&acirc;ncia ordin&aacute;ria a qualquer tempo, podendo, inclusive, ser conhecida de of&iacute;cio. A decis&atilde;o nesse sentido n&atilde;o caracteriza julgamento extra petita, tampouco conduz &agrave; interpreta&ccedil;&atilde;o de ocorr&ecirc;ncia de preclus&atilde;o consumativa, porquanto tais institutos s&atilde;o meros consect&aacute;rios legais da condena&ccedil;&atilde;o (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as altera&ccedil;&otilde;es promovidas pela Lei n&ordm; 14.905/2024 no C&oacute;digo Civil e a tese do Tema n&ordm; 1368 do Superior Tribunal de Justi&ccedil;a, estabelecendo a taxa Selic como taxa legal de atualiza&ccedil;&atilde;o monet&aacute;ria e mora no pagamento at&eacute; o dia anterior ao da vig&ecirc;ncia da Lei n&ordm; 14.905/2024, sendo que, ap&oacute;s esta data, os consect&aacute;rios legais incidir&atilde;o da seguinte forma: a) juros de acordo com a taxa legal, que corresponde &agrave; taxa referencial do Sistema Especial de Liquida&ccedil;&atilde;o e de Cust&oacute;dia (SELIC), deduzido o &iacute;ndice IPCA-E (art. 406, &sect;1&ordm; do CC); e, b) corre&ccedil;&atilde;o monet&aacute;ria, pelo IPCA-E do IBGE (art. 389, par&aacute;grafo &uacute;nico, do CC).
+Recurso conhecido e n&atilde;o provido. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0801015-33.2025.8.12.0018,&nbsp; Parana&iacute;ba,&nbsp; 5&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Alexandre Raslan, j: 09/04/2026, p:&nbsp; 13/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(23 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Práticas Abusivas
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Alexandre Raslan
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Paranaíba
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									5ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									09/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO INDÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR – DIALETICIDADE – AFASTADA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR MANTIDO – HONORÁRIOS ADVOCATÍCIOS – MANTIDOS – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>APELAÇÃO CÍVEL – AÇÃO DECLARATÓRIA DE INEXISTÊNCIA DE DÉBITO C/C REPETIÇÃO INDÉBITO C/C INDENIZAÇÃO POR DANOS MATERIAIS E MORAIS – PRELIMINAR – DIALETICIDADE – AFASTADA – <em>DANO</em> <em>MORAL</em> IN RE IPSA – DEMONSTRADO – DEVIDO – VALOR MANTIDO – HONORÁRIOS ADVOCATÍCIOS – MANTIDOS – ATUALIZAÇÃO MONETÁRIA E MORA NO PAGAMENTO – ÍNDICES – MATÉRIA DE ORDEM PÚBLICA – APLICAÇÃO DA TAXA SELIC ATÉ A ENTRADA EM VIGOR DA LEI 14.905/2024 E, A PARTIR DE ENTÃO, INCIDÊNCIA DAS ALTERAÇÕES DO CÓDIGO CIVIL – RECURSO CONHECIDO E NÃO PROVIDO.
+Os recursos previstos no Código de Processo Civil reclamam dialeticidade. Para tanto, as razões recursais devem se desincumbir do ônus de expor fatos ou fundamentos específicos que justifiquem a integração, a reforma ou a anulação da decisão, da sentença ou do acórdão recorrido, sem prejuízo do pedido de nova decisão. Enfim, deve haver impugnação específica, pertinente e atual, sem a qual os recursos são inadmissíveis e, por isso, não devem ser conhecidos, nos termos do art. 932, inc. III, do Código de Processo Civil.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que o Código de Defesa do Consumidor é aplicável às instituições financeiras, nos termos do enunciado da Súmula nº 297 (STF: ADI nº 2.591).
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a ofensa aos direitos da personalidade implica em danos morais in re ipsa, sendo dispensável a demonstração de dor ou sofrimento, uma vez que intrínseca à própria conduta. E o valor da condenação deve se afastar do irrisório ou do exorbitante, casos em que pode ser revisto (AgRg no AREsp 166.040/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 14/08/2012, DJe 31/08/2012; AgInt no AREsp 1933139/RJ, Rel. Ministro RAUL ARAÚJO, QUARTA TURMA, julgado em 13/12/2021, DJe 17/12/2021).
+O Superior Tribunal de Justiça, nos julgamentos dos Recursos Especiais nº 1.850.512/SP, 1.877.883/SP, 1.906.623/SP e 1.906.618/SP (recursos repetitivos) (Tema 1.076), fixou a seguinte tese: 1) A fixação dos honorários por apreciação equitativa não é permitida quando os valores da condenação ou da causa, ou o proveito econômico da demanda, forem elevados. É obrigatória, nesses casos, a observância dos percentuais previstos nos parágrafos 2º ou 3º do artigo 85 do Código de Processo Civil (CPC) – a depender da presença da Fazenda Pública na lide –, os quais serão subsequentemente calculados sobre o valor: (a) da condenação; ou (b) do proveito econômico obtido; ou (c) do valor atualizado da causa. 2) Apenas se admite o arbitramento de honorários por equidade quando, havendo ou não condenação: (a) o proveito econômico obtido pelo vencedor for inestimável ou irrisório; ou (b) o valor da causa for muito baixo.
+O Superior Tribunal de Justiça tem jurisprudência dominante no sentido de que a aplicação de juros e correção monetária pode ser alegada na instância ordinária a qualquer tempo, podendo, inclusive, ser conhecida de ofício. A decisão nesse sentido não caracteriza julgamento extra petita, tampouco conduz à interpretação de ocorrência de preclusão consumativa, porquanto tais institutos são meros consectários legais da condenação (AgInt no REsp n. 2.173.703/SC, relatora Ministra Maria Thereza de Assis Moura, Segunda Turma, julgado em 27/11/2024, DJEN de 2/12/2024.)
+Aplica-se as alterações promovidas pela Lei nº 14.905/2024 no Código Civil e a tese do Tema nº 1368 do Superior Tribunal de Justiça, estabelecendo a taxa Selic como taxa legal de atualização monetária e mora no pagamento até o dia anterior ao da vigência da Lei nº 14.905/2024, sendo que, após esta data, os consectários legais incidirão da seguinte forma: a) juros de acordo com a taxa legal, que corresponde à taxa referencial do Sistema Especial de Liquidação e de Custódia (SELIC), deduzido o índice IPCA-E (art. 406, §1º do CC); e, b) correção monetária, pelo IPCA-E do IBGE (art. 389, parágrafo único, do CC).
+Recurso conhecido e não provido.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>200&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="1875216" cdForo="0" >
+										0800220-91.2024.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="1875216" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(1875216);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_1875216" style="display: none;" >
+	<div id="textAreaDados_1875216" class="mensagemSemFormatacao" >
+		DIREITO CONSTITUCIONAL E ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. APELA&Ccedil;&Atilde;O C&Iacute;VEL. INDENIZA&Ccedil;&Atilde;O POR DANOS MORAIS. SISTEMA PRISIONAL. ALEGA&Ccedil;&Atilde;O DE SUPERLOTA&Ccedil;&Atilde;O E CONDI&Ccedil;&Otilde;ES DEGRADANTES. NECESSIDADE DE COMPROVA&Ccedil;&Atilde;O CONCRETA E INDIVIDUALIZADA DO DANO. TEMA 365 DO STF. AUS&Ecirc;NCIA DE PROVA DO PREJU&Iacute;ZO INDIVIDUAL. SENTEN&Ccedil;A MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME: Apela&ccedil;&atilde;o c&iacute;vel interposta contra senten&ccedil;a que julgou improcedente a&ccedil;&atilde;o de indeniza&ccedil;&atilde;o por danos morais ajuizada em face do Estado de Mato Grosso do Sul.
+A senten&ccedil;a concluiu pela inexist&ecirc;ncia de prova concreta do dano moral individual suportado pelo autor, raz&atilde;o pela qual afastou a responsabilidade civil do Estado.
+II. QUEST&Atilde;O EM DISCUSS&Atilde;O: A quest&atilde;o em discuss&atilde;o consiste em definir se a alega&ccedil;&atilde;o de superlota&ccedil;&atilde;o e de condi&ccedil;&otilde;es inadequadas no estabelecimento prisional, desacompanhada de prova concreta e individualizada do preju&iacute;zo suportado pelo detento, &eacute; suficiente para caracterizar dano moral indeniz&aacute;vel e gerar responsabilidade civil do Estado.
+III. RAZ&Otilde;ES DE DECIDIR: A responsabilidade civil do Estado &eacute; objetiva, nos termos do art. 37, &sect; 6&ordm;, da Constitui&ccedil;&atilde;o Federal, exigindo, entretanto, a demonstra&ccedil;&atilde;o da ocorr&ecirc;ncia de dano e do nexo causal entre a conduta estatal e o preju&iacute;zo alegado.
+O Supremo Tribunal Federal, ao julgar o Tema 365 da repercuss&atilde;o geral (RE 580.252/MS), firmou entendimento no sentido de que o Estado responde pelos danos morais decorrentes de condi&ccedil;&otilde;es ilegais de encarceramento, desde que haja comprova&ccedil;&atilde;o efetiva do dano suportado pelo detento.
+Nesse contexto, n&atilde;o basta a afirma&ccedil;&atilde;o gen&eacute;rica de precariedade do sistema prisional ou de superlota&ccedil;&atilde;o carcer&aacute;ria, sendo necess&aacute;ria a demonstra&ccedil;&atilde;o concreta da viola&ccedil;&atilde;o &agrave; dignidade do preso, mediante elementos espec&iacute;ficos relacionados &agrave; sua realidade individual no estabelecimento prisional.
+No caso dos autos, as provas testemunhais produzidas descrevem aspectos gerais das condi&ccedil;&otilde;es do pres&iacute;dio, sem indicar viola&ccedil;&atilde;o espec&iacute;fica aos direitos do autor ou situa&ccedil;&atilde;o excepcional que o tenha atingido de forma individualizada.
+Al&eacute;m disso, h&aacute; registros nos autos de melhorias estruturais e de funcionamento da unidade prisional, incluindo assist&ecirc;ncia m&eacute;dica, atividades laborais e educacionais, circunst&acirc;ncias que refor&ccedil;am a aus&ecirc;ncia de comprova&ccedil;&atilde;o de dano moral individual.
+Assim, inexistindo prova concreta do preju&iacute;zo moral suportado pelo apelante, n&atilde;o se configuram os requisitos necess&aacute;rios &agrave; responsabiliza&ccedil;&atilde;o civil do Estado.
+IV. DISPOSITIVO E TESE: Recurso conhecido e desprovido.
+Senten&ccedil;a mantida.
+Tese de julgamento: A indeniza&ccedil;&atilde;o por danos morais decorrentes de condi&ccedil;&otilde;es inadequadas de encarceramento exige a comprova&ccedil;&atilde;o concreta e individualizada do preju&iacute;zo suportado pelo detento, n&atilde;o sendo suficiente a mera alega&ccedil;&atilde;o gen&eacute;rica de superlota&ccedil;&atilde;o ou precariedade do sistema prisional.
+A responsabilidade civil objetiva do Estado por danos sofridos por presos, nos termos do Tema 365 do STF, pressup&otilde;e demonstra&ccedil;&atilde;o do dano efetivo e do nexo causal entre as condi&ccedil;&otilde;es de encarceramento e a viola&ccedil;&atilde;o &agrave; dignidade do custodiado. <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0800220-91.2024.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 2&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jos&eacute; Eduardo Neder Meneghelli, j: 09/04/2026, p:&nbsp; 13/04/2026)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(65 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Direito de Imagem
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. José Eduardo Neder Meneghelli
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									2ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									09/04/2026
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									13/04/2026
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div align="justify">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. APELAÇÃO CÍVEL. INDENIZAÇÃO POR DANOS MORAIS. SISTEMA PRISIONAL. ALEGAÇÃO DE SUPERLOTAÇÃO E CONDIÇÕES DEGRADANTES. NECESSIDADE DE COMPROVAÇÃO CONCRETA E INDIVIDUALIZADA DO <em>DANO</em>. TEMA 365 DO STF. AUSÊNCIA DE PROVA DO PREJUÍZO INDIVIDUAL. SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME: Apelação cível
+											 	<a >
+											 		<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMais.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+											<div align="justify" style="display: none;">
+												<strong>Ementa: </strong>DIREITO CONSTITUCIONAL E ADMINISTRATIVO. RESPONSABILIDADE CIVIL DO ESTADO. APELAÇÃO CÍVEL. INDENIZAÇÃO POR DANOS MORAIS. SISTEMA PRISIONAL. ALEGAÇÃO DE SUPERLOTAÇÃO E CONDIÇÕES DEGRADANTES. NECESSIDADE DE COMPROVAÇÃO CONCRETA E INDIVIDUALIZADA DO <em>DANO</em>. TEMA 365 DO STF. AUSÊNCIA DE PROVA DO PREJUÍZO INDIVIDUAL. SENTENÇA MANTIDA. RECURSO DESPROVIDO.
+I. CASO EM EXAME: Apelação cível interposta contra sentença que julgou improcedente ação de indenização por danos morais ajuizada em face do Estado de Mato Grosso do Sul.
+A sentença concluiu pela inexistência de prova concreta do <em>dano</em> <em>moral</em> individual suportado pelo autor, razão pela qual afastou a responsabilidade civil do Estado.
+II. QUESTÃO EM DISCUSSÃO: A questão em discussão consiste em definir se a alegação de superlotação e de condições inadequadas no estabelecimento prisional, desacompanhada de prova concreta e individualizada do prejuízo suportado pelo detento, é suficiente para caracterizar <em>dano</em> <em>moral</em> indenizável e gerar responsabilidade civil do Estado.
+III. RAZÕES DE DECIDIR: A responsabilidade civil do Estado é objetiva, nos termos do art. 37, § 6º, da Constituição Federal, exigindo, entretanto, a demonstração da ocorrência de <em>dano</em> e do nexo causal entre a conduta estatal e o prejuízo alegado.
+O Supremo Tribunal Federal, ao julgar o Tema 365 da repercussão geral (RE 580.252/MS), firmou entendimento no sentido de que o Estado responde pelos danos morais decorrentes de condições ilegais de encarceramento, desde que haja comprovação efetiva do <em>dano</em> suportado pelo detento.
+Nesse contexto, não basta a afirmação genérica de precariedade do sistema prisional ou de superlotação carcerária, sendo necessária a demonstração concreta da violação à dignidade do preso, mediante elementos específicos relacionados à sua realidade individual no estabelecimento prisional.
+No caso dos autos, as provas testemunhais produzidas descrevem aspectos gerais das condições do presídio, sem indicar violação específica aos direitos do autor ou situação excepcional que o tenha atingido de forma individualizada.
+Além disso, há registros nos autos de melhorias estruturais e de funcionamento da unidade prisional, incluindo assistência médica, atividades laborais e educacionais, circunstâncias que reforçam a ausência de comprovação de <em>dano</em> <em>moral</em> individual.
+Assim, inexistindo prova concreta do prejuízo <em>moral</em> suportado pelo apelante, não se configuram os requisitos necessários à responsabilização civil do Estado.
+IV. DISPOSITIVO E TESE: Recurso conhecido e desprovido.
+Sentença mantida.
+Tese de julgamento: A indenização por danos morais decorrentes de condições inadequadas de encarceramento exige a comprovação concreta e individualizada do prejuízo suportado pelo detento, não sendo suficiente a mera alegação genérica de superlotação ou precariedade do sistema prisional.
+A responsabilidade civil objetiva do Estado por danos sofridos por presos, nos termos do Tema 365 do STF, pressupõe demonstração do <em>dano</em> efetivo e do nexo causal entre as condições de encarceramento e a violação à dignidade do custodiado.
+												<a >
+													<img class="mostrarOcultarEmenta cursorPointer" src="/cjsg/imagens/saj/icoMenos.png" height="12" width="12" border="0" title="Visualizar Ementa Completa"/>
+												</a>
+											</div>
+										</td>
+									</tr>
+
+
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="RECURSO">
+									<label for="ckTermo1">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="APELAÇÃO">
+									<label for="ckTermo2">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="AÇÃO">
+									<label for="ckTermo3">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="CÍVEL">
+									<label for="ckTermo4">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="DANOS">
+									<label for="ckTermo5">
+										DANOS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="EMENTA">
+									<label for="ckTermo6">
+										EMENTA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="MORAIS">
+									<label for="ckTermo7">
+										MORAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="INDENIZAÇÃO">
+									<label for="ckTermo8">
+										INDENIZAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="PROVIDO">
+									<label for="ckTermo9">
+										PROVIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="CONHECIDO">
+									<label for="ckTermo10">
+										CONHECIDO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="DECLARATÓRIA">
+									<label for="ckTermo11">
+										DECLARATÓRIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="DANO">
+									<label for="ckTermo12">
+										DANO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="MORAL">
+									<label for="ckTermo13">
+										MORAL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="INEXISTÊNCIA">
+									<label for="ckTermo14">
+										INEXISTÊNCIA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="danos">
+									<label for="ckTermo15">
+										danos
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				101 a 200
+			</strong>
+			de 149670
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+			<a name="A1" title="Página anterior">
+				&lt;
+			</a>
+
+
+
+
+
+
+
+
+
+
+
+					<a name="A1" style="padding-left:4px" >
+						1
+					</a>
+
+
+
+
+
+					<span class="paginaAtual" >
+						2
+					</span>
+
+
+
+
+
+
+
+					<a name="A3" style="padding-left:4px" >
+						3
+					</a>
+
+
+
+
+
+
+					<a name="A4" style="padding-left:4px" >
+						4
+					</a>
+
+
+
+
+
+
+					<a name="A5" style="padding-left:4px" >
+						5
+					</a>
+
+
+
+
+
+			<a name="A3" title="Próxima página">
+				&gt;
+			</a>
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjms/samples/cjsg/single_page.html
+++ b/tests/tjms/samples/cjsg/single_page.html
@@ -1,0 +1,541 @@
+
+
+
+
+
+
+
+
+<span style="display: none;" id="nomeAbaRetornoFiltro-A" >Acórdãos(2)</span>
+<input id="totalResultadoAbaRetornoFiltro-A" type="hidden" value="2" />
+
+
+
+
+
+
+
+
+
+
+
+	<table cellspacing="0" cellpadding="0" class="" width="100%">
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>1&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="122903" cdForo="0" >
+										0000070-70.2002.8.12.0023
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="122903" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(122903);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_122903" style="display: none;" >
+	<div id="textAreaDados_122903" class="mensagemSemFormatacao" >
+		'APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DE REINTEGRA&Ccedil;&Atilde;O DE POSSE - SERVID&Atilde;O DE TR&Acirc;NSITO APARENTE - PROPRIEDADE N&Atilde;O ENCRAVADA - IRRELEV&Acirc;NCIA - RECURSO IMPROVIDO.'  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0000070-70.2002.8.12.0023,&nbsp; Ang&eacute;lica,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Jo&atilde;o Maria L&oacute;s, j: 30/09/2008, p:&nbsp; 19/10/2008)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(6 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe:
+											</strong> Apelação Cível
+										</td>
+									</tr>
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. João Maria Lós
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Angélica
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									30/09/2008
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									19/10/2008
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa122903" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												'APELAÇÃO CÍVEL - AÇÃO DE REINTEGRAÇÃO DE POSSE - SERVIDÃO DE TRÂNSITO APARENTE - PROPRIEDADE NÃO ENCRAVADA - IRRELEVÂNCIA - RECURSO IMPROVIDO.'
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+			<tr class="fundocinza1">
+				<td width="40" align="left" valign="top" class="ementaClass">
+					<strong>2&nbsp;-</strong>
+				</td>
+				<td valign="top">
+					<table cellspacing="0" cellpadding="0" width="100%"  >
+						<tr class="ementaClass" >
+							<td colspan="2" align="left">
+
+									<a class="esajLinkLogin downloadEmenta" style="vertical-align: top" title="Visualizar Inteiro Teor" cdAcordao="27777" cdForo="0" >
+										0003499-10.1953.8.12.0008
+									</a>
+
+									<a class="downloadEmenta" cdAcordao="27777" cdForo="0">&nbsp;
+										<img src="imagens/saj/ico_pdf.gif" border="0" title="Visualizar inteiro teor"/> <span class="downloadEmenta"></span>
+									</a>
+									<a class="textoSemFormatacao" onclick="abrirPopUpDadosSemFormatacao(27777);" >&nbsp;
+										<img src="imagens/saj/ico_txt.gif" border="0" title="Visualizar ementa sem formatação"/> <span class="textoSemFormatacao"></span>
+
+
+
+
+
+
+
+<div id="dadosSemFormatacao_27777" style="display: none;" >
+	<div id="textAreaDados_27777" class="mensagemSemFormatacao" >
+		'APELA&Ccedil;&Atilde;O C&Iacute;VEL - A&Ccedil;&Atilde;O DE USUCAPI&Atilde;O EXTRAORDIN&Aacute;RIO - LOTES URBANOS - MORADIA EM APENAS UM DOS LOTES - N&Atilde;O-CONFIGURA&Ccedil;&Atilde;O DO ANIMUS DOMINI QUANTO AOS DEMAIS LOTES - DESVIRTUAMENTO DA FUN&Ccedil;&Atilde;O SOCIAL DA PROPRIEDADE - OCORR&Ecirc;NCIA - RECURSO PROVIDO'  <br><br>(<b>TJMS</b>. Apela&ccedil;&atilde;o C&iacute;vel n. 0003499-10.1953.8.12.0008,&nbsp; Corumb&aacute;,&nbsp; 1&ordf; C&acirc;mara C&iacute;vel, Relator (a):&nbsp; Des. Hildebrando Coelho Neto, j: 26/06/2001, p:&nbsp; 09/08/2001)
+	</div>
+</div>
+
+									</a>
+
+
+
+										<span class="segredoJustica">(26 ocorrências encontradas no inteiro teor do documento)</span>
+
+
+							</td>
+						</tr>
+
+						<span class="assuntoClasse">&nbsp;
+
+
+									<tr class="ementaClass2">
+										<td align="left">
+											<strong>
+												Classe/Assunto:
+											</strong> Apelação Cível / Assunto não Especificado
+										</td>
+									</tr>
+
+
+
+
+						</span>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Relator(a):
+									</strong> Des. Hildebrando Coelho Neto
+
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Comarca:
+									</strong>
+									Corumbá
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Órgão julgador:
+									</strong>
+									1ª Câmara Cível
+								</td>
+							</tr>
+
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data do julgamento:
+									</strong>
+									26/06/2001
+								</td>
+							</tr>
+
+
+							<tr class="ementaClass2">
+								<td align="left">
+									<strong>
+										Data de publicação:
+									</strong>
+									09/08/2001
+								</td>
+							</tr>
+
+
+
+
+
+
+
+
+
+
+
+
+									<tr class="ementaClass2">
+										<td colspan="2" align="left">
+											<div id="ementa27777" align="justify">
+												<strong>
+													Ementa:
+												</strong>
+												'APELAÇÃO CÍVEL - AÇÃO DE USUCAPIÃO EXTRAORDINÁRIO - LOTES URBANOS - MORADIA EM APENAS UM DOS LOTES - NÃO-CONFIGURAÇÃO DO ANIMUS DOMINI QUANTO AOS DEMAIS LOTES - DESVIRTUAMENTO DA FUNÇÃO SOCIAL DA PROPRIEDADE - OCORRÊNCIA - RECURSO PROVIDO'
+											</div>
+										</td>
+									</tr>
+
+
+
+					</table>
+					<br /><br />
+				</td>
+			</tr>
+
+	</table>
+
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+<table id="abaAdicionar-A" style="cursor: pointer;" width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+	<tr>
+		<td width="*" height="20" bgcolor="#CCCCCC">
+			<span id="spanTermosRelacionados" >
+				<strong>
+					Termos mais freqüentes
+				</strong>
+			</span>
+		</td>
+		<td width="50px" align="center">
+			<img id="imgAdicionar" src="imagens/saj/fecharFiltro.gif" border="0"
+				align="middle" style="cursor: pointer;">
+		</td>
+	</tr>
+</table>
+
+	<table width="100%" border="0" cellpadding="0" cellspacing="1" align="center" bgcolor="#CCCCCC">
+		<tr>
+			<td bgcolor="#EEEEEE">
+
+					<table width="100%" cellpadding="0" cellspacing="0" class="termosRelacionados">
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo1" value="APELAÇÃO">
+									<label for="ckTermo1">
+										APELAÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo2" value="AÇÃO">
+									<label for="ckTermo2">
+										AÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo3" value="CÍVEL">
+									<label for="ckTermo3">
+										CÍVEL
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo4" value="PROPRIEDADE">
+									<label for="ckTermo4">
+										PROPRIEDADE
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo5" value="RECURSO">
+									<label for="ckTermo5">
+										RECURSO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo6" value="ANIMUS">
+									<label for="ckTermo6">
+										ANIMUS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo7" value="APARENTE">
+									<label for="ckTermo7">
+										APARENTE
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo8" value="APENAS">
+									<label for="ckTermo8">
+										APENAS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo9" value="DEMAIS">
+									<label for="ckTermo9">
+										DEMAIS
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo10" value="DESVIRTUAMENTO">
+									<label for="ckTermo10">
+										DESVIRTUAMENTO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo11" value="DOMINI">
+									<label for="ckTermo11">
+										DOMINI
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo12" value="ENCRAVADA">
+									<label for="ckTermo12">
+										ENCRAVADA
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo13" value="EXTRAORDINÁRIO">
+									<label for="ckTermo13">
+										EXTRAORDINÁRIO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo14" value="FUNÇÃO">
+									<label for="ckTermo14">
+										FUNÇÃO
+									</label>
+								</td>
+							</tr>
+
+							<tr>
+								<td width="*" style="padding-left: 12px;">
+									<input type="checkbox" id="ckTermo15" value="IMPROVIDO">
+									<label for="ckTermo15">
+										IMPROVIDO
+									</label>
+								</td>
+							</tr>
+
+
+					</table>
+
+			</td>
+		</tr>
+		<tr>
+			<td height="20" bgcolor="#DDDDDD">
+				<table width="100%" cellpadding="0" cellspacing="0">
+					<tr>
+						<td align="center" style="padding-left: 10px;">
+							<input type="button" class="conJurisBotaoSec"
+								value="Adicionar à pesquisa" >
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+			#%#quebra_resposta#%#
+
+
+
+
+
+
+
+
+
+<table width="100%" border="0" cellspacing="0" cellpadding="0" >
+	<tr height="20">
+		<td bgcolor="#EEEEEE">
+			Resultados
+
+			<strong>
+				1 a 2
+			</strong>
+			de 2
+		</td>
+
+		<td bgcolor="#EEEEEE" align="right">
+
+		<div class="trocaDePagina">
+
+
+
+
+
+
+
+
+
+
+
+
+					<span class="paginaAtual" >
+						1
+					</span>
+
+
+
+
+
+
+
+		</div>
+
+		</td>
+	</tr>
+
+	<tr>
+		<td height="1" bgcolor="#999999" colspan="2"></td>
+	</tr>
+</table>

--- a/tests/tjms/test_cjsg_contract.py
+++ b/tests/tjms/test_cjsg_contract.py
@@ -1,0 +1,86 @@
+"""Offline contract tests for TJMS cjsg.
+
+Mocks ``resultadoCompleta.do`` + ``trocaDePagina.do`` with captured samples
+(see ``tests/fixtures/capture/tjms.py``) and asserts the public DataFrame
+contract. Covers typical multi-page, single-page, and zero-result scenarios.
+"""
+import pandas as pd
+import responses
+from responses.matchers import query_param_matcher, urlencoded_params_matcher
+
+import juscraper as jus
+from tests._helpers import load_sample_bytes
+from tests.fixtures.capture._util import make_esaj_body
+
+BASE = "https://esaj.tjms.jus.br/cjsg"
+CJSG_MIN_COLUMNS = {"processo", "cd_acordao", "cd_foro", "ementa"}
+
+
+def _add_post(pesquisa: str) -> None:
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjms", "cjsg/post_initial.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(make_esaj_body(pesquisa), allow_blank=True)],
+    )
+
+
+def _add_get(pagina: int, sample_path: str) -> None:
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjms", sample_path),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": str(pagina)})],
+    )
+
+
+@responses.activate
+def test_cjsg_typical_com_paginacao(tmp_path, mocker):
+    """Typical multi-page query returns a DataFrame with the minimum schema."""
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+    _add_get(2, "cjsg/results_normal_page_02.html")
+
+    df = jus.scraper("tjms", download_path=str(tmp_path)).cjsg(
+        "dano moral", paginas=range(1, 3)
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_single_page(tmp_path, mocker):
+    """Query whose hits fit in one page skips the per-page loop."""
+    mocker.patch("time.sleep")
+    _add_post("usucapiao extraordinario predio rural familia")
+    _add_get(1, "cjsg/single_page.html")
+
+    df = jus.scraper("tjms", download_path=str(tmp_path)).cjsg(
+        "usucapiao extraordinario predio rural familia", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert len(df) > 0
+
+
+@responses.activate
+def test_cjsg_no_results(tmp_path, mocker):
+    """Zero-result query returns an empty DataFrame instead of raising."""
+    mocker.patch("time.sleep")
+    _add_post("juscraper_probe_zero_hits_xyzqwe")
+    _add_get(1, "cjsg/no_results.html")
+
+    df = jus.scraper("tjms", download_path=str(tmp_path)).cjsg(
+        "juscraper_probe_zero_hits_xyzqwe", paginas=1
+    )
+
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty


### PR DESCRIPTION
## Summary

Primeira fatia da Fase 1 da política de testes (refs #19, #104) — contratos offline para os 5 tribunais eSAJ "puros" (só `cjsg`, estrutura idêntica).

- Contratos em `tests/<sigla>/test_cjsg_contract.py` cobrindo 3 cenários por tribunal (typical com paginação, página única, sem resultados) via `responses` + `pytest-mock`; matchers validam o body do POST (`urlencoded_params_matcher` com o body eSAJ completo) e os query params do GET.
- Samples HTML reais em `tests/<sigla>/samples/cjsg/`, capturados pelos scripts em `tests/fixtures/capture/<sigla>.py` (`python -m tests.fixtures.capture.<sigla>`) — 5 arquivos por tribunal (`post_initial`, `results_normal_page_01/02`, `single_page`, `no_results`).
- TJCE recebe teste extra de regressão que confirma que `_TJCETLSAdapter` seta `SSLContext` em `init_poolmanager`.
- Helper compartilhado `tests/fixtures/capture/_util.py` (body eSAJ, session, `fetch_cjsg_pages`, `capture_cjsg_samples`) + README.
- `tests/__init__.py` adicionado para o mypy ancorar o pacote `tests`; `check-added-large-files` ganha `exclude` para samples em `tests/*/samples/` (os HTMLs do TJMS passam de 500KB).

**Fora do escopo (vai na 1A.2):** TJSP (cjsg/cjpg/cpopg/cposg com html/api), migração dos samples flat de `tests/tjsp/samples/` para subdirs, nova seção no CLAUDE.md, remoção do `load_sample_html` local.

**Dependência:** baseia em #105 (chore cleanup). Fazer merge dessa antes — os fixes de mypy nela são pré-requisito para o pre-commit rodar limpo aqui.

## Test plan

- [x] `pytest tests/{tjac,tjal,tjam,tjce,tjms}` → 18 passed em ~1.2s offline
- [x] `pytest` (default, exclui integration) → 148 passed
- [x] `pre-commit` (todos os hooks) → passa
- [ ] `pytest -m integration tests/{tjac,tjal,tjam,tjce,tjms}` — não regride (testes antigos `@pytest.mark.integration` intocados)
- [ ] Re-rodar captura quando eSAJ mudar layout (documentado em `tests/fixtures/capture/README.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)