### PR TITLE
fix(tjsp): cjsg aceita pesquisa="" por default (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Changed
+
+- `TJSPScraper.cjsg` aceita `pesquisa=""` por default — antes o argumento era obrigatorio e `tjsp.cjsg(classe="...", assunto="...")` levantava `TypeError`. Agora o usuario pode buscar so por filtros (sem termo textual), igualando o comportamento de `cjpg`. Refs #229.
+
 ## [0.3.0] - 2026-05-03
 
 ### Added

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -68,7 +68,7 @@ class TJSPScraper(EsajSearchScraper):
 
     def cjsg(
         self,
-        pesquisa: str,
+        pesquisa: str = "",
         paginas: int | list | range | None = None,
         **kwargs: Any,
     ):
@@ -80,9 +80,15 @@ class TJSPScraper(EsajSearchScraper):
         (sem ``numero_recurso``/``data_publicacao_*``/``origem``; com
         ``baixar_sg``). A logica de execucao continua na base.
 
+        Diferente da familia eSAJ pura, ``pesquisa`` aceita string vazia
+        — o usuario pode buscar so por filtros (ex.: ``classe``,
+        ``assunto``, ``data_julgamento_*``) sem termo textual. Mesmo
+        comportamento de :meth:`cjpg` (issue #229).
+
         Args:
-            pesquisa (str): Termo livre buscado no acordao/ementa.
-                Limite de 120 caracteres (raises ``QueryTooLongError``).
+            pesquisa (str): Termo livre buscado no acordao/ementa. Default
+                ``""`` (sem termo, busca aberta por filtros). Limite de
+                120 caracteres (raises ``QueryTooLongError``).
             paginas (int | list | range | None): Paginas 1-based;
                 ``None`` baixa todas. Default ``None``.
             **kwargs: Filtros aceitos por :class:`InputCJSGTJSP` (todos
@@ -141,7 +147,7 @@ class TJSPScraper(EsajSearchScraper):
 
     def cjsg_download(
         self,
-        pesquisa: str,
+        pesquisa: str = "",
         paginas: int | list | range | None = None,
         diretorio: str | None = None,
         **kwargs: Any,
@@ -154,7 +160,8 @@ class TJSPScraper(EsajSearchScraper):
         veja la a lista completa.
 
         Args:
-            pesquisa (str): Termo livre. Limite de 120 chars.
+            pesquisa (str): Termo livre. Default ``""`` (sem termo).
+                Limite de 120 chars.
             paginas (int | list | range | None): Paginas 1-based;
                 ``None`` baixa todas. Default ``None``.
             diretorio (str | None): Sobrescreve :attr:`download_path`

--- a/tests/tjsp/test_cjsg_contract.py
+++ b/tests/tjsp/test_cjsg_contract.py
@@ -104,3 +104,22 @@ def test_cjsg_query_too_long_raises(tmp_path):
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
     with pytest.raises(QueryTooLongError):
         scraper.cjsg(pesquisa, paginas=1)
+
+
+@responses.activate
+def test_cjsg_busca_aberta_sem_pesquisa(tmp_path, mocker):
+    """``cjsg(paginas=...)`` sem ``pesquisa`` deve funcionar (issue #229).
+
+    Espelha o comportamento de :meth:`TJSPScraper.cjpg`: ``pesquisa`` tem
+    default ``""``, permitindo busca aberta por filtros (classe, assunto,
+    data) sem termo textual. Antes do fix, faltava o argumento e Python
+    levantava ``TypeError: cjsg() missing 1 required positional argument:
+    'pesquisa'``.
+    """
+    mocker.patch("time.sleep")
+    _add_post("")
+    _add_get(1, "cjsg/no_results.html")
+
+    df = jus.scraper("tjsp", download_path=str(tmp_path)).cjsg(paginas=1)
+
+    assert isinstance(df, pd.DataFrame)


### PR DESCRIPTION
## Resumo

- `TJSPScraper.cjsg` e `cjsg_download` passam a aceitar `pesquisa=""` por default. Antes, chamar `tjsp.cjsg(classe="...", assunto="...")` (busca aberta por filtros, sem termo) levantava `TypeError: cjsg() missing 1 required positional argument: 'pesquisa'`.
- Comportamento agora espelha `tjsp.cjpg`, que ja aceitava busca aberta por filtros. Aliana as duas pontas da API publica do TJSP no mesmo padrao mais permissivo (a discussao em #229 estava aberta entre tornar `cjpg` obrigatorio ou relaxar `cjsg` — relaxar e nao-breaking e resolve o caso reportado sem exigir migracao).
- Schema `InputCJSGTJSP` ja aceitava string vazia em `pesquisa: str` (pydantic), entao nao precisou de mudanca de schema. `validate_pesquisa_length("")` tambem passa naturalmente.

## Test plan

- [x] `pytest tests/tjsp tests/schemas` — 775 passed, 22 skipped (sem regressao).
- [x] Novo teste de contrato `test_cjsg_busca_aberta_sem_pesquisa` mockando POST com pesquisa vazia + GET de pagina 1 e validando que `scraper.cjsg(paginas=1)` retorna DataFrame em vez de levantar `TypeError`.
- [ ] Smoke ao vivo do script reportado no issue (busca por `assuntos`/`classes` sem `pesquisa`) — fora do escopo do contrato offline; o teste novo cobre o caminho que produzia o erro.

Refs #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)