### PR TITLE
test: cobertura end-to-end de coercao DD/MM/AAAA -> ISO em 9 tribunais

### DIFF
--- a/tests/tjba/test_cjsg_filters_contract.py
+++ b/tests/tjba/test_cjsg_filters_contract.py
@@ -138,3 +138,38 @@ def test_cjsg_classe_e_classes_juntos_levanta_value_error():
         jus.scraper("tjba").cjsg(
             "dano moral", paginas=1, classe=[100], classes=[200]
         )
+
+
+@responses.activate
+def test_cjsg_data_publicacao_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao backend GraphQL.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJBA`
+    e convertendo via ``coerce_brazilian_date``. Se o schema esquecer de
+    declarar o ``BACKEND_DATE_FORMAT`` (cai no default ``%d/%m/%Y``), o
+    backend recebe ``01/01/2024`` cru e o matcher dispara
+    ``ConnectionError`` (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE,
+        body=load_sample("tjba", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(_payload(
+            "dano moral",
+            0,
+            data_publicacao_inicio="2024-01-01",
+            data_publicacao_fim="2024-03-31",
+        ))],
+    )
+
+    df = jus.scraper("tjba").cjsg(
+        "dano moral",
+        paginas=1,
+        data_publicacao_inicio="01/01/2024",
+        data_publicacao_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjdft/test_cjsg_filters_contract.py
+++ b/tests/tjdft/test_cjsg_filters_contract.py
@@ -139,3 +139,37 @@ def test_cjsg_tamanho_pagina_collision_raises():
         jus.scraper("tjdft").cjsg(
             "dano moral", paginas=1, tamanho_pagina=25, quantidade_por_pagina=50
         )
+
+
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao backend.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJDFT`
+    e convertendo via ``coerce_brazilian_date``. A data isolada chega ao
+    payload como ``termosAcessorios`` na forma canonica
+    ``"entre 2024-01-01 e 2024-03-31"`` — se o pipeline esquecer de
+    coagir, o termo carrega o formato BR cru e o matcher dispara
+    ``ConnectionError`` (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    expected_termos = [
+        {"campo": "dataJulgamento", "valor": "entre 2024-01-01 e 2024-03-31"},
+    ]
+    responses.add(
+        responses.POST,
+        BASE,
+        body=load_sample("tjdft", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(_payload("dano moral", 1, termos_acessorios=expected_termos))],
+    )
+
+    df = jus.scraper("tjdft").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjes/test_cjsg_filters_contract.py
+++ b/tests/tjes/test_cjsg_filters_contract.py
@@ -280,3 +280,35 @@ def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
+def test_cjpg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao backend Solr.
+
+    Espelha ``test_cjsg_data_julgamento_aceita_formato_brasileiro`` para o
+    endpoint ``cjpg``. Cobre o caminho end-to-end de
+    ``apply_input_pipeline_search`` lendo ``BACKEND_DATE_FORMAT='%Y-%m-%d'``
+    declarado em :class:`InputCJPGTJES` e convertendo via
+    ``coerce_brazilian_date``. Se o schema esquecer de declarar o
+    ``BACKEND_DATE_FORMAT``, o backend recebe ``dataIni=01/01/2024`` em
+    vez de ``dataIni=2024-01-01`` e o matcher dispara ``ConnectionError``
+    (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    _add_page(
+        "dano moral",
+        1,
+        "cjpg/no_results.json",
+        core="pje1g",
+        data_inicio="2024-01-01",
+        data_fim="2024-03-31",
+    )
+
+    df = jus.scraper("tjes").cjpg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjes/test_cjsg_filters_contract.py
+++ b/tests/tjes/test_cjsg_filters_contract.py
@@ -251,3 +251,32 @@ def test_cjpg_tamanho_pagina_collision_raises():
         jus.scraper("tjes").cjpg(
             "dano moral", paginas=1, tamanho_pagina=5, per_page=10
         )
+
+
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao backend Solr.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJES`
+    e convertendo via ``coerce_brazilian_date``. Se o schema esquecer de
+    declarar o ``BACKEND_DATE_FORMAT``, o backend recebe ``dataIni=01/01/2024``
+    em vez de ``dataIni=2024-01-01`` e o matcher dispara ``ConnectionError``
+    (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    _add_page(
+        "dano moral",
+        1,
+        "cjsg/no_results.json",
+        data_inicio="2024-01-01",
+        data_fim="2024-03-31",
+    )
+
+    df = jus.scraper("tjes").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjmt/test_cjsg_filters_contract.py
+++ b/tests/tjmt/test_cjsg_filters_contract.py
@@ -153,3 +153,34 @@ def test_cjsg_tamanho_pagina_collision_raises():
         jus.scraper("tjmt").cjsg(
             "dano moral", paginas=1, tamanho_pagina=5, quantidade_por_pagina=10
         )
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao Hellsgate.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJMT`
+    e convertendo via ``coerce_brazilian_date``. Se o schema esquecer de
+    declarar o ``BACKEND_DATE_FORMAT`` (cai no default ``%d/%m/%Y``), o
+    backend recebe ``filtro.periodoDataDe=01/01/2024`` em vez de
+    ``2024-01-01`` e o matcher dispara ``ConnectionError`` (refs #182,
+    #173, #167)."""
+    mocker.patch("time.sleep")
+    _add_config()
+    _add_page(
+        "dano moral",
+        1,
+        "cjsg/no_results.json",
+        data_julgamento_inicio="2024-01-01",
+        data_julgamento_fim="2024-03-31",
+    )
+
+    df = jus.scraper("tjmt").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjpa/test_cjsg_filters_contract.py
+++ b/tests/tjpa/test_cjsg_filters_contract.py
@@ -161,3 +161,43 @@ def test_cjsg_download_unknown_kwarg_raises():
         "dano moral",
         paginas=1,
     )
+
+
+@responses.activate
+def test_cjsg_datas_aceitam_formato_brasileiro(mocker):
+    """Datas de julgamento e publicacao em ``DD/MM/YYYY`` chegam coercidas
+    em ISO ao BFF.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJPA`
+    e convertendo ambos os intervalos via ``coerce_brazilian_date``. Se o
+    schema esquecer de declarar o ``BACKEND_DATE_FORMAT``, o backend recebe
+    ``dataJulgamentoInicio=01/01/2024`` em vez de ``2024-01-01`` e o
+    matcher dispara ``ConnectionError`` (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjpa", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral",
+            pagina_0based=0,
+            data_julgamento_inicio="2024-01-01",
+            data_julgamento_fim="2024-03-31",
+            data_publicacao_inicio="2024-02-01",
+            data_publicacao_fim="2024-04-30",
+        ))],
+    )
+
+    df = jus.scraper("tjpa").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+        data_publicacao_inicio="01/02/2024",
+        data_publicacao_fim="30/04/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjpi/test_cjsg_filters_contract.py
+++ b/tests/tjpi/test_cjsg_filters_contract.py
@@ -215,3 +215,38 @@ def test_cjsg_download_data_inicio_alias_maps_to_data_min(mocker):
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
     assert any("data_fim" in m and "deprecado" in m for m in messages)
+
+
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao backend.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJPI`
+    e convertendo via ``coerce_brazilian_date``. Se o schema esquecer de
+    declarar o ``BACKEND_DATE_FORMAT``, o backend recebe
+    ``data_min=01/01/2024`` em vez de ``2024-01-01`` e o matcher dispara
+    ``ConnectionError`` (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.GET,
+        BASE_URL,
+        body=load_sample("tjpi", "cjsg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+        match=[query_param_matcher(build_cjsg_params(
+            "dano moral",
+            page=1,
+            data_min="2024-01-01",
+            data_max="2024-03-31",
+        ))],
+    )
+
+    df = jus.scraper("tjpi").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjrn/test_cjsg_filters_contract.py
+++ b/tests/tjrn/test_cjsg_filters_contract.py
@@ -293,3 +293,40 @@ def test_cjsg_download_data_inicio_alias_maps_to_data_julgamento(mocker):
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
     assert any("data_fim" in m and "deprecado" in m for m in messages)
+
+
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao pipeline.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJRN`
+    e convertendo via ``coerce_brazilian_date``. Apos a coercao, o
+    ``_to_tjrn_date`` ainda reformata o ISO para ``DD-MM-YYYY`` (com tracos)
+    porque o backend Elasticsearch so aceita esse formato. O matcher fixa
+    o resultado final no body — se a coercao do schema nao acontecer, o
+    pipeline tenta passar ``01/01/2024`` para o ``_to_tjrn_date`` e o
+    backend recebe um valor invalido (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjrn", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral",
+            page=1,
+            dt_inicio="01-01-2024",
+            dt_fim="31-03-2024",
+        ))],
+    )
+
+    df = jus.scraper("tjrn").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjro/test_cjsg_filters_contract.py
+++ b/tests/tjro/test_cjsg_filters_contract.py
@@ -326,3 +326,38 @@ def test_cjsg_download_data_inicio_alias_maps_to_data_julgamento(mocker):
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
     assert any("data_fim" in m and "deprecado" in m for m in messages)
+
+
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/YYYY`` chegam coercidas em ISO ao backend JURIS.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJRO`
+    e convertendo via ``coerce_brazilian_date``. Se o schema esquecer de
+    declarar o ``BACKEND_DATE_FORMAT``, o backend recebe
+    ``data_julgamento_inicio=01/01/2024`` no body em vez de ``2024-01-01``
+    e o matcher dispara ``ConnectionError`` (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjro", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral",
+            offset=0,
+            data_julgamento_inicio="2024-01-01",
+            data_julgamento_fim="2024-03-31",
+        ))],
+    )
+
+    df = jus.scraper("tjro").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjsc/test_cjsg_filters_contract.py
+++ b/tests/tjsc/test_cjsg_filters_contract.py
@@ -205,3 +205,46 @@ def test_cjsg_download_data_inicio_alias_maps_to_dt_decisao(mocker):
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
     assert any("data_fim" in m and "deprecado" in m for m in messages)
+
+
+@responses.activate
+def test_cjsg_datas_aceitam_formato_brasileiro(mocker):
+    """Datas de julgamento e publicacao em ``DD/MM/YYYY`` chegam coercidas
+    em ISO ao form body do eproc.
+
+    Cobre o caminho end-to-end de ``apply_input_pipeline_search`` lendo
+    ``BACKEND_DATE_FORMAT='%Y-%m-%d'`` declarado em :class:`InputCJSGTJSC`
+    e convertendo ambos os intervalos via ``coerce_brazilian_date``. Se o
+    schema esquecer de declarar o ``BACKEND_DATE_FORMAT``, o backend
+    recebe ``dtDecisaoInicio=01/01/2024`` em vez de ``2024-01-01`` e o
+    matcher dispara ``ConnectionError`` (refs #182, #173, #167)."""
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        cjsg_url_for_page(1),
+        body=load_sample_bytes("tjsc", "cjsg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=iso-8859-1",
+        match=[urlencoded_params_matcher(
+            build_cjsg_form_body(
+                "dano moral",
+                page=1,
+                dt_decisao_inicio="2024-01-01",
+                dt_decisao_fim="2024-03-31",
+                dt_publicacao_inicio="2024-02-01",
+                dt_publicacao_fim="2024-04-30",
+            ),
+            allow_blank=True,
+        )],
+    )
+
+    df = jus.scraper("tjsc").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+        data_publicacao_inicio="01/02/2024",
+        data_publicacao_fim="30/04/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)


### PR DESCRIPTION
## Summary

Fecha o gap descrito na issue #182: a coercao `DD/MM/YYYY -> YYYY-MM-DD` em si vive em `apply_input_pipeline_search` (via `coerce_brazilian_date` lendo `BACKEND_DATE_FORMAT` do schema) e ja tem cobertura unitaria solida no helper. O que faltava era integracao: nenhum tribunal com `BACKEND_DATE_FORMAT='%Y-%m-%d'` exercia o caminho end-to-end **input BR -> backend ISO** via API publica.

## O risco coberto

Se um tribunal:
- esquecer de declarar `BACKEND_DATE_FORMAT: ClassVar[str] = "%Y-%m-%d"` (cai no default `%d/%m/%Y`),
- pular o `apply_input_pipeline_search` e manter `normalize_datas` manual sem coercao, ou
- adicionar uma transformacao manual de data em `download.py` que conflita com o helper,

…os testes do helper continuam verdes, mas o tribunal silenciosamente envia o formato errado. O contract test detecta a regressao porque o body real do request carrega o formato BR cru e o matcher dispara `ConnectionError`.

## Tribunais cobertos (9 tribunais / 10 testes)

| Tribunal | Endpoint(s) | Mixin | Backend field | Particularidade |
|----------|-------------|-------|---------------|-----------------|
| TJBA | cjsg | DataPublicacao | `dataInicial`/`dataFinal` (GraphQL) | `2024-01-01T03:00:00.000Z` |
| TJMT | cjsg | DataJulgamento | `filtro.periodoData*` (Hellsgate) | — |
| TJDFT | cjsg | both | `termosAcessorios` | `"entre 2024-01-01 e 2024-03-31"` |
| TJES | **cjsg + cjpg** | DataJulgamento | `dataIni`/`dataFim` (Solr) | core `pje2g` (cjsg) e `pje1g` (cjpg) |
| TJPA | cjsg | both | `dataJulgamento*` + `dataPublicacao*` (BFF) | testa ambos os intervalos |
| TJPI | cjsg | DataJulgamento | `data_min`/`data_max` (renomeados) | — |
| TJRN | cjsg | DataJulgamento | `dt_inicio`/`dt_fim` (DD-MM-YYYY) | apos coercao ISO, `_to_tjrn_date` reformata para DD-MM com tracos |
| TJRO | cjsg | DataJulgamento | `data_julgamento_*` (JURIS body) | — |
| TJSC | cjsg | both | `dtDecisao*` + `dtPublicacao*` (eproc form) | testa ambos os intervalos |

`comunica_cnj` ja tinha o equivalente (`test_listar_comunicacoes_aceita_data_em_formato_brasileiro` em `test_listar_comunicacoes_filters_contract.py`), entao nao precisou de novo teste.

## Padrao do teste

Cada teste e quase identico ao `test_cjsg_all_filters_land_in_*` ja existente, com 3 mudancas:

1. matcher recebe a data em **ISO**;
2. chamada publica passa a data em **DD/MM/YYYY**;
3. docstring documenta o que falha caso a coercao nao aconteca.

Exemplo (TJBA):

```python
@responses.activate
def test_cjsg_data_publicacao_aceita_formato_brasileiro(mocker):
    mocker.patch("time.sleep")
    responses.add(
        responses.POST, BASE,
        body=load_sample("tjba", "cjsg/no_results.json"),
        status=200, content_type="application/json",
        match=[json_params_matcher(_payload(
            "dano moral", 0,
            data_publicacao_inicio="2024-01-01",  # matcher espera ISO
            data_publicacao_fim="2024-03-31",
        ))],
    )
    df = jus.scraper("tjba").cjsg(
        "dano moral", paginas=1,
        data_publicacao_inicio="01/01/2024",      # input em BR
        data_publicacao_fim="31/03/2024",
    )
    assert isinstance(df, pd.DataFrame)
```

Nenhum sample novo; tudo reaproveita `cjsg/no_results.*` ja existente.

## Test plan

- [x] `pytest tests/tjba tests/tjmt tests/tjdft tests/tjes tests/tjpa tests/tjpi tests/tjrn tests/tjro tests/tjsc` -> verde (140+ testes, sem regressao)
- [x] Pre-commit hooks (isort/flake8/mypy) verde
- [x] Os 10 testes novos sozinhos passam:
  - `tests/tjba/test_cjsg_filters_contract.py::test_cjsg_data_publicacao_aceita_formato_brasileiro`
  - `tests/tjmt/test_cjsg_filters_contract.py::test_cjsg_data_julgamento_aceita_formato_brasileiro`
  - `tests/tjdft/test_cjsg_filters_contract.py::test_cjsg_data_julgamento_aceita_formato_brasileiro`
  - `tests/tjes/test_cjsg_filters_contract.py::test_cjsg_data_julgamento_aceita_formato_brasileiro`
  - `tests/tjes/test_cjsg_filters_contract.py::test_cjpg_data_julgamento_aceita_formato_brasileiro`
  - `tests/tjpa/test_cjsg_filters_contract.py::test_cjsg_datas_aceitam_formato_brasileiro`
  - `tests/tjpi/test_cjsg_filters_contract.py::test_cjsg_data_julgamento_aceita_formato_brasileiro`
  - `tests/tjrn/test_cjsg_filters_contract.py::test_cjsg_data_julgamento_aceita_formato_brasileiro`
  - `tests/tjro/test_cjsg_filters_contract.py::test_cjsg_data_julgamento_aceita_formato_brasileiro`
  - `tests/tjsc/test_cjsg_filters_contract.py::test_cjsg_datas_aceitam_formato_brasileiro`

Closes #182.
