### PR TITLE
feat(filtros): uniformizar interface cjpg/cjsg + alias singular em TJBA/DataJud (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - `TJSPScraper.cjsg` aceita `pesquisa=""` por default — antes o argumento era obrigatorio e `tjsp.cjsg(classe="...", assunto="...")` levantava `TypeError`. Agora o usuario pode buscar so por filtros (sem termo textual), igualando o comportamento de `cjpg`. Refs #229.
+- Filtros `classe`, `assunto` e `orgao_julgador` em `cjsg` (TJAC, TJAL, TJAM, TJCE, TJMS, TJSP) e em `cjpg` (TJSP) passam a aceitar `int`, `str` ou `list[int | str]`. Antes so aceitavam `str`. `comarca` em `cjsg` aceita `int` ou `str` (single-value, backend `cdComarca`). Listas viram CSV automaticamente; valores `int` viram `str`. A chamada `tjsp.cjsg(classe=[417], assunto=[3607, 5885])` deixa de levantar `ValidationError`. Refs #232.
+- `TJSPScraper.cjpg` adota o nome canonico singular para IDs de filtro: `classe`/`assunto`/`vara` substituem `classes`/`assuntos`/`varas`. Os nomes plurais continuam funcionando como alias deprecados (com `DeprecationWarning`) por pelo menos um minor release. Passar plural e singular simultaneamente (`cjpg(classe=12728, classes=[5885])`) levanta `ValueError`. Refs #232.
+- `TJBAScraper.cjsg`/`cjsg_download` e `DatajudScraper.listar_processos`/`contar_processos` adotam o nome canonico singular: `classe` (TJBA) substitui `classes`; `assunto` (Datajud) substitui `assuntos`. Os plurais seguem funcionando como alias deprecados (`DeprecationWarning`) por pelo menos um minor release; plural + singular juntos -> `ValueError`. Refs #232.
+
+### Deprecated
+
+- `TJSPScraper.cjpg`: parametros `classes`/`assuntos`/`varas` emitem `DeprecationWarning`. Use os singulares canonicos `classe`/`assunto`/`vara`. Refs #232.
+- `TJBAScraper.cjsg`/`cjsg_download`: parametro `classes` emite `DeprecationWarning`. Use `classe`. Refs #232.
+- `DatajudScraper.listar_processos`/`contar_processos`: parametro `assuntos` emite `DeprecationWarning`. Use `assunto`. Refs #232.
 
 ### Fixed
 

--- a/src/juscraper/aggregators/datajud/client.py
+++ b/src/juscraper/aggregators/datajud/client.py
@@ -16,7 +16,7 @@ from tqdm.auto import tqdm
 
 from ...core.base import BaseScraper
 from ...utils.cnj import clean_cnj  # Assuming this utility exists and is relevant
-from ...utils.params import normalize_paginas, raise_on_extra_kwargs
+from ...utils.params import normalize_paginas, pop_deprecated_alias, raise_on_extra_kwargs
 from .download import build_contar_processos_payload, build_listar_processos_payload, call_datajud_api
 
 # Import mappings for tribunal and justice aliases.
@@ -29,6 +29,23 @@ from .schemas import InputContarProcessosDataJud, InputListarProcessosDataJud
 ALIAS_TO_TRIBUNAL = {alias: sigla for sigla, alias in TRIBUNAL_TO_ALIAS.items()}
 
 logger = logging.getLogger(__name__)
+
+
+def _pop_plural_aliases(kwargs: dict) -> None:
+    """Popa aliases plurais deprecados antes de instanciar o schema.
+
+    Refs #232 — singular canonico (``assunto``); ``assuntos`` (plural) emite
+    :class:`DeprecationWarning` e segue funcionando. Passar plural + singular
+    juntos -> :class:`ValueError` (uso conflitante).
+    """
+    if "assuntos" not in kwargs:
+        return
+    if kwargs.get("assunto") is not None:
+        kwargs.pop("assuntos")
+        raise ValueError(
+            "Nao e possivel passar 'assunto' e 'assuntos' simultaneamente."
+        )
+    kwargs["assunto"] = pop_deprecated_alias(kwargs, "assuntos", "assunto")
 
 
 class DatajudScraper(BaseScraper):
@@ -74,7 +91,7 @@ class DatajudScraper(BaseScraper):
 
         Aceita o **mesmo conjunto de filtros** de :meth:`listar_processos`
         (``tribunal``, ``numero_processo``, ``ano_ajuizamento``, ``classe``,
-        ``assuntos``, ``data_ajuizamento_inicio``/``_fim``,
+        ``assunto``, ``data_ajuizamento_inicio``/``_fim``,
         ``tipos_movimentacao``, ``movimentos_codigo``, ``orgao_julgador``,
         ``query``), excluindo apenas os parametros de paginacao
         (``paginas``, ``tamanho_pagina``, ``mostrar_movs``) — nao ha
@@ -124,6 +141,7 @@ class DatajudScraper(BaseScraper):
             :meth:`listar_processos` — usa o mesmo conjunto de filtros mas
             baixa os processos.
         """
+        _pop_plural_aliases(kwargs)
         try:
             inp = InputContarProcessosDataJud(**kwargs)
         except ValidationError as exc:
@@ -154,7 +172,7 @@ class DatajudScraper(BaseScraper):
                 numero_processo=cnjs,
                 ano_ajuizamento=inp.ano_ajuizamento,
                 classe=inp.classe,
-                assuntos=inp.assuntos,
+                assunto=inp.assunto,
                 data_ajuizamento_inicio=inp.data_ajuizamento_inicio,
                 data_ajuizamento_fim=inp.data_ajuizamento_fim,
                 movimentos_codigo=movimentos_codigo,
@@ -284,13 +302,14 @@ class DatajudScraper(BaseScraper):
                   do projeto mapeia esses para ``data_julgamento_*``, e o
                   DataJud filtra por ajuizamento, nao julgamento).
                 * ``classe`` (str): Codigo da classe processual CNJ.
-                * ``assuntos`` (list[str | int]): Lista de codigos de
+                * ``assunto`` (list[str | int]): Lista de codigos de
                   assuntos CNJ (TPU). Aceita int e str — int e a forma
                   natural (codigos TPU sao inteiros); str e aceita por
                   compatibilidade. O schema normaliza para str antes do
                   payload, ja que o Elasticsearch coage int -> str em
                   campos ``keyword``. Backend: ``terms`` em
-                  ``assuntos.codigo``.
+                  ``assuntos.codigo``. ``assuntos`` (plural) e aceito como
+                  alias deprecado. Refs #232.
                 * ``tipos_movimentacao`` (list[str]): Nomes amigaveis de
                   categorias de movimentacao (ex.: ``["decisao", "sentenca"]``).
                   Resolvidos via ``TIPOS_MOVIMENTACAO`` para uma lista plana
@@ -312,7 +331,7 @@ class DatajudScraper(BaseScraper):
                   Quando fornecido, vira a chave ``query`` do payload
                   literalmente. Mutuamente exclusivo com TODOS os filtros
                   amigaveis acima (``numero_processo``, ``ano_ajuizamento``,
-                  ``classe``, ``assuntos``, ``data_ajuizamento_*``,
+                  ``classe``, ``assunto``, ``data_ajuizamento_*``,
                   ``tipos_movimentacao``, ``movimentos_codigo``,
                   ``orgao_julgador``). Exige ``tribunal`` explicito (sem
                   inferencia via CNJ). Em troca, oferece paridade com
@@ -403,6 +422,7 @@ class DatajudScraper(BaseScraper):
                 else None
             )
 
+        _pop_plural_aliases(kwargs)
         try:
             inp = InputListarProcessosDataJud(paginas=paginas_norm, **kwargs)
         except ValidationError as exc:
@@ -413,7 +433,7 @@ class DatajudScraper(BaseScraper):
         tribunal = inp.tribunal
         ano_ajuizamento = inp.ano_ajuizamento
         classe = inp.classe
-        assuntos = inp.assuntos
+        assunto = inp.assunto
         data_ajuizamento_inicio = inp.data_ajuizamento_inicio
         data_ajuizamento_fim = inp.data_ajuizamento_fim
         orgao_julgador = inp.orgao_julgador
@@ -504,7 +524,7 @@ class DatajudScraper(BaseScraper):
                 numero_processo=current_cnjs_for_alias,
                 ano_ajuizamento=ano_ajuizamento,
                 classe=classe,
-                assuntos=assuntos,
+                assunto=assunto,
                 data_ajuizamento_inicio=data_ajuizamento_inicio,
                 data_ajuizamento_fim=data_ajuizamento_fim,
                 movimentos_codigo=movimentos_codigo,
@@ -527,7 +547,7 @@ class DatajudScraper(BaseScraper):
         numero_processo: str | list[str] | None,
         ano_ajuizamento: int | None,
         classe: str | None,
-        assuntos: list[str] | None,
+        assunto: list[str] | None,
         data_ajuizamento_inicio: str | None,
         data_ajuizamento_fim: str | None,
         movimentos_codigo: list[int] | None,
@@ -565,7 +585,7 @@ class DatajudScraper(BaseScraper):
                     numero_processo=numero_processo,
                     ano_ajuizamento=ano_ajuizamento,
                     classe=classe,
-                    assuntos=assuntos,
+                    assunto=assunto,
                     data_ajuizamento_inicio=data_ajuizamento_inicio,
                     data_ajuizamento_fim=data_ajuizamento_fim,
                     movimentos_codigo=movimentos_codigo,

--- a/src/juscraper/aggregators/datajud/download.py
+++ b/src/juscraper/aggregators/datajud/download.py
@@ -29,7 +29,7 @@ def build_listar_processos_payload(
     numero_processo: str | list[str] | None = None,
     ano_ajuizamento: int | None = None,
     classe: str | None = None,
-    assuntos: list[str] | None = None,
+    assunto: list[str] | None = None,
     data_ajuizamento_inicio: str | None = None,
     data_ajuizamento_fim: str | None = None,
     movimentos_codigo: list[int] | None = None,
@@ -57,7 +57,7 @@ def build_listar_processos_payload(
           Mutuamente exclusivos no schema (validator); aqui ``ano_ajuizamento``
           tem precedencia se ambos chegarem.
        3. ``classe`` -> ``match`` em ``classe.codigo``
-       4. ``assuntos`` -> ``terms`` em ``assuntos.codigo``
+       4. ``assunto`` -> ``terms`` em ``assuntos.codigo``
        5. ``movimentos_codigo`` -> ``terms`` em ``movimentos.codigo``
        6. ``orgao_julgador`` -> ``match`` em ``orgaoJulgador.nome``
 
@@ -80,7 +80,7 @@ def build_listar_processos_payload(
             numero_processo=numero_processo,
             ano_ajuizamento=ano_ajuizamento,
             classe=classe,
-            assuntos=assuntos,
+            assunto=assunto,
             data_ajuizamento_inicio=data_ajuizamento_inicio,
             data_ajuizamento_fim=data_ajuizamento_fim,
             movimentos_codigo=movimentos_codigo,
@@ -107,7 +107,7 @@ def _build_query_amigavel(
     numero_processo: str | list[str] | None,
     ano_ajuizamento: int | None,
     classe: str | None,
-    assuntos: list[str] | None,
+    assunto: list[str] | None,
     data_ajuizamento_inicio: str | None,
     data_ajuizamento_fim: str | None,
     movimentos_codigo: list[int] | None,
@@ -168,8 +168,10 @@ def _build_query_amigavel(
         })
     if classe:
         must_conditions.append({"match": {"classe.codigo": classe}})
-    if assuntos:
-        must_conditions.append({"terms": {"assuntos.codigo": assuntos}})
+    if assunto:
+        # ``assuntos.codigo`` e a chave do payload Elasticsearch (campo do
+        # backend). O parametro Python e ``assunto`` (singular, refs #232).
+        must_conditions.append({"terms": {"assuntos.codigo": assunto}})
     if movimentos_codigo:
         must_conditions.append({"terms": {"movimentos.codigo": list(movimentos_codigo)}})
     if orgao_julgador:
@@ -185,7 +187,7 @@ def build_contar_processos_payload(
     numero_processo: str | list[str] | None = None,
     ano_ajuizamento: int | None = None,
     classe: str | None = None,
-    assuntos: list[str] | None = None,
+    assunto: list[str] | None = None,
     data_ajuizamento_inicio: str | None = None,
     data_ajuizamento_fim: str | None = None,
     movimentos_codigo: list[int] | None = None,
@@ -215,7 +217,7 @@ def build_contar_processos_payload(
             numero_processo=numero_processo,
             ano_ajuizamento=ano_ajuizamento,
             classe=classe,
-            assuntos=assuntos,
+            assunto=assunto,
             data_ajuizamento_inicio=data_ajuizamento_inicio,
             data_ajuizamento_fim=data_ajuizamento_fim,
             movimentos_codigo=movimentos_codigo,

--- a/src/juscraper/aggregators/datajud/schemas.py
+++ b/src/juscraper/aggregators/datajud/schemas.py
@@ -25,7 +25,7 @@ _FILTROS_AMIGAVEIS = (
     "numero_processo",
     "ano_ajuizamento",
     "classe",
-    "assuntos",
+    "assunto",
     "data_ajuizamento_inicio",
     "data_ajuizamento_fim",
     "tipos_movimentacao",
@@ -67,14 +67,14 @@ def _coerce_to_int_list(v: Any) -> Any:
 
 class _DatajudCoercaoMixin(BaseModel):
     # Mixin local (refs #217): centraliza os validators de coercao bidirecional
-    # int<->str em ``assuntos`` e ``movimentos_codigo``. Aplicado em ambos
+    # int<->str em ``assunto`` e ``movimentos_codigo``. Aplicado em ambos
     # InputListarProcessosDataJud e InputContarProcessosDataJud. Nao promovido
     # para src/juscraper/schemas/mixins.py — Regra 1 do #84 exige 2+ familias
     # distintas, e por enquanto so o DataJud precisa.
 
-    @field_validator("assuntos", mode="before", check_fields=False)
+    @field_validator("assunto", mode="before", check_fields=False)
     @classmethod
-    def _normalize_assuntos(cls, v: Any) -> Any:
+    def _normalize_assunto(cls, v: Any) -> Any:
         return _coerce_to_str_list(v)
 
     @field_validator("movimentos_codigo", mode="before", check_fields=False)
@@ -118,7 +118,7 @@ class InputListarProcessosDataJud(_DatajudCoercaoMixin, PaginasMixin):
     tribunal: str | None = None
     ano_ajuizamento: int | None = None
     classe: str | None = None
-    assuntos: list[str] | None = None
+    assunto: list[str] | None = None
     data_ajuizamento_inicio: str | None = None
     data_ajuizamento_fim: str | None = None
     tipos_movimentacao: list[str] | None = None
@@ -259,7 +259,7 @@ class InputContarProcessosDataJud(_DatajudCoercaoMixin):
     tribunal: str | None = None
     ano_ajuizamento: int | None = None
     classe: str | None = None
-    assuntos: list[str] | None = None
+    assunto: list[str] | None = None
     data_ajuizamento_inicio: str | None = None
     data_ajuizamento_fim: str | None = None
     tipos_movimentacao: list[str] | None = None

--- a/src/juscraper/courts/_esaj/base.py
+++ b/src/juscraper/courts/_esaj/base.py
@@ -280,10 +280,17 @@ class EsajSearchScraper(BaseScraper):
                 * ``ementa`` (str): Termo buscado especificamente na
                   ementa.
                 * ``numero_recurso`` (str): Numero do recurso.
-                * ``classe`` (str): ID interno da classe processual.
-                * ``assunto`` (str): ID interno do assunto.
-                * ``comarca`` (str): ID interno da comarca.
-                * ``orgao_julgador`` (str): ID interno do orgao julgador.
+                * ``classe`` (int | str | list[int | str]): ID(s) interno(s)
+                  da classe processual. Backend:
+                  ``classesTreeSelection.values`` (CSV).
+                * ``assunto`` (int | str | list[int | str]): ID(s) interno(s)
+                  do assunto. Backend: ``assuntosTreeSelection.values``
+                  (CSV).
+                * ``comarca`` (int | str): ID interno da comarca. Backend:
+                  ``cdComarca`` (single-value, nao aceita lista).
+                * ``orgao_julgador`` (int | str | list[int | str]): ID(s)
+                  interno(s) do orgao julgador. Backend:
+                  ``secoesTreeSelection.values`` (CSV).
                 * ``origem`` (Literal["T", "R"]): ``"T"`` (segundo grau,
                   default) ou ``"R"`` (colegio recursal).
                 * ``tipo_decisao`` (Literal["acordao", "monocratica"]):

--- a/src/juscraper/courts/_esaj/schemas.py
+++ b/src/juscraper/courts/_esaj/schemas.py
@@ -12,6 +12,8 @@ from ...schemas import (
     AutoChunkMixin,
     DataJulgamentoMixin,
     DataPublicacaoMixin,
+    IdFiltro,
+    IdFiltroUnico,
     OutputDataPublicacaoMixin,
     OutputRelatoriaMixin,
     SearchBase,
@@ -26,14 +28,18 @@ class InputCJSGEsajPuro(SearchBase, DataJulgamentoMixin, DataPublicacaoMixin, Au
     arguments raise ``ValidationError`` instead of being silently ignored.
     Herda tambem os filtros de data de julgamento e de publicacao via
     :class:`DataJulgamentoMixin` / :class:`DataPublicacaoMixin`.
+
+    ``classe``/``assunto``/``orgao_julgador`` aceitam ``int``, ``str`` ou
+    ``list[int | str]`` via :data:`IdFiltro` (refs #232). ``comarca`` aceita
+    ``int`` ou ``str`` (single-value, backend ``cdComarca``).
     """
 
     ementa: str | None = None
     numero_recurso: str | None = None
-    classe: str | None = None
-    assunto: str | None = None
-    comarca: str | None = None
-    orgao_julgador: str | None = None
+    classe: IdFiltro = None
+    assunto: IdFiltro = None
+    comarca: IdFiltroUnico = None
+    orgao_julgador: IdFiltro = None
     origem: Literal["T", "R"] = "T"
     tipo_decisao: Literal["acordao", "monocratica"] = "acordao"
 

--- a/src/juscraper/courts/tjba/client.py
+++ b/src/juscraper/courts/tjba/client.py
@@ -6,7 +6,11 @@ import pandas as pd
 import requests
 
 from juscraper.core.base import BaseScraper
-from juscraper.utils.params import apply_input_pipeline_search, resolve_deprecated_alias
+from juscraper.utils.params import (
+    apply_input_pipeline_search,
+    pop_deprecated_alias,
+    resolve_deprecated_alias,
+)
 
 from .download import cjsg_download
 from .parse import cjsg_parse
@@ -41,7 +45,7 @@ class TJBAScraper(BaseScraper):
         numero_recurso: str | None = None,
         orgaos: list | None = None,
         relatores: list | None = None,
-        classes: list | None = None,
+        classe: list | None = None,
         data_publicacao_inicio: str | None = None,
         data_publicacao_fim: str | None = None,
         segundo_grau: bool = True,
@@ -69,8 +73,9 @@ class TJBAScraper(BaseScraper):
             List of orgao julgador IDs to filter.
         relatores : list, optional
             List of relator IDs to filter.
-        classes : list, optional
-            List of class IDs to filter.
+        classe : list, optional
+            List of class IDs to filter. ``classes`` (plural) e aceito como
+            alias deprecado (emite :class:`DeprecationWarning`). Refs #232.
         data_publicacao_inicio : str, optional
             Start date for publication filter (YYYY-MM-DD).
         data_publicacao_fim : str, optional
@@ -95,6 +100,17 @@ class TJBAScraper(BaseScraper):
         tamanho_pagina = resolve_deprecated_alias(
             kwargs, "items_per_page", "tamanho_pagina", tamanho_pagina, sentinel=10
         )
+        # Popa alias plural antes do pydantic — sem isso o schema canonico
+        # (que so declara o singular ``classe``) trataria ``classes`` como
+        # ``extra_forbidden``. Usa ``classe is not None`` (nao ``in kwargs``)
+        # para nao tratar ``classe=None`` explicito como conflito. Refs #232.
+        if "classes" in kwargs:
+            if classe is not None:
+                kwargs.pop("classes")
+                raise ValueError(
+                    "Nao e possivel passar 'classe' e 'classes' simultaneamente."
+                )
+            classe = pop_deprecated_alias(kwargs, "classes", "classe")
         inp = apply_input_pipeline_search(
             InputCJSGTJBA,
             "TJBAScraper.cjsg_download()",
@@ -107,7 +123,7 @@ class TJBAScraper(BaseScraper):
             numero_recurso=numero_recurso,
             orgaos=orgaos,
             relatores=relatores,
-            classes=classes,
+            classe=classe,
             segundo_grau=segundo_grau,
             turmas_recursais=turmas_recursais,
             tipo_acordaos=tipo_acordaos,
@@ -121,7 +137,7 @@ class TJBAScraper(BaseScraper):
             numero_recurso=inp.numero_recurso,
             orgaos=inp.orgaos,
             relatores=inp.relatores,
-            classes=inp.classes,
+            classes=inp.classe,
             data_publicacao_inicio=inp.data_publicacao_inicio,
             data_publicacao_fim=inp.data_publicacao_fim,
             segundo_grau=inp.segundo_grau,
@@ -156,7 +172,7 @@ class TJBAScraper(BaseScraper):
         numero_recurso: str | None = None,
         orgaos: list | None = None,
         relatores: list | None = None,
-        classes: list | None = None,
+        classe: list | None = None,
         data_publicacao_inicio: str | None = None,
         data_publicacao_fim: str | None = None,
         segundo_grau: bool = True,
@@ -189,6 +205,7 @@ class TJBAScraper(BaseScraper):
         Aliases deprecados
         ------------------
         * ``items_per_page`` -> ``tamanho_pagina``
+        * ``classes`` -> ``classe`` (refs #232)
 
         Returns
         -------
@@ -201,7 +218,7 @@ class TJBAScraper(BaseScraper):
             numero_recurso=numero_recurso,
             orgaos=orgaos,
             relatores=relatores,
-            classes=classes,
+            classe=classe,
             data_publicacao_inicio=data_publicacao_inicio,
             data_publicacao_fim=data_publicacao_fim,
             segundo_grau=segundo_grau,

--- a/src/juscraper/courts/tjba/schemas.py
+++ b/src/juscraper/courts/tjba/schemas.py
@@ -33,7 +33,7 @@ class InputCJSGTJBA(SearchBase, DataPublicacaoMixin):
     numero_recurso: str | None = None
     orgaos: list | None = None
     relatores: list | None = None
-    classes: list | None = None
+    classe: list | None = None
     segundo_grau: bool = True
     turmas_recursais: bool = True
     tipo_acordaos: bool = True

--- a/src/juscraper/courts/tjsp/cjpg_download.py
+++ b/src/juscraper/courts/tjsp/cjpg_download.py
@@ -27,13 +27,13 @@ def cjpg_download(
     u_base: str,
     download_path: str,
     sleep_time: float = 0.5,
-    classes: 'list[str] | None' | None = None,
-    assuntos: 'list[str] | None' | None = None,
-    varas: 'list[str] | None' | None = None,
-    id_processo: 'str | None' | None = None,
-    data_inicio: 'str | None' | None = None,
-    data_fim: 'str | None' | None = None,
-    paginas: 'list | range | None' | None = None,
+    classe: str | None = None,
+    assunto: str | None = None,
+    vara: str | None = None,
+    id_processo: str | None = None,
+    data_inicio: str | None = None,
+    data_fim: str | None = None,
+    paginas: 'list | range | None' = None,
     get_n_pags_callback=None,
 ):
     """Download cases from the TJSP jurisprudence search.
@@ -43,13 +43,14 @@ def cjpg_download(
     and pydantic validation before calling this function. Direct callers
     must validate ``pesquisa`` upstream.
 
+    ``classe``/``assunto``/``vara`` chegam ja como CSV (ou ``None``); a coercao
+    de ``int``/``list`` -> CSV acontece no schema (:class:`InputCJPGTJSP`) via
+    :data:`IdFiltro`. Refs #232.
+
     Raises:
         ValueError: If ``get_n_pags_callback`` is missing or fails to
             extract the page count from the first-page HTML.
     """
-    assuntos_str = ','.join(assuntos) if assuntos is not None else None
-    varas_str = ','.join(varas) if varas is not None else None
-    classes_str = ','.join(classes) if classes is not None else None
     id_processo_str = clean_cnj(id_processo) if id_processo is not None else ''
 
     query = {
@@ -59,11 +60,11 @@ def cjpg_download(
         'numeroDigitoAnoUnificado': id_processo_str[:15],
         'foroNumeroUnificado': id_processo_str[-4:],
         'dadosConsulta.nuProcesso': id_processo_str,
-        'classeTreeSelection.values': classes_str,
-        'assuntoTreeSelection.values': assuntos_str,
+        'classeTreeSelection.values': classe,
+        'assuntoTreeSelection.values': assunto,
         'dadosConsulta.dtInicio': data_inicio,
         'dadosConsulta.dtFim': data_fim,
-        'varasTreeSelection.values': varas_str,
+        'varasTreeSelection.values': vara,
         'dadosConsulta.ordenacao': 'DESC'
     }
 

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
-from ...utils.params import SEARCH_ALIASES, apply_input_pipeline_search, normalize_pesquisa
+from ...utils.params import SEARCH_ALIASES, apply_input_pipeline_search, normalize_pesquisa, pop_deprecated_alias
 from .._esaj.base import EsajSearchScraper, run_auto_chunk
 from .cjpg_download import cjpg_download as cjpg_download_mod
 from .cjpg_parse import cjpg_n_pags, cjpg_parse_manager
@@ -233,14 +233,15 @@ class TJSPScraper(EsajSearchScraper):
             **kwargs: Filtros aceitos por :class:`InputCJPGTJSP` (todos
                 opcionais; ``None`` = sem filtro):
 
-                * ``classes`` (list[str]): IDs internos de classe
-                  processual. Backend: ``classeTreeSelection.values``
+                * ``classe`` (int | str | list[int | str]): ID(s) internos
+                  de classe processual. Backend:
+                  ``classeTreeSelection.values`` (CSV).
+                * ``assunto`` (int | str | list[int | str]): ID(s) internos
+                  de assunto. Backend: ``assuntoTreeSelection.values``
                   (CSV).
-                * ``assuntos`` (list[str]): IDs internos de assunto.
-                  Backend: ``assuntoTreeSelection.values`` (CSV).
-                * ``varas`` (list[str]): IDs internos de vara, no
-                  formato em arvore do TJSP (ex.: ``"1-1-1"``). Backend:
-                  ``varasTreeSelection.values`` (CSV).
+                * ``vara`` (int | str | list[int | str]): ID(s) internos de
+                  vara, no formato em arvore do TJSP (ex.: ``"1-1-1"``).
+                  Backend: ``varasTreeSelection.values`` (CSV).
                 * ``id_processo`` (str): Numero CNJ formatado para
                   filtrar uma instancia especifica. Normalizado via
                   :func:`clean_cnj` antes do envio.
@@ -256,6 +257,9 @@ class TJSPScraper(EsajSearchScraper):
         pydantic):
 
             * ``query`` / ``termo`` -> ``pesquisa``
+            * ``classes`` -> ``classe``
+            * ``assuntos`` -> ``assunto``
+            * ``varas`` -> ``vara``
             * ``data_inicio`` / ``data_fim`` -> ``data_julgamento_inicio`` / ``_fim``
             * ``data_julgamento_de`` / ``_ate`` -> ``data_julgamento_inicio`` / ``_fim``
 
@@ -264,6 +268,8 @@ class TJSPScraper(EsajSearchScraper):
                 :func:`raise_on_extra_kwargs`).
             ValidationError: Quando um filtro tem formato invalido.
             QueryTooLongError: Quando ``pesquisa`` excede 120 chars.
+            ValueError: Quando ``classe`` e ``classes`` (ou par equivalente)
+                sao passados simultaneamente.
 
         Returns:
             pd.DataFrame: Resultados parseados; colunas conforme
@@ -277,9 +283,9 @@ class TJSPScraper(EsajSearchScraper):
             >>> tjsp = jus.scraper("tjsp")
             >>> # Busca textual + filtro de vara:
             >>> df = tjsp.cjpg("dano moral", paginas=range(1, 3),
-            ...                varas=["1-1-1"])
-            >>> # So filtros (sem termo):
-            >>> df = tjsp.cjpg(paginas=1, classes=["12728"],
+            ...                vara="1-1-1")
+            >>> # So filtros (sem termo) — IDs como int ou list:
+            >>> df = tjsp.cjpg(paginas=1, classe=12728, assunto=[3607, 5885],
             ...                data_julgamento_inicio="01/01/2024",
             ...                data_julgamento_fim="31/03/2024")
 
@@ -343,10 +349,25 @@ class TJSPScraper(EsajSearchScraper):
             ValidationError: Quando um filtro tem formato invalido.
             QueryTooLongError: Quando ``pesquisa`` (ou alias resolvido)
                 excede 120 chars.
+            ValueError: Quando o usuario passa um alias deprecado e o nome
+                canonico simultaneamente (ex.: ``classe`` e ``classes``;
+                refs #232).
 
         Returns:
             str: Caminho do diretorio onde os HTMLs foram salvos.
         """
+        # Popa aliases plurais antes do pydantic; sem isso virariam
+        # ``extra_forbidden`` (o schema canonico ja so declara o singular).
+        # Refs #232.
+        for _old, _new in (("classes", "classe"), ("assuntos", "assunto"), ("varas", "vara")):
+            if _old in kwargs:
+                if _new in kwargs:
+                    kwargs.pop(_old)
+                    raise ValueError(
+                        f"Nao e possivel passar '{_new}' e '{_old}' simultaneamente."
+                    )
+                kwargs[_new] = pop_deprecated_alias(kwargs, _old, _new)
+
         inp = apply_input_pipeline_search(
             InputCJPGTJSP,
             f"{type(self).__name__}.cjpg_download()",
@@ -374,9 +395,9 @@ class TJSPScraper(EsajSearchScraper):
             u_base=self.u_base,
             download_path=self.download_path,
             sleep_time=self.sleep_time,
-            classes=inp.classes,
-            assuntos=inp.assuntos,
-            varas=inp.varas,
+            classe=inp.classe,
+            assunto=inp.assunto,
+            vara=inp.vara,
             id_processo=inp.id_processo,
             data_inicio=inp.data_julgamento_inicio,
             data_fim=inp.data_julgamento_fim,

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -24,6 +24,42 @@ from .schemas import InputCJPGTJSP, InputCJSGTJSP
 logger = logging.getLogger("juscraper.tjsp")
 
 
+# Plurais legados de cjpg (refs #232). Singular canonico ja declarado em
+# ``InputCJPGTJSP``; plurais aparecem so como alias deprecados.
+_CJPG_PLURAL_ALIASES: tuple[tuple[str, str], ...] = (
+    ("classes", "classe"),
+    ("assuntos", "assunto"),
+    ("varas", "vara"),
+)
+
+
+def _pop_cjpg_plural_aliases(kwargs: dict) -> None:
+    """Popa aliases plurais cjpg (``classes``/``assuntos``/``varas`` -> singular).
+
+    Chamado em duas posicoes do client TJSP:
+
+    1. ``cjpg()`` antes de :func:`run_auto_chunk` — a validacao upfront do
+       schema dentro do chunking nao tolera kwargs nao-canonicos
+       (``extra_forbidden`` em :class:`InputCJPGTJSP`), entao precisa
+       acontecer aqui, nao apenas em ``cjpg_download``.
+    2. ``cjpg_download()`` para chamadas diretas que nao passaram por
+       ``cjpg()``. Idempotente: se ``cjpg()`` ja popou, e no-op.
+
+    Conflito plural+singular usa ``kwargs.get(_new) is not None`` (nao
+    ``_new in kwargs``) para nao tratar ``classe=None`` explicito como
+    conflito — alinha com a checagem de TJBA/DataJud. Refs #232.
+    """
+    for _old, _new in _CJPG_PLURAL_ALIASES:
+        if _old not in kwargs:
+            continue
+        if kwargs.get(_new) is not None:
+            kwargs.pop(_old)
+            raise ValueError(
+                f"Nao e possivel passar '{_new}' e '{_old}' simultaneamente."
+            )
+        kwargs[_new] = pop_deprecated_alias(kwargs, _old, _new)
+
+
 class TJSPScraper(EsajSearchScraper):
     """Main scraper for TJSP — eSAJ web + api.tjsp.jus.br."""
 
@@ -302,6 +338,12 @@ class TJSPScraper(EsajSearchScraper):
             (parcial + warning). ``auto_chunk=True`` + ``paginas != None``
             em janela > 366 dias e :class:`ValueError`.
         """
+        # Popa plurais antes de ``run_auto_chunk`` — a validacao upfront
+        # do schema dentro do chunking via ``extra_forbidden`` em
+        # ``classes``/``assuntos``/``varas`` antes de o caminho noop
+        # delegar para ``cjpg_download``. Refs #232.
+        _pop_cjpg_plural_aliases(kwargs)
+
         chunked = run_auto_chunk(
             method=self.cjpg,
             method_label="TJSPScraper.cjpg()",
@@ -356,17 +398,10 @@ class TJSPScraper(EsajSearchScraper):
         Returns:
             str: Caminho do diretorio onde os HTMLs foram salvos.
         """
-        # Popa aliases plurais antes do pydantic; sem isso virariam
-        # ``extra_forbidden`` (o schema canonico ja so declara o singular).
-        # Refs #232.
-        for _old, _new in (("classes", "classe"), ("assuntos", "assunto"), ("varas", "vara")):
-            if _old in kwargs:
-                if _new in kwargs:
-                    kwargs.pop(_old)
-                    raise ValueError(
-                        f"Nao e possivel passar '{_new}' e '{_old}' simultaneamente."
-                    )
-                kwargs[_new] = pop_deprecated_alias(kwargs, _old, _new)
+        # Aliases plurais ja foram popados em ``cjpg()``; chamada direta a
+        # ``cjpg_download()`` precisa fazer a pop tambem. ``_pop_cjpg_plural_aliases``
+        # e idempotente (no-op quando ``cjpg()`` ja rodou). Refs #232.
+        _pop_cjpg_plural_aliases(kwargs)
 
         inp = apply_input_pipeline_search(
             InputCJPGTJSP,

--- a/src/juscraper/courts/tjsp/schemas.py
+++ b/src/juscraper/courts/tjsp/schemas.py
@@ -20,7 +20,15 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from ...schemas import AutoChunkMixin, CnjInputBase, DataJulgamentoMixin, OutputCnjConsultaBase, SearchBase
+from ...schemas import (
+    AutoChunkMixin,
+    CnjInputBase,
+    DataJulgamentoMixin,
+    IdFiltro,
+    IdFiltroUnico,
+    OutputCnjConsultaBase,
+    SearchBase,
+)
 from ...schemas.cjsg import OutputCJSGBase
 
 
@@ -29,13 +37,17 @@ class InputCJSGTJSP(SearchBase, DataJulgamentoMixin, AutoChunkMixin):
 
     Herda filtro de data de julgamento via :class:`DataJulgamentoMixin`.
     TJSP **nao** suporta ``data_publicacao_*`` nem ``numero_recurso``.
+
+    ``classe``/``assunto``/``orgao_julgador`` aceitam ``int``, ``str`` ou
+    ``list[int | str]`` via :data:`IdFiltro` (refs #232). ``comarca`` aceita
+    ``int`` ou ``str`` (single-value, backend ``cdComarca``).
     """
 
     ementa: str | None = None
-    classe: str | None = None
-    assunto: str | None = None
-    comarca: str | None = None
-    orgao_julgador: str | None = None
+    classe: IdFiltro = None
+    assunto: IdFiltro = None
+    comarca: IdFiltroUnico = None
+    orgao_julgador: IdFiltro = None
     baixar_sg: bool = True
     tipo_decisao: Literal["acordao", "monocratica"] = "acordao"
 
@@ -57,13 +69,19 @@ class InputCJPGTJSP(SearchBase, DataJulgamentoMixin, AutoChunkMixin):
     """Accepted input for TJSP ``cjpg``. Unknown kwargs raise via ``extra='forbid'``.
 
     Sobrescreve ``pesquisa`` com default vazio porque o TJSP permite buscar
-    so por filtros (ex.: ``classes=[...]``) sem termo textual.
+    so por filtros (ex.: ``classe=[417]``) sem termo textual.
+
+    ``classe``/``assunto``/``vara`` aceitam ``int``, ``str`` ou
+    ``list[int | str]`` via :data:`IdFiltro` (refs #232). Nomes canonicos
+    seguem o singular do projeto; os plurais ``classes``/``assuntos``/``varas``
+    sao alias deprecados popados no client (:meth:`TJSPScraper.cjpg_download`)
+    com :class:`DeprecationWarning`.
     """
 
     pesquisa: str = ""
-    classes: list[str] | None = None
-    assuntos: list[str] | None = None
-    varas: list[str] | None = None
+    classe: IdFiltro = None
+    assunto: IdFiltro = None
+    vara: IdFiltro = None
     id_processo: str | None = None
 
 

--- a/src/juscraper/schemas/__init__.py
+++ b/src/juscraper/schemas/__init__.py
@@ -9,6 +9,7 @@ from .mixins import (
     OutputRelatoriaMixin,
     PaginasMixin,
 )
+from .types import IdFiltro, IdFiltroUnico
 
 __all__ = [
     "SearchBase",
@@ -21,4 +22,6 @@ __all__ = [
     "OutputDataPublicacaoMixin",
     "CnjInputBase",
     "OutputCnjConsultaBase",
+    "IdFiltro",
+    "IdFiltroUnico",
 ]

--- a/src/juscraper/schemas/types.py
+++ b/src/juscraper/schemas/types.py
@@ -1,0 +1,69 @@
+"""Type aliases reutilizados pelos schemas pydantic (refs #232).
+
+Centraliza coercoes que aparecem em multiplos endpoints. Cada alias usa
+``Annotated[..., BeforeValidator(...)]`` para colar a coercao no field, em vez
+de duplicar helpers ``coerce_*`` no caller (padrao novo no projeto, alinhado a
+pydantic v2).
+
+Tipos disponiveis:
+
+- :data:`IdFiltro` — IDs internos do tribunal que aceitam ``int``, ``str`` ou
+  ``list[int | str]``. Coage para ``str | None``, montando CSV quando lista.
+  Use em campos cujo backend interpreta CSV (``classeTreeSelection.values``,
+  ``assuntosTreeSelection.values``, ``secoesTreeSelection.values``,
+  ``varasTreeSelection.values``).
+- :data:`IdFiltroUnico` — IDs single-value (``cdComarca`` no eSAJ). Rejeita
+  ``list``/``tuple`` para nao mascarar uso indevido.
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import BeforeValidator
+
+
+def _coerce_id_filtro(value):
+    """Coage ``int | str | list[int | str] | None`` para ``str | None``.
+
+    Lista vazia vira ``None`` (semanticamente equivalente a "sem filtro"); lista
+    nao-vazia vira CSV. ``int`` vira ``str(int)``. Levanta ``ValueError`` (que
+    o pydantic embrulha em ``ValidationError``) para tipos nao suportados.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        # bool e subclasse de int em Python; rejeitar explicitamente para
+        # nao mascarar uso indevido (``classe=True`` viraria ``"True"``).
+        raise ValueError(
+            f"IdFiltro aceita int, str, list ou None — recebeu bool ({value!r})"
+        )
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return None
+        return ",".join(str(v) for v in value)
+    if isinstance(value, (int, str)):
+        return str(value)
+    raise ValueError(
+        f"IdFiltro aceita int, str, list ou None — recebeu {type(value).__name__}"
+    )
+
+
+def _coerce_id_filtro_unico(value):
+    """Igual a :func:`_coerce_id_filtro` mas rejeita ``list``/``tuple``.
+
+    Usado em campos single-value do backend (ex.: ``cdComarca``), onde aceitar
+    lista mascararia uso indevido — o tribunal so consulta uma comarca por
+    chamada. Levanta ``ValueError`` para que o pydantic embrulhe em
+    ``ValidationError``.
+    """
+    if isinstance(value, (list, tuple)):
+        raise ValueError(
+            "Campo single-value: aceita apenas int/str (backend nao suporta CSV aqui)."
+        )
+    return _coerce_id_filtro(value)
+
+
+IdFiltro = Annotated[
+    int | str | list[int | str] | None, BeforeValidator(_coerce_id_filtro)
+]
+IdFiltroUnico = Annotated[int | str | None, BeforeValidator(_coerce_id_filtro_unico)]

--- a/tests/datajud/test_assunto_deprecation_232.py
+++ b/tests/datajud/test_assunto_deprecation_232.py
@@ -1,0 +1,81 @@
+"""Deprecacao do alias plural ``assuntos`` no Datajud (refs #232).
+
+Garante que:
+
+1. ``assuntos`` (plural) ainda funciona, emitindo ``DeprecationWarning`` e
+   produzindo o mesmo body Elasticsearch que o singular ``assunto``.
+2. Passar ``assunto`` e ``assuntos`` juntos -> :class:`ValueError`.
+
+Aplica-se a ``listar_processos`` e ``contar_processos``.
+"""
+from __future__ import annotations
+
+import pytest
+import responses
+from responses.matchers import json_params_matcher
+
+import juscraper as jus
+from juscraper.aggregators.datajud import client as datajud_client
+from tests._helpers import load_sample
+from tests.fixtures.capture.datajud import build_payload as _payload
+
+BASE = "https://api-publica.datajud.cnj.jus.br"
+
+
+@pytest.fixture
+def _captured_payloads(monkeypatch):
+    payloads = []
+
+    def fake_call(*, base_url, alias, api_key, session, query_payload, verbose=False):
+        payloads.append(query_payload)
+        return {"hits": {"total": {"value": 0, "relation": "eq"}, "hits": []}}
+
+    monkeypatch.setattr(datajud_client, "call_datajud_api", fake_call)
+    return payloads
+
+
+@responses.activate
+def test_listar_processos_assuntos_plural_emite_deprecation_warning(mocker):
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        f"{BASE}/api_publica_tjmg/_search",
+        body=load_sample("datajud", "listar_processos/single_page.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(_payload(assunto=["12503"], tamanho_pagina=10))],
+    )
+    with pytest.warns(DeprecationWarning, match=r"'assuntos' .* 'assunto'"):
+        jus.scraper("datajud").listar_processos(
+            tribunal="TJMG",
+            assuntos=[12503],
+            tamanho_pagina=10,
+            paginas=range(1, 2),
+        )
+
+
+def test_listar_processos_assunto_e_assuntos_juntos_levanta_value_error():
+    with pytest.raises(ValueError, match=r"'assunto' e 'assuntos' simultaneamente"):
+        jus.scraper("datajud").listar_processos(
+            tribunal="TJMG",
+            assunto=[12503],
+            assuntos=[5885],
+        )
+
+
+def test_contar_processos_assuntos_plural_emite_deprecation_warning(_captured_payloads):
+    """``contar_processos(assuntos=...)`` continua funcionando com warning."""
+    scraper = jus.scraper("datajud")
+    with pytest.warns(DeprecationWarning, match=r"'assuntos' .* 'assunto'"):
+        scraper.contar_processos(tribunal="TJMG", assuntos=[12503])
+    # Body Elasticsearch usa "assuntos.codigo" (backend); o alias deprecado
+    # nao deve alterar o payload.
+    must = _captured_payloads[0]["query"]["bool"]["must"]
+    assert {"terms": {"assuntos.codigo": ["12503"]}} in must
+
+
+def test_contar_processos_assunto_e_assuntos_juntos_levanta_value_error():
+    with pytest.raises(ValueError, match=r"'assunto' e 'assuntos' simultaneamente"):
+        jus.scraper("datajud").contar_processos(
+            tribunal="TJMG", assunto=[12503], assuntos=[5885]
+        )

--- a/tests/datajud/test_contar_processos.py
+++ b/tests/datajud/test_contar_processos.py
@@ -51,15 +51,17 @@ class TestPayloadShape:
         payload = captured_payloads[0]["payload"]
         assert payload["query"] == {"match_all": {}}
 
-    def test_payload_combina_classe_e_assuntos(self, captured_payloads):
+    def test_payload_combina_classe_e_assunto(self, captured_payloads):
         scraper = jus.scraper("datajud")
         scraper.contar_processos(
-            tribunal="TJSP", classe="436", assuntos=["7780", "1127"]
+            tribunal="TJSP", classe="436", assunto=["7780", "1127"]
         )
 
         payload = captured_payloads[0]["payload"]
         must = payload["query"]["bool"]["must"]
         assert {"match": {"classe.codigo": "436"}} in must
+        # Chave do payload Elasticsearch fica "assuntos.codigo" (backend);
+        # parametro Python e "assunto" (singular, refs #232).
         assert {"terms": {"assuntos.codigo": ["7780", "1127"]}} in must
 
     def test_payload_ano_ajuizamento_dual_range(self, captured_payloads):
@@ -202,16 +204,18 @@ class TestFiltrosNovos176:
 
 
 class TestCoercaoTipos217:
-    """Issue #217: ``assuntos`` aceita int (codigos TPU sao inteiros);
+    """Issue #217: ``assunto`` aceita int (codigos TPU sao inteiros);
     ``movimentos_codigo`` aceita str (vindo de planilha/CSV). Smoke test
     confirmando que o validator do schema tambem roda em ``contar_processos``,
     nao so em ``listar_processos``."""
 
-    def test_assuntos_aceita_int(self, captured_payloads):
+    def test_assunto_aceita_int(self, captured_payloads):
         scraper = jus.scraper("datajud")
-        scraper.contar_processos(tribunal="TJMG", assuntos=[12503])
+        scraper.contar_processos(tribunal="TJMG", assunto=[12503])
 
         must = captured_payloads[0]["payload"]["query"]["bool"]["must"]
+        # Chave Elasticsearch fica "assuntos.codigo" (backend); param Python
+        # e "assunto". Refs #232.
         assert {"terms": {"assuntos.codigo": ["12503"]}} in must
 
     def test_movimentos_codigo_aceita_str(self, captured_payloads):

--- a/tests/datajud/test_listar_processos_filters_contract.py
+++ b/tests/datajud/test_listar_processos_filters_contract.py
@@ -30,7 +30,7 @@ CNJ_TJSP_CLEAN = "10004132220178260415"
 @responses.activate
 def test_listar_processos_all_filters_land_in_body(mocker):
     """All filters propagate simultaneously: numero_processo + ano +
-    classe + assuntos + mostrar_movs + tamanho_pagina. The matcher
+    classe + assunto + mostrar_movs + tamanho_pagina. The matcher
     confirms the body has the four ``must_conditions`` in canonical order
     plus the dual ``dataAjuizamento`` range and ``_source: True``."""
     mocker.patch("time.sleep")
@@ -45,7 +45,7 @@ def test_listar_processos_all_filters_land_in_body(mocker):
                 numero_processo=CNJ_TJSP_CLEAN,
                 ano_ajuizamento=2023,
                 classe="436",
-                assuntos=["1127", "1156"],
+                assunto=["1127", "1156"],
                 mostrar_movs=True,
                 tamanho_pagina=50,
             )),
@@ -60,7 +60,7 @@ def test_listar_processos_all_filters_land_in_body(mocker):
         numero_processo=CNJ_TJSP_FORMATTED,
         ano_ajuizamento=2023,
         classe="436",
-        assuntos=["1127", "1156"],
+        assunto=["1127", "1156"],
         mostrar_movs=True,
         tamanho_pagina=50,
         paginas=range(1, 2),
@@ -304,7 +304,7 @@ def test_tipo_movimentacao_desconhecido_lista_validos():
         ("numero_processo", "10004132220178260415"),
         ("ano_ajuizamento", 2023),
         ("classe", "436"),
-        ("assuntos", ["1127"]),
+        ("assunto", ["1127"]),
         ("data_ajuizamento_inicio", "2024-01-01"),
         ("data_ajuizamento_fim", "2024-03-31"),
         ("tipos_movimentacao", ["decisao"]),
@@ -337,7 +337,7 @@ def test_query_dict_vazio_rejeitado():
 
 
 # =============================================================================
-# Coercao bidirecional int<->str em ``assuntos`` e ``movimentos_codigo``
+# Coercao bidirecional int<->str em ``assunto`` e ``movimentos_codigo``
 # (issue #217). Codigos CNJ TPU sao inteiros por natureza; o backend
 # Elasticsearch coage int -> str em campos keyword transparentemente. O
 # schema aceita ambos no input e normaliza antes do payload, restaurando
@@ -346,9 +346,9 @@ def test_query_dict_vazio_rejeitado():
 
 
 @responses.activate
-def test_assuntos_aceita_int(mocker):
-    """``assuntos=[12503]`` (int) deve produzir o mesmo body que
-    ``assuntos=["12503"]`` — o validator coage int -> str antes do builder.
+def test_assunto_aceita_int(mocker):
+    """``assunto=[12503]`` (int) deve produzir o mesmo body que
+    ``assunto=["12503"]`` — o validator coage int -> str antes do builder.
     Restaura o caso do notebook ``docs/notebooks/datajud.ipynb``."""
     mocker.patch("time.sleep")
     responses.add(
@@ -359,14 +359,14 @@ def test_assuntos_aceita_int(mocker):
         content_type="application/json",
         match=[
             json_params_matcher(_payload(
-                assuntos=["12503"],
+                assunto=["12503"],
                 tamanho_pagina=10,
             )),
         ],
     )
     df = jus.scraper("datajud").listar_processos(
         tribunal="TJMG",
-        assuntos=[12503],
+        assunto=[12503],
         tamanho_pagina=10,
         paginas=range(1, 2),
     )
@@ -374,8 +374,8 @@ def test_assuntos_aceita_int(mocker):
 
 
 @responses.activate
-def test_assuntos_aceita_mix_int_str(mocker):
-    """``assuntos=[12503, "12504"]`` -> ``["12503", "12504"]`` no body."""
+def test_assunto_aceita_mix_int_str(mocker):
+    """``assunto=[12503, "12504"]`` -> ``["12503", "12504"]`` no body."""
     mocker.patch("time.sleep")
     responses.add(
         responses.POST,
@@ -385,14 +385,14 @@ def test_assuntos_aceita_mix_int_str(mocker):
         content_type="application/json",
         match=[
             json_params_matcher(_payload(
-                assuntos=["12503", "12504"],
+                assunto=["12503", "12504"],
                 tamanho_pagina=10,
             )),
         ],
     )
     df = jus.scraper("datajud").listar_processos(
         tribunal="TJMG",
-        assuntos=[12503, "12504"],
+        assunto=[12503, "12504"],
         tamanho_pagina=10,
         paginas=range(1, 2),
     )
@@ -402,7 +402,7 @@ def test_assuntos_aceita_mix_int_str(mocker):
 @responses.activate
 def test_movimentos_codigo_aceita_str(mocker):
     """``movimentos_codigo=["246"]`` (str) deve produzir o mesmo body que
-    ``[246]`` — simetrico a ``assuntos``, normaliza str -> int antes do
+    ``[246]`` — simetrico a ``assunto``, normaliza str -> int antes do
     builder. Cobre o caso de codigos TPU vindos de planilha/CSV."""
     mocker.patch("time.sleep")
     responses.add(

--- a/tests/datajud/test_listar_processos_payload.py
+++ b/tests/datajud/test_listar_processos_payload.py
@@ -165,7 +165,7 @@ class TestBuildPayloadFiltrosFlexiveis:
             numero_processo="00000000000000000001",
             ano_ajuizamento=2023,
             classe="436",
-            assuntos=["1127"],
+            assunto=["1127"],
             data_ajuizamento_inicio="2024-01-01",
             movimentos_codigo=[193],
             orgao_julgador="Vara X",
@@ -175,13 +175,13 @@ class TestBuildPayloadFiltrosFlexiveis:
 
     def test_combinacao_filtros_amigaveis_ordem_canonica(self):
         # Confirma a ordem documentada na docstring do builder:
-        # numero_processo, data, classe, assuntos, movimentos, orgao.
+        # numero_processo, data, classe, assunto, movimentos, orgao.
         payload = build_listar_processos_payload(
             numero_processo="00000000000000000001",
             data_ajuizamento_inicio="2024-01-01",
             data_ajuizamento_fim="2024-03-31",
             classe="436",
-            assuntos=["1127"],
+            assunto=["1127"],
             movimentos_codigo=[193],
             orgao_julgador="Vara X",
             tamanho_pagina=10,

--- a/tests/schemas/test_canonical_types.py
+++ b/tests/schemas/test_canonical_types.py
@@ -81,6 +81,10 @@ DEPRECATED_SYNONYMS: dict[str, str] = {
     "classe_judicial": "classe",
     "assunto_cnj": "assunto",
     "assunto_principal": "assunto",
+    # refs #232 — singular canonico para IDs de filtro de busca (cjpg/cjsg).
+    "classes": "classe",
+    "assuntos": "assunto",
+    "varas": "vara",
 }
 
 

--- a/tests/schemas/test_cjsg_schemas.py
+++ b/tests/schemas/test_cjsg_schemas.py
@@ -110,29 +110,42 @@ class TestInputCJPGTJSP:
         model = InputCJPGTJSP(
             pesquisa="dano",
             paginas=range(1, 2),
-            classes=["Ação Civil Pública"],
-            assuntos=["Direito do Consumidor"],
-            varas=["1ª Vara Cível"],
+            classe=["Ação Civil Pública"],
+            assunto=["Direito do Consumidor"],
+            vara=["1ª Vara Cível"],
             id_processo="1000123-45.2023.8.26.0100",
             data_julgamento_inicio="01/01/2024",
             data_julgamento_fim="31/12/2024",
         )
-        assert model.classes == ["Ação Civil Pública"]
+        # IdFiltro colapsa lista para CSV; refs #232.
+        assert model.classe == "Ação Civil Pública"
         assert model.id_processo == "1000123-45.2023.8.26.0100"
 
     def test_defaults(self):
         model = InputCJPGTJSP()
         assert model.pesquisa == ""
-        assert model.classes is None
-        assert model.assuntos is None
-        assert model.varas is None
+        assert model.classe is None
+        assert model.assunto is None
+        assert model.vara is None
         assert model.id_processo is None
 
     def test_rejects_cjsg_fields(self):
-        """cjpg has no ementa/classe-singular/comarca/orgao_julgador/baixar_sg."""
-        for bad in ("ementa", "classe", "comarca", "orgao_julgador", "baixar_sg", "tipo_decisao"):
+        """cjpg nao tem ementa/comarca/orgao_julgador/baixar_sg.
+
+        ``classe``/``assunto`` agora **sao** aceitos (singular canonico,
+        refs #232). Os plurais ``classes``/``assuntos``/``varas`` viraram
+        alias deprecados tratados na camada do client; no schema eles
+        ainda sao ``extra_forbidden``.
+        """
+        for bad in ("ementa", "comarca", "orgao_julgador", "baixar_sg", "tipo_decisao"):
             with pytest.raises(ValidationError, match="extra_forbidden"):
                 InputCJPGTJSP(**{bad: "x"})
+
+    def test_rejects_plural_aliases_at_schema(self):
+        """Plurais sao tratados no client (deprecation); no schema sao extra_forbidden."""
+        for plural in ("classes", "assuntos", "varas"):
+            with pytest.raises(ValidationError, match="extra_forbidden"):
+                InputCJPGTJSP(**{plural: ["x"]})
 
     def test_unknown_kwarg_rejected(self):
         with pytest.raises(ValidationError, match="extra_forbidden"):

--- a/tests/schemas/test_id_filtro.py
+++ b/tests/schemas/test_id_filtro.py
@@ -1,0 +1,96 @@
+"""Coercao dos tipos IdFiltro / IdFiltroUnico (refs #232).
+
+Cobre a forma como os Annotated+BeforeValidator do schema convertem entradas
+``int``/``str``/``list`` em ``str | None`` (CSV) — ou rejeitam, no caso de
+``IdFiltroUnico`` recebendo lista.
+
+Os testes usam :class:`InputCJSGTJSP` e :class:`InputCJPGTJSP` como instancias
+do tipo (em vez de validar o ``IdFiltro`` isolado), porque pydantic so resolve
+o ``BeforeValidator`` dentro de um ``BaseModel``.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from juscraper.courts.tjsp.schemas import InputCJPGTJSP, InputCJSGTJSP
+
+
+class TestIdFiltroCoercion:
+    """``IdFiltro`` aceita int/str/list e coage para ``str | None`` (CSV)."""
+
+    def test_int_vira_string(self):
+        m = InputCJSGTJSP(pesquisa="x", classe=417)
+        assert m.classe == "417"
+
+    def test_str_passa_inalterado(self):
+        m = InputCJSGTJSP(pesquisa="x", classe="417")
+        assert m.classe == "417"
+
+    def test_lista_de_int_vira_csv(self):
+        m = InputCJSGTJSP(pesquisa="x", assunto=[3607, 5885, 6317])
+        assert m.assunto == "3607,5885,6317"
+
+    def test_lista_de_str_vira_csv(self):
+        m = InputCJSGTJSP(pesquisa="x", assunto=["3607", "5885"])
+        assert m.assunto == "3607,5885"
+
+    def test_lista_mista_int_str(self):
+        m = InputCJSGTJSP(pesquisa="x", assunto=[3607, "5885", 6317])
+        assert m.assunto == "3607,5885,6317"
+
+    def test_csv_string_passa_inalterado(self):
+        """Backend ja interpreta CSV; passar string CSV direto deve ser idempotente."""
+        m = InputCJSGTJSP(pesquisa="x", assunto="3607,5885,6317")
+        assert m.assunto == "3607,5885,6317"
+
+    def test_none_continua_none(self):
+        m = InputCJSGTJSP(pesquisa="x", classe=None)
+        assert m.classe is None
+
+    def test_default_e_none(self):
+        m = InputCJSGTJSP(pesquisa="x")
+        assert m.classe is None
+        assert m.assunto is None
+        assert m.orgao_julgador is None
+
+    def test_lista_vazia_vira_none(self):
+        """Lista vazia equivale a 'sem filtro' (==None), nao a CSV vazio."""
+        m = InputCJSGTJSP(pesquisa="x", classe=[])
+        assert m.classe is None
+
+
+class TestIdFiltroUnicoRejeita:
+    """``IdFiltroUnico`` (usado em ``comarca``) rejeita ``list``."""
+
+    def test_comarca_int(self):
+        m = InputCJSGTJSP(pesquisa="x", comarca=1)
+        assert m.comarca == "1"
+
+    def test_comarca_str(self):
+        m = InputCJSGTJSP(pesquisa="x", comarca="100")
+        assert m.comarca == "100"
+
+    def test_comarca_lista_rejeita(self):
+        with pytest.raises(ValidationError):
+            InputCJSGTJSP(pesquisa="x", comarca=[1, 2])
+
+
+class TestCJPGAceitaSingularComIdFiltro:
+    """``cjpg`` (TJSP) agora aceita ``classe``/``assunto``/``vara`` singulares."""
+
+    def test_classe_int(self):
+        m = InputCJPGTJSP(classe=12728)
+        assert m.classe == "12728"
+
+    def test_assunto_lista(self):
+        m = InputCJPGTJSP(assunto=[3607, 5885])
+        assert m.assunto == "3607,5885"
+
+    def test_vara_string_no_formato_arvore(self):
+        m = InputCJPGTJSP(vara="1-1-1")
+        assert m.vara == "1-1-1"
+
+    def test_vara_lista_string(self):
+        m = InputCJPGTJSP(vara=["1-1-1", "2-2-2"])
+        assert m.vara == "1-1-1,2-2-2"

--- a/tests/tjba/test_cjsg_contract.py
+++ b/tests/tjba/test_cjsg_contract.py
@@ -17,7 +17,7 @@ def _decisao_filter(
     numero_recurso: str | None = None,
     orgaos: list | None = None,
     relatores: list | None = None,
-    classes: list | None = None,
+    classe: list | None = None,
     data_publicacao_inicio: str | None = None,
     data_publicacao_fim: str | None = None,
     segundo_grau: bool = True,
@@ -30,7 +30,8 @@ def _decisao_filter(
         "assunto": pesquisa,
         "orgaos": orgaos or [],
         "relatores": relatores or [],
-        "classes": classes or [],
+        # Chave do payload GraphQL fica "classes" (nome no backend). Refs #232.
+        "classes": classe or [],
         "dataInicial": f"{data_publicacao_inicio}T03:00:00.000Z"
         if data_publicacao_inicio
         else "1980-02-01T03:00:00.000Z",

--- a/tests/tjba/test_cjsg_filters_contract.py
+++ b/tests/tjba/test_cjsg_filters_contract.py
@@ -19,7 +19,7 @@ def test_cjsg_all_filters_land_in_graphql_body(mocker):
         numero_recurso="8000001-11.2024.8.05.0001",
         orgaos=[10, 20],
         relatores=[1],
-        classes=[100],
+        classe=[100],
         data_publicacao_inicio="2024-01-01",
         data_publicacao_fim="2024-03-31",
         segundo_grau=False,
@@ -111,3 +111,30 @@ def test_cjsg_data_julgamento_raises_typeerror():
         "dano moral",
         paginas=1,
     )
+
+
+# --- refs #232 ---------------------------------------------------------------
+
+
+@responses.activate
+def test_cjsg_classes_plural_emite_deprecation_warning(mocker):
+    """``classes`` (plural) ainda funciona, mas emite ``DeprecationWarning``."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE,
+        body=load_sample("tjba", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(_payload("dano moral", 0, classe=[100]))],
+    )
+    with pytest.warns(DeprecationWarning, match=r"'classes' .* 'classe'"):
+        df = jus.scraper("tjba").cjsg("dano moral", paginas=1, classes=[100])
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_cjsg_classe_e_classes_juntos_levanta_value_error():
+    with pytest.raises(ValueError, match=r"'classe' e 'classes' simultaneamente"):
+        jus.scraper("tjba").cjsg(
+            "dano moral", paginas=1, classe=[100], classes=[200]
+        )

--- a/tests/tjsp/test_cjpg_deprecation_232.py
+++ b/tests/tjsp/test_cjpg_deprecation_232.py
@@ -19,6 +19,7 @@ import responses
 from responses.matchers import query_param_matcher
 
 import juscraper as jus
+from juscraper.courts.tjsp.client import TJSPScraper
 from tests._helpers import load_sample_bytes
 from tests.fixtures.capture._util import make_tjsp_cjpg_params
 
@@ -156,3 +157,86 @@ def test_body_parity_plural_alias(tmp_path, mocker):
         jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
             "dano moral", paginas=1, classes=["12728", "5885"]
         )
+
+
+# --- Regressao: plural alias + janela > 366d (auto_chunk) ------------------
+
+
+def test_classes_plural_funciona_com_auto_chunk_long_window(tmp_path, mocker):
+    """Regressao: plural alias + ``data_julgamento`` > 366d nao deve TypeError.
+
+    Antes do fix de pop antes do ``run_auto_chunk``, a validacao upfront do
+    schema :class:`InputCJPGTJSP` dentro do chunking via ``extra_forbidden``
+    em ``classes`` (declarado so como alias deprecado, nao como campo do
+    schema) — virava ``TypeError`` antes da pop acontecer em
+    ``cjpg_download``. Agora o helper :func:`_pop_cjpg_plural_aliases` roda
+    no entry point ``cjpg()`` antes do chunking.
+
+    Mocka ``cjpg_download``/``cjpg_parse`` para isolar a pop+chunking do
+    pipeline real (mesma estrategia de ``test_cjpg_auto_chunk_contract.py``).
+    """
+    mocker.patch.object(TJSPScraper, "cjpg_download", return_value="/fake/path")
+    mocker.patch.object(
+        TJSPScraper,
+        "cjpg_parse",
+        return_value=pd.DataFrame({"id_processo": ["x"]}),
+    )
+    mocker.patch("juscraper.courts.tjsp.client.shutil.rmtree")
+
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.warns(DeprecationWarning, match=r"'classes' .* 'classe'"):
+        df = scraper.cjpg(
+            "dano",
+            classes=["12728"],
+            data_julgamento_inicio="01/01/2022",
+            data_julgamento_fim="31/12/2024",
+        )
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_classes_plural_passa_canonico_para_cjpg_download(tmp_path, mocker):
+    """Apos a pop em ``cjpg()``, ``cjpg_download`` recebe ``classe`` (singular).
+
+    Garante que o helper substitui o alias antes da delegacao — sem isso,
+    chamadas internas de chunking iriam re-popar o alias dentro de cada
+    janela, duplicando o ``DeprecationWarning``.
+    """
+    download = mocker.patch.object(TJSPScraper, "cjpg_download", return_value="/fake/path")
+    mocker.patch.object(
+        TJSPScraper,
+        "cjpg_parse",
+        return_value=pd.DataFrame({"id_processo": ["x"]}),
+    )
+    mocker.patch("juscraper.courts.tjsp.client.shutil.rmtree")
+
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        scraper.cjpg("dano", paginas=1, classes=["12728", "5885"])
+
+    # cjpg_download deve receber 'classe' (canonico), nunca 'classes' (alias)
+    assert download.call_count == 1
+    call_kwargs = download.call_args.kwargs
+    assert "classes" not in call_kwargs
+    assert call_kwargs.get("classe") == ["12728", "5885"]
+
+
+def test_classe_none_explicito_nao_conflita_com_classes_plural(tmp_path, mocker):
+    """``classe=None`` explicito + ``classes=[...]`` nao deve levantar conflito.
+
+    A checagem usa ``kwargs.get(_new) is not None`` (nao ``_new in kwargs``),
+    entao passar ``classe=None`` explicito e tratado como "sem filtro
+    canonico" e o alias plural prossegue normalmente. Alinha com a
+    semantica de TJBA/DataJud.
+    """
+    mocker.patch.object(TJSPScraper, "cjpg_download", return_value="/fake/path")
+    mocker.patch.object(
+        TJSPScraper,
+        "cjpg_parse",
+        return_value=pd.DataFrame({"id_processo": ["x"]}),
+    )
+    mocker.patch("juscraper.courts.tjsp.client.shutil.rmtree")
+
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.warns(DeprecationWarning, match=r"'classes' .* 'classe'"):
+        scraper.cjpg("dano", paginas=1, classe=None, classes=["12728"])

--- a/tests/tjsp/test_cjpg_deprecation_232.py
+++ b/tests/tjsp/test_cjpg_deprecation_232.py
@@ -1,0 +1,158 @@
+"""Deprecacao dos plurais ``classes``/``assuntos``/``varas`` no cjpg TJSP (refs #232).
+
+Garante que:
+
+1. Plurais emitem :class:`DeprecationWarning` e seguem funcionando (1 release de
+   convivencia minimo).
+2. Plural + singular juntos -> :class:`ValueError` (uso conflitante; sem
+   ``DeprecationWarning`` — o uso esta errado, nao apenas legado).
+3. O body final do POST e identico independente do nome usado (singular vs
+   plural-alias) e do tipo (int/str/list).
+"""
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+import responses
+from responses.matchers import query_param_matcher
+
+import juscraper as jus
+from tests._helpers import load_sample_bytes
+from tests.fixtures.capture._util import make_tjsp_cjpg_params
+
+BASE = "https://esaj.tjsp.jus.br/cjpg"
+
+
+def _stub_no_results():
+    responses.add(
+        responses.GET,
+        f"{BASE}/pesquisar.do",
+        body=load_sample_bytes("tjsp", "cjpg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+    )
+
+
+@responses.activate
+def test_classes_plural_emite_deprecation_warning(tmp_path, mocker):
+    mocker.patch("time.sleep")
+    _stub_no_results()
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.warns(DeprecationWarning, match=r"'classes' .* 'classe'"):
+        df = scraper.cjpg("dano", paginas=1, classes=["12728"])
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
+def test_assuntos_plural_emite_deprecation_warning(tmp_path, mocker):
+    mocker.patch("time.sleep")
+    _stub_no_results()
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.warns(DeprecationWarning, match=r"'assuntos' .* 'assunto'"):
+        df = scraper.cjpg("dano", paginas=1, assuntos=["3607"])
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
+def test_varas_plural_emite_deprecation_warning(tmp_path, mocker):
+    mocker.patch("time.sleep")
+    _stub_no_results()
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.warns(DeprecationWarning, match=r"'varas' .* 'vara'"):
+        df = scraper.cjpg("dano", paginas=1, varas=["1-1-1"])
+    assert isinstance(df, pd.DataFrame)
+
+
+def test_classes_e_classe_juntos_levanta_value_error(tmp_path):
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.raises(ValueError, match=r"'classe' e 'classes' simultaneamente"):
+        scraper.cjpg("dano", paginas=1, classe=12728, classes=["5885"])
+
+
+def test_assuntos_e_assunto_juntos_levanta_value_error(tmp_path):
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.raises(ValueError, match=r"'assunto' e 'assuntos' simultaneamente"):
+        scraper.cjpg("dano", paginas=1, assunto=3607, assuntos=["5885"])
+
+
+def test_varas_e_vara_juntos_levanta_value_error(tmp_path):
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.raises(ValueError, match=r"'vara' e 'varas' simultaneamente"):
+        scraper.cjpg("dano", paginas=1, vara="1-1-1", varas=["2-2-2"])
+
+
+# --- Body parity: int / str / list / plural-alias geram o mesmo POST --------
+
+
+def _expected_params(**overrides):
+    base = make_tjsp_cjpg_params(
+        pesquisa="dano moral",
+        id_processo="",
+        classes=["12728", "5885"],
+        assuntos=None,
+        varas=None,
+        data_inicio="",
+        data_fim="",
+    )
+    base.update(overrides)
+    return {k: v for k, v in base.items() if v is not None}
+
+
+@responses.activate
+def test_body_parity_classe_lista_vs_csv_string(tmp_path, mocker):
+    """``classe=[12728, 5885]`` deve produzir o mesmo POST que ``classe='12728,5885'``."""
+    mocker.patch("time.sleep")
+    expected = _expected_params()
+    responses.add(
+        responses.GET,
+        f"{BASE}/pesquisar.do",
+        body=load_sample_bytes("tjsp", "cjpg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+        match=[query_param_matcher(expected)],
+    )
+    jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
+        "dano moral", paginas=1, classe=[12728, 5885]
+    )
+
+
+@responses.activate
+def test_body_parity_classe_int_unico(tmp_path, mocker):
+    """``classe=12728`` (int) deve produzir o mesmo POST que ``classe='12728'``."""
+    mocker.patch("time.sleep")
+    expected = _expected_params(**{"classeTreeSelection.values": "12728"})
+    responses.add(
+        responses.GET,
+        f"{BASE}/pesquisar.do",
+        body=load_sample_bytes("tjsp", "cjpg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+        match=[query_param_matcher(expected)],
+    )
+    jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
+        "dano moral", paginas=1, classe=12728
+    )
+
+
+@responses.activate
+def test_body_parity_plural_alias(tmp_path, mocker):
+    """``classes=['12728','5885']`` deve produzir o mesmo POST que o singular."""
+    mocker.patch("time.sleep")
+    expected = _expected_params()
+    responses.add(
+        responses.GET,
+        f"{BASE}/pesquisar.do",
+        body=load_sample_bytes("tjsp", "cjpg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+        match=[query_param_matcher(expected)],
+    )
+    # Plurais ainda funcionam — so suprimo o DeprecationWarning aqui (testado
+    # nos casos acima) para nao poluir o resultado.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
+            "dano moral", paginas=1, classes=["12728", "5885"]
+        )

--- a/tests/tjsp/test_cjpg_filters_contract.py
+++ b/tests/tjsp/test_cjpg_filters_contract.py
@@ -49,9 +49,9 @@ def test_cjpg_all_filters_land_in_query_params(tmp_path, mocker):
     df = jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
         "dano moral",
         paginas=1,
-        classes=_CLASSES,
-        assuntos=_ASSUNTOS,
-        varas=_VARAS,
+        classe=_CLASSES,
+        assunto=_ASSUNTOS,
+        vara=_VARAS,
         id_processo=_ID_PROCESSO,
         data_julgamento_inicio=_DATA_INI,
         data_julgamento_fim=_DATA_FIM,
@@ -65,7 +65,12 @@ def test_cjpg_unknown_kwarg_raises(tmp_path):
 
 
 def test_cjpg_rejects_cjsg_fields(tmp_path):
-    """cjpg takes plural lists, not cjsg's singular ementa/classe/comarca."""
+    """cjpg ainda nao aceita ementa/comarca/orgao_julgador/baixar_sg.
+
+    Refs #232: ``classe``/``assunto``/``vara`` agora **sao** aceitos (singular
+    canonico). Os plurais (``classes``/``assuntos``/``varas``) viraram alias
+    deprecados na camada do client.
+    """
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
-    for bad in ("ementa", "classe", "comarca", "orgao_julgador", "baixar_sg"):
+    for bad in ("ementa", "comarca", "orgao_julgador", "baixar_sg"):
         assert_unknown_kwarg_raises(scraper.cjpg, bad, "dano moral", paginas=1)

--- a/tests/tjsp/test_cjsg_filters_contract.py
+++ b/tests/tjsp/test_cjsg_filters_contract.py
@@ -87,3 +87,46 @@ def test_cjsg_rejects_esaj_puro_only_fields(tmp_path):
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
     for bad in ("numero_recurso", "data_publicacao_inicio", "origem"):
         assert_unknown_kwarg_raises(scraper.cjsg, bad, "dano moral", paginas=1)
+
+
+# --- refs #232: classe/assunto aceitam int e list (CSV) ---------------------
+
+
+@responses.activate
+def test_cjsg_classe_lista_int_vira_csv_no_body(tmp_path, mocker):
+    """``classe=[417, 5885]`` deve produzir CSV em ``classesTreeSelection.values``."""
+    mocker.patch("time.sleep")
+    expected_body = make_tjsp_cjsg_body(
+        pesquisa="",
+        ementa="",
+        classe="417,5885",
+        assunto="3607",
+        comarca="",
+        orgao_julgador="",
+        data_inicio="",
+        data_fim="",
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjsp", "cjsg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(expected_body, allow_blank=True)],
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjsp", "cjsg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": "1"})],
+    )
+
+    df = jus.scraper("tjsp", download_path=str(tmp_path)).cjsg(
+        pesquisa="",
+        paginas=1,
+        classe=[417, 5885],
+        assunto=3607,
+    )
+    assert isinstance(df, pd.DataFrame)


### PR DESCRIPTION
## Resumo

Fecha #232.

A chamada do issue (`tjsp.cjsg(classe=[417], assunto=['3607',...])`) quebrava com `ValidationError` porque a família eSAJ aceitava só `str` singular. Três divergências entre `cjpg` e `cjsg` foram atacadas:

1. **Tipo**: filtros que são IDs numéricos só aceitavam `str`. Agora aceitam `int`, `str` ou `list[int|str]` via o novo `IdFiltro` (`Annotated + BeforeValidator` no schema — primeiro uso desse padrão em `src/`). Lista vira CSV automaticamente; `comarca` usa `IdFiltroUnico` que rejeita lista (backend single-value).
2. **Cardinalidade**: `cjsg` deixa de aceitar só 1 valor. `classe=[417, 5885]` funciona em todos os 6 tribunais eSAJ (TJAC, TJAL, TJAM, TJCE, TJMS, TJSP).
3. **Nomenclatura**: `cjpg` do TJSP renomeia `classes`/`assuntos`/`varas` para singular (`classe`/`assunto`/`vara`). Plurais viram alias deprecados (emitem `DeprecationWarning`); passar plural + singular juntos -> `ValueError`.

### Escopo estendido (follow-ups do plano original incorporados)

Para fechar a lacuna do teste `test_no_deprecated_synonyms_in_schemas` (já prometia fiscalizar plurais mas faltava `classes`/`assuntos`/`varas` no dicionário), também:

- **TJBA** `cjsg`/`cjsg_download`: `classes` → `classe` (alias deprecado).
- **DataJud** `listar_processos`/`contar_processos`: `assuntos` → `assunto` (alias deprecado).

As chaves do **payload Elasticsearch** (`assuntos.codigo`) e **GraphQL** (`classes`) ficam intactas — são nomes do backend, não da API pública.

## Compat / migração

| Chamada antes | Chamada agora | Funciona? |
|---|---|---|
| `tjsp.cjsg(classe='417')` | `tjsp.cjsg(classe='417')` | ✅ inalterado |
| `tjsp.cjsg(classe=[417, 5885])` | — | ✅ agora aceita (antes: `ValidationError`) |
| `tjsp.cjsg(classe=417)` | — | ✅ agora aceita |
| `tjsp.cjpg(classes=[12728])` | `tjsp.cjpg(classe=[12728])` | ⚠️ `DeprecationWarning`, segue funcionando |
| `tjba.cjsg(classes=[100])` | `tjba.cjsg(classe=[100])` | ⚠️ `DeprecationWarning`, segue funcionando |
| `datajud.listar_processos(assuntos=[12503])` | `...listar_processos(assunto=[12503])` | ⚠️ `DeprecationWarning`, segue funcionando |
| `tjsp.cjpg(classe=12728, classes=[5885])` | — | ❌ `ValueError` (conflito) |

## Test plan

- [x] `IdFiltro` aceita `int`, `str`, `list[int|str]`, `None` — campo final é `str | None` (CSV). Lista vazia → `None`.
- [x] `IdFiltroUnico` rejeita `list` com `ValidationError` (`comarca=[1,2]`).
- [x] Body parity TJSP cjsg: `classe=[417, 5885]` produz o mesmo body que `classe='417,5885'`.
- [x] Deprecação cjpg TJSP: `classes`/`assuntos`/`varas` (plural) emitem `DeprecationWarning` e funcionam; plural + singular juntos → `ValueError`.
- [x] Deprecação TJBA: `classes` (plural) emite `DeprecationWarning`; conflito → `ValueError`.
- [x] Deprecação DataJud: `assuntos` (plural) emite `DeprecationWarning` em `listar_processos` e `contar_processos`; conflito → `ValueError`. Body Elasticsearch fica idêntico (chave `assuntos.codigo` do backend não muda).
- [x] `tests/schemas/test_canonical_types.py` passa com `classes`/`assuntos`/`varas` no `DEPRECATED_SYNONYMS` (lacuna fechada).
- [x] Suite completa: 1464 passed, 26 skipped, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)