### PR TITLE
refactor(tjrn,tjro,tjrr): migrar cjsg para HTTPScraper + core.parse_utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- TJRN, TJRO e TJRR: `cjsg` passa a usar `core.http.HTTPScraper` (backoff exponencial centralizado para 429/5xx, respeito a `Retry-After`) e os helpers de `core.parse_utils` (`clean_html`, `coerce_date_columns` em TJRN/TJRO) + `utils.cnj.format_cnj(strict=False)`. Comportamento observavel preservado byte-a-byte (mesmas colunas, mesmo payload); falha agora levanta `RetryExhaustedError` apos esgotar tentativas em vez de propagar a ultima `requests.HTTPError` cega. Refs #194, #202.
 - `TJSPScraper.cjsg` aceita `pesquisa=""` por default — antes o argumento era obrigatorio e `tjsp.cjsg(classe="...", assunto="...")` levantava `TypeError`. Agora o usuario pode buscar so por filtros (sem termo textual), igualando o comportamento de `cjpg`. Refs #229.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- TJRN, TJRO e TJRR: `cjsg` passa a usar `core.http.HTTPScraper` (backoff exponencial centralizado para 429/5xx, respeito a `Retry-After`) e os helpers de `core.parse_utils` (`clean_html`, `coerce_date_columns` em TJRN/TJRO) + `utils.cnj.format_cnj(strict=False)`. Comportamento observavel preservado byte-a-byte (mesmas colunas, mesmo payload); falha agora levanta `RetryExhaustedError` apos esgotar tentativas em vez de propagar a ultima `requests.HTTPError` cega. Refs #194, #202.
+- TJRN, TJRO e TJRR: `cjsg` passa a usar `core.http.HTTPScraper` (backoff exponencial centralizado para 429/5xx, respeito a `Retry-After`) e os helpers de `core.parse_utils` (`clean_html`, `coerce_date_columns` em TJRN/TJRO) + `utils.cnj.format_cnj(strict=False)`. Mesmas colunas e mesmo payload do request. Duas pequenas mudancas de comportamento herdadas da infra centralizada: (a) esgotar `max_retries` em status retryable agora levanta `RetryExhaustedError` em vez de propagar a ultima `requests.HTTPError`; (b) em TJRN/TJRO, resposta 200 com JSON corrompido deixa de fazer retry e passa a propagar `ValueError` na primeira ocorrencia (o `_fetch_page` antigo capturava `ValueError` no laco de retry; o `_request_with_retry` so retry-a 429/5xx). Refs #194, #202.
 - `TJSPScraper.cjsg` aceita `pesquisa=""` por default — antes o argumento era obrigatorio e `tjsp.cjsg(classe="...", assunto="...")` levantava `TypeError`. Agora o usuario pode buscar so por filtros (sem termo textual), igualando o comportamento de `cjpg`. Refs #229.
 
 ### Fixed

--- a/src/juscraper/core/http.py
+++ b/src/juscraper/core/http.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any
+from collections.abc import Callable
+from typing import Any, TypeAlias
 
 import requests
 
@@ -31,6 +32,29 @@ from juscraper.core.exceptions import RetryExhaustedError
 logger = logging.getLogger("juscraper.core.http")
 
 RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+RequestFn: TypeAlias = Callable[..., requests.Response]
+"""Tipo do callable bound do ``HTTPScraper._request_with_retry``.
+
+Repassado a ``courts/<xx>/download.py::cjsg_download_manager`` (Fase 1 do
+refactor #194) para centralizar retry + ``raise_for_status`` sem expor a
+``session`` do client. Contrato esperado em runtime:
+
+* ``method`` (1o positional) — verbo HTTP (``"GET"``, ``"POST"``, ...).
+* ``url`` (2o positional) — URL alvo.
+* kwargs livres — encaminhados a ``requests.Session.request`` (``json=``,
+  ``data=``, ``headers=``, ``timeout=``, ...). ``max_retries`` e
+  ``base_backoff`` tambem sao aceitos para sobrepor o default.
+
+A response retornada e garantida com ``status_code < 400`` (4xx ja foi
+via ``raise_for_status``; 5xx/429 ja esgotou ``max_retries`` ->
+``RetryExhaustedError``). O caller pode chamar ``.json()`` / ler ``.text``
+sem se preocupar com retry de transitorios.
+
+Implementado como ``Callable[..., Response]`` (e nao ``Protocol``) por
+compatibilidade com mypy: o ``__call__`` do bound method tem keyword
+args nomeados (``session``/``max_retries``/``base_backoff``) que nao
+casam estritamente com ``**kwargs: Any`` em ``Protocol`` matching."""
 
 
 class HTTPScraper(BaseScraper):

