### PR TITLE
chore(packaging): enxuga sdist e torna config hatch explicita (#139)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,14 @@ jobs:
 
     - name: Inspecionar artefatos (sem tests/, sdist < 1MB)
       run: |
-        WHEEL=$(ls dist/juscraper-*.whl)
-        SDIST=$(ls dist/juscraper-*.tar.gz)
+        WHEELS=(dist/juscraper-*.whl)
+        SDISTS=(dist/juscraper-*.tar.gz)
+        if [ ${#WHEELS[@]} -ne 1 ] || [ ${#SDISTS[@]} -ne 1 ]; then
+          echo "ERRO: esperava 1 wheel e 1 sdist em dist/, encontrou ${#WHEELS[@]} wheel(s) e ${#SDISTS[@]} sdist(s)" >&2
+          exit 1
+        fi
+        WHEEL="${WHEELS[0]}"
+        SDIST="${SDISTS[0]}"
         if unzip -l "$WHEEL" | grep -E '(^| )tests/'; then
           echo "ERRO: wheel contem tests/" >&2; exit 1
         fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,22 @@ jobs:
       run: |
         uv build
 
+    - name: Inspecionar artefatos (sem tests/, sdist < 1MB)
+      run: |
+        WHEEL=$(ls dist/juscraper-*.whl)
+        SDIST=$(ls dist/juscraper-*.tar.gz)
+        if unzip -l "$WHEEL" | grep -E '(^| )tests/'; then
+          echo "ERRO: wheel contem tests/" >&2; exit 1
+        fi
+        if tar -tzf "$SDIST" | grep -E '(^|/)tests/'; then
+          echo "ERRO: sdist contem tests/" >&2; exit 1
+        fi
+        SDIST_SIZE=$(stat -c%s "$SDIST")
+        if [ "$SDIST_SIZE" -gt 1048576 ]; then
+          echo "ERRO: sdist excede 1MB ($SDIST_SIZE bytes)" >&2; exit 1
+        fi
+        echo "Artefatos OK (sdist=$SDIST_SIZE bytes)"
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Sdist (`juscraper-X.Y.Z.tar.gz` no PyPI) passa a incluir somente `src/juscraper/`, README, LICENSE, CHANGELOG, CONTRIBUTING, CONDUCT e `pyproject.toml`. Diretorios `tests/`, `docs/`, `issues/`, `scripts/`, `.claude/`, `.github/` e caches deixam de ser empacotados — sem a configuracao explicita o tarball cresceria proporcionalmente a `tests/<tribunal>/samples/` (~25 MB hoje). Wheel ja excluia `tests/` por default do hatchling com layout `src/`; agora a configuracao esta explicita via `[tool.hatch.build.targets.wheel] packages = ["src/juscraper"]`. Adicionado guard no workflow `publish.yml` que falha o build se o wheel/sdist contiver `tests/` ou se o sdist exceder 1 MB. Refs #139.
 - `pyproject.toml`: adicionado `pythonpath = ["tests"]` para permitir `from helpers import ...` sem hacks de `sys.path`.
 - **BREAKING (colunas de saida padronizadas):** DataFrames de `cjsg` dos tribunais TJES, TJMT, TJRS, TJRN, TJPE e TJRO passam a usar nomes canonicos uniformes para colunas semanticamente equivalentes. Renomeacoes: `nr_processo`/`numero_unico` -> `processo` (TJES, TJMT); `classe_cnj`/`classe_judicial` -> `classe` (TJRS, TJRN, TJES, TJPE, TJRO); `assunto_cnj`/`assunto_principal` -> `assunto` (TJRS, TJPE, TJES); `magistrado` -> `relator` (TJES). Codigo que acessa colunas pelo nome antigo (ex.: `df["classe_cnj"]`) precisa ser atualizado. Refs #93, #117.
 - `OutputCJSGBase.ementa` relaxado para `Optional[str]` (TJGO entrega o texto completo em `texto`, nao em `ementa`). `OutputCJSGBase.data_julgamento` aceita agora `date | str | None` para refletir os parsers que ja convertem para `datetime.date`. Redeclaracoes cosmeticas de `paginas` em schemas concretos (TJAP, TJES, TJMG, TJPE, TJPR, TJRO, TJRR, TJRS) removidas — `SearchBase` e a fonte unica. Refs #93, #117.
@@ -62,6 +63,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Removed
 
+- `MANIFEST.in` na raiz. Era vestigio do tempo do setuptools; o backend de build atual (hatchling) ignora completamente. Politica de empacotamento agora vive em `[tool.hatch.build.targets.*]` no `pyproject.toml`. Refs #139.
 - Shim `src/juscraper/courts/tjsp/cjsg_download.py` (apenas compatibility bridge para testes legados que importavam `cjsg_download`/`QueryTooLongError`). Testes em `tests/tjsp/test_query_validation.py` e `tests/tjsp/test_cjsg_contract.py` atualizados para importar direto de `juscraper.courts.tjsp.exceptions`. A docstring de `src/juscraper/courts/tjsp/forms.py::build_tjsp_cjsg_body` reescrita para documentar as diferencas funcionais reais do body do TJSP vs. eSAJ-puros (sem `conversationId`, sem `dtPublicacao*`, `baixar_sg` mapeia para `origem`).
 - `tests/tjsp/test_search_limit.py`: redundante com `tests/tjsp/test_query_validation.py` depois da consolidacao do guard de 120 chars em `validate_pesquisa_length`. Cobertura integral preservada pelo `test_query_validation.py`.
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,0 @@
-include README.md
-include LICENSE
-include CHANGELOG.md
-include CONTRIBUTING.md
-include CONDUCT.md
-recursive-include src *.py
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]
-recursive-exclude * .DS_Store

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -136,12 +136,20 @@ Se o nome `juscraper` já existir:
 ### Problemas de Build
 
 ```bash
-# Testar build localmente
+# Testar build localmente (gera dist/juscraper-X.Y.Z-py3-none-any.whl e dist/juscraper-X.Y.Z.tar.gz)
 uv build
 
-# Verificar conteúdo do pacote
-tar -tzf dist/juscraper-0.1.0.tar.gz
+# Wheel nao deve conter tests/
+unzip -l dist/juscraper-*.whl | grep -E '(^| )tests/' && echo "FALHA: wheel contem tests/" || echo "wheel OK"
+
+# Sdist nao deve conter tests/
+tar -tzf dist/juscraper-*.tar.gz | grep -E '(^|/)tests/' && echo "FALHA: sdist contem tests/" || echo "sdist OK"
+
+# Tamanho esperado: wheel ~200 KB, sdist ~200 KB
+ls -lh dist/
 ```
+
+A politica de empacotamento esta em `[tool.hatch.build.targets.wheel]` e `[tool.hatch.build.targets.sdist]` no `pyproject.toml` (allowlist explicita). O workflow `.github/workflows/publish.yml` valida automaticamente os artefatos antes do upload pra PyPI, mas vale rodar a checagem local antes de publicar a release no GitHub. Refs #139.
 
 ## Recursos Adicionais
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,50 @@ Repository = "https://github.com/jtrecenti/juscraper.git"
 "Bug Tracker" = "https://github.com/jtrecenti/juscraper/issues"
 Changelog = "https://github.com/jtrecenti/juscraper/blob/main/CHANGELOG.md"
 
+# Build configuration (hatchling)
+# Allowlist explicita: o que NAO esta listado fica de fora dos artefatos publicados.
+# Wheel: somente o pacote em src/juscraper/ (tests/, docs/, etc. ficam de fora).
+# Sdist: pacote + arquivos de projeto (README, LICENSE, CHANGELOG, etc.). Tests/samples nao entram.
+# Refs #139.
+[tool.hatch.build.targets.wheel]
+packages = ["src/juscraper"]
+
+[tool.hatch.build.targets.sdist]
+# Patterns ancorados com `/` (sintaxe pathspec) garantem que `README.md` so case com o
+# da raiz e nao com `tests/fixtures/capture/README.md` ou copias dentro de worktrees.
+include = [
+    "/src/juscraper",
+    "/README.md",
+    "/LICENSE",
+    "/CHANGELOG.md",
+    "/CONTRIBUTING.md",
+    "/CONDUCT.md",
+    "/pyproject.toml",
+]
+# Exclude defensivo: se algum dia a allowlist crescer e capturar paths indesejados,
+# estes ficam de fora explicitamente.
+exclude = [
+    "/.claude",
+    "/.codex",
+    "/.github",
+    "/.pytest_cache",
+    "/.mypy_cache",
+    "/.venv",
+    "/dist",
+    "/build",
+    "/issues",
+    "/scripts",
+    "/tests",
+    "/docs",
+    "/uv.lock",
+    "/AGENTS.md",
+    "/MANIFEST.in",
+    "/PUBLISHING.md",
+    "/.pre-commit-config.yaml",
+    "/.readthedocs.yml",
+    "/.gitignore",
+]
+
 # Tool configurations
 [tool.pylint.main]
 load-plugins = ["pylint.extensions.docparams"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ exclude = [
     "/docs",
     "/uv.lock",
     "/AGENTS.md",
-    "/MANIFEST.in",
     "/PUBLISHING.md",
     "/.pre-commit-config.yaml",
     "/.readthedocs.yml",


### PR DESCRIPTION
Closes #139.

## Contexto

A pergunta da issue #139 foi: *"instalar o pacote necessariamente deve demandar baixar testes? Como funciona?"*. Os fixtures HTML/JSON em `tests/<tribunal>/samples/` somam **~25 MB** hoje e tendem a crescer a cada tribunal novo.

## Investigacao

Antes deste PR, o backend de build era `hatchling` rodando 100% nos defaults, sem nenhum bloco `[tool.hatch.build.*]` configurado. Resultado:

| Artefato | Comportamento padrao do hatchling | Problema |
|---|---|---|
| **Wheel** (`pip install juscraper`) | Com layout `src/juscraper/`, hatchling auto-detecta o pacote e ship somente ele. | Sem problema. v0.2.1 wheel = 185 KB. **Tests nunca foram pra wheel.** |
| **Sdist** (`juscraper-X.Y.Z.tar.gz`) | Por padrao inclui *todo* arquivo versionado em VCS. | Hoje produziria sdist de ~25 MB. v0.2.1 sdist (192 KB) era pequeno **so** porque os samples ainda eram poucos. |

Existia ainda um `MANIFEST.in` na raiz com `recursive-include src *.py` etc — convencao do **setuptools**, completamente **ignorada** pelo hatchling. Vestigio enganoso pra quem viesse mexer em build.

## Quando o sdist e usado, na pratica

- `pip install juscraper` em plataforma normal: pega o wheel `py3-none-any.whl`. Sdist nao e tocado. **99% dos usuarios.**
- Fallback do pip quando nao ha wheel compativel: rebuilda do sdist. Pra juscraper (puro Python) isso quase nao acontece.
- Packagers downstream (conda-forge, Debian, conda) que querem rodar a suite durante o build do pacote deles. Pro juscraper isso **nao acontece** hoje (projeto de nicho, sem feedstock no conda-forge ainda).

## Decisao

- **Wheel**: travar via configuracao explicita (`packages = ["src/juscraper"]`) pra nao depender de auto-deteccao implicita.
- **Sdist**: allowlist explicita (so `src/juscraper`, README, LICENSE, CHANGELOG, CONTRIBUTING, CONDUCT, `pyproject.toml`). Diretorios `tests/`, `docs/`, `issues/`, `scripts/`, `.claude/`, `.github/`, caches, etc. ficam de fora.
- **`MANIFEST.in`**: deletado.
- **CI guard**: novo step no `publish.yml` falha o build se wheel/sdist contiverem `tests/` ou se sdist exceder 1 MB.

### Por que allowlist em vez de denylist

Se alguem criar `notebooks/`, `analise/`, etc. na raiz no futuro, ficam fora do sdist por default. Denylist exigiria manutencao manual a cada novo diretorio. (Adicionei tambem um `exclude` defensivo pra robustez contra patterns recursivos.)

### Detalhe tecnico: ancorar com `/`

Hatchling interpreta `include = ["README.md"]` como **glob recursivo** (igual gitignore). No primeiro build de teste, isso capturou copias de `README.md` dentro de `tests/fixtures/capture/` e dentro de worktrees `.claude/`. Solucao: ancorar com `/` no inicio (`/README.md`), que limita ao path root-relativo.

## Mudancas

- `pyproject.toml`: blocos novos `[tool.hatch.build.targets.wheel]` e `[tool.hatch.build.targets.sdist]`.
- `MANIFEST.in`: deletado.
- `.github/workflows/publish.yml`: step `Inspecionar artefatos (sem tests/, sdist < 1MB)` antes do upload-artifact.
- `PUBLISHING.md`: bloco de verificacao local atualizado.
- `CHANGELOG.md`: entradas em `[Unreleased] > Changed` e `> Removed`.

## Verificacao local (`uv build`)

```
$ ls -lh dist/
juscraper-0.2.1.9000-py3-none-any.whl  200K
juscraper-0.2.1.9000.tar.gz            141K

$ unzip -l dist/juscraper-0.2.1.9000-py3-none-any.whl | grep tests/
(zero matches)

$ tar -tzf dist/juscraper-0.2.1.9000.tar.gz | grep tests/
(zero matches)
```

`pytest`: 806 passed, 19 skipped, 4 xfailed. Nao toca codigo.

## Pergunta separada (registrada na #139)

Conda-forge faz sentido pro publico de DS aplicada ao direito (Anaconda e ponto de entrada padrao de cursos de Python no Brasil)? **Nao mexe nada nesse PR**, mas vale conversar como follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)