### PR TITLE
feat(core): coerce_date_columns aceita date_format opcional

### DIFF
--- a/src/juscraper/core/parse_utils.py
+++ b/src/juscraper/core/parse_utils.py
@@ -51,7 +51,12 @@ def clean_html(text: str | None, decode_entities: bool = True) -> str | None:
     return _WHITESPACE_RE.sub(" ", text).strip()
 
 
-def coerce_date_columns(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
+def coerce_date_columns(
+    df: pd.DataFrame,
+    cols: list[str],
+    *,
+    date_format: str | None = None,
+) -> pd.DataFrame:
     """Coage colunas para ``date`` via ``pd.to_datetime(..., errors="coerce").dt.date``.
 
     Mutação **in-place** + retorno (padrão pandas para encadeamento). Colunas
@@ -60,6 +65,11 @@ def coerce_date_columns(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
     Args:
         df: DataFrame alvo.
         cols: Nomes de coluna candidatas a normalizar.
+        date_format: Formato strptime explícito repassado a ``pd.to_datetime``
+            (keyword-only). Use para tribunais que serializam datas em formato
+            ambíguo como ``DD/MM/AAAA`` — sem isso, o pandas pode interpretar o
+            valor no formato americano. Default ``None`` preserva o
+            comportamento de inferência do pandas (ISO e similares).
 
     Returns:
         O próprio ``df``.
@@ -68,5 +78,5 @@ def coerce_date_columns(df: pd.DataFrame, cols: list[str]) -> pd.DataFrame:
         return df
     for col in cols:
         if col in df.columns:
-            df[col] = pd.to_datetime(df[col], errors="coerce").dt.date
+            df[col] = pd.to_datetime(df[col], format=date_format, errors="coerce").dt.date
     return df

--- a/src/juscraper/core/parse_utils.py
+++ b/src/juscraper/core/parse_utils.py
@@ -73,6 +73,12 @@ def coerce_date_columns(
 
     Returns:
         O próprio ``df``.
+
+    Example:
+        >>> # Default: inferência do pandas (ISO e similares).
+        >>> coerce_date_columns(df, ["data_julgamento"])
+        >>> # Formato ambíguo DD/MM/AAAA — usar ``date_format`` explícito.
+        >>> coerce_date_columns(df, ["data_julgamento"], date_format="%d/%m/%Y")
     """
     if df.empty:
         return df

--- a/src/juscraper/courts/tjrr/parse.py
+++ b/src/juscraper/courts/tjrr/parse.py
@@ -4,6 +4,7 @@ import re
 import pandas as pd
 from bs4 import BeautifulSoup
 
+from juscraper.core.parse_utils import coerce_date_columns
 from juscraper.utils.cnj import format_cnj
 
 
@@ -63,13 +64,7 @@ def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
     if df.empty:
         return df
 
-    # TJRR serializa datas como ``DD/MM/AAAA``; sem ``format=`` explicito o
-    # pandas pode interpretar valores ambiguos no formato americano. Mantemos
-    # ``pd.to_datetime`` aqui ate ``core.parse_utils.coerce_date_columns``
-    # ganhar suporte a ``format=``.
-    for col in ["data_julgamento", "data_publicacao"]:
-        if col in df.columns:
-            df[col] = pd.to_datetime(df[col], format="%d/%m/%Y", errors="coerce").dt.date
+    coerce_date_columns(df, ["data_julgamento", "data_publicacao"], date_format="%d/%m/%Y")
 
     principais = [
         "processo", "classe", "relator", "orgao_julgador",

--- a/tests/core/test_parse_utils.py
+++ b/tests/core/test_parse_utils.py
@@ -83,6 +83,30 @@ class TestCoerceDateColumns:
         assert df["data_publicacao"].iloc[0] == dt.date(2024, 1, 20)
         assert df["outra"].iloc[0] == "x"
 
+    def test_date_format_br(self):
+        # Sem ``date_format``, ``03/02/2024`` poderia ser lido como
+        # 2 de março (formato americano). Com ``%d/%m/%Y`` virou 3 de fevereiro.
+        df = pd.DataFrame({"data_julgamento": ["03/02/2024", "15/01/2024"]})
+        coerce_date_columns(df, ["data_julgamento"], date_format="%d/%m/%Y")
+        assert df["data_julgamento"].tolist() == [dt.date(2024, 2, 3), dt.date(2024, 1, 15)]
+
+    def test_date_format_keyword_only(self):
+        df = pd.DataFrame({"data_julgamento": ["03/02/2024"]})
+        with pytest.raises(TypeError):
+            coerce_date_columns(df, ["data_julgamento"], "%d/%m/%Y")  # type: ignore[misc]
+
+    def test_date_format_invalid_for_content_returns_nat(self):
+        # Conteúdo ISO não bate com ``%d/%m/%Y`` -> ``errors="coerce"`` vira NaT.
+        df = pd.DataFrame({"data_julgamento": ["2024-01-15", "2024-02-20"]})
+        coerce_date_columns(df, ["data_julgamento"], date_format="%d/%m/%Y")
+        assert df["data_julgamento"].isna().all()
+
+    def test_date_format_none_default_preserves_iso(self):
+        # ``date_format=None`` (default) mantém o caminho de inferência atual.
+        df = pd.DataFrame({"data_julgamento": ["2024-01-15"]})
+        coerce_date_columns(df, ["data_julgamento"], date_format=None)
+        assert df["data_julgamento"].iloc[0] == dt.date(2024, 1, 15)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/core/test_parse_utils.py
+++ b/tests/core/test_parse_utils.py
@@ -107,6 +107,11 @@ class TestCoerceDateColumns:
         coerce_date_columns(df, ["data_julgamento"], date_format=None)
         assert df["data_julgamento"].iloc[0] == dt.date(2024, 1, 15)
 
+    def test_returns_same_df_with_date_format(self):
+        df = pd.DataFrame({"data_julgamento": ["15/01/2024"]})
+        out = coerce_date_columns(df, ["data_julgamento"], date_format="%d/%m/%Y")
+        assert out is df
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Resumo

- `coerce_date_columns` ganha kwarg keyword-only `date_format: str | None = None`, repassado a `pd.to_datetime`. Default `None` preserva o caminho de inferência atual byte-a-byte (testes existentes passam sem mudança).
- TJRR migra para o helper, eliminando o loop manual e o comentário de workaround (`pd.to_datetime(..., format="%d/%m/%Y", errors="coerce").dt.date`).
- Os próximos batches do refactor #202 (TJAP/TJRS/TJES, todos `DD/MM/AAAA`) já podem usar o helper sem duplicar a gambiarra.

## Spec aplicada (do issue)

- Nome do parâmetro: `date_format` (evita shadow do builtin `format()`).
- Keyword-only após `*`: chamada explícita `coerce_date_columns(df, cols, date_format="%d/%m/%Y")`. Sem risco de quebrar chamadas existentes (`(df, cols)` continua válido).
- Default `None` preserva comportamento atual.
- Aplica a todas as colunas da lista — caso "ISO + DD/MM/AAAA no mesmo DataFrame" resolve com 2 chamadas.

## Testes

Adicionados em `tests/core/test_parse_utils.py::TestCoerceDateColumns`:

- `test_date_format_br` — `03/02/2024` com `%d/%m/%Y` vira 3-fev (não 2-mar).
- `test_date_format_keyword_only` — chamada posicional levanta `TypeError`.
- `test_date_format_invalid_for_content_returns_nat` — ISO contra `%d/%m/%Y` vira `NaT` via `errors="coerce"`.
- `test_date_format_none_default_preserves_iso` — explicita o caminho default.

`pytest` (offline): 1533 passed, 26 skipped, 1 xfailed em ~17s.

## Critério de pronto

- [x] `coerce_date_columns` aceita `date_format: str | None = None` (keyword-only)
- [x] Default `None` preserva comportamento atual (testes existentes verdes sem mudança)
- [x] Teste novo cobrindo (a) caminho default, (b) com `date_format="%d/%m/%Y"`, (c) com `date_format` inválido para o conteúdo (todos `NaT`)
- [x] `tjrr/parse.py` migrado para usar o helper (sem entrada de CHANGELOG — refactor interno sem mudança de API pública)
- [ ] Linha "Conversão de colunas de data" em #194 atualizada para 3/13 migrados (TJRN, TJRO, TJRR) — fica para um update manual no comentário do guarda-chuva.

## Test plan

- [x] `uv run pytest tests/core/test_parse_utils.py tests/tjrr -x`
- [x] `uv run pytest` (suíte offline completa)
- [ ] Reviewer confirma que o naming `date_format` (vs `format`) é o esperado.

Closes #243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)