### PR TITLE
refactor(tjro,tjrn): alinhar nomes canonicos no cjsg (refs #129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `numero_cnj` -> `numero_processo` em TJAP.
   - `magistrado` -> `relator`, `classe_judicial` -> `classe` em TJES (`cjsg` e `cjpg`) e TJRO (`cjsg`). Refs #129.
   - `classe_cnj` -> `classe`, `assunto_cnj` -> `assunto` em TJPE.
+  - `id_classe_judicial` -> `id_classe` em TJRN (`cjsg`), por simetria com `id_relator`/`id_orgao_julgador`/`id_colegiado`. Refs #129.
 
   Helpers `juscraper.utils.params.pop_deprecated_alias` (pop + warning) e `juscraper.utils.params.resolve_deprecated_alias` (pop + checagem de colisao + reatribuicao) centralizam o padrao. Refs #93, #117.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Parametros de Input renomeados para canonicos; os nomes antigos continuam aceitos com `DeprecationWarning` por um ciclo:
   - `nr_processo` -> `numero_processo` em TJPB, TJRN, TJRO.
   - `numero_cnj` -> `numero_processo` em TJAP.
-  - `magistrado` -> `relator`, `classe_judicial` -> `classe` em TJES (`cjsg` e `cjpg`).
+  - `magistrado` -> `relator`, `classe_judicial` -> `classe` em TJES (`cjsg` e `cjpg`) e TJRO (`cjsg`). Refs #129.
   - `classe_cnj` -> `classe`, `assunto_cnj` -> `assunto` em TJPE.
 
   Helpers `juscraper.utils.params.pop_deprecated_alias` (pop + warning) e `juscraper.utils.params.resolve_deprecated_alias` (pop + checagem de colisao + reatribuicao) centralizam o padrao. Refs #93, #117.

--- a/src/juscraper/aggregators/datajud/client.py
+++ b/src/juscraper/aggregators/datajud/client.py
@@ -7,7 +7,7 @@ import tempfile
 import time
 import warnings
 from collections import defaultdict
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 import requests
@@ -17,11 +17,7 @@ from tqdm.auto import tqdm
 from ...core.base import BaseScraper
 from ...utils.cnj import clean_cnj  # Assuming this utility exists and is relevant
 from ...utils.params import normalize_paginas, raise_on_extra_kwargs
-from .download import (
-    build_contar_processos_payload,
-    build_listar_processos_payload,
-    call_datajud_api,
-)
+from .download import build_contar_processos_payload, build_listar_processos_payload, call_datajud_api
 
 # Import mappings for tribunal and justice aliases.
 from .mappings import ID_JUSTICA_TRIBUNAL_TO_ALIAS, TIPOS_MOVIMENTACAO, TRIBUNAL_TO_ALIAS
@@ -244,7 +240,7 @@ class DatajudScraper(BaseScraper):
                     )
             if not processos_por_alias:
                 return []
-            return [(alias, cnjs) for alias, cnjs in processos_por_alias.items()]
+            return list(processos_por_alias.items())
         raise ValueError(
             "É necessário especificar 'tribunal' (sigla) ou 'numero_processo' (CNJ)."
         )

--- a/src/juscraper/courts/tjrn/client.py
+++ b/src/juscraper/courts/tjrn/client.py
@@ -53,7 +53,7 @@ class TJRNScraper(BaseScraper):
         pesquisa: Optional[str] = None,
         paginas: Union[int, list, range, None] = None,
         numero_processo: str = "",
-        id_classe_judicial: str = "",
+        id_classe: str = "",
         id_orgao_julgador: str = "",
         id_relator: str = "",
         id_colegiado: str = "",
@@ -71,7 +71,8 @@ class TJRNScraper(BaseScraper):
                 todas. Default ``None``.
             numero_processo (str): Numero CNJ do processo. Aceita o alias
                 deprecado ``nr_processo``.
