### PR TITLE
test: simetria raises TypeError para data nao suportada (TJPB/TJRR/TJTO)

### DIFF
--- a/tests/tjpb/test_cjsg_filters_contract.py
+++ b/tests/tjpb/test_cjsg_filters_contract.py
@@ -14,7 +14,7 @@ from responses.matchers import json_params_matcher
 
 import juscraper as jus
 from juscraper.courts.tjpb.download import BASE_URL, SEARCH_URL, TOKEN_RE, build_cjsg_payload
-from tests._helpers import load_sample, load_sample_bytes
+from tests._helpers import assert_unknown_kwarg_raises, load_sample, load_sample_bytes
 
 _HOME_HTML_BYTES = load_sample_bytes("tjpb", "cjsg/home.html")
 _TOKEN_MATCH = TOKEN_RE.search(_HOME_HTML_BYTES.decode("utf-8"))
@@ -162,3 +162,16 @@ def test_cjsg_data_inicio_alias_maps_to_data_julgamento(mocker):
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
     assert any("data_fim" in m and "deprecado" in m for m in messages)
+
+
+def test_cjsg_data_publicacao_kwarg_raises():
+    """TJPB backend nao expoe filtro de data de publicacao;
+    :class:`InputCJSGTJPB` so herda :class:`DataJulgamentoMixin`, entao
+    ``data_publicacao_*`` deve cair como ``extra_forbidden`` -> ``TypeError``
+    em vez de silently drop (refs #186)."""
+    assert_unknown_kwarg_raises(
+        jus.scraper("tjpb").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )

--- a/tests/tjrr/test_cjsg_filters_contract.py
+++ b/tests/tjrr/test_cjsg_filters_contract.py
@@ -168,3 +168,16 @@ def test_cjsg_download_unknown_kwarg_raises():
         "dano moral",
         paginas=1,
     )
+
+
+def test_cjsg_data_publicacao_kwarg_raises():
+    """TJRR backend nao expoe filtro de data de publicacao;
+    :class:`InputCJSGTJRR` so herda :class:`DataJulgamentoMixin`, entao
+    ``data_publicacao_*`` deve cair como ``extra_forbidden`` -> ``TypeError``
+    em vez de silently drop (refs #186)."""
+    assert_unknown_kwarg_raises(
+        jus.scraper("tjrr").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )

--- a/tests/tjto/test_cjpg_filters_contract.py
+++ b/tests/tjto/test_cjpg_filters_contract.py
@@ -12,7 +12,7 @@ from responses.matchers import urlencoded_params_matcher
 
 import juscraper as jus
 from juscraper.courts.tjto.download import BASE_URL, build_cjsg_payload
-from tests._helpers import load_sample
+from tests._helpers import assert_unknown_kwarg_raises, load_sample
 
 
 def _add_post(expected_payload: dict) -> None:
@@ -142,3 +142,16 @@ def test_cjpg_so_data_fim_autopreenche_inicio_com_1990(mocker):
         )
 
     assert isinstance(df, pd.DataFrame)
+
+
+def test_cjpg_data_publicacao_kwarg_raises():
+    """Mesmo principio do cjsg: :class:`InputCJPGTJTO` so herda
+    :class:`DataJulgamentoMixin` (o backend Solr nao expoe filtro de data
+    de publicacao), entao ``data_publicacao_*`` deve cair como
+    ``extra_forbidden`` -> ``TypeError`` (refs #186)."""
+    assert_unknown_kwarg_raises(
+        jus.scraper("tjto").cjpg,
+        "data_publicacao_inicio",
+        '"dano moral"',
+        paginas=1,
+    )

--- a/tests/tjto/test_cjsg_filters_contract.py
+++ b/tests/tjto/test_cjsg_filters_contract.py
@@ -11,7 +11,7 @@ from responses.matchers import urlencoded_params_matcher
 
 import juscraper as jus
 from juscraper.courts.tjto.download import BASE_URL, build_cjsg_payload
-from tests._helpers import load_sample
+from tests._helpers import assert_unknown_kwarg_raises, load_sample
 
 
 def _add_post(expected_payload: dict) -> None:
