### PR TITLE
test: cobertura end-to-end da coercao DD/MM/AAAA -> ISO em 9 tribunais

### DIFF
--- a/tests/tjba/test_cjsg_filters_contract.py
+++ b/tests/tjba/test_cjsg_filters_contract.py
@@ -113,6 +113,41 @@ def test_cjsg_data_julgamento_raises_typeerror():
     )
 
 
+@responses.activate
+def test_cjsg_data_publicacao_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJBA` antes de chegar ao body GraphQL.
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que o tribunal nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem
+    pulou o ``apply_input_pipeline_search`` (refs #182, #173).
+    """
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE,
+        body=load_sample("tjba", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(_payload(
+            "dano moral",
+            0,
+            data_publicacao_inicio="2024-01-01",
+            data_publicacao_fim="2024-03-31",
+        ))],
+    )
+
+    df = jus.scraper("tjba").cjsg(
+        "dano moral",
+        paginas=1,
+        data_publicacao_inicio="01/01/2024",
+        data_publicacao_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
 # --- refs #232 ---------------------------------------------------------------
 
 

--- a/tests/tjdft/test_cjsg_filters_contract.py
+++ b/tests/tjdft/test_cjsg_filters_contract.py
@@ -113,6 +113,40 @@ def test_cjsg_unknown_kwarg_raises():
 
 
 @responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJDFT` antes de virar a string
