### PR TITLE
feat(datajud): contar/listar aceitar range/lista de anos e lista de classes

### DIFF
--- a/src/juscraper/aggregators/datajud/client.py
+++ b/src/juscraper/aggregators/datajud/client.py
@@ -82,6 +82,11 @@ class DatajudScraper(BaseScraper):
         (``paginas``, ``tamanho_pagina``, ``mostrar_movs``) — não há
         paginação numa contagem.
 
+        ``ano_ajuizamento`` aceita ``int`` (1 ano), ``tuple[int, int]``
+        (range inclusivo, ex.: ``(2020, 2024)``) ou ``list[int]`` (anos
+        discretos, ex.: ``[2020, 2022, 2024]``). ``classe`` aceita
+        ``str`` (1 código) ou ``list[str]`` (vários códigos OR-ed).
+
         Args:
             **kwargs: Filtros aceitos pelo schema
                 :class:`InputContarProcessosDataJud`.
@@ -106,6 +111,14 @@ class DatajudScraper(BaseScraper):
             >>> dj.contar_processos(tribunal="TJSP", ano_ajuizamento=2023, classe="436")
               tribunal             alias  count relation error
             0     TJSP  api_publica_tjsp  12345       eq   None
+
+            >>> # Range de anos + lista de classes (estudo plurianual):
+            >>> dj.contar_processos(
+            ...     tribunal="TJSP",
+            ...     ano_ajuizamento=(2020, 2024),
+            ...     classe=["7", "436"],
+            ...     assuntos=["7780"],
+            ... )
 
         See also:
             :meth:`listar_processos` — usa o mesmo conjunto de filtros mas
@@ -241,10 +254,15 @@ class DatajudScraper(BaseScraper):
                 * ``tribunal`` (str): Sigla do tribunal (ex.: ``"TJSP"``,
                   ``"TRT2"``, ``"TRE-SP"``). Mutuamente exclusivo com
                   inferencia via ``numero_processo``.
-                * ``ano_ajuizamento`` (int): Filtra por ano de ajuizamento.
-                  Backend recebe ``range`` dual em ``dataAjuizamento`` (ISO
-                  ``YYYY-01-01`` + compacto ``YYYYMMDDhhmmss``).
-                * ``classe`` (str): Codigo da classe processual CNJ.
+                * ``ano_ajuizamento`` (int | tuple[int, int] | list[int]):
+                  Filtra por ano de ajuizamento. ``int`` = 1 ano. ``tuple``
+                  = range inclusivo (ex.: ``(2020, 2024)``). ``list`` =
+                  anos discretos (ex.: ``[2020, 2022]``). Backend recebe
+                  ``range`` dual em ``dataAjuizamento`` (ISO + compacto)
+                  por ano, OR-eds via ``should``.
+                * ``classe`` (str | list[str]): Codigo da classe CNJ.
+                  ``str`` vira ``match``, ``list`` vira ``terms``
+                  (varios codigos OR-ed).
                 * ``assuntos`` (list[str]): Lista de codigos de assuntos CNJ.
                 * ``mostrar_movs`` (bool): Se ``True``, inclui
                   ``movimentos``/``movimentacoes`` no ``_source``. Default

--- a/src/juscraper/aggregators/datajud/download.py
+++ b/src/juscraper/aggregators/datajud/download.py
@@ -22,12 +22,87 @@ FALLBACK_DIVISOR = 4
 FALLBACK_MIN_SIZE = 100
 FALLBACK_RETRY_STATUS = {504}
 
