### PR TITLE
docs(claude): padroniza merge de PRs via commit de merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ Paginas de tribunais mudam estrutura sem aviso. Ao escrever logica que extrai co
 - Nunca tentar aprovar o proprio PR (`gh pr review --approve` falha para o autor do PR)
 - Usar `gh pr review --comment` para deixar notas de revisao nos proprios PRs
 - Sempre fazer push para uma branch de feature e abrir PR — nunca fazer push direto na main
+- **Merge de PRs: sempre usar commit de merge (`gh pr merge <n> --merge --delete-branch`)**, nunca squash nem rebase. O commit de merge preserva cada commit individual da branch *e* adiciona um commit `Merge pull request #<n> from <branch>` que marca o limite do PR — ou seja, `git log --all --graph` continua mostrando o que entrou em cada PR. Squash perde a granularidade dos commits; rebase perde o limite do PR. Deletar a branch remota no merge mantem a lista de branches do repo enxuta (a branch continua acessivel via `gh pr checkout <n>`).
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

- Adiciona bullet na seção "Regras de workflow no GitHub" do `CLAUDE.md` registrando que merge de PRs deve usar `gh pr merge <n> --merge --delete-branch`.
- Racional: commit de merge preserva cada commit individual *e* marca o limite do PR, mantendo `git log --all --graph` legível. Squash perde granularidade; rebase perde o limite.
- A convenção já vinha sendo seguida de fato (ver `Merge pull request #102/#105/#106` em `git log`) — este PR só documenta.

## Test plan

- [x] Diff tem 1 linha só (bullet novo na seção GitHub Workflow Rules)
- [x] Pre-commit passa (trailing whitespace, end-of-files, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)