-            id_classe_judicial (str): ID da classe judicial.
+            id_classe (str): ID da classe judicial. Aceita o alias deprecado
+                ``id_classe_judicial`` (refs #129).
             id_orgao_julgador (str): ID do orgao julgador.
             id_relator (str): ID do relator.
             id_colegiado (str): ID do colegiado.
@@ -91,13 +92,14 @@ class TJRNScraper(BaseScraper):
         Aliases deprecados (popados com ``DeprecationWarning`` antes do pydantic):
             * ``query`` / ``termo`` -> ``pesquisa``
             * ``nr_processo`` -> ``numero_processo``
+            * ``id_classe_judicial`` -> ``id_classe``
             * ``data_inicio`` / ``data_fim`` -> ``data_julgamento_inicio`` / ``_fim``
             * ``data_julgamento_de`` / ``_ate`` -> ``data_julgamento_inicio`` / ``_fim``
 
         Raises:
             TypeError: Quando um kwarg desconhecido e passado.
-            ValueError: Quando ``numero_processo`` e ``nr_processo`` sao
-                passados simultaneamente.
+            ValueError: Quando um canonico e seu alias deprecado sao passados
+                simultaneamente.
             ValidationError: Quando um filtro tem formato invalido.
 
         Returns:
@@ -111,7 +113,7 @@ class TJRNScraper(BaseScraper):
             pesquisa=pesquisa,
             paginas=paginas,
             numero_processo=numero_processo,
-            id_classe_judicial=id_classe_judicial,
+            id_classe=id_classe,
             id_orgao_julgador=id_orgao_julgador,
             id_relator=id_relator,
             id_colegiado=id_colegiado,
@@ -127,7 +129,7 @@ class TJRNScraper(BaseScraper):
         pesquisa: Optional[str] = None,
         paginas: Union[int, list, range, None] = None,
         numero_processo: str = "",
-        id_classe_judicial: str = "",
+        id_classe: str = "",
         id_orgao_julgador: str = "",
         id_relator: str = "",
         id_colegiado: str = "",
@@ -149,6 +151,9 @@ class TJRNScraper(BaseScraper):
         numero_processo = resolve_deprecated_alias(
             kwargs, "nr_processo", "numero_processo", numero_processo, sentinel=""
         )
+        id_classe = resolve_deprecated_alias(
+            kwargs, "id_classe_judicial", "id_classe", id_classe, sentinel=""
+        )
         inp = apply_input_pipeline_search(
             InputCJSGTJRN,
             "TJRNScraper.cjsg_download()",
@@ -157,7 +162,7 @@ class TJRNScraper(BaseScraper):
             kwargs=kwargs,
             consume_pesquisa_aliases=True,
             numero_processo=numero_processo,
-            id_classe_judicial=id_classe_judicial,
+            id_classe=id_classe,
             id_orgao_julgador=id_orgao_julgador,
             id_relator=id_relator,
             id_colegiado=id_colegiado,
@@ -171,7 +176,7 @@ class TJRNScraper(BaseScraper):
             paginas=inp.paginas,
             session=self.session,
             nr_processo=inp.numero_processo,
-            id_classe_judicial=inp.id_classe_judicial,
+            id_classe=inp.id_classe,
             id_orgao_julgador=inp.id_orgao_julgador,
             id_relator=inp.id_relator,
             id_colegiado=inp.id_colegiado,

--- a/src/juscraper/courts/tjrn/download.py
+++ b/src/juscraper/courts/tjrn/download.py
@@ -18,7 +18,7 @@ def build_cjsg_payload(
     page: int = 1,
     inteiro_teor: str = "",
     nr_processo: str = "",
-    id_classe_judicial: str = "",
+    id_classe: str = "",
     id_orgao_julgador: str = "",
     id_relator: str = "",
     id_colegiado: str = "",
@@ -32,13 +32,17 @@ def build_cjsg_payload(
     jurisdicoes: str = "",
     grau: str = "",
 ) -> dict:
-    """Build the JSON payload for the TJRN CJSG search API."""
+    """Build the JSON payload for the TJRN CJSG search API.
+
+    The public parameter ``id_classe`` is the canonical name; the backend
+    PJe field is ``id_classe_judicial`` and stays unchanged.
+    """
     return {
         "jurisprudencia": {
             "ementa": pesquisa,
             "inteiro_teor": inteiro_teor,
             "nr_processo": nr_processo,
-            "id_classe_judicial": id_classe_judicial,
+            "id_classe_judicial": id_classe,
             "id_orgao_julgador": id_orgao_julgador,
             "id_relator": id_relator,
             "id_colegiado": id_colegiado,

--- a/src/juscraper/courts/tjrn/schemas.py
+++ b/src/juscraper/courts/tjrn/schemas.py
@@ -28,7 +28,7 @@ class InputCJSGTJRN(SearchBase, DataJulgamentoMixin):
     BACKEND_DATE_FORMAT: ClassVar[str] = "%Y-%m-%d"
 
     numero_processo: str = ""
-    id_classe_judicial: str = ""
+    id_classe: str = ""
     id_orgao_julgador: str = ""
     id_relator: str = ""
     id_colegiado: str = ""

--- a/src/juscraper/courts/tjro/client.py
+++ b/src/juscraper/courts/tjro/client.py
@@ -41,10 +41,10 @@ class TJROScraper(BaseScraper):
         paginas: Union[int, list, range, None] = None,
         tipo: list | None = None,
         numero_processo: str = "",
-        magistrado: str = "",
+        relator: str = "",
         orgao_julgador: int | str = "",
         orgao_julgador_colegiado: int | str = "",
-        classe_judicial: str = "",
+        classe: str = "",
         instancia: list | None = None,
         termo_exato: bool = False,
         **kwargs,
@@ -60,10 +60,12 @@ class TJROScraper(BaseScraper):
                 ``"SENTENCA"``, ``"VOTO"``, etc.
             numero_processo (str): Numero CNJ. Aceita o alias deprecado
                 ``nr_processo``.
-            magistrado (str): Nome do relator/magistrado.
+            relator (str): Nome do relator. Aceita o alias deprecado
+                ``magistrado`` (refs #129).
             orgao_julgador (int | str): ID do orgao julgador.
             orgao_julgador_colegiado (int | str): ID do orgao colegiado.
-            classe_judicial (str): Nome da classe judicial.
+            classe (str): Nome da classe judicial. Aceita o alias deprecado
+                ``classe_judicial`` (refs #129).
             instancia (list | None): Instancias (ex.: ``[1]``, ``[2]``, ``[1, 2]``).
             termo_exato (bool): Busca por termo exato.
             **kwargs: Filtros aceitos pelo schema :class:`InputCJSGTJRO`.
@@ -75,13 +77,15 @@ class TJROScraper(BaseScraper):
         Aliases deprecados (popados com ``DeprecationWarning`` antes do pydantic):
             * ``query`` / ``termo`` -> ``pesquisa``
             * ``nr_processo`` -> ``numero_processo``
+            * ``magistrado`` -> ``relator``
+            * ``classe_judicial`` -> ``classe``
             * ``data_inicio`` / ``data_fim`` -> ``data_julgamento_inicio`` / ``_fim``
             * ``data_julgamento_de`` / ``_ate`` -> ``data_julgamento_inicio`` / ``_fim``
 
         Raises:
             TypeError: Quando um kwarg desconhecido e passado.
-            ValueError: Quando ``numero_processo`` e ``nr_processo`` sao
-                passados simultaneamente.
+            ValueError: Quando um canonico e seu alias deprecado sao passados
+                simultaneamente.
             ValidationError: Quando um filtro tem formato invalido.
 
         Returns:
@@ -96,10 +100,10 @@ class TJROScraper(BaseScraper):
             paginas=paginas,
             tipo=tipo,
             numero_processo=numero_processo,
-            magistrado=magistrado,
+            relator=relator,
             orgao_julgador=orgao_julgador,
             orgao_julgador_colegiado=orgao_julgador_colegiado,
-            classe_judicial=classe_judicial,
+            classe=classe,
             instancia=instancia,
             termo_exato=termo_exato,
             **kwargs,
@@ -111,10 +115,10 @@ class TJROScraper(BaseScraper):
         paginas: Union[int, list, range, None] = None,
         tipo: list | None = None,
         numero_processo: str = "",
-        magistrado: str = "",
+        relator: str = "",
         orgao_julgador: int | str = "",
         orgao_julgador_colegiado: int | str = "",
-        classe_judicial: str = "",
+        classe: str = "",
         instancia: list | None = None,
         termo_exato: bool = False,
         **kwargs,
@@ -131,6 +135,12 @@ class TJROScraper(BaseScraper):
         numero_processo = resolve_deprecated_alias(
             kwargs, "nr_processo", "numero_processo", numero_processo, sentinel=""
         )
+        relator = resolve_deprecated_alias(
+            kwargs, "magistrado", "relator", relator, sentinel=""
+        )
+        classe = resolve_deprecated_alias(
+            kwargs, "classe_judicial", "classe", classe, sentinel=""
+        )
         inp = apply_input_pipeline_search(
             InputCJSGTJRO,
             "TJROScraper.cjsg_download()",
@@ -140,10 +150,10 @@ class TJROScraper(BaseScraper):
             consume_pesquisa_aliases=True,
             tipo=tipo,
             numero_processo=numero_processo,
-            magistrado=magistrado,
+            relator=relator,
             orgao_julgador=orgao_julgador,
             orgao_julgador_colegiado=orgao_julgador_colegiado,
-            classe_judicial=classe_judicial,
+            classe=classe,
             instancia=instancia,
             termo_exato=termo_exato,
         )
@@ -153,10 +163,10 @@ class TJROScraper(BaseScraper):
             session=self.session,
             tipo=inp.tipo,
             nr_processo=inp.numero_processo,
-            magistrado=inp.magistrado,
+            relator=inp.relator,
             orgao_julgador=inp.orgao_julgador,
             orgao_julgador_colegiado=inp.orgao_julgador_colegiado,
-            classe_judicial=inp.classe_judicial,
+            classe=inp.classe,
             data_julgamento_inicio=to_iso_date(inp.data_julgamento_inicio) or "",
             data_julgamento_fim=to_iso_date(inp.data_julgamento_fim) or "",
             instancia=inp.instancia,

--- a/src/juscraper/courts/tjro/download.py
+++ b/src/juscraper/courts/tjro/download.py
@@ -19,30 +19,35 @@ def build_cjsg_payload(
     size: int = RESULTS_PER_PAGE,
     tipo: list | None = None,
     nr_processo: str = "",
-    magistrado: str = "",
+    relator: str = "",
     orgao_julgador: int | str = "",
     orgao_julgador_colegiado: int | str = "",
-    classe_judicial: str = "",
+    classe: str = "",
     data_julgamento_inicio: str = "",
     data_julgamento_fim: str = "",
     instancia: list | None = None,
     termo_exato: bool = False,
 ) -> dict:
-    """Build the JSON payload for the TJRO CJSG search API."""
+    """Build the JSON payload for the TJRO CJSG search API.
+
+    Public parameters use canonical names (``relator``, ``classe``); the
+    backend Elasticsearch field names (``ds_nome``, ``ds_classe_judicial``)
+    are an internal detail of the JURIS API and stay unchanged.
+    """
     if tipo is None:
         tipo = ["EMENTA"]
 
     fields: dict = {"tipo": tipo, "query": pesquisa}
     if nr_processo:
         fields["nr_processo"] = nr_processo
-    if magistrado:
-        fields["ds_nome"] = magistrado
+    if relator:
+        fields["ds_nome"] = relator
     if orgao_julgador:
         fields["id_orgao_julgador"] = str(orgao_julgador)
     if orgao_julgador_colegiado:
         fields["id_orgao_julgador_colegiado"] = str(orgao_julgador_colegiado)
-    if classe_judicial:
-        fields["ds_classe_judicial"] = classe_judicial
+    if classe:
+        fields["ds_classe_judicial"] = classe
     if data_julgamento_inicio:
         fields["dtjulgamento_inicio"] = data_julgamento_inicio
     if data_julgamento_fim:

--- a/src/juscraper/courts/tjro/schemas.py
+++ b/src/juscraper/courts/tjro/schemas.py
@@ -27,10 +27,10 @@ class InputCJSGTJRO(SearchBase, DataJulgamentoMixin):
 
     tipo: list | None = None
     numero_processo: str = ""
-    magistrado: str = ""
+    relator: str = ""
     orgao_julgador: int | str = ""
     orgao_julgador_colegiado: int | str = ""
-    classe_judicial: str = ""
+    classe: str = ""
     instancia: list | None = None
     termo_exato: bool = False
 

--- a/tests/schemas/test_canonical_types.py
+++ b/tests/schemas/test_canonical_types.py
@@ -15,8 +15,10 @@ Dois enforcamentos em schemas concretos Input/Output (mapeados em
 
 :data:`TYPE_GRACE_PERIOD` e :data:`SYNONYM_GRACE_PERIOD` documentam
 excecoes conhecidas que ainda aparecem por razao explicita — p.ex.
-TJRO/TJPI nao foram renomeados neste PR, DataJud ainda so aceita
-``range`` na assinatura. Cada entrada tem a razao e o PR pendente.
+TJPI/TJGO nao convertem ``data_publicacao`` para ``date``, DataJud
+ainda so aceita ``range`` na assinatura, ``OutputCJSGEsaj`` declara
+``relatora`` por causa do parser ``_normalize_key``. Cada entrada
+tem a razao e o PR pendente.
 """
 from __future__ import annotations
 
@@ -113,18 +115,6 @@ TYPE_GRACE_PERIOD: dict[tuple[str, str], str] = {
 # Documentam tribunais que ainda nao passaram pelo rename canonico
 # mas estao na agenda.
 SYNONYM_GRACE_PERIOD: dict[tuple[str, str], str] = {
-    # TJRO cjsg ainda expoe ``magistrado`` e ``classe_judicial`` na
-    # assinatura do client — rename para ``relator``/``classe`` foi
-    # feito apenas no parser (coluna canonica). Proximo PR TJRO deve
-    # deprecar os aliases no client tambem, como TJES/TJPE.
-    (
-        "InputCJSGTJRO",
-        "magistrado",
-    ): "TJRO client ainda nao renomeado — proximo PR TJRO com deprecacao via pop_deprecated_alias",
-    (
-        "InputCJSGTJRO",
-        "classe_judicial",
-    ): "TJRO client ainda nao renomeado — proximo PR TJRO com deprecacao via pop_deprecated_alias",
     # OutputCJSGEsaj declara ``relatora`` explicito porque o parser eSAJ
     # _normalize_key transforma "Relator(a):" em "relatora". Correcao
     # estrutural no parser e breaking para 6 tribunais — PR dedicado.

--- a/tests/tjrn/test_cjsg_filters_contract.py
+++ b/tests/tjrn/test_cjsg_filters_contract.py
@@ -1,4 +1,11 @@
-"""Filter-propagation contract for TJRN cjsg."""
+"""Filter-propagation contract for TJRN cjsg.
+
+``id_classe`` is the canonical kwarg in ``TJRNScraper.cjsg`` (refs #129).
+The legacy ``id_classe_judicial`` alias is still accepted and emits
+``DeprecationWarning`` for one version. The backend PJe payload keeps
+the original field name (``id_classe_judicial``) — that is an internal
+detail of the PJe API and not exposed in the public signature.
+"""
 import pandas as pd
 import pytest
 import responses
@@ -33,7 +40,7 @@ def test_cjsg_all_filters_land_in_json_body(mocker):
             "dano moral",
             page=1,
             nr_processo="00000000000000000000",
-            id_classe_judicial="123",
+            id_classe="123",
             id_orgao_julgador="456",
             id_relator="789",
             id_colegiado="10",
@@ -50,7 +57,7 @@ def test_cjsg_all_filters_land_in_json_body(mocker):
         "dano moral",
         paginas=1,
         numero_processo="00000000000000000000",
-        id_classe_judicial="123",
+        id_classe="123",
         id_orgao_julgador="456",
         id_relator="789",
         id_colegiado="10",
@@ -124,6 +131,32 @@ def test_cjsg_nr_processo_alias_emits_deprecation_warning(mocker):
             "dano moral",
             paginas=1,
             nr_processo="00000000000000000000",
+        )
+
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
+def test_cjsg_id_classe_judicial_alias_emits_deprecation_warning(mocker):
+    """The deprecated ``id_classe_judicial`` alias maps to ``id_classe`` and
+    the backend body keeps the ``id_classe_judicial`` field (refs #129)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjrn", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral", page=1, id_classe="123",
+        ))],
+    )
+
+    with pytest.warns(DeprecationWarning, match="id_classe_judicial.*id_classe"):
+        df = jus.scraper("tjrn").cjsg(
+            "dano moral",
+            paginas=1,
+            id_classe_judicial="123",
         )
 
     assert isinstance(df, pd.DataFrame)

--- a/tests/tjro/test_cjsg_filters_contract.py
+++ b/tests/tjro/test_cjsg_filters_contract.py
@@ -1,10 +1,11 @@
 """Filter-propagation contract for TJRO cjsg.
 
-``magistrado`` and ``classe_judicial`` are still canonical kwargs in
-``TJROScraper.cjsg`` today (no ``DeprecationWarning``). The repo-wide
-canonical names defined in ``CLAUDE.md`` > "Nomes canonicos de coluna"
-are ``relator`` and ``classe`` — alignment here is tracked as part of
-the family 1C refactor (#84), not within this contract PR.
+``relator`` and ``classe`` are the canonical kwargs in ``TJROScraper.cjsg``
+(refs #129). The legacy ``magistrado`` / ``classe_judicial`` aliases are
+still accepted and emit ``DeprecationWarning`` for one version. The
+backend Elasticsearch payload keeps the original field names
+(``ds_nome``, ``ds_classe_judicial``) — that is an internal detail of
+the JURIS API and not exposed in the public signature.
 """
 import pandas as pd
 import pytest
@@ -20,8 +21,8 @@ from tests._helpers import load_sample
 def test_cjsg_all_filters_land_in_json_body(mocker):
     """Every public filter must reach the POST JSON payload via ``build_cjsg_payload``.
 
-    ``magistrado`` / ``classe_judicial`` are passed as-is (canonical in TJRO today —
-    see module docstring).
+    Public filters are passed in canonical form (``relator``, ``classe``);
+    the matcher asserts the backend body keeps ``ds_nome`` / ``ds_classe_judicial``.
 
     Note: ``TJROScraper.cjsg`` exposes only ``data_julgamento_inicio``/``fim``;
     ``data_publicacao_*`` is not in the public signature, so the publication
@@ -39,10 +40,10 @@ def test_cjsg_all_filters_land_in_json_body(mocker):
             offset=0,
             tipo=["ACORDAO"],
             nr_processo="00000000000000000000",
-            magistrado="FULANO DE TAL",
+            relator="FULANO DE TAL",
             orgao_julgador=42,
             orgao_julgador_colegiado=7,
-            classe_judicial="Apelacao",
+            classe="Apelacao",
             data_julgamento_inicio="2024-01-01",
             data_julgamento_fim="2024-03-31",
             instancia=[2],
@@ -55,10 +56,10 @@ def test_cjsg_all_filters_land_in_json_body(mocker):
         paginas=1,
         tipo=["ACORDAO"],
         numero_processo="00000000000000000000",
-        magistrado="FULANO DE TAL",
+        relator="FULANO DE TAL",
         orgao_julgador=42,
         orgao_julgador_colegiado=7,
-        classe_judicial="Apelacao",
+        classe="Apelacao",
         data_julgamento_inicio="2024-01-01",
         data_julgamento_fim="2024-03-31",
         instancia=[2],
@@ -127,6 +128,58 @@ def test_cjsg_nr_processo_alias_emits_deprecation_warning(mocker):
             "dano moral",
             paginas=1,
             nr_processo="00000000000000000000",
+        )
+
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
+def test_cjsg_magistrado_alias_emits_deprecation_warning(mocker):
+    """The deprecated ``magistrado`` alias maps to ``relator`` and the
+    backend body keeps the ``ds_nome`` field (refs #129)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjro", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral", offset=0, relator="FULANO DE TAL",
+        ))],
+    )
+
+    with pytest.warns(DeprecationWarning, match="magistrado.*relator"):
+        df = jus.scraper("tjro").cjsg(
+            "dano moral",
+            paginas=1,
+            magistrado="FULANO DE TAL",
+        )
+
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
+def test_cjsg_classe_judicial_alias_emits_deprecation_warning(mocker):
+    """The deprecated ``classe_judicial`` alias maps to ``classe`` and the
+    backend body keeps the ``ds_classe_judicial`` field (refs #129)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjro", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral", offset=0, classe="Apelacao",
+        ))],
+    )
+
+    with pytest.warns(DeprecationWarning, match="classe_judicial.*classe"):
+        df = jus.scraper("tjro").cjsg(
+            "dano moral",
+            paginas=1,
+            classe_judicial="Apelacao",
         )
 
     assert isinstance(df, pd.DataFrame)


### PR DESCRIPTION
## Sumário

Substitui o PR #138, fechado automaticamente pelo GitHub em 30/04/2026 quando a branch base (`refactor/wire-pydantic-1c-a`) foi deletada após o merge de #136 — o conteúdo nunca foi mergeado.

Resolve parcialmente #129 (TJRO + TJRN; TJPB continua na issue #137 dedicada, junto com o refactor 1C-b/#121).

## Mudanças

### chore(datajud) — destravar pre-commit (commit `2500b3d`)

`datajud/client.py:155` declarava `List[Dict[str, Any]]` sem `Dict` no import (mypy `name-defined`), e a linha 247 usava uma comprehension trivial sobre `dict.items()` (pylint `R1721`). Os dois warnings são pré-existentes em main e atravessam o follow-imports do mypy, fazendo o pre-commit falhar em qualquer PR que toque arquivos que importam `aggregators.datajud`. Sem mudança de comportamento.

### refactor(tjro) — `magistrado→relator`, `classe_judicial→classe` (commit `ea6a328`)

CLAUDE.md > \"Nomes canônicos de coluna\" proíbe explicitamente `magistrado` e `classe_judicial` para `relator`/`classe`. Esta era a única violação explícita restante na família 1C.

- **`client.py`**: assinatura pública renomeia os parâmetros; aliases antigos populados via `resolve_deprecated_alias` antes do `apply_input_pipeline_search` (`DeprecationWarning` + checagem de colisão por uma versão).
- **`schemas.py`**: `InputCJSGTJRO.magistrado`→`relator`, `InputCJSGTJRO.classe_judicial`→`classe`.
- **`download.py`**: parâmetros públicos do helper `build_cjsg_payload` renomeados; o JSON enviado ao backend Elasticsearch **continua** usando `ds_nome`/`ds_classe_judicial` (fronteira do backend, não da API pública).
- **`tests/schemas/test_canonical_types.py`**: removidas as 2 entradas `SYNONYM_GRACE_PERIOD` para `InputCJSGTJRO.magistrado`/`classe_judicial` — meta-teste agora valida o canônico.

Testes novos (regra 6a do CLAUDE.md): `test_cjsg_magistrado_alias_emits_deprecation_warning`, `test_cjsg_classe_judicial_alias_emits_deprecation_warning`.

### refactor(tjrn) — `id_classe_judicial→id_classe` (commit `7e410d5`)

Judgment-call de simetria com os demais filtros `id_*` (`id_relator`, `id_orgao_julgador`, `id_colegiado`).

- **`client.py`**: renomeio + `resolve_deprecated_alias`.
- **`schemas.py`**: `InputCJSGTJRN.id_classe_judicial`→`id_classe`.
- **`download.py`**: parâmetro do helper renomeado; o JSON do backend PJe **continua** usando `id_classe_judicial`.

Teste novo: `test_cjsg_id_classe_judicial_alias_emits_deprecation_warning`.

## Impacto

- **API pública**: `cjsg(magistrado=...)` em TJRO passa a emitir `DeprecationWarning`; idem `classe_judicial` em TJRO e `id_classe_judicial` em TJRN. Nenhum caller funcional quebra — só recebe warning.
- **Suite**: 1083 passed (antes: 1080), zero regressão.

## TJPB (fora do escopo)

TJPB também usa `id_classe_judicial`, mas:
1. Não tem contrato offline ainda (família 1C-b, #121).
2. Refactor 1C-b ainda não começou.

Issue dedicada **#137** registra o débito.

## Test plan

- [x] \`uv run pytest\` — 1083 passed
- [x] \`uv run pytest tests/tjrn tests/tjro\` — 21 passed
- [x] \`uv run pytest tests/schemas/\` — sem regressão (2 grace-period exceptions removidas; meta-teste confirma)
- [x] \`uv run pre-commit run\` (via hooks de cada commit) — verde

## Resolves

- Resolve parcialmente #129 (TJRO + TJRN). TJPB fica em #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)