### PR TITLE
refactor(tjap, tjrs): adotar consume_pesquisa_aliases=True (refs #187)

### DIFF
--- a/src/juscraper/courts/tjap/client.py
+++ b/src/juscraper/courts/tjap/client.py
@@ -5,12 +5,7 @@ import pandas as pd
 import requests
 
 from juscraper.core.base import BaseScraper
-from juscraper.utils.params import (
-    apply_input_pipeline_search,
-    normalize_paginas,
-    normalize_pesquisa,
-    resolve_deprecated_alias,
-)
+from juscraper.utils.params import apply_input_pipeline_search, resolve_deprecated_alias
 
 from .download import cjsg_download_manager
 from .parse import cjsg_parse_manager
@@ -136,14 +131,13 @@ class TJAPScraper(BaseScraper):
         numero_processo = resolve_deprecated_alias(
             kwargs, "numero_cnj", "numero_processo", numero_processo
         )
-        pesquisa = normalize_pesquisa(pesquisa, **kwargs)
-        paginas = normalize_paginas(paginas)
         inp = apply_input_pipeline_search(
             InputCJSGTJAP,
             "TJAPScraper.cjsg_download()",
             pesquisa=pesquisa,
             paginas=paginas,
             kwargs=kwargs,
+            consume_pesquisa_aliases=True,
             orgao=orgao,
             numero_processo=numero_processo,
             numero_acordao=numero_acordao,

--- a/src/juscraper/courts/tjrs/client.py
+++ b/src/juscraper/courts/tjrs/client.py
@@ -7,7 +7,7 @@ import pandas as pd
 import requests
 
 from juscraper.core.base import BaseScraper
-from juscraper.utils.params import apply_input_pipeline_search, normalize_paginas, normalize_pesquisa
+from juscraper.utils.params import apply_input_pipeline_search
 
 from .download import cjsg_download_manager
 from .parse import cjsg_parse_manager
@@ -79,14 +79,13 @@ class TJRSScraper(BaseScraper):
                 None: downloads all available pages.
             secao: 'civel', 'crime', or None.
         """
-        pesquisa = normalize_pesquisa(pesquisa, **kwargs)
-        paginas = normalize_paginas(paginas)
         inp = apply_input_pipeline_search(
             InputCJSGTJRS,
             "TJRSScraper.cjsg_download()",
             pesquisa=pesquisa,
             paginas=paginas,
             kwargs=kwargs,
+            consume_pesquisa_aliases=True,
             data_julgamento_inicio=data_julgamento_inicio,
             data_julgamento_fim=data_julgamento_fim,
             data_publicacao_inicio=data_publicacao_inicio,


### PR DESCRIPTION
## Resumo

- Substitui as chamadas manuais a `normalize_pesquisa` + `normalize_paginas` em `cjsg_download` de TJAP e TJRS pela flag `consume_pesquisa_aliases=True` no helper `apply_input_pipeline_search`.
- Alinha esses dois clients com o padrão já adotado por TJBA, TJDFT, TJES (cjsg+cjpg), TJGO, TJMG, TJMT, TJPA, TJPI, TJPR, TJRN, TJRO, TJRR, TJSC e TJSP cjpg.
- Fecha o checklist remanescente da issue #187: TJBA e TJMT (L2 do #167) já haviam sido migrados em PRs anteriores; restavam apenas TJAP e TJRS (L3 do #168).

## Mudanças

- `src/juscraper/courts/tjap/client.py`: remove `normalize_pesquisa`/`normalize_paginas` dos imports e do corpo de `cjsg_download`; adiciona `consume_pesquisa_aliases=True`. `resolve_deprecated_alias` para `numero_cnj` continua rodando antes do helper (alias tribunal-específico não consumido por `normalize_pesquisa`).
- `src/juscraper/courts/tjrs/client.py`: mesma mudança no `cjsg_download`; import passa a ter apenas `apply_input_pipeline_search`.

Saldo: 4 linhas removidas, 2 linhas adicionadas (a flag em cada client). Sem entrada no `CHANGELOG.md` — refactor interno sem efeito observável pelo usuário (regra do `CLAUDE.md` § Changelog).

## Test plan

- [x] `pytest tests/tjap tests/tjrs tests/schemas` — 564 passed
- [x] `pytest` (suíte offline completa) — 1109 passed
- [x] Pre-commit (isort, pylint, flake8, mypy) — verde
- [x] Coberturas críticas continuam verdes:
  - `tests/tjrs/test_cjsg_filters_contract.py::test_cjsg_query_alias_emits_deprecation_warning`
  - `tests/tjrs/test_cjsg_filters_contract.py::test_cjsg_termo_alias_emits_deprecation_warning`
  - `tests/tjap/test_cjsg_filters_contract.py::test_cjsg_numero_cnj_alias_emits_deprecation_warning` (valida que `resolve_deprecated_alias` segue rodando *antes* do helper)
  - `tests/schemas/test_signature_parity.py`

Refs #187, #165, #174.