+# Tipo composto aceito por ``ano_ajuizamento``: int unico, range
+# ``(inicio, fim)`` inclusivo, ou lista discreta de anos. Mantido aqui pra
+# reuso entre listar_processos / contar_processos / schemas.
+AnoAjuizamento = Union[int, "tuple[int, int]", List[int]]
+
+
+def _build_ano_ajuizamento_clause(
+    ano_ajuizamento: Optional[AnoAjuizamento],
+) -> Optional[Dict[str, Any]]:
+    """Constroi a clausula ``must`` para ``dataAjuizamento`` aceitando 3 formas
+    de input. Retorna ``None`` quando ``ano_ajuizamento`` e None/vazio.
+
+    Cada ano vira um par ``range`` (ISO + compacto) OR-ed via ``should`` —
+    historico do datajud tem documentos com ``dataAjuizamento`` nos dois
+    formatos, entao manter os dois e necessario pra cobertura.
+    """
+    if ano_ajuizamento is None:
+        return None
+
+    # Normaliza para uma lista de anos discretos.
+    if isinstance(ano_ajuizamento, int):
+        anos: List[int] = [ano_ajuizamento]
+    elif isinstance(ano_ajuizamento, tuple):
+        if len(ano_ajuizamento) != 2:
+            raise ValueError(
+                "ano_ajuizamento como tuple deve ser (inicio, fim) com 2 elementos."
+            )
+        lo, hi = sorted(ano_ajuizamento)
+        anos = list(range(lo, hi + 1))
+    else:  # list
+        anos = list(ano_ajuizamento)
+
+    if not anos:
+        return None
+
+    shoulds: List[Dict[str, Any]] = []
+    for ano in anos:
+        shoulds.append({
+            "range": {
+                "dataAjuizamento": {
+                    "gte": f"{ano}-01-01",
+                    "lte": f"{ano}-12-31",
+                }
+            }
+        })
+        shoulds.append({
+            "range": {
+                "dataAjuizamento": {
+                    "gte": f"{ano}0101000000",
+                    "lte": f"{ano}1231235959",
+                }
+            }
+        })
+
+    return {"bool": {"should": shoulds, "minimum_should_match": 1}}
+
+
+def _build_classe_clause(
+    classe: Optional[Union[str, List[str]]],
+) -> Optional[Dict[str, Any]]:
+    """``str`` -> ``match`` (1 codigo). ``list`` -> ``terms`` (varios codigos
+    OR-ed). ``None``/vazio -> sem clausula."""
+    if classe is None:
+        return None
+    if isinstance(classe, str):
+        if not classe:
+            return None
+        return {"match": {"classe.codigo": classe}}
+    codes = [str(c) for c in classe if str(c).strip()]
+    if not codes:
+        return None
+    if len(codes) == 1:
+        return {"match": {"classe.codigo": codes[0]}}
+    return {"terms": {"classe.codigo": codes}}
+
 
 def build_listar_processos_payload(
     *,
     numero_processo: Optional[Union[str, List[str]]] = None,
-    ano_ajuizamento: Optional[int] = None,
-    classe: Optional[str] = None,
+    ano_ajuizamento: Optional[AnoAjuizamento] = None,
+    classe: Optional[Union[str, List[str]]] = None,
     assuntos: Optional[List[str]] = None,
     mostrar_movs: bool = False,
     tamanho_pagina: int = 5000,
@@ -42,6 +117,11 @@ def build_listar_processos_payload(
     contratos offline em ``tests/datajud/test_listar_processos_*_contract.py``
     via ``json_params_matcher`` — qualquer alteracao tem que ser refletida
     nos samples.
+
+    ``ano_ajuizamento`` aceita ``int`` (ano unico, mantido por retro-compat),
+    ``tuple[int, int]`` (range inclusivo) ou ``list[int]`` (anos discretos).
+    ``classe`` aceita ``str`` (codigo unico) ou ``list[str]`` (varios codigos
+    OR-ed via ``terms`` no ES).
     """
     must_conditions: List[Dict[str, Any]] = []
     if numero_processo:
@@ -51,26 +131,15 @@ def build_listar_processos_payload(
             nproc = list(numero_processo)
         nproc = [clean_cnj(n) for n in nproc]
         must_conditions.append({"terms": {"numeroProcesso": nproc}})
-    if ano_ajuizamento:
-        date_range_iso = {
-            "gte": f"{ano_ajuizamento}-01-01",
-            "lte": f"{ano_ajuizamento}-12-31",
-        }
-        date_range_compact = {
-            "gte": f"{ano_ajuizamento}0101000000",
-            "lte": f"{ano_ajuizamento}1231235959",
-        }
-        must_conditions.append({
-            "bool": {
-                "should": [
-                    {"range": {"dataAjuizamento": date_range_iso}},
-                    {"range": {"dataAjuizamento": date_range_compact}},
-                ],
-                "minimum_should_match": 1,
-            }
-        })
-    if classe:
-        must_conditions.append({"match": {"classe.codigo": str(classe)}})
+
+    ano_clause = _build_ano_ajuizamento_clause(ano_ajuizamento)
+    if ano_clause is not None:
+        must_conditions.append(ano_clause)
+
+    classe_clause = _build_classe_clause(classe)
+    if classe_clause is not None:
+        must_conditions.append(classe_clause)
+
     if assuntos:
         must_conditions.append({"terms": {"assuntos.codigo": assuntos}})
 
@@ -97,8 +166,8 @@ def build_listar_processos_payload(
 def build_contar_processos_payload(
     *,
     numero_processo: Optional[Union[str, List[str]]] = None,
-    ano_ajuizamento: Optional[int] = None,
-    classe: Optional[str] = None,
+    ano_ajuizamento: Optional[AnoAjuizamento] = None,
+    classe: Optional[Union[str, List[str]]] = None,
     assuntos: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Body Elasticsearch para ``DatajudScraper.contar_processos``.
@@ -108,6 +177,10 @@ def build_contar_processos_payload(
     ``track_total_hits=True`` — não baixa documento nenhum, apenas o
     ``hits.total`` (``value`` + ``relation``). Sem ``sort`` nem
     ``_source`` (não há paginação).
+
+    ``ano_ajuizamento`` aceita ``int``, ``tuple[int, int]`` (range
+    inclusivo) ou ``list[int]`` (anos discretos). ``classe`` aceita
+    ``str`` ou ``list[str]``.
     """
     must_conditions: List[Dict[str, Any]] = []
     if numero_processo:
@@ -117,26 +190,15 @@ def build_contar_processos_payload(
             nproc = list(numero_processo)
         nproc = [clean_cnj(n) for n in nproc]
         must_conditions.append({"terms": {"numeroProcesso": nproc}})
-    if ano_ajuizamento:
-        date_range_iso = {
-            "gte": f"{ano_ajuizamento}-01-01",
-            "lte": f"{ano_ajuizamento}-12-31",
-        }
-        date_range_compact = {
-            "gte": f"{ano_ajuizamento}0101000000",
-            "lte": f"{ano_ajuizamento}1231235959",
-        }
-        must_conditions.append({
-            "bool": {
-                "should": [
-                    {"range": {"dataAjuizamento": date_range_iso}},
-                    {"range": {"dataAjuizamento": date_range_compact}},
-                ],
-                "minimum_should_match": 1,
-            }
-        })
-    if classe:
-        must_conditions.append({"match": {"classe.codigo": str(classe)}})
+
+    ano_clause = _build_ano_ajuizamento_clause(ano_ajuizamento)
+    if ano_clause is not None:
+        must_conditions.append(ano_clause)
+
+    classe_clause = _build_classe_clause(classe)
+    if classe_clause is not None:
+        must_conditions.append(classe_clause)
+
     if assuntos:
         must_conditions.append({"terms": {"assuntos.codigo": assuntos}})
 

--- a/src/juscraper/aggregators/datajud/schemas.py
+++ b/src/juscraper/aggregators/datajud/schemas.py
@@ -31,8 +31,18 @@ class InputListarProcessosDataJud(PaginasMixin):
 
     numero_processo: str | list[str] | None = None
     tribunal: str | None = None
-    ano_ajuizamento: int | None = None
-    classe: str | None = None
+    # ``ano_ajuizamento`` aceita 3 formas:
+    # - ``int`` (ex.: ``2023``): filtra por ano-calendario unico (1 jan a 31 dez).
+    # - ``tuple[int, int]`` (ex.: ``(2020, 2024)``): range inclusivo de
+    #   anos, ``min(t) <= ano <= max(t)``. Implementado como ``range`` ES
+    #   em ``dataAjuizamento`` (``YYYY-01-01`` a ``YYYY-12-31`` dos extremos).
+    # - ``list[int]`` (ex.: ``[2020, 2022, 2024]``): lista discreta de anos.
+    #   Util para excluir um ano intermediario; backend gera ``should``
+    #   com um ``range`` por ano.
+    ano_ajuizamento: int | tuple[int, int] | list[int] | None = None
+    # ``classe`` aceita ``str`` (codigo unico) ou ``list[str]`` (varios
+    # codigos OR-ed via ``terms`` no ES). Compativel com ``assuntos``.
+    classe: str | list[str] | None = None
     assuntos: list[str] | None = None
     mostrar_movs: bool = False
     # Limites do parametro ``size`` da API publica do DataJud
@@ -68,8 +78,9 @@ class InputContarProcessosDataJud(BaseModel):
 
     numero_processo: str | list[str] | None = None
     tribunal: str | None = None
-    ano_ajuizamento: int | None = None
-    classe: str | None = None
+    # Mesmo contrato extendido de InputListarProcessosDataJud — ver docstring la.
+    ano_ajuizamento: int | tuple[int, int] | list[int] | None = None
+    classe: str | list[str] | None = None
     assuntos: list[str] | None = None
 
     model_config = ConfigDict(

--- a/tests/datajud/test_range_and_lista_classes.py
+++ b/tests/datajud/test_range_and_lista_classes.py
@@ -1,0 +1,189 @@
+"""Cobertura dos novos formatos extendidos de ``ano_ajuizamento`` e ``classe``.
+
+- ``ano_ajuizamento``: ``int`` (retro-compat) | ``tuple[int, int]`` (range
+  inclusivo) | ``list[int]`` (anos discretos).
+- ``classe``: ``str`` (retro-compat) | ``list[str]`` (varios codigos OR-ed
+  via ``terms`` no ES).
+
+Os testes usam o ``build_*_payload`` direto pra validar a forma do payload
+Elasticsearch — caminho minimo, sem mockar API.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from juscraper.aggregators.datajud.download import (
+    build_contar_processos_payload,
+    build_listar_processos_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# ano_ajuizamento — 3 formas
+# ---------------------------------------------------------------------------
+
+
+def test_listar_int_gera_should_com_dois_ranges_iso_e_compacto():
+    payload = build_listar_processos_payload(ano_ajuizamento=2023)
+    must = payload["query"]["bool"]["must"]
+    ano_clause = next(c for c in must if "bool" in c)
+    shoulds = ano_clause["bool"]["should"]
+    assert len(shoulds) == 2
+    formats = {next(iter(s["range"]["dataAjuizamento"].values())) for s in shoulds}
+    # Um deve estar em formato ISO, outro em formato compacto
+    assert "2023-01-01" in formats
+    assert "20230101000000" in formats
+
+
+def test_contar_int_gera_should_com_dois_ranges():
+    payload = build_contar_processos_payload(ano_ajuizamento=2023)
+    must = payload["query"]["bool"]["must"]
+    ano_clause = next(c for c in must if "bool" in c)
+    assert len(ano_clause["bool"]["should"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# ano_ajuizamento — tuple (range inclusivo)
+# ---------------------------------------------------------------------------
+
+
+def test_tuple_range_2020_2024_gera_5_anos_x_2_formatos():
+    """``(2020, 2024)`` deve cobrir 5 anos × 2 formatos = 10 ranges no should."""
+    payload = build_contar_processos_payload(ano_ajuizamento=(2020, 2024))
+    must = payload["query"]["bool"]["must"]
+    ano_clause = next(c for c in must if "bool" in c)
+    shoulds = ano_clause["bool"]["should"]
+    assert len(shoulds) == 10  # 5 anos × 2 formatos
+
+    anos_iso = sorted({
+        s["range"]["dataAjuizamento"]["gte"][:4]
+        for s in shoulds
+        if "-" in s["range"]["dataAjuizamento"]["gte"]
+    })
+    assert anos_iso == ["2020", "2021", "2022", "2023", "2024"]
+
+
+def test_tuple_invertida_e_normalizada():
+    """``(2024, 2020)`` é equivalente a ``(2020, 2024)`` — ordem não importa."""
+    a = build_contar_processos_payload(ano_ajuizamento=(2020, 2024))
+    b = build_contar_processos_payload(ano_ajuizamento=(2024, 2020))
+    assert a == b
+
+
+def test_tuple_mesmo_ano_e_equivalente_a_int():
+    """``(2023, 2023)`` deve dar o mesmo payload que ``2023``."""
+    a = build_contar_processos_payload(ano_ajuizamento=2023)
+    b = build_contar_processos_payload(ano_ajuizamento=(2023, 2023))
+    assert a == b
+
+
+def test_tuple_com_3_elementos_levanta():
+    with pytest.raises(ValueError, match="2 elementos"):
+        build_contar_processos_payload(ano_ajuizamento=(2020, 2022, 2024))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# ano_ajuizamento — list (anos discretos)
+# ---------------------------------------------------------------------------
+
+
+def test_list_de_3_anos_gera_3_x_2_ranges():
+    payload = build_contar_processos_payload(ano_ajuizamento=[2020, 2022, 2024])
+    must = payload["query"]["bool"]["must"]
+    ano_clause = next(c for c in must if "bool" in c)
+    assert len(ano_clause["bool"]["should"]) == 6  # 3 anos × 2 formatos
+    anos_iso = sorted({
+        s["range"]["dataAjuizamento"]["gte"][:4]
+        for s in ano_clause["bool"]["should"]
+        if "-" in s["range"]["dataAjuizamento"]["gte"]
+    })
+    assert anos_iso == ["2020", "2022", "2024"]
+
+
+def test_list_vazia_nao_gera_clausula():
+    """``ano_ajuizamento=[]`` deve ser equivalente a ``None`` — sem clausula."""
+    a = build_contar_processos_payload()
+    b = build_contar_processos_payload(ano_ajuizamento=[])
+    assert a == b
+
+
+def test_list_com_1_ano_e_equivalente_a_int():
+    a = build_contar_processos_payload(ano_ajuizamento=2023)
+    b = build_contar_processos_payload(ano_ajuizamento=[2023])
+    assert a == b
+
+
+# ---------------------------------------------------------------------------
+# classe — str (retro-compat) | list[str]
+# ---------------------------------------------------------------------------
+
+
+def test_classe_str_unica_gera_match():
+    payload = build_contar_processos_payload(classe="436")
+    must = payload["query"]["bool"]["must"]
+    assert {"match": {"classe.codigo": "436"}} in must
+
+
+def test_classe_lista_com_um_elemento_gera_match():
+    """Lista com 1 elemento → ``match`` (igual ao caso str)."""
+    payload = build_contar_processos_payload(classe=["436"])
+    must = payload["query"]["bool"]["must"]
+    assert {"match": {"classe.codigo": "436"}} in must
+
+
+def test_classe_lista_com_n_elementos_gera_terms():
+    payload = build_contar_processos_payload(classe=["436", "159", "22"])
+    must = payload["query"]["bool"]["must"]
+    assert {"terms": {"classe.codigo": ["436", "159", "22"]}} in must
+
+
+def test_classe_lista_filtra_vazias_e_strip():
+    """Strings vazias são descartadas; brancos não fazem terms estourar."""
+    payload = build_contar_processos_payload(classe=["", "436", "  ", "159"])
+    must = payload["query"]["bool"]["must"]
+    assert {"terms": {"classe.codigo": ["436", "159"]}} in must
+
+
+def test_classe_lista_vazia_nao_gera_clausula():
+    a = build_contar_processos_payload()
+    b = build_contar_processos_payload(classe=[])
+    assert a == b
+
+
+def test_classe_mesma_no_listar_processos():
+    """``classe`` na ``listar_processos`` segue o mesmo contrato."""
+    payload = build_listar_processos_payload(classe=["7", "159"])
+    must = payload["query"]["bool"]["must"]
+    assert {"terms": {"classe.codigo": ["7", "159"]}} in must
+
+
+# ---------------------------------------------------------------------------
+# Combinação: range + lista de classes (caso real do labdados)
+# ---------------------------------------------------------------------------
+
+
+def test_caso_real_viabilidade_labdados():
+    """Caso típico do escritório de apoio do LabDados:
+
+    - 5 anos (2020 a 2024)
+    - 2 classes (Procedimento Comum + Apelação Cível)
+    - 1 assunto (Saúde Suplementar)
+    """
+    payload = build_contar_processos_payload(
+        ano_ajuizamento=(2020, 2024),
+        classe=["7", "436"],
+        assuntos=["7780"],
+    )
+
+    assert payload["size"] == 0
+    assert payload["track_total_hits"] is True
+
+    must = payload["query"]["bool"]["must"]
+    # Tem clausula de ano (10 should)
+    ano_clause = next(c for c in must if "bool" in c)
+    assert len(ano_clause["bool"]["should"]) == 10
+    # Tem clausula de classe (terms)
+    assert {"terms": {"classe.codigo": ["7", "436"]}} in must
+    # Tem clausula de assunto
+    assert {"terms": {"assuntos.codigo": ["7780"]}} in must


### PR DESCRIPTION
## Summary

Estende ``DatajudScraper.{contar,listar}_processos`` para cobrir os 2 formatos
mais comuns em estudos plurianuais e multi-classe — sem breaking change:

- **``ano_ajuizamento``**: agora aceita ``int`` (mantido) | ``tuple[int, int]``
  (range inclusivo) | ``list[int]`` (anos discretos).
- **``classe``**: agora aceita ``str`` (mantido) | ``list[str]`` (vários
  códigos OR-ed via ``terms``).

## Motivação

Resolve #178. O [labdados-core](https://github.com/lab-dados/labdados-core)
tem hoje um cliente HTTP DataJud caseiro que existe SÓ porque
``contar_processos`` ainda não suportava range de anos nem múltiplas classes
— o caso de uso típico do escritório de apoio do LabDados é \"5 anos × 2
classes × 3 tribunais\". Com este PR, dá pra remover o cliente duplicado e
usar ``juscraper.scraper(\"datajud\").contar_processos(...)`` direto.

## Exemplo

\`\`\`python
import juscraper as jus

dj = jus.scraper(\"datajud\")

# Range plurianual + múltiplas classes
dj.contar_processos(
    tribunal=\"TJSP\",
    ano_ajuizamento=(2020, 2024),    # 5 anos
    classe=[\"7\", \"436\"],
    assuntos=[\"7780\"],
)

# Anos discretos:
dj.contar_processos(tribunal=\"TJSP\", ano_ajuizamento=[2020, 2022, 2024])
\`\`\`

## Implementação

- Schemas: ``ano_ajuizamento: int | tuple[int, int] | list[int] | None`` e
  ``classe: str | list[str] | None``.
- Helpers ``_build_ano_ajuizamento_clause`` e ``_build_classe_clause`` em
  ``download.py`` — reusados pelos 2 builders.
- Cada ano discreto vira 2 ``range``s (ISO + compacto) OR-ed via
  ``should``; lista de classes vira ``terms``.
- Normalização: tuple invertida ``(2024, 2020)`` é ordenada;
  ``(2023, 2023)`` ≡ ``2023`` (mesmo payload); list vazia ≡ None.

## Test plan

- [x] 16 novos testes em ``test_range_and_lista_classes.py``.
- [x] Suite ``tests/datajud/`` completa: 65 verdes (49 antigos + 16 novos).
- [x] Contract-tests offline passam sem alteração (compat preservada).

## Próximo passo no consumidor

Após merge, abro PR no ``lab-dados/labdados-core`` removendo ~120 linhas
de cliente HTTP duplicado.