### PR TITLE
fix(params): mensagem de colisao de aliases cita nomes passados pelo usuario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - TJSP `get_cpopg_download_links`: ramo `else` nunca populava a lista de links (atribuia `processos = lista.find_all('a')` e descartava o resultado). Agora itera sobre os `<a href>` e devolve a lista corretamente.
 - TJSP `cpopg_download`/`cposg_download`: `RuntimeError` introduzido ao trocar `dict.get(k, [None])[0]` por early-raise (PR #105) escapava dos `except` de batch e abortava o download de todos os CNJs seguintes quando um link de listagem vinha sem `processo.codigo`. Agora o `RuntimeError` e capturado no loop externo e o batch segue.
 - TJMT/TJBA `cjsg_parse`: respostas sem resultados podem vir do backend real com `null` em qualquer nivel intermediario; os parsers tratam `null` como lista vazia / dict ausente e retornam DataFrame vazio em vez de quebrar.
+- `normalize_datas`: quando o usuario passa dois aliases distintos para o mesmo campo canonico (ex.: `data_inicio` + `data_julgamento_de`), a mensagem de `ValueError` agora cita os nomes que ele realmente escreveu, em vez do canonico que ele nunca digitou. O canonico aparece apenas como sugestao no trecho "Use apenas 'X'". Vale para todos os tribunais (a normalizacao e centralizada). Refs #193.
 
 ### Known Issues
 

--- a/src/juscraper/utils/params.py
+++ b/src/juscraper/utils/params.py
@@ -145,16 +145,12 @@ def normalize_datas(**kwargs):
         dict with the four canonical keys (values may be ``None``).
 
     Raises:
-        ValueError: When mais de uma fonte (canônico ou alias) preenche o
-            mesmo campo canônico. A mensagem cita os nomes que o usuário
-            realmente passou — não o canônico (refs #193).
+        ValueError: When more than one source (canonical or alias) fills the
+            same canonical field. The message quotes the names the user
+            actually passed — not the canonical one (refs #193). No
+            ``DeprecationWarning`` is emitted before the raise; the conflict
+            is the user's mistake to fix, not a soft deprecation event.
     """
-    canonicals: tuple[str, ...] = (
-        "data_julgamento_inicio",
-        "data_julgamento_fim",
-        "data_publicacao_inicio",
-        "data_publicacao_fim",
-    )
     deprecated_map = {
         "data_julgamento_de": "data_julgamento_inicio",
         "data_julgamento_ate": "data_julgamento_fim",
@@ -170,7 +166,7 @@ def normalize_datas(**kwargs):
     # nas três fases (canônico, _de/_ate, genérico). Único valor None
     # entra silenciosamente no pop e nao gera fonte — preserva o
     # comportamento antigo de aceitar canonical=None ao lado de alias.
-    sources: dict[str, list[tuple[str, Any]]] = {c: [] for c in canonicals}
+    sources: dict[str, list[tuple[str, Any]]] = {c: [] for c in DATE_CANONICAL}
 
     def _collect(name: str, canonical: str) -> None:
         if name not in kwargs:
@@ -179,7 +175,7 @@ def normalize_datas(**kwargs):
         if value is not None:
             sources[canonical].append((name, value))
 
-    for canonical in canonicals:
+    for canonical in DATE_CANONICAL:
         _collect(canonical, canonical)
     for old_name, canonical in deprecated_map.items():
         _collect(old_name, canonical)
@@ -199,7 +195,7 @@ def normalize_datas(**kwargs):
                 f"Use apenas '{canonical}'."
             )
 
-    result: dict[str, Any] = {c: None for c in canonicals}
+    result: dict[str, Any] = {c: None for c in DATE_CANONICAL}
     for canonical, srcs in sources.items():
         if not srcs:
             continue

--- a/src/juscraper/utils/params.py
+++ b/src/juscraper/utils/params.py
@@ -145,65 +145,72 @@ def normalize_datas(**kwargs):
         dict with the four canonical keys (values may be ``None``).
 
     Raises:
-        ValueError: If a generic alias conflicts with the specific canonical name.
+        ValueError: When mais de uma fonte (canônico ou alias) preenche o
+            mesmo campo canônico. A mensagem cita os nomes que o usuário
+            realmente passou — não o canônico (refs #193).
     """
-    result = {
-        "data_julgamento_inicio": None,
-        "data_julgamento_fim": None,
-        "data_publicacao_inicio": None,
-        "data_publicacao_fim": None,
-    }
-
+    canonicals: tuple[str, ...] = (
+        "data_julgamento_inicio",
+        "data_julgamento_fim",
+        "data_publicacao_inicio",
+        "data_publicacao_fim",
+    )
     deprecated_map = {
         "data_julgamento_de": "data_julgamento_inicio",
         "data_julgamento_ate": "data_julgamento_fim",
         "data_publicacao_de": "data_publicacao_inicio",
         "data_publicacao_ate": "data_publicacao_fim",
     }
-
     generic_map = {
         "data_inicio": "data_julgamento_inicio",
         "data_fim": "data_julgamento_fim",
     }
 
-    # 1. Canonical names first
-    for key in list(result.keys()):
-        if key in kwargs:
-            result[key] = kwargs.pop(key)
+    # canonical -> [(source_name, value), ...] na ordem em que apareceram
+    # nas três fases (canônico, _de/_ate, genérico). Único valor None
+    # entra silenciosamente no pop e nao gera fonte — preserva o
+    # comportamento antigo de aceitar canonical=None ao lado de alias.
+    sources: dict[str, list[tuple[str, Any]]] = {c: [] for c in canonicals}
 
-    # 2. Deprecated _de/_ate aliases
+    def _collect(name: str, canonical: str) -> None:
+        if name not in kwargs:
+            return
+        value = kwargs.pop(name)
+        if value is not None:
+            sources[canonical].append((name, value))
+
+    for canonical in canonicals:
+        _collect(canonical, canonical)
     for old_name, canonical in deprecated_map.items():
-        if old_name in kwargs:
-            value = kwargs.pop(old_name)
-            if value is not None:
-                if result[canonical] is not None:
-                    raise ValueError(
-                        f"Não é possível passar '{old_name}' e '{canonical}' ao mesmo tempo. "
-                        f"Use apenas '{canonical}'."
-                    )
-                warnings.warn(
-                    f"O parâmetro '{old_name}' está deprecado. Use '{canonical}' em vez disso.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                result[canonical] = value
-
-    # 3. Generic aliases
+        _collect(old_name, canonical)
     for generic, canonical in generic_map.items():
-        if generic in kwargs:
-            value = kwargs.pop(generic)
-            if value is not None:
-                if result[canonical] is not None:
-                    raise ValueError(
-                        f"Não é possível passar '{generic}' e '{canonical}' ao mesmo tempo. "
-                        f"Use apenas '{canonical}'."
-                    )
-                warnings.warn(
-                    f"O parâmetro '{generic}' está deprecado. Use '{canonical}' em vez disso.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                result[canonical] = value
+        _collect(generic, canonical)
+
+    # Detecta colisão olhando todas as fontes coletadas. Mensagem cita os
+    # nomes que o usuário escreveu (em vez do canônico, que ele pode nem
+    # ter digitado — refs #193).
+    for canonical, srcs in sources.items():
+        if len(srcs) > 1:
+            names = [name for name, _ in srcs]
+            quoted = [f"'{n}'" for n in names]
+            joined = ", ".join(quoted[:-1]) + f" e {quoted[-1]}"
+            raise ValueError(
+                f"Não é possível passar {joined} ao mesmo tempo. "
+                f"Use apenas '{canonical}'."
+            )
+
+    result: dict[str, Any] = {c: None for c in canonicals}
+    for canonical, srcs in sources.items():
+        if not srcs:
+            continue
+        name, value = srcs[0]
+        if name != canonical:
+            warnings.warn(
+                f"O parâmetro '{name}' está deprecado. Use '{canonical}' em vez disso.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        result[canonical] = value
 
     return result
 

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -136,11 +136,19 @@ class TestNormalizeDatas:
         # Reprodução literal da issue #193: usuário passou só aliases (não
         # passou o canônico). A mensagem deve citar os dois aliases que ele
         # de fato escreveu, e o canônico só aparece como sugestão.
-        with pytest.raises(ValueError) as excinfo:
-            normalize_datas(
-                data_julgamento_de="02/01/2023",
-                data_inicio="01/01/2023",
-            )
+        # Adicionalmente trava: nenhum DeprecationWarning é emitido antes
+        # do raise. A colisão é erro do chamador, não evento de migração;
+        # emitir warning + raise no mesmo fluxo confunde o tracebacks.
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            with pytest.raises(ValueError) as excinfo:
+                normalize_datas(
+                    data_julgamento_de="02/01/2023",
+                    data_inicio="01/01/2023",
+                )
+        assert not any(
+            issubclass(w.category, DeprecationWarning) for w in captured
+        ), "colisão alias+alias não deve emitir DeprecationWarning antes do raise"
         msg = str(excinfo.value)
         assert "'data_julgamento_de'" in msg
         assert "'data_inicio'" in msg

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -132,6 +132,48 @@ class TestNormalizeDatas:
                 data_julgamento_inicio="01/01/2023",
             )
 
+    def test_conflict_two_aliases_same_canonical_inicio(self):
+        # Reprodução literal da issue #193: usuário passou só aliases (não
+        # passou o canônico). A mensagem deve citar os dois aliases que ele
+        # de fato escreveu, e o canônico só aparece como sugestão.
+        with pytest.raises(ValueError) as excinfo:
+            normalize_datas(
+                data_julgamento_de="02/01/2023",
+                data_inicio="01/01/2023",
+            )
+        msg = str(excinfo.value)
+        assert "'data_julgamento_de'" in msg
+        assert "'data_inicio'" in msg
+        # canônico aparece apenas no trecho "Use apenas 'X'"; antes desse
+        # trecho a mensagem só pode citar o que o usuário escreveu.
+        antes_use_apenas, _, depois = msg.partition("Use apenas")
+        assert "'data_julgamento_inicio'" not in antes_use_apenas
+        assert "'data_julgamento_inicio'" in depois
+
+    def test_conflict_two_aliases_same_canonical_fim(self):
+        with pytest.raises(ValueError) as excinfo:
+            normalize_datas(
+                data_julgamento_ate="31/12/2023",
+                data_fim="30/12/2023",
+            )
+        msg = str(excinfo.value)
+        assert "'data_julgamento_ate'" in msg
+        assert "'data_fim'" in msg
+        antes_use_apenas, _, _ = msg.partition("Use apenas")
+        assert "'data_julgamento_fim'" not in antes_use_apenas
+
+    def test_conflict_three_sources_same_canonical(self):
+        # Canônico + alias _de + alias genérico → mensagem cita os três.
+        with pytest.raises(ValueError) as excinfo:
+            normalize_datas(
+                data_julgamento_inicio="01/01/2023",
+                data_julgamento_de="02/01/2023",
+                data_inicio="03/01/2023",
+            )
+        msg = str(excinfo.value)
+        for nome in ("'data_julgamento_inicio'", "'data_julgamento_de'", "'data_inicio'"):
+            assert nome in msg
+
     def test_all_none(self):
         result = normalize_datas()
         assert all(v is None for v in result.values())


### PR DESCRIPTION
Fecha #193.

## Resumo

`normalize_datas` reescrita com coleta single-pass. Cada fase (canônico, alias `_de`/`_ate`, alias genérico) anexa `(nome, valor)` em `sources[canonical]`; a colisão é detectada olhando essa lista, então a mensagem cita exatamente os nomes que o usuário escreveu — o canônico só aparece no trecho `Use apenas 'X'`.

Antes:

```python
cjsg("dano moral", data_inicio="01/01/2023", data_julgamento_de="02/01/2023")
# ValueError: Não é possível passar 'data_julgamento_inicio' e
#             'data_julgamento_de' ao mesmo tempo. Use apenas
#             'data_julgamento_inicio'.
```

O usuário não digitou `data_julgamento_inicio` em momento nenhum.

Depois:

```python
# ValueError: Não é possível passar 'data_julgamento_de' e 'data_inicio'
#             ao mesmo tempo. Use apenas 'data_julgamento_inicio'.
```

## Cobertura

Vale para todos os tribunais — `normalize_datas` é o único ponto da base que resolve aliases de data. Nenhum client tem laço próprio. Os caminhos cobertos:

| Caminho | Tribunais |
|---|---|
| `apply_input_pipeline_search` → `normalize_datas` (etapa 4) | família eSAJ (TJSP/TJAC/TJAL/TJAM/TJCE/TJMS) + TJPB |
| `run_auto_chunk` → `normalize_datas` (sniff) | mesmos eSAJ acima quando a janela > 366 dias |
| Chamada direta no client | TJPE (`tjpe/client.py:71`), TJRJ (`tjrj/client.py:72`) |
| Schemas que documentam aliases mas delegam à normalização | TJRR/TJRN/TJTO/TJPA/TJMT/TJSC/TJRO/TJPI/TJMG/TJGO/TJPR/TJDFT/TJES/TJBA/TJAP |

## Comportamento preservado

- Canônico passado sozinho → passthrough, sem warning.
- Aliases `_de`/`_ate` ou `data_inicio`/`data_fim` sozinhos → emite `DeprecationWarning`.
- `None` em alias junto com canônico preenchido → não levanta (passthrough silencioso).
- Colisão canônico + alias → segue levantando, citando os dois nomes.

## Comportamento novo

- Colisão alias + alias → mensagem cita os dois aliases que o usuário escreveu (bug fix).
- Colisão tripla (canônico + `_de` + genérico) → mensagem cita os três.

## Test plan

- [x] `pytest tests/test_params.py -x -v` (63 passed, incluindo 3 testes novos: `test_conflict_two_aliases_same_canonical_inicio`, `..._fim`, `test_conflict_three_sources_same_canonical`)
- [x] `pytest -x` na suíte completa offline (1277 passed, 23 skipped, 1 xfailed — sem regressão)
- [x] Repro manual da issue: mensagem agora cita `'data_julgamento_de'` e `'data_inicio'`, com `'data_julgamento_inicio'` apenas no trecho `Use apenas 'X'`
- [x] Pre-commit hooks (ruff, isort, pylint, flake8, mypy) passaram

🤖 Generated with [Claude Code](https://claude.com/claude-code)