--- a/src/juscraper/courts/tjrn/client.py
+++ b/src/juscraper/courts/tjrn/client.py
@@ -1,9 +1,8 @@
 """Scraper for the Tribunal de Justica do Rio Grande do Norte (TJRN)."""
 
 import pandas as pd
-import requests
 
-from juscraper.core.base import BaseScraper
+from juscraper.core.http import HTTPScraper
 from juscraper.utils.params import apply_input_pipeline_search, resolve_deprecated_alias, to_br_date
 
 from .download import cjsg_download_manager
@@ -24,7 +23,7 @@ def _to_tjrn_date(date_str):
     return br.replace("/", "-") if br else ""
 
 
-class TJRNScraper(BaseScraper):
+class TJRNScraper(HTTPScraper):
     """Scraper for the Tribunal de Justica do Rio Grande do Norte (TJRN).
 
     Uses the TJRN Elasticsearch-based JSON API at jurisprudencia.tjrn.jus.br.
@@ -34,10 +33,6 @@ class TJRNScraper(BaseScraper):
 
     def __init__(self):
         super().__init__("TJRN")
-        self.session = requests.Session()
-        self.session.headers.update({
-            "User-Agent": "juscraper/0.1 (https://github.com/jtrecenti/juscraper)",
-        })
 
     def cpopg(self, id_cnj: str | list[str]):
         """Stub: first instance case consultation not implemented for TJRN."""
@@ -173,7 +168,7 @@ class TJRNScraper(BaseScraper):
         return cjsg_download_manager(
             pesquisa=inp.pesquisa,
             paginas=inp.paginas,
-            session=self.session,
+            request_fn=self._request_with_retry,
             nr_processo=inp.numero_processo or "",
             id_classe=inp.id_classe or "",
             id_orgao_julgador=inp.id_orgao_julgador or "",

--- a/src/juscraper/courts/tjrn/download.py
+++ b/src/juscraper/courts/tjrn/download.py
@@ -1,10 +1,10 @@
 """Downloads raw results from the TJRN jurisprudence search (Elasticsearch API)."""
 import math
 import time
-from collections.abc import Callable
 
-import requests
 from tqdm import tqdm
+
+from juscraper.core.http import RequestFn
 
 BASE_URL = "https://jurisprudencia.tjrn.jus.br/api/pesquisar"
 RESULTS_PER_PAGE = 10
@@ -62,7 +62,7 @@ def cjsg_download_manager(
     pesquisa: str,
     paginas=None,
     *,
-    request_fn: Callable[..., requests.Response],
+    request_fn: RequestFn,
     **kwargs,
 ) -> list:
     """Download raw results from the TJRN jurisprudence search.

--- a/src/juscraper/courts/tjrn/download.py
+++ b/src/juscraper/courts/tjrn/download.py
@@ -1,13 +1,10 @@
 """Downloads raw results from the TJRN jurisprudence search (Elasticsearch API)."""
-import logging
 import math
 import time
 from collections.abc import Callable
 
 import requests
 from tqdm import tqdm
-
-logger = logging.getLogger(__name__)
 
 BASE_URL = "https://jurisprudencia.tjrn.jus.br/api/pesquisar"
 RESULTS_PER_PAGE = 10

--- a/src/juscraper/courts/tjrn/download.py
+++ b/src/juscraper/courts/tjrn/download.py
@@ -2,6 +2,7 @@
 import logging
 import math
 import time
+from collections.abc import Callable
 
 import requests
 from tqdm import tqdm
@@ -60,30 +61,11 @@ def build_cjsg_payload(
     }
 
 
-def _fetch_page(session: requests.Session, payload: dict, max_retries: int = 3) -> dict:
-    """Fetch a single page from the TJRN API with retry logic."""
-    for attempt in range(1, max_retries + 1):
-        try:
-            resp = session.post(BASE_URL, json=payload, timeout=30)
-            resp.raise_for_status()
-            data: dict = resp.json()
-            return data
-        except (requests.RequestException, ValueError) as exc:
-            if attempt == max_retries:
-                raise
-            wait = 2 ** attempt
-            logger.warning(
-                "TJRN request failed (attempt %d/%d): %s. Retrying in %ds...",
-                attempt, max_retries, exc, wait,
-            )
-            time.sleep(wait)
-    return {}  # unreachable
-
-
 def cjsg_download_manager(
     pesquisa: str,
     paginas=None,
-    session: requests.Session | None = None,
+    *,
+    request_fn: Callable[..., requests.Response],
     **kwargs,
 ) -> list:
     """Download raw results from the TJRN jurisprudence search.
@@ -93,18 +75,16 @@ def cjsg_download_manager(
     Args:
         pesquisa: Search term.
         paginas (list, range, or None): Pages to download (1-based).
-        session: Optional requests.Session to reuse.
+        request_fn: HTTP callable that handles retry + raise_for_status — em
+            uso normal e ``TJRNScraper._request_with_retry`` (via
+            ``core.http.HTTPScraper``), centralizando backoff exponencial
+            para 429/5xx.
         **kwargs: Additional filter parameters.
     """
