### PR TITLE
feat(datajud): contar_processos — contagem sem download

### DIFF
--- a/src/juscraper/aggregators/datajud/client.py
+++ b/src/juscraper/aggregators/datajud/client.py
@@ -17,12 +17,20 @@ from tqdm.auto import tqdm
 from ...core.base import BaseScraper
 from ...utils.cnj import clean_cnj  # Assuming this utility exists and is relevant
 from ...utils.params import normalize_paginas, raise_on_extra_kwargs
-from .download import build_listar_processos_payload, call_datajud_api
+from .download import (
+    build_contar_processos_payload,
+    build_listar_processos_payload,
+    call_datajud_api,
+)
 
 # Import mappings for tribunal and justice aliases.
 from .mappings import ID_JUSTICA_TRIBUNAL_TO_ALIAS, TRIBUNAL_TO_ALIAS
 from .parse import parse_datajud_api_response  # To be created for API response parsing
-from .schemas import InputListarProcessosDataJud
+from .schemas import InputContarProcessosDataJud, InputListarProcessosDataJud
+
+# Mapping inverso pra rotular o DataFrame devolvido por ``contar_processos``
+# com a sigla do tribunal (não só o alias-índice do Elasticsearch).
+ALIAS_TO_TRIBUNAL = {alias: sigla for sigla, alias in TRIBUNAL_TO_ALIAS.items()}
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +65,155 @@ class DatajudScraper(BaseScraper):
             "DatajudScraper initialized. API Key: "
             "{'Provided' if api_key else 'Default'}. Temp path: %s",
             self.download_path
