### PR TITLE
Adicionar nbmake como sanity check + consertar tjes/tjgo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,27 @@ As seções a seguir são notas internas para quem contribui com novos raspadore
 
 Antes de refatorar um tribunal pela #84, ele precisa ter contratos passando. A camada de contrato valida só a API pública e sobrevive à mudança estrutural; serve como rede de segurança da refatoração. Granulares vêm depois, na estrutura já refatorada. **TJSP refatora por último** (mais usado, mais complexo).
 
+### Notebooks como sanity check (`pytest --nbmake`)
+
+Os notebooks de exemplo em `docs/notebooks/<tribunal>.ipynb` exercitam o fluxo público de cada raspador (cjsg, cjpg, cpopg, cposg, listar_processos) com chamadas reais ao tribunal. Servem ao mesmo tempo como documentação executável (build do site Quarto) e como **canário de regressão pós-refactor** — pegam quebras visíveis ao usuário (parser quebrado, schema rejeitando input antes válido, coluna renomeada sem migração) que um teste granular pode mascarar.
+
+Comando padrão (rodar localmente antes de release ou após refactor amplo):
+
+```bash
+pytest --nbmake docs/notebooks/ \
+  --ignore=docs/notebooks/jusbr.ipynb \
+  --ignore=docs/notebooks/tjmg.ipynb \
+  --nbmake-timeout=300 \
+  -n auto
+```
+
+Notas:
+
+- **Não rodar em `pre-commit` nem em CI por PR.** São 25 notebooks contra rede real (~10-30 min com `pytest-xdist`); flakiness de tribunal vai bloquear merge sem motivo. O lugar certo, se um dia entrar no CI, é o workflow nightly proposto em #101 com `continue-on-error`.
+- `jusbr.ipynb` é excluído porque depende de token gov.br (`JUSBR_ACCESS_TOKEN`); `tjmg.ipynb` depende do extra `[tjmg]` instalado (`txtcaptcha`). Ambos rodam sob demanda quando as condições estão presentes.
+- Falha 5xx em um único notebook normalmente é instabilidade do tribunal — re-rodar o notebook isolado antes de reportar regressão (`pytest --nbmake docs/notebooks/<tribunal>.ipynb`).
+- Quando o resultado real divergir do output cacheado (ex.: coluna nova, ementa em formato diferente), o notebook deve ser **commitado com outputs limpos** (`jupyter nbconvert --clear-output --inplace docs/notebooks/<tribunal>.ipynb`) para que `git diff` futuro fique focado em código.
+
 ## Adding a new tribunal
 
 Todo raspador novo em `src/juscraper/courts/<xx>/` ou `src/juscraper/aggregators/<xx>/` deve entrar acompanhado de **pelo menos um teste de contrato** por método público (`cjsg`, `cjpg`, `cpopg`, `cposg`, `listar_processos`, etc.). O PR fica bloqueado sem isso.