+    ``"entre AAAA-MM-DD e AAAA-MM-DD"`` no ``termosAcessorios``.
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que TJDFT nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem pulou o
+    ``apply_input_pipeline_search`` (refs #182, #173).
+    """
+    mocker.patch("time.sleep")
+    expected_termos = [
+        {"campo": "dataJulgamento", "valor": "entre 2024-01-01 e 2024-03-31"},
+    ]
+    responses.add(
+        responses.POST,
+        BASE,
+        body=load_sample("tjdft", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(_payload("dano moral", 1, termos_acessorios=expected_termos))],
+    )
+
+    df = jus.scraper("tjdft").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
 def test_cjsg_quantidade_por_pagina_alias_emits_deprecation_warning(mocker):
     """``quantidade_por_pagina`` e alias deprecado de ``tamanho_pagina`` (refs #211)."""
     mocker.patch("time.sleep")

--- a/tests/tjes/test_cjsg_filters_contract.py
+++ b/tests/tjes/test_cjsg_filters_contract.py
@@ -251,3 +251,55 @@ def test_cjpg_tamanho_pagina_collision_raises():
         jus.scraper("tjes").cjpg(
             "dano moral", paginas=1, tamanho_pagina=5, per_page=10
         )
+
+
+# --- Coercao BR -> ISO end-to-end (refs #182) --------------------------------
+# Confirma que TJES nao se esqueceu de declarar ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+# em :class:`InputCJSGTJES`/:class:`InputCJPGTJES`, nem pulou o
+# ``apply_input_pipeline_search``. O backend Solr exige ISO; coercao acontece
+# antes de virar query param.
+
+
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """``DD/MM/AAAA`` -> ``YYYY-MM-DD`` (BACKEND_DATE_FORMAT) -> Solr query param."""
+    mocker.patch("time.sleep")
+    _add_page(
+        "dano moral",
+        1,
+        "cjsg/no_results.json",
+        data_inicio="2024-01-01",
+        data_fim="2024-03-31",
+    )
+
+    df = jus.scraper("tjes").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate
+def test_cjpg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Mesmo que ``test_cjsg_data_julgamento_aceita_formato_brasileiro`` para cjpg."""
+    mocker.patch("time.sleep")
+    _add_page(
+        "obrigacao de fazer",
+        1,
+        "cjpg/no_results.json",
+        core="pje1g",
+        data_inicio="2024-01-01",
+        data_fim="2024-03-31",
+    )
+
+    df = jus.scraper("tjes").cjpg(
+        "obrigacao de fazer",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjmt/test_cjsg_filters_contract.py
+++ b/tests/tjmt/test_cjsg_filters_contract.py
@@ -133,6 +133,36 @@ def test_cjsg_data_publicacao_raises_typeerror():
 
 
 @responses.activate(registry=OrderedRegistry)
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJMT` antes de chegar a query string Hellsgate.
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que TJMT nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem pulou o
+    ``apply_input_pipeline_search`` (refs #182, #173).
+    """
+    mocker.patch("time.sleep")
+    _add_config()
+    _add_page(
+        "dano moral",
+        1,
+        "cjsg/no_results.json",
+        data_julgamento_inicio="2024-01-01",
+        data_julgamento_fim="2024-03-31",
+    )
+
+    df = jus.scraper("tjmt").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
+@responses.activate(registry=OrderedRegistry)
 def test_cjsg_quantidade_por_pagina_alias_emits_deprecation_warning(mocker):
     """``quantidade_por_pagina`` e alias deprecado de ``tamanho_pagina`` (refs #211)."""
     mocker.patch("time.sleep")

--- a/tests/tjpa/test_cjsg_filters_contract.py
+++ b/tests/tjpa/test_cjsg_filters_contract.py
@@ -161,3 +161,43 @@ def test_cjsg_download_unknown_kwarg_raises():
         "dano moral",
         paginas=1,
     )
+
+
+@responses.activate
+def test_cjsg_datas_aceitam_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJPA` antes de chegar ao body BFF.
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que TJPA nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem pulou o
+    ``apply_input_pipeline_search`` (refs #182, #173). Cobre os dois filtros
+    de data (julgamento e publicacao).
+    """
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjpa", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral",
+            pagina_0based=0,
+            data_julgamento_inicio="2024-01-01",
+            data_julgamento_fim="2024-03-31",
+            data_publicacao_inicio="2024-02-01",
+            data_publicacao_fim="2024-04-30",
+        ))],
+    )
+
+    df = jus.scraper("tjpa").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+        data_publicacao_inicio="01/02/2024",
+        data_publicacao_fim="30/04/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)

--- a/tests/tjpi/test_cjsg_filters_contract.py
+++ b/tests/tjpi/test_cjsg_filters_contract.py
@@ -142,6 +142,42 @@ def test_cjsg_unknown_kwarg_raises():
     )
 
 
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJPI` antes de virar ``data_min``/``data_max``
+    na query string.
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que TJPI nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem pulou o
+    ``apply_input_pipeline_search`` (refs #182, #173).
+    """
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.GET,
+        BASE_URL,
+        body=load_sample("tjpi", "cjsg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+        match=[query_param_matcher(build_cjsg_params(
+            "dano moral",
+            page=1,
+            data_min="2024-01-01",
+            data_max="2024-03-31",
+        ))],
+    )
+
+    df = jus.scraper("tjpi").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
 def test_cjsg_data_publicacao_kwarg_raises():
     """TJPI backend nao expoe filtro de data de publicacao; ``InputCJSGTJPI``
     nao herda ``DataPublicacaoMixin``, entao ``data_publicacao_*`` deve cair

--- a/tests/tjrn/test_cjsg_filters_contract.py
+++ b/tests/tjrn/test_cjsg_filters_contract.py
@@ -199,6 +199,44 @@ def test_cjsg_data_inicio_alias_maps_to_data_julgamento(mocker):
     assert any("data_fim" in m and "deprecado" in m for m in messages)
 
 
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJRN` antes de o cliente reescrever para
+    ``DD-MM-YYYY`` (formato exigido pelo backend Elasticsearch via
+    ``_to_tjrn_date``).
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que TJRN nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem pulou o
+    ``apply_input_pipeline_search`` (refs #182, #173). A reescrita extra para
+    DD-MM-YYYY e particularidade do TJRN, nao do pipeline canonico.
+    """
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjrn", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral",
+            page=1,
+            dt_inicio="01-01-2024",
+            dt_fim="31-03-2024",
+        ))],
+    )
+
+    df = jus.scraper("tjrn").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
 def test_cjsg_unknown_kwarg_raises():
     """Kwargs not declared in :class:`InputCJSGTJRN` raise ``TypeError`` with
     the field name, instead of being silently dropped (refs #84, #93)."""

--- a/tests/tjro/test_cjsg_filters_contract.py
+++ b/tests/tjro/test_cjsg_filters_contract.py
@@ -220,6 +220,42 @@ def test_cjsg_data_inicio_alias_maps_to_data_julgamento(mocker):
     assert any("data_fim" in m and "deprecado" in m for m in messages)
 
 
+@responses.activate
+def test_cjsg_data_julgamento_aceita_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJRO` antes de virar ``dtjulgamento_inicio``/
+    ``dtjulgamento_fim`` no body do BFF.
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que TJRO nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem pulou o
+    ``apply_input_pipeline_search`` (refs #182, #173).
+    """
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        BASE_URL,
+        body=load_sample("tjro", "cjsg/no_results.json"),
+        status=200,
+        content_type="application/json",
+        match=[json_params_matcher(build_cjsg_payload(
+            "dano moral",
+            offset=0,
+            data_julgamento_inicio="2024-01-01",
+            data_julgamento_fim="2024-03-31",
+        ))],
+    )
+
+    df = jus.scraper("tjro").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
 def test_cjsg_unknown_kwarg_raises():
     """Kwargs not declared in :class:`InputCJSGTJRO` raise ``TypeError`` with
     the field name (refs #84, #93)."""

--- a/tests/tjsc/test_cjsg_filters_contract.py
+++ b/tests/tjsc/test_cjsg_filters_contract.py
@@ -128,6 +128,49 @@ def test_cjsg_data_inicio_alias_maps_to_dt_decisao(mocker):
     assert any("data_fim" in m and "deprecado" in m for m in messages)
 
 
+@responses.activate
+def test_cjsg_datas_aceitam_formato_brasileiro(mocker):
+    """Datas em ``DD/MM/AAAA`` sao coercidas para o ``BACKEND_DATE_FORMAT="%Y-%m-%d"``
+    declarado em :class:`InputCJSGTJSC` antes de chegar ao form body do eproc.
+
+    Cobre o caminho end-to-end (input via API publica -> backend) que o teste
+    unitario do helper (``test_apply_input_pipeline_*``) nao exercita: confirma
+    que TJSC nao se esqueceu de declarar ``BACKEND_DATE_FORMAT`` nem pulou o
+    ``apply_input_pipeline_search`` (refs #182, #173). Cobre os dois filtros
+    de data (julgamento e publicacao).
+    """
+    mocker.patch("time.sleep")
+    responses.add(
+        responses.POST,
+        cjsg_url_for_page(1),
+        body=load_sample_bytes("tjsc", "cjsg/no_results.html"),
+        status=200,
+        content_type="text/html; charset=iso-8859-1",
+        match=[urlencoded_params_matcher(
+            build_cjsg_form_body(
+                "dano moral",
+                page=1,
+                dt_decisao_inicio="2024-01-01",
+                dt_decisao_fim="2024-03-31",
+                dt_publicacao_inicio="2024-02-01",
+                dt_publicacao_fim="2024-04-30",
+            ),
+            allow_blank=True,
+        )],
+    )
+
+    df = jus.scraper("tjsc").cjsg(
+        "dano moral",
+        paginas=1,
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+        data_publicacao_inicio="01/02/2024",
+        data_publicacao_fim="30/04/2024",
+    )
+
+    assert isinstance(df, pd.DataFrame)
+
+
 def test_cjsg_unknown_kwarg_raises():
     """Kwargs not declared in :class:`InputCJSGTJSC` raise ``TypeError`` with
     the field name (refs #84, #93)."""


### PR DESCRIPTION
## Resumo

Adiciona um teste de contrato por tribunal/endpoint com `BACKEND_DATE_FORMAT="%Y-%m-%d"`, exercendo o caminho **input via API publica (`"01/01/2024"`) -> backend (ISO no body/query)**.

O caminho ja era coberto na camada do helper (`test_apply_input_pipeline_*` em `tests/utils/test_input_pipeline.py`), mas nenhum tribunal afetado exercia end-to-end — o que deixava silenciosamente passar regressoes como:

- esquecer `BACKEND_DATE_FORMAT: ClassVar[str] = "%Y-%m-%d"` no schema (cai no default `%d/%m/%Y`),
- pular o `apply_input_pipeline_search` e manter `normalize_datas` manual (sem coercao),
- adicionar transformacao manual de data em `download.py` que conflite com o que o helper ja fez.

## Tribunais cobertos

| Tribunal | Endpoint(s) | Filtros testados |
| -------- | ----------- | ---------------- |
| TJBA     | cjsg        | `data_publicacao_*` (schema herda apenas `DataPublicacaoMixin`) |
| TJMT     | cjsg        | `data_julgamento_*` |
| TJDFT    | cjsg        | `data_julgamento_*` (vira `"entre AAAA-MM-DD e AAAA-MM-DD"` em `termosAcessorios`) |
| TJES     | cjsg + cjpg | `data_julgamento_*` |
| TJPA     | cjsg        | `data_julgamento_*` + `data_publicacao_*` |
| TJPI     | cjsg        | `data_julgamento_*` (vira `data_min`/`data_max` na query) |
| TJRN     | cjsg        | `data_julgamento_*` (passa por reescrita extra `_to_tjrn_date` para DD-MM-YYYY com hifens) |
| TJRO     | cjsg        | `data_julgamento_*` (vira `dtjulgamento_inicio`/`_fim`) |
| TJSC     | cjsg        | `data_julgamento_*` + `data_publicacao_*` |

ComunicaCNJ ja tinha o teste end-to-end equivalente (`test_listar_comunicacoes_aceita_data_em_formato_brasileiro` em `tests/comunica_cnj/test_listar_comunicacoes_filters_contract.py:64-91`), entao nao precisou de teste novo.

## Padrao adotado

Cada teste segue o mesmo molde dos `test_*_data_inicio_alias_maps_to_data_julgamento` ja existentes nos mesmos arquivos: `responses` mocka o backend com matcher esperando o formato ISO (ou DD-MM-YYYY no caso TJRN), e o teste chama o metodo publico com `"01/01/2024"`. Se a coercao nao acontecer, o `responses` levanta `ConnectionError` antes de chegar no `assert isinstance(df, pd.DataFrame)`.

Reusamos os helpers ja exportados pelos respectivos `test_cjsg_contract.py` (`_payload`, `_add_page`, `build_cjsg_payload`, `build_cjsg_form_body`, etc.) — nenhum sample novo necessario.

## Test plan

- [x] `pytest tests/tjba tests/tjmt tests/tjdft tests/tjes tests/tjpa tests/tjpi tests/tjrn tests/tjro tests/tjsc tests/comunica_cnj` -> 154 passed, 52 deselected
- [x] `pytest` (suite completa) -> 1544 passed, 26 skipped, 1 xfailed

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)