### PR TITLE
chore(tjrj): atualizar razão do xfail em test_release_date_filter pós-#220

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Known Issues
 
-- Dois tribunais tem o teste de filtro de datas marcado como `xfail` estrito em `test_release_date_filter.py`: **TJAP** (Tucujuris genuinamente nao expoe filtro por data — confirmado na engenharia reversa do site) e **TJRJ** (endpoint legado ASP.NET devolve HTTP 500 ate sem filtros). Ambas sao server-side — nao dependem do cliente.
+- Dois tribunais tem o teste de filtro de datas marcado como `xfail` estrito em `test_release_date_filter.py`: **TJAP** (Tucujuris genuinamente nao expoe filtro por data — confirmado na engenharia reversa do site) e **TJRJ** (backend ASPX expoe apenas granularidade anual via `ano_inicio`/`ano_fim`; `InputCJSGTJRJ` rejeita `data_julgamento_*`/`data_publicacao_*` com `TypeError` por design — refs #143, #220). Ambas sao limitacoes server-side — nao dependem do cliente.
 
 ## [0.2.1] - 2026-04-13
 

--- a/tests/test_release_date_filter.py
+++ b/tests/test_release_date_filter.py
@@ -52,13 +52,15 @@ TRIBUNAIS = [
 # Tribunals where the date filter itself is broken. Remove once fixed.
 KNOWN_FILTRO_FAILURES = {
     "tjap": "Tucujuris UI/backend does not expose date filtering (no date input exists)",
-    "tjrj": "legacy ASP.NET endpoint returns HTTP 500; scraper does not wire date filter",
+    "tjrj": "ASP.NET backend exposes only year-level filter (ano_inicio/ano_fim); "
+            "InputCJSGTJRJ rejects data_julgamento_*/data_publicacao_* via extra=forbid (refs #143, #220)",
 }
 
 # Tribunals where pagination specifically is broken (usually HTTP errors
 # bubbling up on page 2). Subset of above for clarity.
 KNOWN_PAGINACAO_FAILURES = {
-    "tjrj": "legacy endpoint returns HTTP 500",
+    "tjrj": "test passes data_julgamento_*/data_publicacao_* kwargs that TJRJ rejects via "
+            "extra=forbid (granularidade so anual). Same root cause as KNOWN_FILTRO_FAILURES (refs #220).",
 }
 
 

--- a/tests/tjrj/test_cjsg_filters_contract.py
+++ b/tests/tjrj/test_cjsg_filters_contract.py
@@ -15,7 +15,7 @@ from responses.matchers import json_params_matcher
 
 import juscraper as jus
 from juscraper.courts.tjrj.download import FORM_URL, RESULT_URL, build_cjsg_payload, extract_viewstate_fields
-from tests._helpers import assert_unsupported_date_filter_raises, load_sample, urlencoded_body_subset_matcher
+from tests._helpers import assert_unknown_kwarg_raises, load_sample, urlencoded_body_subset_matcher
 
 
 def _form_html() -> str:
@@ -29,7 +29,7 @@ def _xhr_no_results() -> dict:
 
 def _expected_body_subset(pesquisa: str, **overrides) -> dict:
     hidden = extract_viewstate_fields(_form_html())
-    body = build_cjsg_payload(hidden=hidden, pesquisa=pesquisa, **overrides)
+    body: dict = build_cjsg_payload(hidden=hidden, pesquisa=pesquisa, **overrides)
     body.pop("__VIEWSTATE", None)
     body.pop("__VIEWSTATEGENERATOR", None)
     body.pop("__EVENTVALIDATION", None)
@@ -120,14 +120,14 @@ def test_cjsg_termo_alias_emits_deprecation_warning(mocker):
 
 def test_cjsg_data_julgamento_raises_typeerror():
     """``data_julgamento_*`` not accepted — TJRJ has only year granularity."""
-    assert_unsupported_date_filter_raises(
+    assert_unknown_kwarg_raises(
         jus.scraper("tjrj").cjsg, "data_julgamento_inicio", "dano moral", paginas=1,
     )
 
 
 def test_cjsg_data_publicacao_raises_typeerror():
     """``data_publicacao_*`` is also rejected — TJRJ does not expose it."""
-    assert_unsupported_date_filter_raises(
+    assert_unknown_kwarg_raises(
         jus.scraper("tjrj").cjsg, "data_publicacao_inicio", "dano moral", paginas=1,
     )
 
@@ -150,12 +150,14 @@ def test_cjsg_data_inicio_alias_raises_typeerror():
 def test_cjsg_unknown_kwarg_raises():
     """Kwargs not declared in :class:`InputCJSGTJRJ` raise ``TypeError`` with
     the field name, instead of being silently dropped (refs #93, #143)."""
-    with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'kwarg_inventado'"):
-        jus.scraper("tjrj").cjsg("dano moral", paginas=1, kwarg_inventado="x")
+    assert_unknown_kwarg_raises(
+        jus.scraper("tjrj").cjsg, "kwarg_inventado", "dano moral", paginas=1,
+    )
 
 
 def test_cjsg_download_unknown_kwarg_raises():
     """``cjsg_download`` rejects unknown kwargs at the lower-level entry point
     too — guards against silent drop when the caller skips :meth:`cjsg`."""
-    with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'kwarg_inventado'"):
-        jus.scraper("tjrj").cjsg_download("dano moral", paginas=1, kwarg_inventado="x")
+    assert_unknown_kwarg_raises(
+        jus.scraper("tjrj").cjsg_download, "kwarg_inventado", "dano moral", paginas=1,
+    )


### PR DESCRIPTION
## Resumo

Follow-up textual + correção de regressão induzida por timing de merges, ambos relacionados ao PR #220 (resolve #143):

### 1. Razão do xfail TJRJ atualizada

O fix do hidden `hfListaPalavrasBloqueadas` reativou o backend TJRJ, mas o teste `test_release_date_filter.py` ainda marcava o tribunal como xfail por "HTTP 500". A razão correta agora é diferente:

- **Backend ASPX volta a funcionar** quando o POST envia o hidden (PR #220).
- Mas o backend **expõe apenas granularidade anual** (`cmbAnoInicio`/`cmbAnoFim`) — não há campo para `data_julgamento_*` nem `data_publicacao_*`.
- `InputCJSGTJRJ` (wired no PR #220) rejeita esses kwargs via `extra="forbid"` → `TypeError`.
- `run_filtro_data_unica` passa esses kwargs, então o teste continua falhando — por design do schema, não por bug do backend.

Conclusão: **xfail strict continua válido** (igual `tjap`); só a razão muda.

### 2. Fix do import quebrado pelo timing do merge do #219

O PR #219 renomeou `assert_unsupported_date_filter_raises` → `assert_unknown_kwarg_raises` (helper generalizado). O #219 mergeou em main **entre** o polish do #220 e o merge do #220 — então `tests/tjrj/test_cjsg_filters_contract.py` (entrou pelo #220) ficou apontando para o nome antigo e a coleta quebrou:

```
ImportError: cannot import name 'assert_unsupported_date_filter_raises'
```

Renomeia o import e migra os 2 testes de `unknown_kwarg_raises` para usar o helper canônico — alinha com o objetivo do #219 de centralizar o regex em um lugar só.

Bônus: `body: dict` em `_expected_body_subset` satisfaz o mypy strict do pre-commit hook (que só roda no arquivo modificado).

## Mudanças

- `tests/test_release_date_filter.py:KNOWN_FILTRO_FAILURES["tjrj"]` — razão atualizada (refs #143/#220).
- `tests/test_release_date_filter.py:KNOWN_PAGINACAO_FAILURES["tjrj"]` — mesma razão (mesmo root cause).
- `CHANGELOG.md` `[Unreleased] / Known Issues` — entrada do TJRJ reescrita.
- `tests/tjrj/test_cjsg_filters_contract.py` — import e 2 testes migrados para `assert_unknown_kwarg_raises`; anotação `body: dict` para mypy.

## Test plan

- [x] `pytest tests/tjrj/ tests/schemas/` — 683 verde
- [x] `pytest` (full offline) — 1292 passed, 23 skipped, 1 xfailed
- [x] `pytest tests/test_release_date_filter.py -m release -k tjrj` — 2 xfailed (strict ainda válido)
- [x] `pre-commit run --all-files` — todos verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)