-    if session is None:
-        session = requests.Session()
-        session.headers.update({
-            "User-Agent": "juscraper/0.1 (https://github.com/jtrecenti/juscraper)",
-        })
-
     def _get_page(pagina_1based):
         payload = build_cjsg_payload(pesquisa, page=pagina_1based, **kwargs)
-        data = _fetch_page(session, payload)
+        resp = request_fn("POST", BASE_URL, json=payload, timeout=30)
+        data: dict = resp.json()
         time.sleep(1)
         return data
 

--- a/src/juscraper/courts/tjrn/parse.py
+++ b/src/juscraper/courts/tjrn/parse.py
@@ -1,16 +1,8 @@
 """Parse raw results from the TJRN jurisprudence search (Elasticsearch)."""
-import re
-
 import pandas as pd
 
-
-def _clean_html(html_text: str | None) -> str | None:
-    """Remove HTML tags from text."""
-    if not html_text:
-        return html_text
-    text = re.sub(r"<[^>]+>", " ", html_text)
-    text = re.sub(r"\s+", " ", text).strip()
-    return text
+from juscraper.core.parse_utils import clean_html, coerce_date_columns
+from juscraper.utils.cnj import format_cnj
 
 
 def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
@@ -40,20 +32,17 @@ def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
                 "data_publicacao": source.get("dt_publicacao"),
                 "sistema": source.get("sistema"),
                 "sigiloso": source.get("sigiloso"),
-                "ementa": _clean_html(source.get("ementa")),
+                "ementa": clean_html(source.get("ementa")),
             })
 
     df = pd.DataFrame(registros)
     if df.empty:
         return df
 
-    for col in ["data_julgamento", "data_publicacao"]:
-        if col in df.columns:
-            df[col] = pd.to_datetime(df[col], errors="coerce").dt.date
+    coerce_date_columns(df, ["data_julgamento", "data_publicacao"])
 
-    # Format processo as CNJ pattern
     if "processo" in df.columns:
-        df["processo"] = df["processo"].apply(_format_cnj)
+        df["processo"] = df["processo"].apply(lambda v: format_cnj(v, strict=False))
 
     principais = [
         "processo", "classe", "orgao_julgador", "colegiado",
@@ -64,13 +53,3 @@ def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
     cols_restantes = [c for c in df.columns if c not in principais]
     df = df[cols_principais + cols_restantes]
     return df
-
-
-def _format_cnj(numero: str | None) -> str | None:
-    """Format a raw 20-digit number as CNJ pattern NNNNNNN-DD.YYYY.J.TR.OOOO."""
-    if not numero or not numero.isdigit() or len(numero) != 20:
-        return numero
-    return (
-        f"{numero[:7]}-{numero[7:9]}.{numero[9:13]}."
-        f"{numero[13]}.{numero[14:16]}.{numero[16:]}"
-    )

--- a/src/juscraper/courts/tjro/client.py
+++ b/src/juscraper/courts/tjro/client.py
@@ -1,9 +1,8 @@
 """Scraper for the Tribunal de Justica de Rondonia (TJRO)."""
 
 import pandas as pd
-import requests
 
-from juscraper.core.base import BaseScraper
+from juscraper.core.http import HTTPScraper
 from juscraper.utils.params import apply_input_pipeline_search, resolve_deprecated_alias, to_iso_date
 
 from .download import cjsg_download_manager
@@ -11,7 +10,7 @@ from .parse import cjsg_parse_manager
 from .schemas import InputCJSGTJRO
 
 
-class TJROScraper(BaseScraper):
+class TJROScraper(HTTPScraper):
     """Scraper for the Tribunal de Justica de Rondonia (TJRO).
 
     Uses the JURIS Elasticsearch backend at juris-back.tjro.jus.br.
@@ -21,10 +20,6 @@ class TJROScraper(BaseScraper):
 
     def __init__(self):
         super().__init__("TJRO")
-        self.session = requests.Session()
-        self.session.headers.update({
-            "User-Agent": "juscraper/0.1 (https://github.com/jtrecenti/juscraper)",
-        })
 
     def cpopg(self, id_cnj: str | list[str]):
         """Stub: first instance case consultation not implemented for TJRO."""
@@ -159,7 +154,7 @@ class TJROScraper(BaseScraper):
         return cjsg_download_manager(
             pesquisa=inp.pesquisa,
             paginas=inp.paginas,
-            session=self.session,
+            request_fn=self._request_with_retry,
             tipo=inp.tipo,
             nr_processo=inp.numero_processo or "",
             relator=inp.relator or "",

--- a/src/juscraper/courts/tjro/download.py
+++ b/src/juscraper/courts/tjro/download.py
@@ -1,13 +1,10 @@
 """Downloads raw results from the TJRO jurisprudence search (Elasticsearch API)."""
-import logging
 import math
 import time
 from collections.abc import Callable
 
 import requests
 from tqdm import tqdm
-
-logger = logging.getLogger(__name__)
 
 BASE_URL = "https://juris-back.tjro.jus.br/search/varios_parametros/"
 RESULTS_PER_PAGE = 10

--- a/src/juscraper/courts/tjro/download.py
+++ b/src/juscraper/courts/tjro/download.py
@@ -1,10 +1,10 @@
 """Downloads raw results from the TJRO jurisprudence search (Elasticsearch API)."""
 import math
 import time
-from collections.abc import Callable
 
-import requests
 from tqdm import tqdm
+
+from juscraper.core.http import RequestFn
 
 BASE_URL = "https://juris-back.tjro.jus.br/search/varios_parametros/"
 RESULTS_PER_PAGE = 10
@@ -76,7 +76,7 @@ def cjsg_download_manager(
     pesquisa: str,
     paginas=None,
     *,
-    request_fn: Callable[..., requests.Response],
+    request_fn: RequestFn,
     **kwargs,
 ) -> list:
     """Download raw results from the TJRO jurisprudence search.

--- a/src/juscraper/courts/tjro/download.py
+++ b/src/juscraper/courts/tjro/download.py
@@ -2,6 +2,7 @@
 import logging
 import math
 import time
+from collections.abc import Callable
 
 import requests
 from tqdm import tqdm
@@ -74,30 +75,11 @@ def build_cjsg_payload(
     }
 
 
-def _fetch_page(session: requests.Session, payload: dict, max_retries: int = 3) -> dict:
-    """Fetch a single page from the TJRO API with retry logic."""
-    for attempt in range(1, max_retries + 1):
-        try:
-            resp = session.post(BASE_URL, json=payload, timeout=30)
-            resp.raise_for_status()
-            data: dict = resp.json()
-            return data
-        except (requests.RequestException, ValueError) as exc:
-            if attempt == max_retries:
-                raise
-            wait = 2 ** attempt
-            logger.warning(
-                "TJRO request failed (attempt %d/%d): %s. Retrying in %ds...",
-                attempt, max_retries, exc, wait,
-            )
-            time.sleep(wait)
-    return {}  # unreachable
-
-
 def cjsg_download_manager(
     pesquisa: str,
     paginas=None,
-    session: requests.Session | None = None,
+    *,
+    request_fn: Callable[..., requests.Response],
     **kwargs,
 ) -> list:
     """Download raw results from the TJRO jurisprudence search.
@@ -107,19 +89,16 @@ def cjsg_download_manager(
     Args:
         pesquisa: Search term.
         paginas (list, range, or None): Pages to download (1-based).
-        session: Optional requests.Session to reuse.
+        request_fn: HTTP callable que faz retry + raise_for_status — em uso
+            normal e ``TJROScraper._request_with_retry`` (via
+            ``core.http.HTTPScraper``), centralizando backoff para 429/5xx.
         **kwargs: Additional filter parameters forwarded to ``build_cjsg_payload``.
     """
-    if session is None:
-        session = requests.Session()
-        session.headers.update({
-            "User-Agent": "juscraper/0.1 (https://github.com/jtrecenti/juscraper)",
-        })
-
     def _get_page(pagina_1based):
         offset = (pagina_1based - 1) * RESULTS_PER_PAGE
         payload = build_cjsg_payload(pesquisa, offset=offset, **kwargs)
-        data = _fetch_page(session, payload)
+        resp = request_fn("POST", BASE_URL, json=payload, timeout=30)
+        data: dict = resp.json()
         time.sleep(1)
         return data
 

--- a/src/juscraper/courts/tjro/parse.py
+++ b/src/juscraper/courts/tjro/parse.py
@@ -1,26 +1,8 @@
 """Parse raw results from the TJRO jurisprudence search (Elasticsearch)."""
-import re
-
 import pandas as pd
 
-
-def _clean_html(html_text: str | None) -> str | None:
-    """Remove HTML tags from text."""
-    if not html_text:
-        return html_text
-    text = re.sub(r"<[^>]+>", " ", html_text)
-    text = re.sub(r"\s+", " ", text).strip()
-    return text
-
-
-def _format_cnj(numero: str | None) -> str | None:
-    """Format a raw 20-digit number as CNJ pattern NNNNNNN-DD.YYYY.J.TR.OOOO."""
-    if not numero or not numero.isdigit() or len(numero) != 20:
-        return numero
-    return (
-        f"{numero[:7]}-{numero[7:9]}.{numero[9:13]}."
-        f"{numero[13]}.{numero[14:16]}.{numero[16:]}"
-    )
+from juscraper.core.parse_utils import clean_html, coerce_date_columns
+from juscraper.utils.cnj import format_cnj
 
 
 def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
@@ -48,19 +30,17 @@ def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
                 "data_publicacao": source.get("dtpublicacao"),
                 "grau_jurisdicao": source.get("grau_jurisdicao"),
                 "sistema_origem": source.get("sistema_origem"),
-                "ementa": _clean_html(source.get("ds_modelo_documento")),
+                "ementa": clean_html(source.get("ds_modelo_documento")),
             })
 
     df = pd.DataFrame(registros)
     if df.empty:
         return df
 