--- a/docs/notebooks/tjes.ipynb
+++ b/docs/notebooks/tjes.ipynb
@@ -319,136 +319,27 @@
    "source": [
     "## Using filters\n",
     "\n",
-    "The TJES scraper supports several filters: `magistrado`, `orgao_julgador`, `classe_judicial`, `jurisdicao`, `assunto`, date range (`data_julgamento_inicio` / `data_julgamento_fim`), `busca_exata`, and `ordenacao`."
+    "The TJES scraper supports several filters: `relator`, `orgao_julgador`, `classe`, `jurisdicao`, `assunto`, date range (`data_julgamento_inicio` / `data_julgamento_fim`), `busca_exata`, and `ordenacao`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "34a75d9d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Baixando paginas TJES: 100%|██████████| 1/1 [00:00<00:00, 10.22it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(20, 23)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>nr_processo</th>\n",
-       "      <th>magistrado</th>\n",
-       "      <th>classe_judicial</th>\n",
-       "      <th>dt_juntada</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>5005361-74.2024.8.08.0000</td>\n",
-       "      <td>HELIMAR PINTO</td>\n",
-       "      <td>AGRAVO DE EXECUÇÃO PENAL</td>\n",
-       "      <td>2024-06-25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0001362-38.2023.8.08.0000</td>\n",
-       "      <td>HELIMAR PINTO</td>\n",
-       "      <td>MANDADO DE SEGURANÇA CÍVEL</td>\n",
-       "      <td>2024-02-29</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>5003125-52.2024.8.08.0000</td>\n",
-       "      <td>HELIMAR PINTO</td>\n",
-       "      <td>HABEAS CORPUS CRIMINAL</td>\n",
-       "      <td>2024-04-18</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0026004-72.2016.8.08.0048</td>\n",
-       "      <td>HELIMAR PINTO</td>\n",
-       "      <td>APELAÇÃO CRIMINAL</td>\n",
-       "      <td>2024-04-25</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5005989-63.2024.8.08.0000</td>\n",
-       "      <td>HELIMAR PINTO</td>\n",
-       "      <td>HABEAS CORPUS CRIMINAL</td>\n",
-       "      <td>2024-06-25</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 nr_processo     magistrado             classe_judicial  \\\n",
-       "0  5005361-74.2024.8.08.0000  HELIMAR PINTO    AGRAVO DE EXECUÇÃO PENAL   \n",
-       "1  0001362-38.2023.8.08.0000  HELIMAR PINTO  MANDADO DE SEGURANÇA CÍVEL   \n",
-       "2  5003125-52.2024.8.08.0000  HELIMAR PINTO      HABEAS CORPUS CRIMINAL   \n",
-       "3  0026004-72.2016.8.08.0048  HELIMAR PINTO           APELAÇÃO CRIMINAL   \n",
-       "4  5005989-63.2024.8.08.0000  HELIMAR PINTO      HABEAS CORPUS CRIMINAL   \n",
-       "\n",
-       "   dt_juntada  \n",
-       "0  2024-06-25  \n",
-       "1  2024-02-29  \n",
-       "2  2024-04-18  \n",
-       "3  2024-04-25  \n",
-       "4  2024-06-25  "
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# Filter by date range and magistrado\n",
+    "# Filter by date range and relator\n",
     "dados_filtrados = tjes.cjsg(\n",
     "    'direito',\n",
     "    data_julgamento_inicio='2024-01-01',\n",
     "    data_julgamento_fim='2024-06-30',\n",
-    "    magistrado='HELIMAR PINTO',\n",
+    "    relator='HELIMAR PINTO',\n",
     "    paginas=1,\n",
     ")\n",
     "\n",
     "print(dados_filtrados.shape)\n",
-    "dados_filtrados[['nr_processo', 'magistrado', 'classe_judicial', 'dt_juntada']].head(5)"
+    "dados_filtrados[['processo', 'relator', 'classe', 'dt_juntada']].head(5)"
    ]
   },
   {
@@ -463,103 +354,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "66f3ceb5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Baixando paginas TJES: 100%|██████████| 1/1 [00:00<00:00, 10.46it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Monocratic results: 20 rows\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>nr_processo</th>\n",
-       "      <th>magistrado</th>\n",
-       "      <th>classe_judicial</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>5001274-40.2022.8.08.0002</td>\n",
-       "      <td>GRECIO NOGUEIRA GREGIO</td>\n",
-       "      <td>Recurso Inominado Cível</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>5023551-77.2024.8.08.0035</td>\n",
-       "      <td>DOUGLAS DEMONER FIGUEIREDO</td>\n",
-       "      <td>RECURSO INOMINADO CÍVEL</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>5001473-59.2023.8.08.0024</td>\n",
-       "      <td>SALOMAO AKHNATON ZOROASTRO SPENCER ELESBON</td>\n",
-       "      <td>Recurso Inominado Cível</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 nr_processo                                  magistrado  \\\n",
-       "0  5001274-40.2022.8.08.0002                      GRECIO NOGUEIRA GREGIO   \n",
-       "1  5023551-77.2024.8.08.0035                  DOUGLAS DEMONER FIGUEIREDO   \n",
-       "2  5001473-59.2023.8.08.0024  SALOMAO AKHNATON ZOROASTRO SPENCER ELESBON   \n",
-       "\n",
-       "           classe_judicial  \n",
-       "0  Recurso Inominado Cível  \n",
-       "1  RECURSO INOMINADO CÍVEL  \n",
-       "2  Recurso Inominado Cível  "
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Search monocratic decisions (2nd instance)\n",
     "dados_mono = tjes.cjsg('dano moral', core='pje2g_mono', paginas=1)\n",
     "\n",
     "print(f\"Monocratic results: {len(dados_mono)} rows\")\n",
-    "dados_mono[['nr_processo', 'magistrado', 'classe_judicial']].head(3)"
+    "dados_mono[['processo', 'relator', 'classe']].head(3)"
    ]
   },
   {
@@ -576,125 +380,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "116996c0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Baixando paginas TJES: 100%|██████████| 1/1 [00:00<00:00,  5.04it/s]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "First instance results: 20 rows\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>nr_processo</th>\n",
-       "      <th>magistrado</th>\n",
-       "      <th>classe_judicial</th>\n",
-       "      <th>dt_juntada</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>5000704-46.2022.8.08.0037</td>\n",
-       "      <td>MARCELO MATTAR COUTINHO</td>\n",
-       "      <td>Procedimento do Juizado Especial Cível</td>\n",
-       "      <td>2023-09-28</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>5000057-89.2018.8.08.0005</td>\n",
-       "      <td>EVANDRO COELHO DE LIMA</td>\n",
-       "      <td>Procedimento do Juizado Especial Cível</td>\n",
-       "      <td>2019-12-17</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>5004066-91.2024.8.08.0035</td>\n",
-       "      <td>INES VELLO CORREA</td>\n",
-       "      <td>Procedimento do Juizado Especial Cível</td>\n",
-       "      <td>2024-11-08</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>5000045-13.2017.8.08.0037</td>\n",
-       "      <td>MARCELO MATTAR COUTINHO</td>\n",
-       "      <td>Procedimento do Juizado Especial Cível</td>\n",
-       "      <td>2020-01-04</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5005643-41.2022.8.08.0014</td>\n",
-       "      <td>SALOMAO AKHNATON ZOROASTRO SPENCER ELESBON</td>\n",
-       "      <td>Procedimento do Juizado Especial Cível</td>\n",
-       "      <td>2022-11-01</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                 nr_processo                                  magistrado  \\\n",
-       "0  5000704-46.2022.8.08.0037                     MARCELO MATTAR COUTINHO   \n",
-       "1  5000057-89.2018.8.08.0005                      EVANDRO COELHO DE LIMA   \n",
-       "2  5004066-91.2024.8.08.0035                           INES VELLO CORREA   \n",
-       "3  5000045-13.2017.8.08.0037                     MARCELO MATTAR COUTINHO   \n",
-       "4  5005643-41.2022.8.08.0014  SALOMAO AKHNATON ZOROASTRO SPENCER ELESBON   \n",
-       "\n",
-       "                          classe_judicial  dt_juntada  \n",
-       "0  Procedimento do Juizado Especial Cível  2023-09-28  \n",
-       "1  Procedimento do Juizado Especial Cível  2019-12-17  \n",
-       "2  Procedimento do Juizado Especial Cível  2024-11-08  \n",
-       "3  Procedimento do Juizado Especial Cível  2020-01-04  \n",
-       "4  Procedimento do Juizado Especial Cível  2022-11-01  "
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Search first-instance decisions\n",
     "dados_1g = tjes.cjpg('dano moral', paginas=1)\n",
     "\n",
     "print(f\"First instance results: {len(dados_1g)} rows\")\n",
-    "dados_1g[['nr_processo', 'magistrado', 'classe_judicial', 'dt_juntada']].head(5)"
+    "dados_1g[['processo', 'relator', 'classe', 'dt_juntada']].head(5)"
    ]
   },
   {

--- a/docs/notebooks/tjgo.ipynb
+++ b/docs/notebooks/tjgo.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "dbdd918f",
    "metadata": {},
    "source": [
     "# TJGO — Court of Justice of Goiás\n",
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "36edeb0f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,6 +27,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "788b8d7e",
    "metadata": {},
    "source": [
     "## Basic search\n",
@@ -35,6 +38,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "013ecb45",
    "metadata": {},
    "outputs": [
     {
@@ -144,6 +148,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "574f761c",
    "metadata": {},
    "source": [
     "## Available columns"
@@ -152,6 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "e041d0bd",
    "metadata": {},
    "outputs": [
     {
@@ -177,6 +183,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a75570f8",
    "metadata": {},
    "source": [
     "## Text preview"
@@ -185,6 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "06e8e60d",
    "metadata": {},
    "outputs": [
     {
@@ -201,6 +209,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "82f58469",
    "metadata": {},
    "source": [
     "## Filtering by instance and area\n",
@@ -214,6 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "d0ef70bc",
    "metadata": {},
    "outputs": [
     {
@@ -305,6 +315,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "68daad01",
    "metadata": {},
    "source": [
     "## Download and parse separately\n",
@@ -316,6 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "76414407",
    "metadata": {},
    "outputs": [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ dev = [
     "ruff>=0.15.0",
     "types-requests>=2.32.0",
     "pre-commit>=3.0.0",
+    "nbmake>=1.5.0",
+    "pytest-xdist>=3.0.0",
 ]
 docs = [
     "quartodoc>=0.11.1",


### PR DESCRIPTION
## Resumo

Formaliza \`nbmake\` como sanity check local de notebooks e consertam-se os dois notebooks que quebravam quando rodados via \`pytest --nbmake\`.

Closes #215

## Mudancas

### Commit 1 — \`chore(dev): adicionar nbmake como sanity check de notebooks\`

- \`pyproject.toml\`: \`nbmake>=1.5.0\` e \`pytest-xdist>=3.0.0\` em \`[dev]\`.
- \`CONTRIBUTING.md\`: nova subsecao \"### Notebooks como sanity check (\`pytest --nbmake\`)\" com comando documentado, exclusoes padrao (\`jusbr.ipynb\` por token gov.br; \`tjmg.ipynb\` por extra \`[tjmg]\` opcional) e nota explicita **\"nao rodar em pre-commit nem em CI por PR\"** — 25 notebooks contra rede real + flakiness de tribunal tornam isso impraticavel como gate.

Comando documentado:

\`\`\`bash
pytest --nbmake docs/notebooks/ \\
  --ignore=docs/notebooks/jusbr.ipynb \\
  --ignore=docs/notebooks/tjmg.ipynb \\
  --nbmake-timeout=300 \\
  -n auto
\`\`\`

### Commit 2 — \`fix(notebooks): consertar tjes (colunas renomeadas) e tjgo (cell ids ausentes)\`

**\`tjes.ipynb\`** estava usando os nomes antigos das colunas que ja foram padronizados como BREAKING em \`[Unreleased]\`:

- \`nr_processo\` -> \`processo\`
- \`magistrado\` -> \`relator\`
- \`classe_judicial\` -> \`classe\` (mantem \`classe_judicial_sigla\`, \`cd_classe_judicial\`, \`id_classe_judicial\`)
- \`assunto_principal\` -> \`assunto\`
- filtro \`magistrado='HELIMAR PINTO'\` -> \`relator='HELIMAR PINTO'\`

Outputs cacheados das celulas afetadas foram limpos para evitar drift visual.

**\`tjgo.ipynb\`** estava em formato anterior a \`nbformat 4.5\` (celulas sem campo \`id\`). Combinado com \`filterwarnings = [\"error\"]\` no pytest, o \`MissingIDFieldWarning\` virava erro fatal e o nbmake abortava com \`NBMAKE INTERNAL ERROR\`. Re-salvo via \`nbformat.write\` para adicionar ids deterministicos. Refs #215.

## Validacao

Apos as correcoes, \`pytest --nbmake docs/notebooks/ --ignore=docs/notebooks/jusbr.ipynb --ignore=docs/notebooks/tjmg.ipynb\` deve subir de **20/25 -> 23/25** (resta apenas \`tjpb\` e \`tjpe\` falhando intermitentemente por instabilidade de servidor — comentado em #112). E **24/25** se contar a regressao real do \`datajud.ipynb\` (\`assuntos=[12503]\` int rejeitado por schema strict — fora do escopo deste PR; sera issue propria).

## Test plan

- [x] \`pre-commit run --files pyproject.toml CONTRIBUTING.md docs/notebooks/tjes.ipynb docs/notebooks/tjgo.ipynb\` passa
- [x] \`pytest --nbmake docs/notebooks/tjes.ipynb docs/notebooks/tjgo.ipynb --nbmake-timeout=300\` -> 2 passed
- [ ] Re-rodar a suite completa apos merge para confirmar 23/25

## Relacionado

- Issue #215 (notebook tjgo sem id de celula) — fechada por este PR.
- Issue #112 (retry/backoff universal) — comentario adicional posted com observacao sobre tjpb/tjpe.
- Issue #101 (CI: workflow de testes) — comentario com sugestao de incluir nbmake no nightly.
- PR #214 (enxugar CHANGELOG) — independente, mas detectou as mesmas falhas no sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