@@ -98,3 +98,16 @@ def test_cjsg_data_inicio_alias_maps_to_data_julgamento(mocker):
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
     assert any("data_fim" in m and "deprecado" in m for m in messages)
+
+
+def test_cjsg_data_publicacao_kwarg_raises():
+    """TJTO backend Solr so expoe filtro de data de julgamento
+    (``dat_jul_ini``/``dat_jul_fim``); :class:`InputCJSGTJTO` so herda
+    :class:`DataJulgamentoMixin`, entao ``data_publicacao_*`` deve cair como
+    ``extra_forbidden`` -> ``TypeError`` em vez de silently drop (refs #186)."""
+    assert_unknown_kwarg_raises(
+        jus.scraper("tjto").cjsg,
+        "data_publicacao_inicio",
+        "dano moral",
+        paginas=1,
+    )


### PR DESCRIPTION
## Summary

Fecha o gap de simetria descrito na issue #186: tribunais wired cujo `Input*` so herda **um** dos mixins (`DataJulgamentoMixin` xor `DataPublicacaoMixin`) precisam ter um teste explicito que fixa que o kwarg de data oposto cai como `extra_forbidden` -> `TypeError` em vez de ser silently dropped.

Auditoria do escopo da issue #186 (com main em 166c8ce):

**Faltavam (cobertos por este PR):**
- TJPB cjsg
- TJRR cjsg
- TJTO cjsg
- TJTO cjpg

Todos os 4 schemas (`InputCJSGTJPB`, `InputCJSGTJRR`, `InputCJSGTJTO`, `InputCJPGTJTO`) so herdam `DataJulgamentoMixin` — entao o teste fixa que `data_publicacao_inicio` levanta `TypeError`.

**Ja cobertos (sem mudanca aqui):**
- TJBA: `data_julgamento_*` (so tem `DataPublicacaoMixin`)
- TJMT, TJPI, TJRN, TJRO, TJES cjsg+cjpg, TJGO: `data_publicacao_*` (`DataJulgamentoMixin` only) ou inverso
- comunica_cnj: `data_inicio` (canonico e `data_disponibilizacao_*`)
- TJSP cjsg/cjpg: cobertos via `test_data_publicacao_long_window_raises_typeerror_immediately` no `*_auto_chunk_contract.py`

**Nao se aplica (ambos os mixins):** TJDFT, TJPA, TJSC, TJMG, TJPR, TJRS, esaj puro (TJAC/TJAL/TJAM/TJCE/TJMS).

## Por que sem helper compartilhado

A issue mencionou promover o padrao a `assert_unsupported_date_filter_raises` com >= 2 ocorrencias (Regra 1 do #84). Optei por **nao** criar o helper:

- `assert_unknown_kwarg_raises` ja absorve todo o boilerplate (asserva o sufixo canonico do `TypeError`).
- Cada teste novo e literalmente um wrapper de 6 linhas onde o conteudo *explicativo* (qual mixin esta faltando, qual backend nao expoe o filtro) vive na docstring — exatamente o tipo de informacao que se perderia num helper-de-helper que so encapsula um nome.

Se aparecerem novos casos no futuro com **mesma justificativa** que justifique extrair, da pra promover ai. Por enquanto, 4 docstrings pequenas batem 1 abstracao em legibilidade.

## Test plan

- [x] `pytest tests/tjpb tests/tjto tests/tjrr` -> verde (62 passed, 1 xfail pre-existente em TJRR `relator`)
- [x] Pre-commit hooks (isort/flake8/mypy) verde
- [x] Os 4 testes novos sozinhos passam:
  - `tests/tjpb/test_cjsg_filters_contract.py::test_cjsg_data_publicacao_kwarg_raises`
  - `tests/tjto/test_cjsg_filters_contract.py::test_cjsg_data_publicacao_kwarg_raises`
  - `tests/tjto/test_cjpg_filters_contract.py::test_cjpg_data_publicacao_kwarg_raises`
  - `tests/tjrr/test_cjsg_filters_contract.py::test_cjsg_data_publicacao_kwarg_raises`

Closes #186.