### PR TITLE
test: simetria raises TypeError para datas em scrapers wired (refs #186)

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -9,8 +9,11 @@ Examples
 >>> from tests._helpers import load_sample
 >>> html = load_sample("tjsp", "cjsg/results_normal.html")
 """
+from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
+
+import pytest
 
 _SAMPLES_ROOT = Path(__file__).parent
 
@@ -76,6 +79,40 @@ def urlencoded_body_subset_matcher(expected: dict[str, str]):
             return False, f"body fields mismatch: {missing}"
         return True, ""
     return matcher
+
+
+def assert_unsupported_date_filter_raises(
+    method: Callable,
+    kwarg: str,
+    *args,
+    valor: str = "2024-01-01",
+    **extra_kwargs,
+) -> None:
+    """Confirma que ``kwarg`` dispara ``TypeError`` canonico no endpoint.
+
+    Padrao da issue #186 — backends que so aceitam um dos intervalos de
+    data (``data_julgamento_*`` xor ``data_publicacao_*``) devem rejeitar
+    o oposto via ``extra="forbid"`` do schema pydantic.
+
+    Parameters
+    ----------
+    method : callable
+        Bound method publico do scraper (e.g., ``jus.scraper("tjmt").cjsg``).
+    kwarg : str
+        Nome do filtro de data nao suportado (e.g., ``"data_publicacao_inicio"``).
+    *args
+        Argumentos posicionais propagados para ``method`` (tipicamente
+        ``"pesquisa"``).
+    valor : str
+        Valor passado em ``kwarg``. Default ``"2024-01-01"``.
+    **extra_kwargs
+        Kwargs extras propagados para ``method`` — util para cenarios que
+        precisam de filtros adicionais (ex.: TJSP auto_chunk exige uma
+        janela longa de ``data_julgamento_*`` para acionar o sniff).
+    """
+    pattern = rf"got unexpected keyword argument\(s\): '{kwarg}'"
+    with pytest.raises(TypeError, match=pattern):
+        method(*args, **{kwarg: valor, **extra_kwargs})
 
 
 def query_param_subset_matcher(expected: dict[str, str]):

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -94,21 +94,21 @@ def assert_unsupported_date_filter_raises(
     data (``data_julgamento_*`` xor ``data_publicacao_*``) devem rejeitar
     o oposto via ``extra="forbid"`` do schema pydantic.
 
-    Parameters
-    ----------
-    method : callable
-        Bound method publico do scraper (e.g., ``jus.scraper("tjmt").cjsg``).
-    kwarg : str
-        Nome do filtro de data nao suportado (e.g., ``"data_publicacao_inicio"``).
-    *args
-        Argumentos posicionais propagados para ``method`` (tipicamente
-        ``"pesquisa"``).
-    valor : str
-        Valor passado em ``kwarg``. Default ``"2024-01-01"``.
-    **extra_kwargs
-        Kwargs extras propagados para ``method`` — util para cenarios que
-        precisam de filtros adicionais (ex.: TJSP auto_chunk exige uma
-        janela longa de ``data_julgamento_*`` para acionar o sniff).
+    Args:
+        method (callable): Bound method publico do scraper (e.g.,
+            ``jus.scraper("tjmt").cjsg``).
+        kwarg (str): Nome do filtro de data nao suportado (e.g.,
+            ``"data_publicacao_inicio"``).
+        *args: Argumentos posicionais propagados para ``method``
+            (tipicamente ``"pesquisa"``).
+        valor (str): Valor passado em ``kwarg``. Cosmetico — o
+            ``TypeError`` e emitido pelo pydantic *antes* de qualquer
+            validacao de formato, entao qualquer string serve. Default
+            ``"2024-01-01"``.
+        **extra_kwargs: Kwargs extras propagados para ``method`` — util
+            para cenarios que precisam de filtros adicionais (ex.: TJSP
+            auto_chunk exige uma janela longa de ``data_julgamento_*``
+            para acionar o sniff).
     """
     pattern = rf"got unexpected keyword argument\(s\): '{kwarg}'"
     with pytest.raises(TypeError, match=pattern):

--- a/tests/tjba/test_cjsg_filters_contract.py
+++ b/tests/tjba/test_cjsg_filters_contract.py
@@ -7,7 +7,7 @@ import responses
 from responses.matchers import json_params_matcher
 
 import juscraper as jus
-from tests._helpers import load_sample
+from tests._helpers import assert_unsupported_date_filter_raises, load_sample
 from tests.tjba.test_cjsg_contract import BASE, _payload
 
 
@@ -67,3 +67,16 @@ def test_cjsg_unknown_kwarg_raises():
     the field name, instead of being silently dropped (refs #84, #93, #165)."""
     with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'kwarg_inventado'"):
         jus.scraper("tjba").cjsg("dano moral", paginas=1, kwarg_inventado="x")
+
+
+def test_cjsg_data_julgamento_raises_typeerror():
+    """TJBA backend GraphQL so expoe filtro de data de publicacao —
+    ``InputCJSGTJBA`` herda apenas :class:`DataPublicacaoMixin`, entao
+    ``data_julgamento_*`` deve cair como ``extra_forbidden`` -> ``TypeError``
+    em vez de ser silently dropped (refs #186)."""
+    assert_unsupported_date_filter_raises(
+        jus.scraper("tjba").cjsg,
+        "data_julgamento_inicio",
+        "dano moral",
+        paginas=1,
+    )

--- a/tests/tjes/test_cjsg_filters_contract.py
+++ b/tests/tjes/test_cjsg_filters_contract.py
@@ -4,6 +4,7 @@ import pytest
 import responses
 
 import juscraper as jus
+from tests._helpers import assert_unsupported_date_filter_raises
 from tests.tjes.test_cjsg_contract import _add_page
 
 
@@ -129,12 +130,20 @@ def test_cjpg_unknown_kwarg_raises():
 def test_cjsg_data_publicacao_raises_typeerror():
     """TJES backend nao expoe filtro de data de publicacao — passar
     ``data_publicacao_*`` deve levantar ``TypeError`` em vez de silently drop
-    (refs #165, #173)."""
-    with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'data_publicacao_inicio'"):
-        jus.scraper("tjes").cjsg("dano moral", paginas=1, data_publicacao_inicio="2024-01-01")
+    (refs #165, #173, #186)."""
+    assert_unsupported_date_filter_raises(
+        jus.scraper("tjes").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )
 
 
 def test_cjpg_data_publicacao_raises_typeerror():
     """Mesmo que ``test_cjsg_data_publicacao_raises_typeerror`` para cjpg."""
-    with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'data_publicacao_inicio'"):
-        jus.scraper("tjes").cjpg("dano moral", paginas=1, data_publicacao_inicio="2024-01-01")
+    assert_unsupported_date_filter_raises(
+        jus.scraper("tjes").cjpg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )

--- a/tests/tjmt/test_cjsg_filters_contract.py
+++ b/tests/tjmt/test_cjsg_filters_contract.py
@@ -5,6 +5,7 @@ import responses
 from responses.registries import OrderedRegistry
 
 import juscraper as jus
+from tests._helpers import assert_unsupported_date_filter_raises
 from tests.tjmt.test_cjsg_contract import _add_config, _add_page
 
 
@@ -118,6 +119,10 @@ def test_cjsg_unknown_kwarg_raises():
 def test_cjsg_data_publicacao_raises_typeerror():
     """TJMT backend nao expoe filtro de data de publicacao — passar
     ``data_publicacao_*`` deve levantar ``TypeError`` em vez de silently drop
-    (refs #165, #173)."""
-    with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'data_publicacao_inicio'"):
-        jus.scraper("tjmt").cjsg("dano moral", paginas=1, data_publicacao_inicio="2024-01-01")
+    (refs #165, #173, #186)."""
+    assert_unsupported_date_filter_raises(
+        jus.scraper("tjmt").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )

--- a/tests/tjpi/test_cjsg_filters_contract.py
+++ b/tests/tjpi/test_cjsg_filters_contract.py
@@ -12,7 +12,7 @@ from responses.matchers import query_param_matcher
 
 import juscraper as jus
 from juscraper.courts.tjpi.download import BASE_URL, build_cjsg_params
-from tests._helpers import load_sample
+from tests._helpers import assert_unsupported_date_filter_raises, load_sample
 
 
 @responses.activate
@@ -141,13 +141,13 @@ def test_cjsg_unknown_kwarg_raises():
 def test_cjsg_data_publicacao_kwarg_raises():
     """TJPI backend nao expoe filtro de data de publicacao; ``InputCJSGTJPI``
     nao herda ``DataPublicacaoMixin``, entao ``data_publicacao_*`` deve cair
-    como ``extra_forbidden`` -> ``TypeError`` (refs #84, #93, #125)."""
-    with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'data_publicacao_inicio'"):
-        jus.scraper("tjpi").cjsg(
-            "dano moral",
-            paginas=1,
-            data_publicacao_inicio="2024-01-01",
-        )
+    como ``extra_forbidden`` -> ``TypeError`` (refs #84, #93, #125, #186)."""
+    assert_unsupported_date_filter_raises(
+        jus.scraper("tjpi").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )
 
 
 def test_cjsg_download_unknown_kwarg_raises():

--- a/tests/tjrn/test_cjsg_filters_contract.py
+++ b/tests/tjrn/test_cjsg_filters_contract.py
@@ -13,7 +13,7 @@ from responses.matchers import json_params_matcher
 
 import juscraper as jus
 from juscraper.courts.tjrn.download import BASE_URL, build_cjsg_payload
-from tests._helpers import load_sample
+from tests._helpers import assert_unsupported_date_filter_raises, load_sample
 
 
 @responses.activate
@@ -204,6 +204,19 @@ def test_cjsg_unknown_kwarg_raises():
     the field name, instead of being silently dropped (refs #84, #93)."""
     with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'kwarg_inventado'"):
         jus.scraper("tjrn").cjsg("dano moral", paginas=1, kwarg_inventado="x")
+
+
+def test_cjsg_data_publicacao_raises_typeerror():
+    """TJRN backend Elasticsearch nao expoe filtro de data de publicacao —
+    ``InputCJSGTJRN`` herda apenas :class:`DataJulgamentoMixin`, entao
+    ``data_publicacao_*`` deve cair como ``extra_forbidden`` -> ``TypeError``
+    em vez de ser silently dropped (refs #186)."""
+    assert_unsupported_date_filter_raises(
+        jus.scraper("tjrn").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )
 
 
 def test_cjsg_alias_conflict_raises():

--- a/tests/tjro/test_cjsg_filters_contract.py
+++ b/tests/tjro/test_cjsg_filters_contract.py
@@ -14,7 +14,7 @@ from responses.matchers import json_params_matcher
 
 import juscraper as jus
 from juscraper.courts.tjro.download import BASE_URL, build_cjsg_payload
-from tests._helpers import load_sample
+from tests._helpers import assert_unsupported_date_filter_raises, load_sample
 
 
 @responses.activate
@@ -225,6 +225,19 @@ def test_cjsg_unknown_kwarg_raises():
     the field name (refs #84, #93)."""
     with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'kwarg_inventado'"):
         jus.scraper("tjro").cjsg("dano moral", paginas=1, kwarg_inventado="x")
+
+
+def test_cjsg_data_publicacao_raises_typeerror():
+    """TJRO backend Elasticsearch nao expoe filtro de data de publicacao —
+    ``InputCJSGTJRO`` herda apenas :class:`DataJulgamentoMixin`, entao
+    ``data_publicacao_*`` deve cair como ``extra_forbidden`` -> ``TypeError``
+    em vez de ser silently dropped (refs #186)."""
+    assert_unsupported_date_filter_raises(
+        jus.scraper("tjro").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )
 
 
 def test_cjsg_unknown_kwarg_suggests_close_match():

--- a/tests/tjsp/test_cjpg_auto_chunk_contract.py
+++ b/tests/tjsp/test_cjpg_auto_chunk_contract.py
@@ -11,6 +11,7 @@ import pytest
 
 import juscraper as jus
 from juscraper.courts.tjsp.client import TJSPScraper
+from tests._helpers import assert_unsupported_date_filter_raises
 
 
 def _patch_pipeline(mocker, parse_side_effect=None, parse_return=None):
@@ -156,13 +157,14 @@ def test_data_publicacao_long_window_raises_typeerror_immediately(tmp_path, mock
     download, _ = _patch_pipeline(mocker)
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
 
-    with pytest.raises(TypeError, match="data_publicacao"):
-        scraper.cjpg(
-            "dano moral",
-            data_julgamento_inicio="01/01/2022",
-            data_julgamento_fim="31/12/2024",  # > 366 dias -> chunked
-            data_publicacao_inicio="01/03/2023",
-        )
+    assert_unsupported_date_filter_raises(
+        scraper.cjpg,
+        "data_publicacao_inicio",
+        "dano moral",
+        valor="01/03/2023",
+        data_julgamento_inicio="01/01/2022",
+        data_julgamento_fim="31/12/2024",  # > 366 dias -> chunked
+    )
 
     download.assert_not_called()
 

--- a/tests/tjsp/test_cjsg_auto_chunk_contract.py
+++ b/tests/tjsp/test_cjsg_auto_chunk_contract.py
@@ -20,6 +20,7 @@ import pytest
 
 import juscraper as jus
 from juscraper.courts.tjsp.client import TJSPScraper
+from tests._helpers import assert_unsupported_date_filter_raises
 
 
 def _patch_pipeline(mocker, parse_side_effect=None, parse_return=None):
@@ -188,13 +189,14 @@ def test_data_publicacao_long_window_raises_typeerror_immediately(tmp_path, mock
     download, _ = _patch_pipeline(mocker)
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
 
-    with pytest.raises(TypeError, match="data_publicacao"):
-        scraper.cjsg(
-            "dano moral",
-            data_julgamento_inicio="01/01/2022",
-            data_julgamento_fim="31/12/2024",  # > 366 dias -> chunked
-            data_publicacao_inicio="01/03/2023",
-        )
+    assert_unsupported_date_filter_raises(
+        scraper.cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        valor="01/03/2023",
+        data_julgamento_inicio="01/01/2022",
+        data_julgamento_fim="31/12/2024",  # > 366 dias -> chunked
+    )
 
     download.assert_not_called()
 


### PR DESCRIPTION
## Resumo

Fecha a auditoria pedida pela issue #186: para cada scraper wired cujo backend so expoe **um** dos intervalos de data (`data_julgamento_*` xor `data_publicacao_*`), confirma via teste explicito que passar o intervalo nao suportado dispara `TypeError` (via `extra=\"forbid\"` do schema pydantic).

## Auditoria

Cobertura final dos casos assimetricos wired:

| Tribunal | Endpoint | Mixin presente | Filtro que dispara TypeError | Status |
|---|---|---|---|---|
| TJMT | cjsg | `DataJulgamentoMixin` | `data_publicacao_inicio` | ja existia (referencia da issue) |
| TJES | cjsg/cjpg | `DataJulgamentoMixin` | `data_publicacao_inicio` | ja existia |
| TJPI | cjsg | `DataJulgamentoMixin` | `data_publicacao_inicio` | ja existia |
| TJSP | cjsg/cjpg | `DataJulgamentoMixin` | `data_publicacao_inicio` | match endurecido (era frouxo) |
| **TJBA** | **cjsg** | **`DataPublicacaoMixin`** | **`data_julgamento_inicio`** | **adicionado** |
| **TJRN** | **cjsg** | **`DataJulgamentoMixin`** | **`data_publicacao_inicio`** | **adicionado** |
| **TJRO** | **cjsg** | **`DataJulgamentoMixin`** | **`data_publicacao_inicio`** | **adicionado** |

Schemas que herdam ambos os mixins (TJDFT, TJPA, TJSC, TJAC/TJAL/TJAM/TJCE/TJMS) nao tem caso assimetrico — fora de escopo.

## Mudancas

1. **Helper compartilhado** (`tests/_helpers.py`): novo `assert_unsupported_date_filter_raises(method, kwarg, *args, valor, **extra_kwargs)`. Centraliza o regex canonico (`got unexpected keyword argument\\(s\\): '<kwarg>'`); 11 sites passam a usa-lo, atendendo a Regra 1 do #84 (>= 2 ocorrencias).
2. **Testes novos** em TJBA/TJRN/TJRO — paralelo simetrico ao do TJMT.
3. **Endurecimento de match no TJSP** (`test_cjsg_auto_chunk_contract.py`, `test_cjpg_auto_chunk_contract.py`): troca `match=\"data_publicacao\"` (frouxo, casa so o prefixo) pelo regex canonico via helper. Sem mudanca de semantica do teste.
4. **Refactor** dos 4 testes existentes (TJMT, TJES x2, TJPI) para usar o helper.

Sem mudanca em codigo de producao — schemas ja estavam corretos; faltava so a documentacao executavel.

## Fora de escopo (decididos)

- **DataJud `listar_processos`** e **ComunicaCNJ `listar_comunicacoes`**: tem filtros de data customizados (`data_ajuizamento_*` / `data_disponibilizacao_*`), nao se enquadram no padrao julgamento xor publicacao da issue.
- **Wiring do DataJud** ao `InputListarProcessosDataJud`: PR separado (segue o padrao wiring-only pos-contrato; fora do escopo desta auditoria de testes).
- **Tribunais sem schema wired** para cjsg (TJTO, TJPB, TJPR, TJRR, TJRS, TJMG, TJGO, TJAP): nada a fixar enquanto nao houver wiring.

## Test plan

- [x] `pytest tests/tjba tests/tjrn tests/tjro tests/tjsp tests/tjmt tests/tjes tests/tjpi` — 182 passed, 59 deselected, 1.4s.
- [x] `pytest` (default offline) — 1274 passed, 23 skipped, 1 xfail, sem regressao.
- [x] Pre-commit (ruff + isort + flake8 + mypy) — clean.

Refs:
- #186 (auditoria)
- #84 (Regra 1 — generalizacao com >= 2 ocorrencias)
- #93 (schemas pydantic)
- #167 (PR original que motivou a issue)
- #173 (mixins de data e backend coupling)