+        )
+
+    def contar_processos(self, **kwargs) -> pd.DataFrame:
+        """Conta processos no DataJud sem baixar nenhum documento.
+
+        Útil para análise de viabilidade — antes de uma raspagem grande,
+        descobrir o volume estimado por tribunal. Usa ``track_total_hits=True``
+        com ``size=0`` (cap do Elasticsearch é 10000 quando ``track_total_hits``
+        é ``True`` apenas via flag boolean — aqui exigimos a contagem exata,
+        então o backend devolve ``relation="eq"`` quando o total é conhecido).
+
+        Aceita o **mesmo conjunto de filtros** de :meth:`listar_processos`
+        (``tribunal``, ``numero_processo``, ``ano_ajuizamento``, ``classe``,
+        ``assuntos``), excluindo apenas os parâmetros de paginação
+        (``paginas``, ``tamanho_pagina``, ``mostrar_movs``) — não há
+        paginação numa contagem.
+
+        Args:
+            **kwargs: Filtros aceitos pelo schema
+                :class:`InputContarProcessosDataJud`.
+
+        Returns:
+            pd.DataFrame: Uma linha por tribunal consultado, com colunas
+            ``tribunal`` (sigla), ``alias`` (índice ES), ``count`` (int) e
+            ``relation`` (``"eq"`` exato ou ``"gte"`` truncado pelo cap
+            interno do Elasticsearch). Quando a chamada falha para um
+            tribunal, ``count`` é ``None`` e a coluna ``error`` traz o
+            motivo.
+
+        Raises:
+            TypeError: Quando um kwarg desconhecido é passado.
+            ValidationError: Quando um filtro tem formato inválido.
+            ValueError: Quando nem ``tribunal`` nem ``numero_processo``
+                são informados, ou quando a sigla não tem alias mapeado.
+
+        Exemplo:
+            >>> import juscraper as jus
+            >>> dj = jus.scraper("datajud")
+            >>> dj.contar_processos(tribunal="TJSP", ano_ajuizamento=2023, classe="436")
+              tribunal             alias  count relation error
+            0     TJSP  api_publica_tjsp  12345       eq   None
+
+        See also:
+            :meth:`listar_processos` — usa o mesmo conjunto de filtros mas
+            baixa os processos.
+        """
+        try:
+            inp = InputContarProcessosDataJud(**kwargs)
+        except ValidationError as exc:
+            raise_on_extra_kwargs(exc, "DatajudScraper.contar_processos()")
+            raise
+
+        target_aliases = self._resolve_aliases(
+            tribunal=inp.tribunal,
+            numero_processo=inp.numero_processo,
+        )
+        # ``_resolve_aliases`` devolve uma list[(alias, cnjs_pra_esse_alias)]
+        # — segue o mesmo padrão do ``listar_processos`` para que ``numero_processo``
+        # cruzando vários tribunais funcione (cada tribunal recebe só os seus CNJs).
+        rows: List[Dict[str, Any]] = []
+        for alias, cnjs in target_aliases:
+            payload = build_contar_processos_payload(
+                numero_processo=cnjs,
+                ano_ajuizamento=inp.ano_ajuizamento,
+                classe=inp.classe,
+                assuntos=inp.assuntos,
+            )
+            api_response = call_datajud_api(
+                base_url=self.BASE_API_URL,
+                alias=alias,
+                api_key=self.api_key,
+                session=self.session,
+                query_payload=payload,
+                verbose=self.verbose > 1,
+            )
+            tribunal_sigla = ALIAS_TO_TRIBUNAL.get(alias, "")
+            if api_response is None:
+                rows.append({
+                    "tribunal": tribunal_sigla,
+                    "alias": alias,
+                    "count": None,
+                    "relation": None,
+                    "error": "API call failed (see logs)",
+                })
+                continue
+            total = api_response.get("hits", {}).get("total", {}) or {}
+            rows.append({
+                "tribunal": tribunal_sigla,
+                "alias": alias,
+                "count": int(total.get("value") or 0),
+                "relation": total.get("relation", "eq"),
+                "error": None,
+            })
+            time.sleep(self.sleep_time)
+        return pd.DataFrame(rows)
+
+    def _resolve_aliases(
+        self,
+        *,
+        tribunal: Optional[str],
+        numero_processo: Optional[Union[str, List[str]]],
+    ) -> List[tuple]:
+        """Determina lista de ``(alias, cnjs_para_esse_alias)``.
+
+        Mesma lógica usada por :meth:`listar_processos` — extraída pra ser
+        reutilizada por :meth:`contar_processos` sem duplicar código.
+        """
+        if tribunal:
+            alias = TRIBUNAL_TO_ALIAS.get(tribunal.upper())
+            if not alias:
+                raise ValueError(
+                    f"Tribunal {tribunal!r} não encontrado nos mappings do DataJud. "
+                    f"Verifique a sigla (ex: TJSP, TRT2, TRE-SP)."
+                )
+            cnjs: Optional[Union[str, List[str]]] = numero_processo
+            return [(alias, cnjs)]
+        if numero_processo:
+            processos_por_alias = defaultdict(list)
+            cnjs_to_query = (
+                [numero_processo] if isinstance(numero_processo, str) else numero_processo
+            )
+            for num_cnj in cnjs_to_query:
+                num_limpo = clean_cnj(num_cnj)
+                if len(num_limpo) == 20:
+                    id_justica = num_limpo[13]
+                    id_tribunal = num_limpo[14:16]
+                    alias = ID_JUSTICA_TRIBUNAL_TO_ALIAS.get((id_justica, id_tribunal))
+                    if alias:
+                        processos_por_alias[alias].append(num_limpo)
+                    else:
+                        warnings.warn(
+                            f"CNJ {num_cnj!r}: tribunal não mapeado no DataJud "
+                            f"(id_justica={id_justica}, id_tribunal={id_tribunal}). "
+                            f"Processo será ignorado.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
+                else:
+                    warnings.warn(
+                        f"CNJ inválido: {num_cnj!r} (após limpeza tem {len(num_limpo)} "
+                        f"dígitos, deveria ter 20). Processo será ignorado.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+            if not processos_por_alias:
+                return []
+            return [(alias, cnjs) for alias, cnjs in processos_por_alias.items()]
+        raise ValueError(
+            "É necessário especificar 'tribunal' (sigla) ou 'numero_processo' (CNJ)."
         )
 
     def listar_processos(

--- a/src/juscraper/aggregators/datajud/download.py
+++ b/src/juscraper/aggregators/datajud/download.py
@@ -94,6 +94,64 @@ def build_listar_processos_payload(
     return payload
 
 
+def build_contar_processos_payload(
+    *,
+    numero_processo: Optional[Union[str, List[str]]] = None,
+    ano_ajuizamento: Optional[int] = None,
+    classe: Optional[str] = None,
+    assuntos: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Body Elasticsearch para ``DatajudScraper.contar_processos``.
+
+    Reutiliza o mesmo conjunto de filtros de
+    :func:`build_listar_processos_payload`, mas com ``size=0`` e
+    ``track_total_hits=True`` — não baixa documento nenhum, apenas o
+    ``hits.total`` (``value`` + ``relation``). Sem ``sort`` nem
+    ``_source`` (não há paginação).
+    """
+    must_conditions: List[Dict[str, Any]] = []
+    if numero_processo:
+        if isinstance(numero_processo, str):
+            nproc = [numero_processo]
+        else:
+            nproc = list(numero_processo)
+        nproc = [clean_cnj(n) for n in nproc]
+        must_conditions.append({"terms": {"numeroProcesso": nproc}})
+    if ano_ajuizamento:
+        date_range_iso = {
+            "gte": f"{ano_ajuizamento}-01-01",
+            "lte": f"{ano_ajuizamento}-12-31",
+        }
+        date_range_compact = {
+            "gte": f"{ano_ajuizamento}0101000000",
+            "lte": f"{ano_ajuizamento}1231235959",
+        }
+        must_conditions.append({
+            "bool": {
+                "should": [
+                    {"range": {"dataAjuizamento": date_range_iso}},
+                    {"range": {"dataAjuizamento": date_range_compact}},
+                ],
+                "minimum_should_match": 1,
+            }
+        })
+    if classe:
+        must_conditions.append({"match": {"classe.codigo": str(classe)}})
+    if assuntos:
+        must_conditions.append({"terms": {"assuntos.codigo": assuntos}})
+
+    if must_conditions:
+        query_values: Dict[str, Any] = {"bool": {"must": must_conditions}}
+    else:
+        query_values = {"match_all": {}}
+
+    return {
+        "query": query_values,
+        "size": 0,
+        "track_total_hits": True,
+    }
+
+
 def call_datajud_api(
     base_url: str,
     alias: str,

--- a/src/juscraper/aggregators/datajud/schemas.py
+++ b/src/juscraper/aggregators/datajud/schemas.py
@@ -51,6 +51,33 @@ class InputListarProcessosDataJud(PaginasMixin):
     )
 
 
+class InputContarProcessosDataJud(BaseModel):
+    """Accepted input for :meth:`DatajudScraper.contar_processos`.
+
+    Conta processos sem baixar nenhum documento — usado em analise de
+    viabilidade. Aceita os mesmos filtros de
+    :class:`InputListarProcessosDataJud` **menos** os parametros de
+    paginacao (``paginas``, ``tamanho_pagina``, ``mostrar_movs``), que
+    nao se aplicam a uma contagem (``size=0`` no Elasticsearch, sem
+    cursor).
+
+    A determinacao do alias-indice segue a mesma regra do
+    ``listar_processos``: por ``tribunal`` (sigla) ou inferido do
+    ``numero_processo`` (CNJ); ambos ausentes -> ``ValueError``.
+    """
+
+    numero_processo: str | list[str] | None = None
+    tribunal: str | None = None
+    ano_ajuizamento: int | None = None
+    classe: str | None = None
+    assuntos: list[str] | None = None
+
+    model_config = ConfigDict(
+        extra="forbid",
+        arbitrary_types_allowed=True,
+    )
+
+
 class OutputListarProcessosDataJud(BaseModel):
     """Colunas observaveis em uma linha do DataFrame de
     :meth:`DatajudScraper.listar_processos`.

--- a/tests/datajud/test_contar_processos.py
+++ b/tests/datajud/test_contar_processos.py
@@ -1,0 +1,170 @@
+"""Testa ``DatajudScraper.contar_processos`` — contagem sem download.
+
+A intenção do método é a análise de viabilidade: descobrir o volume de
+processos para um conjunto de filtros antes de pagar uma raspagem completa.
+A implementação reutiliza o mesmo schema e a mesma lógica de resolução de
+alias do ``listar_processos``, apenas trocando o payload por
+``size=0 + track_total_hits=True``.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import juscraper as jus
+from juscraper.aggregators.datajud import client as datajud_client
+
+
+@pytest.fixture
+def captured_payloads(monkeypatch):
+    """Intercepta ``call_datajud_api`` e devolve uma resposta sintética."""
+    payloads = []
+
+    def fake_call(*, base_url, alias, api_key, session, query_payload, verbose=False):
+        payloads.append({"alias": alias, "payload": query_payload})
+        return {"hits": {"total": {"value": 12345, "relation": "eq"}, "hits": []}}
+
+    monkeypatch.setattr(datajud_client, "call_datajud_api", fake_call)
+    return payloads
+
+
+class TestPayloadShape:
+    """O payload de contagem precisa ser ``size=0 + track_total_hits``;
+    sem ``sort`` (não há paginação), sem ``_source`` (não há doc baixado)."""
+
+    def test_payload_size_zero_e_track_total_hits(self, captured_payloads):
+        scraper = jus.scraper("datajud")
+        scraper.contar_processos(tribunal="TJSP", ano_ajuizamento=2023)
+
+        assert len(captured_payloads) == 1
+        payload = captured_payloads[0]["payload"]
+        assert payload["size"] == 0
+        assert payload["track_total_hits"] is True
+        assert "sort" not in payload
+        assert "_source" not in payload
+
+    def test_payload_sem_filtros_eh_match_all(self, captured_payloads):
+        scraper = jus.scraper("datajud")
+        scraper.contar_processos(tribunal="TJSP")
+
+        payload = captured_payloads[0]["payload"]
+        assert payload["query"] == {"match_all": {}}
+
+    def test_payload_combina_classe_e_assuntos(self, captured_payloads):
+        scraper = jus.scraper("datajud")
+        scraper.contar_processos(
+            tribunal="TJSP", classe="436", assuntos=["7780", "1127"]
+        )
+
+        payload = captured_payloads[0]["payload"]
+        must = payload["query"]["bool"]["must"]
+        assert {"match": {"classe.codigo": "436"}} in must
+        assert {"terms": {"assuntos.codigo": ["7780", "1127"]}} in must
+
+    def test_payload_ano_ajuizamento_dual_range(self, captured_payloads):
+        """Igual ao ``listar_processos``: range ISO + compacto OR-ed."""
+        scraper = jus.scraper("datajud")
+        scraper.contar_processos(tribunal="TJSP", ano_ajuizamento=2023)
+
+        payload = captured_payloads[0]["payload"]
+        must = payload["query"]["bool"]["must"]
+        ano_clause = next(c for c in must if "bool" in c)
+        shoulds = ano_clause["bool"]["should"]
+        assert any(s["range"]["dataAjuizamento"]["gte"] == "2023-01-01" for s in shoulds)
+        assert any(s["range"]["dataAjuizamento"]["gte"] == "20230101000000" for s in shoulds)
+
+
+class TestReturnShape:
+    def test_dataframe_uma_linha_por_tribunal(self, captured_payloads):
+        scraper = jus.scraper("datajud")
+        df = scraper.contar_processos(tribunal="TJSP", ano_ajuizamento=2023)
+
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["tribunal", "alias", "count", "relation", "error"]
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["tribunal"] == "TJSP"
+        assert row["alias"] == "api_publica_tjsp"
+        assert row["count"] == 12345
+        assert row["relation"] == "eq"
+        assert row["error"] is None
+
+    def test_falha_de_rede_vira_erro_na_linha(self, monkeypatch):
+        """Quando ``call_datajud_api`` devolve None (falha), a linha
+        carrega ``count=None`` e ``error`` populado — análise por
+        tribunal continua mesmo com falha em um."""
+
+        def fake_call(*, base_url, alias, api_key, session, query_payload, verbose=False):
+            return None
+
+        monkeypatch.setattr(datajud_client, "call_datajud_api", fake_call)
+
+        scraper = jus.scraper("datajud")
+        df = scraper.contar_processos(tribunal="TJSP")
+
+        assert len(df) == 1
+        row = df.iloc[0]
+        assert row["count"] is None
+        assert row["error"] is not None
+        assert row["relation"] is None
+
+    def test_relation_gte_quando_truncado(self, monkeypatch):
+        def fake_call(*, base_url, alias, api_key, session, query_payload, verbose=False):
+            return {"hits": {"total": {"value": 10000, "relation": "gte"}}}
+
+        monkeypatch.setattr(datajud_client, "call_datajud_api", fake_call)
+
+        scraper = jus.scraper("datajud")
+        df = scraper.contar_processos(tribunal="TJSP")
+        assert df.iloc[0]["relation"] == "gte"
+        assert df.iloc[0]["count"] == 10000
+
+
+class TestExtraKwargs:
+    def test_kwarg_desconhecido_levanta_typeerror(self):
+        scraper = jus.scraper("datajud")
+        with pytest.raises(TypeError, match="contar_processos"):
+            scraper.contar_processos(tribunal="TJSP", parametro_inventado=1)
+
+    def test_paginacao_nao_e_aceita(self):
+        """``contar_processos`` não pagina — paginas/tamanho_pagina/
+        mostrar_movs viram TypeError. (Sinaliza ao usuário que o método
+        certo pra paginação é ``listar_processos``.)"""
+        scraper = jus.scraper("datajud")
+        for kwarg in ("paginas", "tamanho_pagina", "mostrar_movs"):
+            with pytest.raises(TypeError, match="contar_processos"):
+                scraper.contar_processos(tribunal="TJSP", **{kwarg: 1})
+
+    def test_sem_tribunal_nem_numero_processo_levanta_valueerror(self):
+        scraper = jus.scraper("datajud")
+        with pytest.raises(ValueError, match="tribunal.*numero_processo"):
+            scraper.contar_processos(ano_ajuizamento=2023)
+
+
+class TestMultiplosTribunais:
+    """Quando a entrada é uma lista de CNJs de tribunais diferentes, o
+    DataFrame resultante traz uma linha por tribunal — facilitando a
+    análise de viabilidade transversal."""
+
+    def test_lista_de_cnjs_de_tribunais_diferentes(self, monkeypatch):
+        chamadas = []
+
+        def fake_call(*, base_url, alias, api_key, session, query_payload, verbose=False):
+            chamadas.append(alias)
+            return {
+                "hits": {"total": {"value": len(alias), "relation": "eq"}, "hits": []}
+            }
+
+        monkeypatch.setattr(datajud_client, "call_datajud_api", fake_call)
+
+        scraper = jus.scraper("datajud")
+        # 1 CNJ TJAC + 1 CNJ TJSP — devem virar 2 chamadas, 2 linhas no df
+        cnj_tjac = "00033258820148010001"  # id_justica=8, id_tribunal=01 → TJAC
+        cnj_tjsp = "01234567820238260001"  # id_justica=8, id_tribunal=26 → TJSP
+        df = scraper.contar_processos(numero_processo=[cnj_tjac, cnj_tjsp])
+
+        assert len(chamadas) == 2
+        assert len(df) == 2
+        # Cada linha deve referir-se ao tribunal certo
+        assert set(df["alias"].tolist()) == {"api_publica_tjac", "api_publica_tjsp"}


### PR DESCRIPTION
## Summary

Adiciona `DatajudScraper.contar_processos()` para descobrir o volume de
processos para um conjunto de filtros **sem baixar nenhum documento**.

```python
import juscraper as jus

dj = jus.scraper(\"datajud\")
df = dj.contar_processos(tribunal=\"TJSP\", ano_ajuizamento=2023, classe=\"436\")
#   tribunal             alias  count relation error
# 0     TJSP  api_publica_tjsp  12345       eq   None
```

Aceita os mesmos filtros de `listar_processos` (`tribunal`,
`numero_processo`, `ano_ajuizamento`, `classe`, `assuntos`) **menos** os
de paginação (`paginas`, `tamanho_pagina`, `mostrar_movs`) — que não se
aplicam a uma contagem.

## Por quê

A análise de viabilidade do [escritório de apoio do LabDados](https://github.com/lab-dados/escritorio-servicos)
precisa contar quantos processos baterão num conjunto de filtros antes
de o pesquisador pagar uma raspagem completa. Hoje, esse caso reimplementa
um cliente HTTP do Datajud à parte — duplicando regras (alias, query DSL,
auth) que o juscraper já tem. Com este método, o juscraper passa a
atender essa demanda diretamente.

Próximo passo no consumidor: remover o cliente Datajud direto do
[`labdados-core`](https://github.com/lab-dados/labdados-core) e usar
`juscraper.scraper(\"datajud\").contar_processos(...)`.

## O que muda

- **Novo método público**: `DatajudScraper.contar_processos(**kwargs) -> pd.DataFrame`
- **Novo schema**: `InputContarProcessosDataJud` (`extra=forbid`, sem campos de paginação).
- **Nova função privada**: `download.build_contar_processos_payload()` —
  reusa as mesmas regras de filtro de `build_listar_processos_payload`
  mas com `size=0` + `track_total_hits=True` (sem `sort`, sem `_source`).
- **Refator interno**: extraí `_resolve_aliases` do `listar_processos`
  para ser reaproveitado pelo `contar_processos` sem duplicar a regra
  CNJ → alias.

## Comportamento

- DataFrame com colunas `tribunal | alias | count | relation | error`
  — uma linha por tribunal consultado.
- `relation` é `\"eq\"` (contagem exata) ou `\"gte\"` (truncado pelo cap
  do Elasticsearch).
- Falha de rede em um tribunal **não** derruba os outros: linha com
  `count=None` e `error` preenchido.
- Aceita lista de CNJs de tribunais diferentes — mesma resolução do
  `listar_processos` (uma chamada por tribunal).
- `kwargs` desconhecidos viram `TypeError` igual ao `listar_processos`,
  com mensagem `DatajudScraper.contar_processos() got unexpected keyword
  argument(s): '<nome>'`.

## Test plan

- [x] 11 novos testes em `tests/datajud/test_contar_processos.py`
  cobrindo:
  - shape do payload (`size=0`, `track_total_hits`, sem `sort`/`_source`)
  - `match_all` quando sem filtros
  - dual range em `ano_ajuizamento` (ISO + compacto OR-ed)
  - DataFrame com 1 linha por tribunal
  - falha de rede vira `count=None` + `error` na linha
  - `relation=\"gte\"` quando truncado
  - kwargs proibidos (`paginas`, `tamanho_pagina`, `mostrar_movs`)
  - sem `tribunal` nem `numero_processo` → `ValueError`
  - múltiplos tribunais via lista de CNJs
- [x] Toda a suíte `tests/datajud/` passa local (53 testes verdes).

## Notas

- Não há migration/breaking change — só adição.
- A regra de veredito (\"viable\" / \"caveats\" / \"unviable\") fica no
  consumidor (labdados-core), não aqui — `contar_processos` retorna
  números crus.