-    for col in ["data_julgamento", "data_publicacao"]:
-        if col in df.columns:
-            df[col] = pd.to_datetime(df[col], errors="coerce").dt.date
+    coerce_date_columns(df, ["data_julgamento", "data_publicacao"])
 
     if "processo" in df.columns:
-        df["processo"] = df["processo"].apply(_format_cnj)
+        df["processo"] = df["processo"].apply(lambda v: format_cnj(v, strict=False))
 
     principais = [
         "processo", "tipo", "classe", "orgao_julgador",

--- a/src/juscraper/courts/tjrr/client.py
+++ b/src/juscraper/courts/tjrr/client.py
@@ -1,9 +1,8 @@
 """Scraper for the Tribunal de Justica de Roraima (TJRR)."""
 
 import pandas as pd
-import requests
 
-from juscraper.core.base import BaseScraper
+from juscraper.core.http import HTTPScraper
 from juscraper.utils.params import apply_input_pipeline_search
 
 from .download import cjsg_download_manager
@@ -11,7 +10,7 @@ from .parse import cjsg_parse_manager
 from .schemas import InputCJSGTJRR
 
 
-class TJRRScraper(BaseScraper):
+class TJRRScraper(HTTPScraper):
     """Scraper for the Tribunal de Justica de Roraima (TJRR).
 
     Uses the JSF/PrimeFaces-based jurisprudence search at jurisprudencia.tjrr.jus.br.
@@ -21,10 +20,6 @@ class TJRRScraper(BaseScraper):
 
     def __init__(self):
         super().__init__("TJRR")
-        self.session = requests.Session()
-        self.session.headers.update({
-            "User-Agent": "juscraper/0.1 (https://github.com/jtrecenti/juscraper)",
-        })
 
     def cpopg(self, id_cnj: str | list[str]):
         """Stub: first instance case consultation not implemented for TJRR."""
@@ -126,7 +121,7 @@ class TJRRScraper(BaseScraper):
         return cjsg_download_manager(
             pesquisa=inp.pesquisa,
             paginas=inp.paginas,
-            session=self.session,
+            request_fn=self._request_with_retry,
             relator=inp.relator or "",
             data_inicio=inp.data_julgamento_inicio or "",
             data_fim=inp.data_julgamento_fim or "",

--- a/src/juscraper/courts/tjrr/download.py
+++ b/src/juscraper/courts/tjrr/download.py
@@ -1,5 +1,4 @@
 """Downloads raw results from the TJRR jurisprudence search (JSF/PrimeFaces)."""
-import logging
 import re
 import time
 from collections.abc import Callable
@@ -9,8 +8,6 @@ from bs4 import BeautifulSoup
 from tqdm import tqdm
 
 from juscraper.utils.pagination import extract_count_with_cascade
-
-logger = logging.getLogger(__name__)
 
 BASE_URL = "https://jurisprudencia.tjrr.jus.br/index.xhtml"
 RESULTS_PER_PAGE = 10

--- a/src/juscraper/courts/tjrr/download.py
+++ b/src/juscraper/courts/tjrr/download.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import time
+from collections.abc import Callable
 
 import requests
 from bs4 import BeautifulSoup
@@ -63,7 +64,7 @@ def _collect_form_defaults(soup: BeautifulSoup) -> dict:
     return {k: (v[0] if len(v) == 1 else v) for k, v in defaults.items()}
 
 
-def _get_form_fields(session: requests.Session) -> dict:
+def _get_form_fields(request_fn: Callable[..., requests.Response]) -> dict:
     """Fetch the initial page and discover JSF field names and defaults.
 
     JSF auto-generates component IDs like ``menuinicial:j_idt28`` that
@@ -72,8 +73,7 @@ def _get_form_fields(session: requests.Session) -> dict:
     (``id=consultaAtual`` for the search input) and snapshot every form
     default so the POST matches what a browser would send.
     """
-    resp = session.get(BASE_URL, timeout=30)
-    resp.raise_for_status()
+    resp = request_fn("GET", BASE_URL, timeout=30)
     soup = BeautifulSoup(resp.text, "html.parser")
     vs_input = soup.find("input", {"name": "javax.faces.ViewState"})
     if not vs_input:
@@ -96,7 +96,7 @@ def _get_form_fields(session: requests.Session) -> dict:
 
 
 def _search(
-    session: requests.Session,
+    request_fn: Callable[..., requests.Response],
     form_fields: dict,
     pesquisa: str,
     relator: str = "",  # noqa: ARG001 - accepted for API compat; no longer a text input in TJRR
@@ -104,7 +104,6 @@ def _search(
     data_fim: str = "",
     orgao_julgador: list | None = None,
     especie: list | None = None,
-    max_retries: int = 3,
 ) -> str:
     """Submit the search form and return the HTML response."""
     data: dict = dict(form_fields.get("defaults", {}))
@@ -126,22 +125,9 @@ def _search(
         "Origin": "https://jurisprudencia.tjrr.jus.br",
         "Referer": "https://jurisprudencia.tjrr.jus.br/",
     }
-    for attempt in range(1, max_retries + 1):
-        try:
-            resp = session.post(BASE_URL, data=data, headers=headers, timeout=60)
-            resp.raise_for_status()
-            resp.encoding = "utf-8"
-            return resp.text
-        except requests.RequestException as exc:
-            if attempt == max_retries:
-                raise
-            wait = 2 ** attempt
-            logger.warning(
-                "TJRR request failed (attempt %d/%d): %s. Retrying in %ds...",
-                attempt, max_retries, exc, wait,
-            )
-            time.sleep(wait)
-    return ""  # unreachable
+    resp = request_fn("POST", BASE_URL, data=data, headers=headers, timeout=60)
+    resp.encoding = "utf-8"
+    return resp.text
 
 
 _PAGINATION_CSS_SELECTORS: tuple[str, ...] = ("span.ui-paginator-current",)
@@ -163,10 +149,9 @@ def _get_total_pages(html: str) -> int:
 
 
 def _paginate(
-    session: requests.Session,
+    request_fn: Callable[..., requests.Response],
     html: str,
     page: int,
-    max_retries: int = 3,
 ) -> str:
     """Navigate to a specific page using PrimeFaces AJAX pagination."""
     soup = BeautifulSoup(html, "html.parser")
@@ -190,28 +175,16 @@ def _paginate(
         "javax.faces.ViewState": viewstate,
     }
 
-    for attempt in range(1, max_retries + 1):
-        try:
-            resp = session.post(BASE_URL, data=data, timeout=60)
-            resp.raise_for_status()
-            resp.encoding = "utf-8"
-            return _extract_cdata(resp.text)
-        except requests.RequestException as exc:
-            if attempt == max_retries:
-                raise
-            wait = 2 ** attempt
-            logger.warning(
-                "TJRR pagination failed (attempt %d/%d): %s. Retrying in %ds...",
-                attempt, max_retries, exc, wait,
-            )
-            time.sleep(wait)
-    return ""  # unreachable
+    resp = request_fn("POST", BASE_URL, data=data, timeout=60)
+    resp.encoding = "utf-8"
+    return _extract_cdata(resp.text)
 
 
 def cjsg_download_manager(
     pesquisa: str,
     paginas=None,
-    session: requests.Session | None = None,
+    *,
+    request_fn: Callable[..., requests.Response],
     **kwargs,
 ) -> list:
     """Download raw HTML results from the TJRR jurisprudence search.
@@ -221,17 +194,13 @@ def cjsg_download_manager(
     Args:
         pesquisa: Search term.
         paginas (list, range, or None): Pages to download (1-based).
-        session: Optional requests.Session to reuse.
+        request_fn: HTTP callable que faz retry + raise_for_status — em uso
+            normal e ``TJRRScraper._request_with_retry`` (via
+            ``core.http.HTTPScraper``), centralizando backoff para 429/5xx.
         **kwargs: Additional filter parameters.
     """
-    if session is None:
-        session = requests.Session()
-        session.headers.update({
-            "User-Agent": "juscraper/0.1 (https://github.com/jtrecenti/juscraper)",
-        })
-
-    form_fields = _get_form_fields(session)
-    first_html = _search(session, form_fields, pesquisa, **kwargs)
+    form_fields = _get_form_fields(request_fn)
+    first_html = _search(request_fn, form_fields, pesquisa, **kwargs)
     time.sleep(1)
 
     if paginas is None:
@@ -239,7 +208,7 @@ def cjsg_download_manager(
         n_pags = _get_total_pages(first_html)
         if n_pags > 1:
             for pagina in tqdm(range(2, n_pags + 1), desc="Baixando CJSG TJRR"):
-                html = _paginate(session, first_html, pagina)
+                html = _paginate(request_fn, first_html, pagina)
                 resultados.append(html)
                 time.sleep(1)
         return resultados
@@ -250,7 +219,7 @@ def cjsg_download_manager(
         if pagina_1based == 1:
             resultados.append(first_html)
         else:
-            html = _paginate(session, first_html, pagina_1based)
+            html = _paginate(request_fn, first_html, pagina_1based)
             resultados.append(html)
             time.sleep(1)
     return resultados

--- a/src/juscraper/courts/tjrr/download.py
+++ b/src/juscraper/courts/tjrr/download.py
@@ -1,12 +1,11 @@
 """Downloads raw results from the TJRR jurisprudence search (JSF/PrimeFaces)."""
 import re
 import time
-from collections.abc import Callable
 
-import requests
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
+from juscraper.core.http import RequestFn
 from juscraper.utils.pagination import extract_count_with_cascade
 
 BASE_URL = "https://jurisprudencia.tjrr.jus.br/index.xhtml"
@@ -61,7 +60,7 @@ def _collect_form_defaults(soup: BeautifulSoup) -> dict:
     return {k: (v[0] if len(v) == 1 else v) for k, v in defaults.items()}
 
 
-def _get_form_fields(request_fn: Callable[..., requests.Response]) -> dict:
+def _get_form_fields(request_fn: RequestFn) -> dict:
     """Fetch the initial page and discover JSF field names and defaults.
 
     JSF auto-generates component IDs like ``menuinicial:j_idt28`` that
@@ -93,7 +92,7 @@ def _get_form_fields(request_fn: Callable[..., requests.Response]) -> dict:
 
 
 def _search(
-    request_fn: Callable[..., requests.Response],
+    request_fn: RequestFn,
     form_fields: dict,
     pesquisa: str,
     relator: str = "",  # noqa: ARG001 - accepted for API compat; no longer a text input in TJRR
@@ -146,7 +145,7 @@ def _get_total_pages(html: str) -> int:
 
 
 def _paginate(
-    request_fn: Callable[..., requests.Response],
+    request_fn: RequestFn,
     html: str,
     page: int,
 ) -> str:
@@ -181,7 +180,7 @@ def cjsg_download_manager(
     pesquisa: str,
     paginas=None,
     *,
-    request_fn: Callable[..., requests.Response],
+    request_fn: RequestFn,
     **kwargs,
 ) -> list:
     """Download raw HTML results from the TJRR jurisprudence search.

--- a/src/juscraper/courts/tjrr/parse.py
+++ b/src/juscraper/courts/tjrr/parse.py
@@ -4,6 +4,8 @@ import re
 import pandas as pd
 from bs4 import BeautifulSoup
 
+from juscraper.utils.cnj import format_cnj
+
 
 def _parse_result_div(div) -> dict:
     """Parse a single result div from the TJRR search page."""
@@ -23,7 +25,7 @@ def _parse_result_div(div) -> dict:
             for line in lines:
                 line = line.strip()
                 if re.match(r"^\d{20}$", line):
-                    result["processo"] = _format_cnj(line)
+                    result["processo"] = format_cnj(line, strict=False)
                 elif re.match(r"^[A-Z]", line) and "Segredo" not in line:
                     result["classe"] = line.strip()
         elif "RELATOR" in title.upper():
@@ -38,16 +40,6 @@ def _parse_result_div(div) -> dict:
             result["ementa"] = text
 
     return result
-
-
-def _format_cnj(numero: str | None) -> str | None:
-    """Format a raw 20-digit number as CNJ pattern."""
-    if not numero or not numero.isdigit() or len(numero) != 20:
-        return numero
-    return (
-        f"{numero[:7]}-{numero[7:9]}.{numero[9:13]}."
-        f"{numero[13]}.{numero[14:16]}.{numero[16:]}"
-    )
 
 
 def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
@@ -71,6 +63,10 @@ def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
     if df.empty:
         return df
 
+    # TJRR serializa datas como ``DD/MM/AAAA``; sem ``format=`` explicito o
+    # pandas pode interpretar valores ambiguos no formato americano. Mantemos
+    # ``pd.to_datetime`` aqui ate ``core.parse_utils.coerce_date_columns``
+    # ganhar suporte a ``format=``.
     for col in ["data_julgamento", "data_publicacao"]:
         if col in df.columns:
             df[col] = pd.to_datetime(df[col], format="%d/%m/%Y", errors="coerce").dt.date


### PR DESCRIPTION
Primeiro batch da Fase 1 do refactor [#194](https://github.com/jtrecenti/juscraper/issues/194) (sub-issue [#202](https://github.com/jtrecenti/juscraper/issues/202)). Migra TJRN, TJRO e TJRR para a infra centralizada entregue por #201.

## O que muda

- **`client.py`** dos 3 passa a herdar `core.http.HTTPScraper` em vez de `BaseScraper`. Construtor enxuto (`super().__init__("TJRN")`); a session com `User-Agent` padrão vem da base.
- **`download.py`** dos 3 remove o `_fetch_page` local (retry exponencial duplicado). O `cjsg_download_manager` troca `session=` por `request_fn=` (callable do retry centralizado, alimentado pelo client com `self._request_with_retry`).
- **`parse.py`**:
  - TJRN/TJRO: `_clean_html` privado → `core.parse_utils.clean_html`; loop `pd.to_datetime(..., errors="coerce").dt.date` → `coerce_date_columns`
  - TJRN/TJRO/TJRR: `_format_cnj` privado → `utils.cnj.format_cnj(strict=False)`
  - TJRR mantém `pd.to_datetime(..., format="%d/%m/%Y", errors="coerce")` explícito porque o helper `coerce_date_columns` ainda não expõe `format=` e as datas TJRR são `DD/MM/AAAA` (ambíguas sem hint)

Saldo: **-131 linhas líquidas** (195 removidas, 64 adicionadas).

## Itens da checklist da #202

- [x] Regra 1: 3 clients herdam `HTTPScraper`
- [x] Regra 2: 3 download.py usam retry centralizado via `request_fn` (substitui `session.post` + `_fetch_page`)
- [x] Regra 3: parsers importam `clean_html`/`coerce_date_columns`/`format_cnj`
- [x] Regra 4: nada de teste granular novo — `session="oops"` → `TypeError` já é coberto em `tests/core/test_http.py` (caso #185) e os 3 herdam a validação
- [x] Regra 5: entrada em `CHANGELOG.md > [Unreleased] > Changed`
- [x] Regra 6: tribunais wired (`InputCJSGTJRN`/`InputCJSGTJRO`/`InputCJSGTJRR` já existem com `extra="forbid"`) — validação `session=` herdada do `HTTPScraper._request_with_retry`
- [x] Regra 7: `pytest tests/{tjrn,tjro,tjrr} tests/core` → 78 passed; `pytest -k contract` → 499 passed, zero-diff de schema (as 10 falhas restantes em TRF1/TRF3/TRF5 são pré-existentes — lxml ausente; verificadas via `git stash` na main)
- [ ] Regra 8: atualizar tabela na #194 — a fazer no comentário desta issue após merge

## Pré-requisitos

- ✅ #201 (infra `core/`) — merged via #209 em 2026-05-02

## Refs

- [#194](https://github.com/jtrecenti/juscraper/issues/194) (guarda-chuva)
- [#202](https://github.com/jtrecenti/juscraper/issues/202) (Fase 1 — esta issue)
- [#201](https://github.com/jtrecenti/juscraper/issues/201) (infra; pré-requisito)
- [#185](https://github.com/jtrecenti/juscraper/issues/185) (validação `session=`; resolvida pela infra)

## Test plan

- [x] `pytest tests/tjrn tests/tjro tests/tjrr tests/core` (78 passed, 1 xfail TJRR #158)
- [x] `pytest -k contract` (499 passed; 10 failures pré-existentes em TRF1/TRF3/TRF5 sem lxml — confirmado idêntico na `main`)
- [x] `pytest` completo (1458 passed; falhas TRF reproduzidas na main)
- [ ] Smoke test live com `tjrn.cjsg("direito", paginas=1)` (deixei pendente — `@pytest.mark.integration` não roda no CI offline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)