### PR TITLE
test(tjpe): contrato offline de propagação de filtros para cjsg

### DIFF
--- a/tests/tjpe/test_cjsg_filters_contract.py
+++ b/tests/tjpe/test_cjsg_filters_contract.py
@@ -18,7 +18,9 @@ junto com :class:`InputCJSGTJPE` no PR de wiring.
 """
 from __future__ import annotations
 
+import logging
 import warnings
+from urllib.parse import parse_qs
 
 import pandas as pd
 import pytest
@@ -30,6 +32,15 @@ from tests._helpers import load_sample, urlencoded_body_subset_matcher
 from tests.tjpe.test_cjsg_contract import CONSULTA_URL
 
 FORM = "formPesquisaJurisprudencia"
+
+
+@pytest.fixture(autouse=True)
+def _silence_unexpected_response_warning(caplog):
+    # ``no_results.html`` nao casa com ``_is_results_page`` nem com
+    # ``_is_escolha_page``, entao o scraper cai no ramo "unexpected response"
+    # e emite ``logger.warning``. Limita a captura do caplog para que o ruido
+    # nao polua a saida se algum teste vier a falhar.
+    caplog.set_level(logging.ERROR, logger="juscraper.courts.tjpe.download")
 
 
 def _add_get_consulta() -> None:
@@ -95,7 +106,6 @@ def test_cjsg_tipo_decisao_monocraticas_marks_only_monocratica_checkbox(mocker):
     todos = f"{FORM}:tipoTodos"
 
     def assert_only_monocratica(request):
-        from urllib.parse import parse_qs
         body = request.body or b""
         if isinstance(body, bytes):
             body = body.decode("utf-8")

--- a/tests/tjpe/test_cjsg_filters_contract.py
+++ b/tests/tjpe/test_cjsg_filters_contract.py
@@ -1,0 +1,223 @@
+"""Filter-propagation contract for TJPE cjsg.
+
+TJPE e JSF/RichFaces: filtros viajam como campos form-urlencoded no corpo do
+``POST consulta.xhtml``. O scraper carrega o ``ViewState`` do GET inicial, entao
+a suite usa ``OrderedRegistry`` (mesmo padrao do
+:mod:`tests.tjpe.test_cjsg_contract`) e cada teste registra GET + POST em ordem.
+
+Cada teste responde o POST com ``no_results.html`` ("Nenhum documento
+encontrado"). A sample nao bate em ``_is_results_page`` nem em
+``_is_escolha_page``, entao o scraper retorna lista vazia antes de qualquer
+AJAX de paginacao — duas chamadas HTTP bastam para fechar o contrato dos
+campos do form, sem precisar fixar pagina seguinte.
+
+TJPE ainda nao foi wired com pydantic (etapa 2 da #197), entao nao ha
+``test_cjsg_unknown_kwarg_raises`` aqui: kwargs desconhecidos sao silenciosamente
+descartados via ``**kwargs`` ate o wiring entrar. Esse teste deve ser adicionado
+junto com :class:`InputCJSGTJPE` no PR de wiring.
+"""
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+import responses
+from responses.registries import OrderedRegistry
+
+import juscraper as jus
+from tests._helpers import load_sample, urlencoded_body_subset_matcher
+from tests.tjpe.test_cjsg_contract import CONSULTA_URL
+
+FORM = "formPesquisaJurisprudencia"
+
+
+def _add_get_consulta() -> None:
+    responses.add(
+        responses.GET,
+        CONSULTA_URL,
+        body=load_sample("tjpe", "cjsg/step_01_consulta.html"),
+        status=200,
+        content_type="text/html; charset=UTF-8",
+    )
+
+
+def _add_post_no_results(*, match=None) -> None:
+    responses.add(
+        responses.POST,
+        CONSULTA_URL,
+        body=load_sample("tjpe", "cjsg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=UTF-8",
+        match=match or [],
+    )
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_all_filters_land_in_form_body(mocker):
+    """Todos os filtros publicos chegam ao corpo do POST consulta.xhtml."""
+    mocker.patch("time.sleep")
+    expected = {
+        f"{FORM}:inputBuscaSimples": "dano moral",
+        f"{FORM}:j_id59InputDate": "01/01/2024",
+        f"{FORM}:periodoFimInputDate": "31/03/2024",
+        f"{FORM}:selectRelator": "REL-123",
+        f"{FORM}:selectClasseCNJ": "100",
+        f"{FORM}:selectAssuntoCNJ": "200",
+        f"{FORM}:selectMeioTramitacao": "ELETRONICO",
+        f"{FORM}:tipoAcordao": "on",
+    }
+    _add_get_consulta()
+    _add_post_no_results(match=[urlencoded_body_subset_matcher(expected)])
+
+    df = jus.scraper("tjpe").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+        relator="REL-123",
+        classe="100",
+        assunto="200",
+        meio_tramitacao="ELETRONICO",
+        tipo_decisao="acordaos",
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_tipo_decisao_monocraticas_marks_only_monocratica_checkbox(mocker):
+    """``tipo_decisao='monocraticas'`` ativa so o checkbox tipoDecisaoMonocratica."""
+    mocker.patch("time.sleep")
+
+    monocratica = f"{FORM}:tipoDecisaoMonocratica"
+    acordao = f"{FORM}:tipoAcordao"
+    todos = f"{FORM}:tipoTodos"
+
+    def assert_only_monocratica(request):
+        from urllib.parse import parse_qs
+        body = request.body or b""
+        if isinstance(body, bytes):
+            body = body.decode("utf-8")
+        parsed = {
+            k: v[0] if v else ""
+            for k, v in parse_qs(body, keep_blank_values=True).items()
+        }
+        if parsed.get(monocratica) != "on":
+            return False, "tipoDecisaoMonocratica ausente"
+        if acordao in parsed:
+            return False, "tipoAcordao nao deveria estar presente"
+        if todos in parsed:
+            return False, "tipoTodos nao deveria estar presente"
+        return True, ""
+
+    _add_get_consulta()
+    _add_post_no_results(match=[assert_only_monocratica])
+
+    df = jus.scraper("tjpe").cjsg("dano moral", paginas=1, tipo_decisao="monocraticas")
+    assert df.empty
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_tipo_decisao_todos_marks_all_three_checkboxes(mocker):
+    """``tipo_decisao='todos'`` ativa tipoAcordao + tipoDecisaoMonocratica + tipoTodos."""
+    mocker.patch("time.sleep")
+    expected = {
+        f"{FORM}:tipoAcordao": "on",
+        f"{FORM}:tipoDecisaoMonocratica": "on",
+        f"{FORM}:tipoTodos": "on",
+    }
+    _add_get_consulta()
+    _add_post_no_results(match=[urlencoded_body_subset_matcher(expected)])
+
+    df = jus.scraper("tjpe").cjsg("dano moral", paginas=1, tipo_decisao="todos")
+    assert df.empty
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_query_alias_emits_deprecation_warning(mocker):
+    """O alias deprecado ``query`` e normalizado antes do form ser montado."""
+    mocker.patch("time.sleep")
+    _add_get_consulta()
+    _add_post_no_results(
+        match=[urlencoded_body_subset_matcher({f"{FORM}:inputBuscaSimples": "dano moral"})]
+    )
+
+    with pytest.warns(DeprecationWarning, match="query.*deprecado"):
+        df = jus.scraper("tjpe").cjsg(pesquisa=None, query="dano moral", paginas=1)
+
+    assert df.empty
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_termo_alias_emits_deprecation_warning(mocker):
+    """O alias deprecado ``termo`` tambem e normalizado para ``pesquisa``."""
+    mocker.patch("time.sleep")
+    _add_get_consulta()
+    _add_post_no_results(
+        match=[urlencoded_body_subset_matcher({f"{FORM}:inputBuscaSimples": "dano moral"})]
+    )
+
+    with pytest.warns(DeprecationWarning, match="termo.*deprecado"):
+        df = jus.scraper("tjpe").cjsg(pesquisa=None, termo="dano moral", paginas=1)
+
+    assert df.empty
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_classe_cnj_alias_emits_deprecation_warning(mocker):
+    """``classe_cnj`` e alias deprecado de ``classe`` (consumido por
+    :func:`resolve_deprecated_alias` no client antes do envio)."""
+    mocker.patch("time.sleep")
+    _add_get_consulta()
+    _add_post_no_results(
+        match=[urlencoded_body_subset_matcher({f"{FORM}:selectClasseCNJ": "100"})]
+    )
+
+    with pytest.warns(DeprecationWarning, match="classe_cnj.*deprecado"):
+        df = jus.scraper("tjpe").cjsg("dano moral", paginas=1, classe_cnj="100")
+
+    assert df.empty
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_assunto_cnj_alias_emits_deprecation_warning(mocker):
+    """``assunto_cnj`` e alias deprecado de ``assunto``."""
+    mocker.patch("time.sleep")
+    _add_get_consulta()
+    _add_post_no_results(
+        match=[urlencoded_body_subset_matcher({f"{FORM}:selectAssuntoCNJ": "200"})]
+    )
+
+    with pytest.warns(DeprecationWarning, match="assunto_cnj.*deprecado"):
+        df = jus.scraper("tjpe").cjsg("dano moral", paginas=1, assunto_cnj="200")
+
+    assert df.empty
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_data_inicio_alias_maps_to_data_julgamento(mocker):
+    """``data_inicio`` / ``data_fim`` mapeiam para ``data_julgamento_inicio`` /
+    ``data_julgamento_fim`` via :func:`normalize_datas` e chegam ao form com o
+    mesmo formato passado pelo usuario (``DD/MM/AAAA``)."""
+    mocker.patch("time.sleep")
+    expected = {
+        f"{FORM}:j_id59InputDate": "01/01/2024",
+        f"{FORM}:periodoFimInputDate": "31/03/2024",
+    }
+    _add_get_consulta()
+    _add_post_no_results(match=[urlencoded_body_subset_matcher(expected)])
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        df = jus.scraper("tjpe").cjsg(
+            "dano moral",
+            paginas=1,
+            data_inicio="01/01/2024",
+            data_fim="31/03/2024",
+        )
+
+    assert df.empty
+    msgs = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert any("data_inicio" in m and "deprecado" in m for m in msgs)
+    assert any("data_fim" in m and "deprecado" in m for m in msgs)


### PR DESCRIPTION
## Resumo

Fecha o item 4 da issue #145 (sub-PR 1C-c original) e a última pendência da **Etapa 1** do umbrella #197.

Adiciona `tests/tjpe/test_cjsg_filters_contract.py` cobrindo todos os filtros públicos do `cjsg` do TJPE:

- **Filtros canônicos**: `relator`, `classe`, `assunto`, `meio_tramitacao`, `tipo_decisao` (3 variantes: `acordaos`, `monocraticas`, `todos`), `data_julgamento_inicio` / `data_julgamento_fim`.
- **Aliases deprecados**: `query` / `termo` → `pesquisa`; `classe_cnj` → `classe`; `assunto_cnj` → `assunto`; `data_inicio` / `data_fim` → `data_julgamento_*`. Cada um verifica que o `DeprecationWarning` é emitido.

## Como verifica

- Reusa `OrderedRegistry` (mesmo padrão de `test_cjsg_contract.py`) + samples capturados em `tests/tjpe/samples/cjsg/` (commit 9abbc23).
- Cada teste responde o `POST consulta.xhtml` com `no_results.html` ("Nenhum documento encontrado"): a sample não bate em `_is_results_page` nem em `_is_escolha_page`, então o scraper retorna lista vazia antes do AJAX. **Duas chamadas HTTP** bastam para pinar os campos do form, sem precisar fixar resposta de paginação.
- Usa `urlencoded_body_subset_matcher` já em `tests/_helpers.py` (refs #84) — confere campos específicos do form sem casar o body inteiro (que carrega `ViewState` dinâmico).

## Decisões

- **Sem `test_cjsg_unknown_kwarg_raises`**: TJPE ainda não foi wired com pydantic (etapa 2 da #197). Kwargs desconhecidos são silenciosamente descartados via `**kwargs`. Esse teste entra junto com `InputCJSGTJPE` no PR de wiring.
- **`tipo_decisao` ganha 3 testes** (acordaos no _all_filters_, monocraticas isolado, todos isolado) porque o encoding dos checkboxes diverge entre as variantes — o all-filters_lands cobre só `acordaos`.

## Test plan

- [x] `pytest tests/tjpe` → 11 passed, 5 deselected (integração).
- [x] `pytest` completo offline → 1542 passed, 26 skipped, 1 xfailed (TJRR pré-existente).
- [x] pre-commit hooks (isort, flake8, mypy) → ok.

Refs #84, #93, #122, #145, #197.

Closes #145