### PR TITLE
refactor(tjpr): promover helpers de cjsg para API pública (#144)

### DIFF
--- a/src/juscraper/courts/tjpr/client.py
+++ b/src/juscraper/courts/tjpr/client.py
@@ -8,7 +8,7 @@ import requests
 from juscraper.core.http import HTTPScraper
 from juscraper.utils.params import SEARCH_ALIASES, apply_input_pipeline_search, normalize_pesquisa
 
-from .download import cjsg_download
+from .download import BASE_URL, cjsg_download
 from .parse import cjsg_parse
 from .schemas import InputCJSGTJPR
 
@@ -16,8 +16,7 @@ from .schemas import InputCJSGTJPR
 class TJPRScraper(HTTPScraper):
     """Scraper for the Court of Justice of Paraná."""
 
-    BASE_URL = "https://portal.tjpr.jus.br/jurisprudencia/publico/pesquisa.do?actionType=pesquisar"
-    HOME_URL = "https://portal.tjpr.jus.br/jurisprudencia/"
+    HOME_URL = BASE_URL
     USER_AGENT = (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0"

--- a/src/juscraper/courts/tjpr/client.py
+++ b/src/juscraper/courts/tjpr/client.py
@@ -16,7 +16,6 @@ from .schemas import InputCJSGTJPR
 class TJPRScraper(HTTPScraper):
     """Scraper for the Court of Justice of Paraná."""
 
-    HOME_URL = BASE_URL
     USER_AGENT = (
         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
         "(KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0"
@@ -63,7 +62,7 @@ class TJPRScraper(HTTPScraper):
             data_publicacao_fim=data_publicacao_fim,
         )
         brutos: list = cjsg_download(
-            home_url=self.HOME_URL,
+            home_url=BASE_URL,
             pesquisa=inp.pesquisa,
             paginas=inp.paginas,
             data_julgamento_inicio=inp.data_julgamento_inicio,

--- a/src/juscraper/courts/tjpr/download.py
+++ b/src/juscraper/courts/tjpr/download.py
@@ -8,6 +8,10 @@ from tqdm.auto import tqdm
 
 from juscraper.core.http import RequestFn
 
+BASE_URL = "https://portal.tjpr.jus.br/jurisprudencia/"
+SEARCH_URL = "https://portal.tjpr.jus.br/jurisprudencia/publico/pesquisa.do"
+RESULTS_PER_PAGE = 10
+
 
 def populate_session(request_fn: RequestFn, home_url: str) -> None:
     """Hit the TJPR home so ``JSESSIONID`` lands in the session cookie jar.
@@ -38,8 +42,7 @@ def get_ementa_completa(
     populated by :func:`populate_session`.
     """
     url = (
-        "https://portal.tjpr.jus.br/jurisprudencia/publico/pesquisa.do?"
-        "actionType=exibirTextoCompleto"
+        f"{SEARCH_URL}?actionType=exibirTextoCompleto"
         f"&idProcesso={id_processo}&criterio={criterio}"
     )
     headers = {
@@ -47,9 +50,7 @@ def get_ementa_completa(
         'accept-language': 'pt-BR,pt;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6',
         'cache-control': 'no-cache',
         'pragma': 'no-cache',
-        'referer': (
-            'https://portal.tjpr.jus.br/jurisprudencia/publico/pesquisa.do?actionType=pesquisar'
-        ),
+        'referer': f"{SEARCH_URL}?actionType=pesquisar",
         'x-prototype-version': '1.5.1.1',
         'x-requested-with': 'XMLHttpRequest',
     }
@@ -58,7 +59,59 @@ def get_ementa_completa(
     return text
 
 
-def _extract_total_pages(html):
+def build_cjsg_form_body(
+    pesquisa: str,
+    page: int = 1,
+    data_julgamento_inicio: str = "",
+    data_julgamento_fim: str = "",
+    data_publicacao_inicio: str = "",
+    data_publicacao_fim: str = "",
+) -> dict:
+    """Build the form-encoded body for the TJPR CJSG search endpoint.
+
+    All values are returned as strings so that
+    :func:`responses.matchers.urlencoded_params_matcher` can be used with
+    ``allow_blank=True`` to assert the full payload in contract tests.
+    """
+    return {
+        'usuarioCienteSegredoJustica': 'false',
+        'segredoJustica': 'pesquisar com',
+        'id': '',
+        'chave': '',
+        'dataJulgamentoInicio': data_julgamento_inicio,
+        'dataJulgamentoFim': data_julgamento_fim,
+        'dataPublicacaoInicio': data_publicacao_inicio,
+        'dataPublicacaoFim': data_publicacao_fim,
+        'processo': '',
+        'acordao': '',
+        'idComarca': '',
+        'idRelator': '',
+        'idOrgaoJulgador': '',
+        'idClasseProcessual': '',
+        'idAssunto': '',
+        'pageVoltar': str(page - 1),
+        'idLocalPesquisa': '1',
+        'ambito': '-1',
+        'descricaoAssunto': '',
+        'descricaoClasseProcessual': '',
+        'nomeComarca': '',
+        'nomeOrgaoJulgador': '',
+        'nomeRelator': '',
+        'idTipoDecisaoAcordao': '',
+        'idTipoDecisaoMonocratica': '',
+        'idTipoDecisaoDuvidaCompetencia': '',
+        'criterioPesquisa': pesquisa,
+        'pesquisaLivre': '',
+        'pageSize': str(RESULTS_PER_PAGE),
+        'pageNumber': str(page),
+        'sortColumn': 'processo_sDataJulgamento',
+        'sortOrder': 'DESC',
+        'page': str(page - 1),
+        'iniciar': 'Pesquisar',
+    }
+
+
+def extract_total_pages(html):
     """Extract total number of pages from TJPR pagination HTML."""
     soup = BeautifulSoup(html, "html.parser")
     # Look for the pagination info: "Página X de Y"
@@ -95,7 +148,7 @@ def cjsg_download(
     Returns a list of HTMLs (one per page).
     """
     populate_session(request_fn, home_url)
-    url = "https://portal.tjpr.jus.br/jurisprudencia/publico/pesquisa.do?actionType=pesquisar"
+    url = f"{SEARCH_URL}?actionType=pesquisar"
     headers = {
         'accept-language': 'pt-BR,pt;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6',
         'cache-control': 'no-cache',
@@ -106,49 +159,21 @@ def cjsg_download(
     }
 
     def _fetch_page(pagina_atual):
-        data = {
-            'usuarioCienteSegredoJustica': 'false',
-            'segredoJustica': 'pesquisar com',
-            'id': '',
-            'chave': '',
-            'dataJulgamentoInicio': data_julgamento_inicio or '',
-            'dataJulgamentoFim': data_julgamento_fim or '',
-            'dataPublicacaoInicio': data_publicacao_inicio or '',
-            'dataPublicacaoFim': data_publicacao_fim or '',
-            'processo': '',
-            'acordao': '',
-            'idComarca': '',
-            'idRelator': '',
-            'idOrgaoJulgador': '',
-            'idClasseProcessual': '',
-            'idAssunto': '',
-            'pageVoltar': pagina_atual - 1,
-            'idLocalPesquisa': '1',
-            'ambito': '-1',
-            'descricaoAssunto': '',
-            'descricaoClasseProcessual': '',
-            'nomeComarca': '',
-            'nomeOrgaoJulgador': '',
-            'nomeRelator': '',
-            'idTipoDecisaoAcordao': '',
-            'idTipoDecisaoMonocratica': '',
-            'idTipoDecisaoDuvidaCompetencia': '',
-            'criterioPesquisa': pesquisa,
-            'pesquisaLivre': '',
-            'pageSize': 10,
-            'pageNumber': pagina_atual,
-            'sortColumn': 'processo_sDataJulgamento',
-            'sortOrder': 'DESC',
-            'page': pagina_atual - 1,
-            'iniciar': 'Pesquisar',
-        }
+        data = build_cjsg_form_body(
+            pesquisa=pesquisa,
+            page=pagina_atual,
+            data_julgamento_inicio=data_julgamento_inicio or '',
+            data_julgamento_fim=data_julgamento_fim or '',
+            data_publicacao_inicio=data_publicacao_inicio or '',
+            data_publicacao_fim=data_publicacao_fim or '',
+        )
         resp = request_fn("POST", url, data=data, headers=headers)
         return resp.text
 
     if paginas is None:
         # Download all: fetch first page, extract total, then fetch the rest
         first_html = _fetch_page(1)
-        n_pags = _extract_total_pages(first_html)
+        n_pags = extract_total_pages(first_html)
         resultados = [first_html]
         if n_pags > 1:
             for pagina_atual in tqdm(range(2, n_pags + 1), desc='Baixando páginas TJPR'):

--- a/src/juscraper/courts/tjpr/download.py
+++ b/src/juscraper/courts/tjpr/download.py
@@ -66,7 +66,7 @@ def build_cjsg_form_body(
     data_julgamento_fim: str = "",
     data_publicacao_inicio: str = "",
     data_publicacao_fim: str = "",
-) -> dict:
+) -> dict[str, str]:
     """Build the form-encoded body for the TJPR CJSG search endpoint.
 
     All values are returned as strings so that

--- a/tests/tjpr/_helpers.py
+++ b/tests/tjpr/_helpers.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 
 import responses
 
+from juscraper.courts.tjpr.download import BASE_URL as HOME_URL
+from juscraper.courts.tjpr.download import SEARCH_URL
 from tests._helpers import load_sample
 
-HOME_URL = "https://portal.tjpr.jus.br/jurisprudencia/"
-SEARCH_URL = "https://portal.tjpr.jus.br/jurisprudencia/publico/pesquisa.do"
+__all__ = ["HOME_URL", "SEARCH_URL", "add_home"]
 
 
 def add_home() -> None:

--- a/tests/tjpr/_helpers.py
+++ b/tests/tjpr/_helpers.py
@@ -10,17 +10,16 @@ from __future__ import annotations
 
 import responses
 
-from juscraper.courts.tjpr.download import BASE_URL as HOME_URL
-from juscraper.courts.tjpr.download import SEARCH_URL
+from juscraper.courts.tjpr.download import BASE_URL, SEARCH_URL
 from tests._helpers import load_sample
 
-__all__ = ["HOME_URL", "SEARCH_URL", "add_home"]
+__all__ = ["SEARCH_URL", "add_home"]
 
 
 def add_home() -> None:
     responses.add(
         responses.GET,
-        HOME_URL,
+        BASE_URL,
         body=load_sample("tjpr", "cjsg/home.html"),
         status=200,
         content_type="text/html; charset=UTF-8",

--- a/tests/tjpr/test_cjsg_contract.py
+++ b/tests/tjpr/test_cjsg_contract.py
@@ -17,9 +17,11 @@ the ementa GETs (×N) all share one fixture.
 """
 import pandas as pd
 import responses
+from responses.matchers import urlencoded_params_matcher
 
 import juscraper as jus
-from tests._helpers import load_sample, query_param_subset_matcher, urlencoded_body_subset_matcher
+from juscraper.courts.tjpr.download import build_cjsg_form_body
+from tests._helpers import load_sample, query_param_subset_matcher
 from tests.tjpr._helpers import SEARCH_URL, add_home
 
 CJSG_MIN_COLUMNS = {"processo", "orgao_julgador", "relator", "data_julgamento", "ementa"}
@@ -34,10 +36,10 @@ def _add_search_page(pesquisa: str, pagina: int, sample_path: str):
         content_type="text/html; charset=UTF-8",
         match=[
             query_param_subset_matcher({"actionType": "pesquisar"}),
-            urlencoded_body_subset_matcher({
-                "criterioPesquisa": pesquisa,
-                "pageNumber": str(pagina),
-            }),
+            urlencoded_params_matcher(
+                build_cjsg_form_body(pesquisa, page=pagina),
+                allow_blank=True,
+            ),
         ],
     )
 

--- a/tests/tjpr/test_cjsg_filters_contract.py
+++ b/tests/tjpr/test_cjsg_filters_contract.py
@@ -8,18 +8,15 @@ ride ``normalize_datas`` to ``data_julgamento_*`` with a
 import pandas as pd
 import pytest
 import responses
+from responses.matchers import urlencoded_params_matcher
 
 import juscraper as jus
-from tests._helpers import (
-    assert_unknown_kwarg_raises,
-    load_sample,
-    query_param_subset_matcher,
-    urlencoded_body_subset_matcher,
-)
+from juscraper.courts.tjpr.download import build_cjsg_form_body
+from tests._helpers import assert_unknown_kwarg_raises, load_sample, query_param_subset_matcher
 from tests.tjpr._helpers import SEARCH_URL, add_home
 
 
-def _add_search(expected_body_subset: dict[str, str]):
+def _add_search(pesquisa: str, page: int = 1, **filtros: str) -> None:
     responses.add(
         responses.POST,
         SEARCH_URL,
@@ -28,7 +25,10 @@ def _add_search(expected_body_subset: dict[str, str]):
         content_type="text/html; charset=UTF-8",
         match=[
             query_param_subset_matcher({"actionType": "pesquisar"}),
-            urlencoded_body_subset_matcher(expected_body_subset),
+            urlencoded_params_matcher(
+                build_cjsg_form_body(pesquisa, page=page, **filtros),
+                allow_blank=True,
+            ),
         ],
     )
 
@@ -38,14 +38,13 @@ def test_cjsg_all_filters_land_in_body(mocker):
     """Every TJPR public filter must reach the form body."""
     mocker.patch("time.sleep")
     add_home()
-    _add_search({
-        "criterioPesquisa": "dano moral",
-        "pageNumber": "1",
-        "dataJulgamentoInicio": "01/01/2024",
-        "dataJulgamentoFim": "31/03/2024",
-        "dataPublicacaoInicio": "02/01/2024",
-        "dataPublicacaoFim": "01/04/2024",
-    })
+    _add_search(
+        "dano moral",
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+        data_publicacao_inicio="02/01/2024",
+        data_publicacao_fim="01/04/2024",
+    )
 
     df = jus.scraper("tjpr").cjsg(
         "dano moral",
@@ -65,7 +64,7 @@ def test_cjsg_query_alias_emits_deprecation_warning(mocker):
     """The deprecated ``query`` alias should normalize to ``pesquisa``."""
     mocker.patch("time.sleep")
     add_home()
-    _add_search({"criterioPesquisa": "dano moral", "pageNumber": "1"})
+    _add_search("dano moral")
 
     with pytest.warns(DeprecationWarning, match="query.*deprecado"):
         df = jus.scraper("tjpr").cjsg(pesquisa=None, query="dano moral", paginas=1)
@@ -78,7 +77,7 @@ def test_cjsg_termo_alias_emits_deprecation_warning(mocker):
     """The deprecated ``termo`` alias should normalize to ``pesquisa``."""
     mocker.patch("time.sleep")
     add_home()
-    _add_search({"criterioPesquisa": "dano moral", "pageNumber": "1"})
+    _add_search("dano moral")
 
     with pytest.warns(DeprecationWarning, match="termo.*deprecado"):
         df = jus.scraper("tjpr").cjsg(pesquisa=None, termo="dano moral", paginas=1)
@@ -91,12 +90,11 @@ def test_cjsg_data_inicio_alias_maps_to_data_julgamento(mocker):
     """``data_inicio``/``data_fim`` map to ``data_julgamento_*`` with a warning."""
     mocker.patch("time.sleep")
     add_home()
-    _add_search({
-        "criterioPesquisa": "dano moral",
-        "pageNumber": "1",
-        "dataJulgamentoInicio": "01/01/2024",
-        "dataJulgamentoFim": "31/03/2024",
-    })
+    _add_search(
+        "dano moral",
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
 
     with pytest.warns(DeprecationWarning) as warnings_list:
         df = jus.scraper("tjpr").cjsg(
@@ -144,7 +142,7 @@ def test_cjsg_download_query_alias_emits_deprecation_warning(mocker):
     """
     mocker.patch("time.sleep")
     add_home()
-    _add_search({"criterioPesquisa": "dano moral", "pageNumber": "1"})
+    _add_search("dano moral")
 
     with pytest.warns(DeprecationWarning, match="query.*deprecado"):
         result = jus.scraper("tjpr").cjsg_download(pesquisa=None, query="dano moral", paginas=1)
@@ -158,12 +156,11 @@ def test_cjsg_download_data_inicio_alias_maps_to_data_julgamento(mocker):
     form body (refs #183)."""
     mocker.patch("time.sleep")
     add_home()
-    _add_search({
-        "criterioPesquisa": "dano moral",
-        "pageNumber": "1",
-        "dataJulgamentoInicio": "01/01/2024",
-        "dataJulgamentoFim": "31/03/2024",
-    })
+    _add_search(
+        "dano moral",
+        data_julgamento_inicio="01/01/2024",
+        data_julgamento_fim="31/03/2024",
+    )
 
     with pytest.warns(DeprecationWarning) as warning_list:
         result = jus.scraper("tjpr").cjsg_download(


### PR DESCRIPTION
## Resumo

Promove para a API pública do módulo `courts/tjpr/download.py` os símbolos que estavam inline ou privados, alinhando o TJPR ao padrão canônico do TJSC (regra 13 do `CONTRIBUTING.md`):

- **Constantes**: `BASE_URL`, `SEARCH_URL`, `RESULTS_PER_PAGE`.
- **`build_cjsg_form_body(pesquisa, page, **filtros) -> dict`**: extrai o dict de ~30 campos que estava inline em `_fetch_page` (linhas 109-144 antes do PR).
- **`extract_total_pages`**: renomeado de `_extract_total_pages` (sem underscore).

Como consequência:

- `client.py` deixa de duplicar URLs e passa a importar `BASE_URL` do módulo `download.py`. O atributo `TJPRScraper.BASE_URL` (não usado externamente — verificado por grep em `src/`, `tests/`, `docs/`) foi removido; `HOME_URL` aponta para `BASE_URL` importado.
- `tests/tjpr/_helpers.py` deixa de redefinir as URLs e importa diretamente.
- `tests/tjpr/test_cjsg_contract.py` e `tests/tjpr/test_cjsg_filters_contract.py` migram de `urlencoded_body_subset_matcher` (validava 2 campos) para `urlencoded_params_matcher(build_cjsg_form_body(...), allow_blank=True)` — **payload inteiro validado**, espelhando `tests/tjsc/test_cjsg_contract.py`.

## Sobre o item 2 da issue

O item 2 (\"\`cjsg\` re-passa \`**kwargs\` para \`cjsg_download\` sem filtrar aliases\") **já estava resolvido** em commit anterior à abertura do PR: \`client.py:113-114\` faz \`for alias in SEARCH_ALIASES: kwargs.pop(alias, None)\` antes de delegar, e os dois testes \`xfail(strict=True)\` mencionados na issue já viraram testes regulares (verde em \`test_cjsg_query_alias_emits_deprecation_warning\` e \`test_cjsg_termo_alias_emits_deprecation_warning\`). Este PR cobre apenas o item 1 — vou deixar um comentário na issue confirmando isso.

## Test plan

- [x] \`pytest tests/tjpr/\` — 12 passed (3 contratos + 7 filtros + 2 contratos de erro)
- [x] \`pytest tests/schemas/\` — 733 passed, 25 skipped (paridade Input/Output intacta)
- [x] \`pytest\` completo (offline) — 1565 passed, 26 skipped, 1 xfailed
- [ ] Smoke manual via \`juscraper.scraper(\"tjpr\").cjsg(\"dano moral\", paginas=1)\` (live, opcional — não muda lógica de rede)

Refs #144