### PR TITLE
feat(cjsg,cjpg): adiciona count_only=True para estimativa pré-scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Novo agregador `pdpj` (`PdpjScraper`) para a API DATALAKE - Processos do PDPJ (`api-processo-integracao.data-lake.pdpj.jus.br`). Autenticacao via JWT com `auth(token)` e endpoints publicos `existe`, `cpopg`, `documentos`, `movimentos`, `partes`, `pesquisa`, `contar` e `download_documents` (texto e/ou binario). Validacao via pydantic com `extra="forbid"`.
+- Parametro `count_only=True` em `cjsg` (TJAC, TJAL, TJAM, TJCE, TJMS, TJSP) e `cjpg` (TJSP). Quando passado, o metodo faz so a chamada inicial (POST + 1 GET no caso eSAJ; 1 GET no caso CJPG), extrai o total de resultados da primeira pagina e retorna `int` em vez do `pd.DataFrame` completo. Util para estimativa de wall-clock antes de coletas longas — ~2s/resultado em `cjsg`/`cjpg`, entao 5000 hits = ~3h. Com `auto_chunk=True` (default) e janela `data_julgamento_*` > 366 dias, itera as janelas disjuntas (`iter_date_windows`) e soma; e **soma bruta** (sem dedup por `cd_acordao`/`id_processo`), entao pode divergir ligeiramente de `len(cjsg(...))` quando ha acordaos republicados em janelas diferentes. `paginas` e ignorado em count_only (emite `UserWarning`); `auto_chunk=False` + janela > 366d continua levantando `ValueError`. Refs #92.
 
 ### Changed
 

--- a/docs/api-conventions.qmd
+++ b/docs/api-conventions.qmd
@@ -214,6 +214,58 @@ semantics for `paginas` are ambiguous (each window? aggregated budget?)
 and the design prefers to fail explicitly. For short intervals where
 chunking is a no-op, `paginas` works as usual.
 
+## Pre-scraping count (`count_only`)
+
+Empirical legal research often benefits from a quick estimate of how many
+results a query will return before committing to a long collection job
+(~2 s/result in `cjsg`/`cjpg` with `sleep_time=0.5`, so 5 000 hits ≈ 3 h).
+The `count_only: bool = False` flag — accepted by `cjsg` in TJAC, TJAL,
+TJAM, TJCE, TJMS, TJSP and by `cjpg` in TJSP — short-circuits the public
+method to a single network call per window, extracts the total result
+count from the first-page HTML, and returns an `int` instead of a
+`pd.DataFrame`:
+
+```python
+import juscraper as jus
+
+tjsp = jus.scraper("tjsp")
+
+# One POST + one GET. Returns an int.
+n = tjsp.cjpg(
+    pesquisa="dano moral",
+    data_julgamento_inicio="01/01/2024",
+    data_julgamento_fim="31/12/2024",
+    count_only=True,
+)
+print(f"Estimated wall-clock for full collection: {n * 2 / 3600:.1f}h")
+```
+
+Interaction with `auto_chunk`: when the interval exceeds 366 days and
+`auto_chunk=True` (default), `count_only` iterates the disjoint windows
+produced by `iter_date_windows` and **sums** the per-window counts. The
+sum is raw — the de-duplication step that the normal path performs by
+`cd_acordao` / `id_processo` does not apply here, so the returned number
+can slightly overestimate `len(cjsg(...))` when documents are republished
+across windows (same `cd_acordao` appearing in two windows). For most
+estimation use cases this is the desired behaviour: the count reflects
+what the backend will hand over, not the deduplicated final shape.
+
+Other edge cases:
+
+- `paginas` is ignored when `count_only=True` (the probe always inspects
+  page 1). A `UserWarning` is emitted if both are passed.
+- `auto_chunk=False` plus an interval longer than 366 days still raises
+  `ValueError` — consistent with the strict path.
+- Captcha or layout-change failures on page 1 propagate as `ValueError`
+  with the same message as the regular path.
+- Tribunals not yet wired reject `count_only` via `extra="forbid"`
+  (`TypeError`).
+
+The underlying helpers `cjsg_n_results(html)` and `cjpg_n_results(html)`
+are exposed from `juscraper.courts._esaj.parse` and
+`juscraper.courts.tjsp.cjpg_parse` for callers that already hold the
+raw HTML.
+
 ## Normalization Utilities
 
 The `juscraper.utils.params` module provides normalization functions used internally by all scrapers:

--- a/src/juscraper/courts/_esaj/__init__.py
+++ b/src/juscraper/courts/_esaj/__init__.py
@@ -7,11 +7,12 @@ six eSAJ courts (TJAC/TJAL/TJAM/TJCE/TJMS/TJSP).
 """
 from .base import EsajSearchScraper
 from .forms import build_cjsg_form_body
-from .parse import cjsg_n_pags, cjsg_parse_manager
+from .parse import cjsg_n_pags, cjsg_n_results, cjsg_parse_manager
 
 __all__ = [
     "EsajSearchScraper",
     "build_cjsg_form_body",
     "cjsg_n_pags",
+    "cjsg_n_results",
     "cjsg_parse_manager",
 ]

--- a/src/juscraper/courts/_esaj/base.py
+++ b/src/juscraper/courts/_esaj/base.py
@@ -395,7 +395,17 @@ class EsajSearchScraper(HTTPScraper):
         e ``auto_chunk=True`` (default), itera janelas disjuntas
         (:func:`iter_date_windows`) e soma. ``auto_chunk=False`` + janela
         > 366 dias levanta :class:`ValueError` (mesmo comportamento do
-        caminho normal).
+        caminho normal). Intervalo ``data_publicacao_*`` > 366 dias tambem
+        levanta :class:`ValueError` em qualquer ``auto_chunk`` — auto-chunk
+        so pivota em ``data_julgamento``, entao publicacao precisa ser
+        validada explicitamente para consistencia com o caminho normal.
+
+        **Fail-fast no auto-chunk**: diferente do caminho normal
+        (:func:`run_auto_chunk`), que tolera falha por janela como
+        :class:`UserWarning` e devolve resultado parcial deduplicado, este
+        probe usa ``sum()`` — qualquer :class:`ValueError` em uma janela
+        aborta toda a iteracao. Decisao deliberada: estimativa parcial sem
+        aviso seria pior que erro explicito.
         """
         if paginas is not None:
             warnings.warn(
@@ -404,31 +414,47 @@ class EsajSearchScraper(HTTPScraper):
                 stacklevel=3,
             )
 
-        pesquisa = normalize_pesquisa(pesquisa, **kwargs)
-
         # Validacao do schema com max_dias=None — vamos iterar janelas
         # manualmente ou disparar ValueError abaixo conforme auto_chunk.
+        # ``consume_pesquisa_aliases=True`` deixa o helper consumir
+        # ``query``/``termo`` em uma unica passagem; sem ``nullable_pesquisa``
+        # porque o caminho normal de cjsg tambem nao aceita pesquisa vazia
+        # sem filtro (excecao TJSP, onde a chamada parte com ``pesquisa=""``
+        # e seguiria pelo mesmo fluxo do caminho normal).
         input_model = apply_input_pipeline_search(
             self.INPUT_CJSG,
             f"{type(self).__name__}.cjsg(count_only=True)",
             pesquisa=pesquisa,
             paginas=None,
             kwargs=kwargs,
+            consume_pesquisa_aliases=True,
             max_dias=None,
             origem_mensagem="O eSAJ",
         )
 
-        di = getattr(input_model, "data_julgamento_inicio", None)
-        df_ = getattr(input_model, "data_julgamento_fim", None)
-        auto_chunk = getattr(input_model, "auto_chunk", True)
-        tipo_decisao = getattr(input_model, "tipo_decisao", "acordao")
+        di = input_model.data_julgamento_inicio
+        df_ = input_model.data_julgamento_fim
+        auto_chunk = input_model.auto_chunk
+        tipo_decisao = input_model.tipo_decisao
+
+        # ``data_publicacao_*`` existe so em InputCJSGEsajPuro (via
+        # DataPublicacaoMixin); InputCJSGTJSP nao herda. ``getattr`` cobre
+        # ambos os schemas sem ramo if/else.
+        dp_i = getattr(input_model, "data_publicacao_inicio", None)
+        dp_f = getattr(input_model, "data_publicacao_fim", None)
 
         # auto_chunk=False + janela > 366d: replicar o ValueError do caminho
         # normal para consistencia. validate_intervalo_datas tolera None.
+        # ``data_julgamento`` so quando auto_chunk=False (auto_chunk=True
+        # divide em janelas). ``data_publicacao`` sempre, porque auto-chunk
+        # nao pivota em publicacao — caminho normal valida nos dois fluxos.
         if not auto_chunk:
             validate_intervalo_datas(
                 di, df_, max_dias=366, rotulo="data_julgamento", origem="O eSAJ",
             )
+        validate_intervalo_datas(
+            dp_i, dp_f, max_dias=366, rotulo="data_publicacao", origem="O eSAJ",
+        )
 
         def _probe(win_i: str | None, win_f: str | None) -> int:
             body_input = input_model.model_copy(update={

--- a/src/juscraper/courts/_esaj/base.py
+++ b/src/juscraper/courts/_esaj/base.py
@@ -34,10 +34,11 @@ from ...utils.params import (
     pop_normalize_aliases,
     raise_on_extra_kwargs,
     run_chunked_search,
+    validate_intervalo_datas,
 )
-from .download import download_cjsg_pages
+from .download import download_cjsg_pages, fetch_cjsg_first_page
 from .forms import build_cjsg_form_body
-from .parse import cjsg_n_pags, cjsg_parse_manager
+from .parse import cjsg_n_pags, cjsg_n_results, cjsg_parse_manager
 from .schemas import InputCJSGEsajPuro
 
 logger = logging.getLogger("juscraper._esaj.base")
@@ -300,6 +301,16 @@ class EsajSearchScraper(HTTPScraper):
                   divide internamente em janelas, baixa cada uma e
                   concatena com dedup por ``cd_acordao``. Veja a secao
                   "Auto-chunking" abaixo.
+                * ``count_only`` (bool): Default ``False``. Se ``True``,
+                  faz so a chamada inicial da pagina 1, extrai o total
+                  de resultados via ``cjsg_n_results`` e retorna ``int``
+                  em vez de ``pd.DataFrame``. Util pra estimar wall-clock
+                  antes de uma coleta longa (issue #92). Com
+                  ``auto_chunk=True`` + janela > 366 dias, itera janelas
+                  disjuntas e soma — **soma bruta** (sem dedup por
+                  ``cd_acordao``), pode divergir ligeiramente de
+                  ``len(cjsg(...))`` quando ha acordaos republicados.
+                  ``paginas`` e ignorado (emite ``UserWarning``).
 
         Aliases deprecados (popados com ``DeprecationWarning`` antes do
         pydantic):
@@ -315,16 +326,19 @@ class EsajSearchScraper(HTTPScraper):
             ValidationError: Quando um filtro tem formato invalido.
 
         Returns:
-            pd.DataFrame: Resultados parseados; colunas conforme
-            :class:`OutputCJSGEsaj` (``processo``, ``ementa``, ``relator``
+            pd.DataFrame | int: Resultados parseados (colunas conforme
+            :class:`OutputCJSGEsaj` — ``processo``, ``ementa``, ``relator``
             via mixin, ``data_publicacao`` via mixin, ``cd_acordao``,
-            ``cd_foro``).
+            ``cd_foro``); ``int`` com o total de resultados quando
+            ``count_only=True``.
 
         Exemplo:
             >>> import juscraper as jus
             >>> tjac = jus.scraper("tjac")
             >>> df = tjac.cjsg("dano moral", paginas=range(1, 3),
             ...                data_julgamento_inicio="01/01/2024")
+            >>> # Estimativa pre-scraping (issue #92):
+            >>> n = tjac.cjsg("dano moral", count_only=True)
 
         See also:
             :class:`InputCJSGEsajPuro` (ou
@@ -342,6 +356,11 @@ class EsajSearchScraper(HTTPScraper):
             comportamento estrito antigo (``ValueError`` em janelas
             longas), passe ``auto_chunk=False``.
         """
+        # count_only=True: probe leve antes do run_auto_chunk (issue #92).
+        # auto_chunk soma DataFrames com dedup; count_only soma ints brutos.
+        if kwargs.get("count_only", False):
+            return self._cjsg_count_only(pesquisa=pesquisa, paginas=paginas, **kwargs)
+
         chunked = run_auto_chunk(
             method=self.cjsg,
             method_label=f"{type(self).__name__}.cjsg()",
@@ -359,6 +378,78 @@ class EsajSearchScraper(HTTPScraper):
             return self.cjsg_parse(path)
         finally:
             shutil.rmtree(path, ignore_errors=True)
+
+    def _cjsg_count_only(
+        self,
+        pesquisa: str,
+        paginas: int | list | range | None,
+        **kwargs: Any,
+    ) -> int:
+        """Probe leve para ``cjsg(count_only=True)`` — refs #92.
+
+        Faz POST + GET da primeira pagina por janela, extrai ``n_results``
+        via :func:`cjsg_n_results` e retorna a soma. ``paginas`` e
+        ignorado (count_only sempre olha a pagina 1).
+
+        Multi-janela: se o intervalo ``data_julgamento_*`` excede 366 dias
+        e ``auto_chunk=True`` (default), itera janelas disjuntas
+        (:func:`iter_date_windows`) e soma. ``auto_chunk=False`` + janela
+        > 366 dias levanta :class:`ValueError` (mesmo comportamento do
+        caminho normal).
+        """
+        if paginas is not None:
+            warnings.warn(
+                "paginas e ignorado quando count_only=True (probe sempre olha so a pagina 1).",
+                UserWarning,
+                stacklevel=3,
+            )
+
+        pesquisa = normalize_pesquisa(pesquisa, **kwargs)
+
+        # Validacao do schema com max_dias=None — vamos iterar janelas
+        # manualmente ou disparar ValueError abaixo conforme auto_chunk.
+        input_model = apply_input_pipeline_search(
+            self.INPUT_CJSG,
+            f"{type(self).__name__}.cjsg(count_only=True)",
+            pesquisa=pesquisa,
+            paginas=None,
+            kwargs=kwargs,
+            max_dias=None,
+            origem_mensagem="O eSAJ",
+        )
+
+        di = getattr(input_model, "data_julgamento_inicio", None)
+        df_ = getattr(input_model, "data_julgamento_fim", None)
+        auto_chunk = getattr(input_model, "auto_chunk", True)
+        tipo_decisao = getattr(input_model, "tipo_decisao", "acordao")
+
+        # auto_chunk=False + janela > 366d: replicar o ValueError do caminho
+        # normal para consistencia. validate_intervalo_datas tolera None.
+        if not auto_chunk:
+            validate_intervalo_datas(
+                di, df_, max_dias=366, rotulo="data_julgamento", origem="O eSAJ",
+            )
+
+        def _probe(win_i: str | None, win_f: str | None) -> int:
+            body_input = input_model.model_copy(update={
+                "data_julgamento_inicio": win_i,
+                "data_julgamento_fim": win_f,
+            })
+            body = self._build_cjsg_body(body_input)
+            html = fetch_cjsg_first_page(
+                scraper=self,
+                base_url=self.BASE_URL,
+                body=body,
+                tipo_decisao=tipo_decisao,
+                sleep_time=self.sleep_time,
+                chrome_ua=self.CJSG_CHROME_UA,
+            )
+            return cjsg_n_results(html)
+
+        if not auto_chunk or di is None or df_ is None:
+            return _probe(di, df_)
+
+        return sum(_probe(win_i, win_f) for win_i, win_f in iter_date_windows(di, df_, max_dias=366))
 
     def cjsg_download(
         self,

--- a/src/juscraper/courts/_esaj/download.py
+++ b/src/juscraper/courts/_esaj/download.py
@@ -73,6 +73,62 @@ def _extract_conversation_id(html: str) -> str:
     return ""
 
 
+def fetch_cjsg_first_page(
+    *,
+    scraper: "HTTPScraper",
+    base_url: str,
+    body: dict,
+    tipo_decisao: str,
+    sleep_time: float = 1.0,
+    chrome_ua: bool = False,
+) -> str:
+    """Run ``POST resultadoCompleta + GET pagina=1`` and return the HTML.
+
+    Shared by :func:`download_cjsg_pages` (continues into paginated download)
+    and by the ``count_only=True`` short-circuit in
+    :meth:`EsajSearchScraper.cjsg` (issue #92), which only needs the
+    first-page HTML to extract ``n_results``.
+
+    Side effect: updates ``scraper.session.headers`` with the eSAJ or Chrome
+    UA, mirroring :func:`download_cjsg_pages`.
+
+    Args:
+        scraper: :class:`HTTPScraper` providing ``session`` and
+            ``_request_with_retry`` (#203 retry policy).
+        base_url: ``https://esaj.<tribunal>.jus.br/`` (trailing slash).
+        body: Form body for ``POST cjsg/resultadoCompleta.do``.
+        tipo_decisao: ``"acordao"`` or ``"monocratica"``.
+        sleep_time: Seconds between the POST and the subsequent GET.
+        chrome_ua: When ``True`` sends the Chrome UA (TJSP); otherwise the
+            polite juscraper UA.
+
+    Returns:
+        First-page HTML as a ``str`` (latin1-decoded).
+    """
+    session = scraper.session
+    session.headers.update(_CHROME_HEADERS if chrome_ua else _ESAJ_HEADERS)
+
+    tipo_param = "A" if tipo_decisao == "acordao" else "D"
+    link_cjsg = f"{base_url}cjsg/resultadoCompleta.do"
+    first_page_url = f"{base_url}cjsg/trocaDePagina.do?tipoDeDecisao={tipo_param}&pagina=1"
+
+    # Body do POST descartado: a resposta é só o "ack" do form submit; o HTML
+    # com os resultados vem do GET subsequente em ``trocaDePagina.do?pagina=1``.
+    scraper._request_with_retry(
+        "POST", link_cjsg, data=body, timeout=30, allow_redirects=True,
+    )
+
+    time.sleep(sleep_time)
+    first_resp = scraper._request_with_retry(
+        "GET",
+        first_page_url,
+        timeout=30,
+        headers={"Accept": "text/html; charset=latin1;", "Referer": link_cjsg},
+    )
+    first_resp.encoding = "latin1"
+    return first_resp.text
+
+
 def _pages_to_fetch(
     paginas: "list | range | None" | None,
     n_pags: int,
@@ -137,33 +193,22 @@ def download_cjsg_pages(
     Returns:
         Path to the directory containing the downloaded files.
     """
-    session = scraper.session
-    session.headers.update(_CHROME_HEADERS if chrome_ua else _ESAJ_HEADERS)
-
     tipo_param = "A" if tipo_decisao == "acordao" else "D"
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
     path = os.path.join(download_path, "cjsg", timestamp)
     os.makedirs(path, exist_ok=True)
 
     link_cjsg = f"{base_url}cjsg/resultadoCompleta.do"
-    first_page_url = f"{base_url}cjsg/trocaDePagina.do?tipoDeDecisao={tipo_param}&pagina=1"
 
     logger.info("Submetendo formulário de busca...")
-    # Body do POST descartado: a resposta é só o "ack" do form submit; o HTML
-    # com os resultados vem do GET subsequente em ``trocaDePagina.do?pagina=1``.
-    scraper._request_with_retry(
-        "POST", link_cjsg, data=body, timeout=30, allow_redirects=True,
+    first_html = fetch_cjsg_first_page(
+        scraper=scraper,
+        base_url=base_url,
+        body=body,
+        tipo_decisao=tipo_decisao,
+        sleep_time=sleep_time,
+        chrome_ua=chrome_ua,
     )
-
-    time.sleep(sleep_time)
-    first_resp = scraper._request_with_retry(
-        "GET",
-        first_page_url,
-        timeout=30,
-        headers={"Accept": "text/html; charset=latin1;", "Referer": link_cjsg},
-    )
-    first_resp.encoding = "latin1"
-    first_html = first_resp.text
 
     n_pags = get_n_pags_callback(first_html)
 
@@ -206,4 +251,4 @@ def download_cjsg_pages(
     return path
 
 
-__all__ = ["download_cjsg_pages"]
+__all__ = ["download_cjsg_pages", "fetch_cjsg_first_page"]

--- a/src/juscraper/courts/_esaj/parse.py
+++ b/src/juscraper/courts/_esaj/parse.py
@@ -34,13 +34,26 @@ _TYPO_FIXES = {
 }
 
 
-def cjsg_n_pags(html_source: str) -> int:
-    """Extract the total number of pages from a cjsg first-page HTML.
+def cjsg_n_results(html_source: str) -> int:
+    """Extract the total number of results from a cjsg first-page HTML.
+
+    Canonical implementation — used by all six eSAJ courts. Sibling of
+    :func:`cjsg_n_pags`, which is now a thin wrapper that divides by the
+    20-hits-per-page constant.
+
+    Used by the ``count_only=True`` short-circuit in
+    :meth:`EsajSearchScraper.cjsg` (issue #92) and by
+    :func:`juscraper.courts._esaj.download.download_cjsg_pages` to size the
+    pagination loop.
 
     Uses a cascade of selectors and regex to survive layout changes. See the
     "Extração de número de páginas/resultados em raspadores HTML" section of
-    CLAUDE.md for the rationale. Canonical implementation — used by all six
-    eSAJ courts.
+    CLAUDE.md for the rationale.
+
+    Fallback for the "results table present but pagination marker missing"
+    edge case: counts ``tr.fundocinza1`` rows on the page (the row class used
+    by the eSAJ results table). Ensures ``count_only`` returns a meaningful
+    estimate instead of a hardcoded ``1``.
 
     Raises:
         ValueError: If the HTML contains a captcha/error marker, if it still
@@ -48,7 +61,7 @@ def cjsg_n_pags(html_source: str) -> int:
             pagination marker can be found.
 
     Returns:
-        Number of pages (0 when the search returned no hits, >=1 otherwise).
+        Number of results (0 when the search returned no hits, >=1 otherwise).
     """
     soup = BeautifulSoup(html_source, "html.parser")
 
@@ -106,7 +119,11 @@ def cjsg_n_pags(html_source: str) -> int:
                 "na resposta HTML. Verifique se a busca retornou resultados "
                 "ou se a estrutura da página mudou."
             )
-        return 1
+        # Pagination marker missing but results table present: count the
+        # result rows (eSAJ uses ``tr.fundocinza1`` for each hit). Minimum
+        # of 1 when the table exists but the row class differs.
+        n_rows = len(soup.find_all("tr", class_="fundocinza1"))
+        return max(n_rows, 1)
 
     txt_pag = td_npags.get_text()
 
@@ -126,8 +143,25 @@ def cjsg_n_pags(html_source: str) -> int:
             f"Formato inesperado encontrado. Texto: {txt_pag[:100]}"
         )
 
-    n_results = int(encontrados[0])
-    return (n_results + 19) // 20  # 20 hits per page, ceil div
+    return int(encontrados[0])
+
+
+def cjsg_n_pags(html_source: str) -> int:
+    """Extract the total number of pages from a cjsg first-page HTML.
+
+    Thin wrapper over :func:`cjsg_n_results` that converts result count into
+    page count via ``ceil(n_results / 20)`` (eSAJ serves 20 hits per page).
+
+    Raises:
+        ValueError: Same conditions as :func:`cjsg_n_results`.
+
+    Returns:
+        Number of pages (0 when the search returned no hits, >=1 otherwise).
+    """
+    n_results = cjsg_n_results(html_source)
+    if n_results == 0:
+        return 0
+    return (n_results + 19) // 20
 
 
 def _normalize_key(label: str) -> str:

--- a/src/juscraper/courts/_esaj/schemas.py
+++ b/src/juscraper/courts/_esaj/schemas.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 from ...schemas import (
     AutoChunkMixin,
+    CountOnlyMixin,
     DataJulgamentoMixin,
     DataPublicacaoMixin,
     IdFiltro,
@@ -21,7 +22,9 @@ from ...schemas import (
 from ...schemas.cjsg import OutputCJSGBase
 
 
-class InputCJSGEsajPuro(SearchBase, DataJulgamentoMixin, DataPublicacaoMixin, AutoChunkMixin):
+class InputCJSGEsajPuro(
+    SearchBase, DataJulgamentoMixin, DataPublicacaoMixin, AutoChunkMixin, CountOnlyMixin,
+):
     """Accepted input for TJAC/TJAL/TJAM/TJCE/TJMS ``cjsg``.
 
     Inherits ``extra='forbid'`` from :class:`SearchBase`, so unknown keyword

--- a/src/juscraper/courts/tjsp/cjpg_download.py
+++ b/src/juscraper/courts/tjsp/cjpg_download.py
@@ -18,7 +18,49 @@ from tqdm import tqdm
 from ...utils.cnj import clean_cnj
 from .exceptions import QueryTooLongError
 
-__all__ = ["QueryTooLongError", "cjpg_download"]
+__all__ = ["QueryTooLongError", "cjpg_download", "fetch_cjpg_first_page"]
+
+
+def fetch_cjpg_first_page(
+    *,
+    pesquisa: str,
+    session: requests.Session,
+    u_base: str,
+    classe: str | None = None,
+    assunto: str | None = None,
+    vara: str | None = None,
+    id_processo: str | None = None,
+    data_inicio: str | None = None,
+    data_fim: str | None = None,
+) -> requests.Response:
+    """Run the CJPG initial GET and return the raw :class:`requests.Response`.
+
+    Shared by :func:`cjpg_download` (continues into paginated download) and
+    by the ``count_only=True`` short-circuit in :meth:`TJSPScraper.cjpg`
+    (issue #92), which only needs the first-page HTML.
+
+    Returns the response (not just ``.text``) so that the download path can
+    persist it to disk and the count-only path can extract ``n_results``
+    from ``.text`` without an extra request.
+    """
+    id_processo_str = clean_cnj(id_processo) if id_processo is not None else ''
+
+    query = {
+        'conversationId': '',
+        'dadosConsulta.pesquisaLivre': pesquisa,
+        'tipoNumero': 'UNIFICADO',
+        'numeroDigitoAnoUnificado': id_processo_str[:15],
+        'foroNumeroUnificado': id_processo_str[-4:],
+        'dadosConsulta.nuProcesso': id_processo_str,
+        'classeTreeSelection.values': classe,
+        'assuntoTreeSelection.values': assunto,
+        'dadosConsulta.dtInicio': data_inicio,
+        'dadosConsulta.dtFim': data_fim,
+        'varasTreeSelection.values': vara,
+        'dadosConsulta.ordenacao': 'DESC'
+    }
+
+    return session.get(f"{u_base}cjpg/pesquisar.do", params=query)
 
 
 def cjpg_download(
@@ -51,24 +93,17 @@ def cjpg_download(
         ValueError: If ``get_n_pags_callback`` is missing or fails to
             extract the page count from the first-page HTML.
     """
-    id_processo_str = clean_cnj(id_processo) if id_processo is not None else ''
-
-    query = {
-        'conversationId': '',
-        'dadosConsulta.pesquisaLivre': pesquisa,
-        'tipoNumero': 'UNIFICADO',
-        'numeroDigitoAnoUnificado': id_processo_str[:15],
-        'foroNumeroUnificado': id_processo_str[-4:],
-        'dadosConsulta.nuProcesso': id_processo_str,
-        'classeTreeSelection.values': classe,
-        'assuntoTreeSelection.values': assunto,
-        'dadosConsulta.dtInicio': data_inicio,
-        'dadosConsulta.dtFim': data_fim,
-        'varasTreeSelection.values': vara,
-        'dadosConsulta.ordenacao': 'DESC'
-    }
-
-    r0 = session.get(f"{u_base}cjpg/pesquisar.do", params=query)
+    r0 = fetch_cjpg_first_page(
+        pesquisa=pesquisa,
+        session=session,
+        u_base=u_base,
+        classe=classe,
+        assunto=assunto,
+        vara=vara,
+        id_processo=id_processo,
+        data_inicio=data_inicio,
+        data_fim=data_fim,
+    )
     try:
         if get_n_pags_callback is None:
             raise ValueError(

--- a/src/juscraper/courts/tjsp/cjpg_parse.py
+++ b/src/juscraper/courts/tjsp/cjpg_parse.py
@@ -13,18 +13,34 @@ from tqdm import tqdm
 logger = logging.getLogger("juscraper.cjpg_parse")
 
 
-def cjpg_n_pags(page_source):
-    """
-    Extracts the number of pages from the CJPG search results HTML.
+def cjpg_n_results(page_source) -> int:
+    """Extracts the total number of results from a CJPG first-page HTML.
+
+    Sibling of :func:`cjpg_n_pags`, which is now a thin wrapper that divides
+    by the 10-hits-per-page constant. Used by the ``count_only=True``
+    short-circuit in :meth:`TJSPScraper.cjpg` (issue #92).
 
     Uses cascading selector + regex strategy to tolerate TJSP layout changes.
-    Mirrors the approach in ``cjsg_n_pags`` (CJSG uses 20 results/page; CJPG uses 10).
+    Mirrors :func:`juscraper.courts._esaj.parse.cjsg_n_results`.
+
+    Fallback for "results table present but pagination marker missing":
+    counts ``tr.fundocinza1`` rows inside ``divDadosResultado`` instead of
+    returning a hardcoded ``1`` — ensures ``count_only`` returns a meaningful
+    estimate.
+
+    Returns:
+        int: Number of results (0 when the search returned no hits).
+
+    Raises:
+        ValueError: When no pagination marker is found and the results table
+            is also absent — typically signals the search form did not submit
+            or the HTML layout changed.
     """
     soup = BeautifulSoup(page_source, "html.parser")
 
     # Zero-results guard: eSAJ returns the search form (without
     # ``divDadosResultado``) when nothing matches. Mirror the pattern in
-    # ``cjsg_n_pags`` so ``cjpg_download`` can short-circuit and the public
+    # ``cjsg_n_results`` so ``cjpg_download`` can short-circuit and the public
     # call returns an empty DataFrame instead of raising. Refs #109.
     page_text = soup.get_text().lower()
     if (
@@ -56,11 +72,12 @@ def cjpg_n_pags(page_source):
                 page_element = td
                 break
 
-    # 4) If results table exists but no pagination element, assume 1 page
+    # 4) Pagination marker missing but results table present: count rows.
     if page_element is None:
         div_dados = soup.find('div', {'id': 'divDadosResultado'})
         if div_dados is not None and div_dados.find('tr', class_='fundocinza1'):
-            return 1
+            n_rows = len(div_dados.find_all('tr', class_='fundocinza1'))
+            return max(n_rows, 1)
         raise ValueError(
             "Não foi possível encontrar o seletor de número de páginas "
             "na resposta HTML. Verifique se a busca retornou resultados "
@@ -93,8 +110,20 @@ def cjpg_n_pags(page_source):
     else:
         results = int(match.group(1))
 
-    pags = (results + 9) // 10  # math.ceil(results / 10)
-    return pags
+    return results
+
+
+def cjpg_n_pags(page_source) -> int:
+    """Extracts the number of pages from a CJPG first-page HTML.
+
+    Thin wrapper over :func:`cjpg_n_results` that converts result count into
+    page count via ``ceil(n_results / 10)`` (CJPG serves 10 hits per page;
+    differs from CJSG's 20).
+    """
+    n_results = cjpg_n_results(page_source)
+    if n_results == 0:
+        return 0
+    return (n_results + 9) // 10
 
 
 def cjpg_parse_single(path):

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -198,6 +198,31 @@ class TJSPScraper(EsajSearchScraper):
         """
         return super().cjsg(pesquisa=pesquisa, paginas=paginas, **kwargs)
 
+    def _cjsg_count_only(
+        self,
+        pesquisa: str,
+        paginas: int | list | range | None,
+        **kwargs: Any,
+    ) -> int:
+        """Override TJSP — valida limite de 120 chars antes do probe (#92).
+
+        O caminho normal de cjsg em TJSP passa por :meth:`cjsg_download`
+        (override), que roda :func:`validate_pesquisa_length` antes de
+        delegar para a base. Com ``count_only=True``, o ramo na base desvia
+        direto para :meth:`_cjsg_count_only` e pula esse check — entao
+        replicamos a validacao aqui antes de delegar para
+        :meth:`EsajSearchScraper._cjsg_count_only`. Espelha o padrao de
+        :meth:`cjsg_download` (pop manual dos search aliases para evitar
+        reprocessamento no helper de pipeline).
+        """
+        pesquisa = normalize_pesquisa(pesquisa, **kwargs)
+        for alias in SEARCH_ALIASES:
+            kwargs.pop(alias, None)
+        validate_pesquisa_length(pesquisa, endpoint="CJSG")
+        return super()._cjsg_count_only(
+            pesquisa=pesquisa, paginas=paginas, **kwargs,
+        )
+
     def cjsg_download(
         self,
         pesquisa: str = "",
@@ -409,6 +434,13 @@ class TJSPScraper(EsajSearchScraper):
         e ``auto_chunk=True``, itera janelas disjuntas via
         :func:`iter_date_windows`. ``auto_chunk=False`` + janela > 366d
         levanta :class:`ValueError` (consistencia com caminho normal).
+
+        **Fail-fast no auto-chunk**: diferente do caminho normal
+        (:func:`run_auto_chunk`), que tolera falha por janela como
+        :class:`UserWarning` e devolve resultado parcial deduplicado, este
+        probe usa ``sum()`` — qualquer :class:`ValueError` em uma janela
+        aborta toda a iteracao. Decisao deliberada: estimativa parcial sem
+        aviso seria pior que erro explicito.
         """
         if paginas is not None:
             warnings.warn(
@@ -430,7 +462,7 @@ class TJSPScraper(EsajSearchScraper):
         )
         validate_pesquisa_length(inp.pesquisa, endpoint="CJPG")
 
-        auto_chunk = getattr(inp, "auto_chunk", True)
+        auto_chunk = inp.auto_chunk
         di = inp.data_julgamento_inicio
         df_ = inp.data_julgamento_fim
 

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -5,14 +5,23 @@ import logging
 import os
 import shutil
 import tempfile
+import warnings
 from typing import Any, Literal
 
 from pydantic import BaseModel
 
-from ...utils.params import SEARCH_ALIASES, apply_input_pipeline_search, normalize_pesquisa, pop_deprecated_alias
+from ...utils.params import (
+    SEARCH_ALIASES,
+    apply_input_pipeline_search,
+    iter_date_windows,
+    normalize_pesquisa,
+    pop_deprecated_alias,
+    validate_intervalo_datas,
+)
 from .._esaj.base import EsajSearchScraper, run_auto_chunk
 from .cjpg_download import cjpg_download as cjpg_download_mod
-from .cjpg_parse import cjpg_n_pags, cjpg_parse_manager
+from .cjpg_download import fetch_cjpg_first_page
+from .cjpg_parse import cjpg_n_pags, cjpg_n_results, cjpg_parse_manager
 from .cpopg_download import cpopg_download_api, cpopg_download_html
 from .cpopg_parse import cpopg_parse_manager, get_cpopg_download_links
 from .cposg_download import cposg_download_api, cposg_download_html
@@ -146,6 +155,11 @@ class TJSPScraper(EsajSearchScraper):
                   intervalo ``data_julgamento_*`` excede 366 dias,
                   divide internamente em janelas, baixa cada uma e
                   concatena com dedup por ``cd_acordao``.
+                * ``count_only`` (bool): Default ``False``. Se ``True``,
+                  faz so a chamada inicial e retorna ``int`` com o total
+                  de resultados em vez de ``pd.DataFrame``. Util pra
+                  estimar wall-clock antes de coleta longa (issue #92).
+                  Soma bruta cross-janela em ``auto_chunk=True``.
 
         Aliases deprecados (popados com ``DeprecationWarning`` antes do
         pydantic):
@@ -160,10 +174,11 @@ class TJSPScraper(EsajSearchScraper):
             QueryTooLongError: Quando ``pesquisa`` excede 120 chars.
 
         Returns:
-            pd.DataFrame: Resultados parseados; colunas conforme
-            :class:`OutputCJSGTJSP` (``processo``, ``ementa``,
+            pd.DataFrame | int: Resultados parseados (colunas conforme
+            :class:`OutputCJSGTJSP` — ``processo``, ``ementa``,
             ``data_julgamento``, ``cd_acordao``, ``relator``,
-            ``orgao_julgador``).
+            ``orgao_julgador``); ``int`` com o total de resultados quando
+            ``count_only=True``.
 
         Exemplo:
             >>> import juscraper as jus
@@ -171,6 +186,8 @@ class TJSPScraper(EsajSearchScraper):
             >>> df = tjsp.cjsg("dano moral", paginas=range(1, 3),
             ...                tipo_decisao="acordao",
             ...                data_julgamento_inicio="01/01/2024")
+            >>> # Estimativa pre-scraping (issue #92):
+            >>> n = tjsp.cjsg("dano moral", count_only=True)
 
         See also:
             :class:`~juscraper.courts.tjsp.schemas.InputCJSGTJSP` —
@@ -288,6 +305,14 @@ class TJSPScraper(EsajSearchScraper):
                   divide internamente em janelas, baixa cada uma e
                   concatena com dedup por ``id_processo``. Veja a secao
                   "Auto-chunking" abaixo.
+                * ``count_only`` (bool): Default ``False``. Se ``True``,
+                  faz so o GET inicial, extrai o total de resultados via
+                  ``cjpg_n_results`` e retorna ``int`` em vez de
+                  ``pd.DataFrame``. Util pra estimar wall-clock antes de
+                  coleta longa (issue #92). Com ``auto_chunk=True`` +
+                  janela > 366 dias, itera janelas disjuntas e soma —
+                  soma bruta (sem dedup por ``id_processo``). ``paginas``
+                  e ignorado (emite ``UserWarning``).
 
         Aliases deprecados (popados com ``DeprecationWarning`` antes do
         pydantic):
@@ -308,11 +333,12 @@ class TJSPScraper(EsajSearchScraper):
                 sao passados simultaneamente.
 
         Returns:
-            pd.DataFrame: Resultados parseados; colunas conforme
-            :class:`OutputCJPGTJSP` (``id_processo``, ``cd_processo`` e
+            pd.DataFrame | int: Resultados parseados (colunas conforme
+            :class:`OutputCJPGTJSP` — ``id_processo``, ``cd_processo`` e
             campos extras emitidos pelo parser via ``extra='allow'`` —
             ``classe``, ``assunto``, ``magistrado``, ``comarca``,
-            ``foro``, ``vara``, ``data_disponibilizacao``, ``decisao``).
+            ``foro``, ``vara``, ``data_disponibilizacao``, ``decisao``);
+            ``int`` com o total de resultados quando ``count_only=True``.
 
         Exemplo:
             >>> import juscraper as jus
@@ -324,6 +350,8 @@ class TJSPScraper(EsajSearchScraper):
             >>> df = tjsp.cjpg(paginas=1, classe=12728, assunto=[3607, 5885],
             ...                data_julgamento_inicio="01/01/2024",
             ...                data_julgamento_fim="31/03/2024")
+            >>> # Estimativa pre-scraping (issue #92):
+            >>> n = tjsp.cjpg("dano moral", count_only=True)
 
         See also:
             :class:`~juscraper.courts.tjsp.schemas.InputCJPGTJSP` —
@@ -344,6 +372,10 @@ class TJSPScraper(EsajSearchScraper):
         # delegar para ``cjpg_download``. Refs #232.
         _pop_cjpg_plural_aliases(kwargs)
 
+        # count_only=True: probe leve antes do run_auto_chunk (issue #92).
+        if kwargs.get("count_only", False):
+            return self._cjpg_count_only(pesquisa=pesquisa, paginas=paginas, **kwargs)
+
         chunked = run_auto_chunk(
             method=self.cjpg,
             method_label="TJSPScraper.cjpg()",
@@ -361,6 +393,70 @@ class TJSPScraper(EsajSearchScraper):
             return self.cjpg_parse(path)
         finally:
             shutil.rmtree(path, ignore_errors=True)
+
+    def _cjpg_count_only(
+        self,
+        pesquisa: str,
+        paginas: int | list | range | None,
+        **kwargs: Any,
+    ) -> int:
+        """Probe leve para ``cjpg(count_only=True)`` — refs #92.
+
+        Faz o GET inicial por janela, extrai ``n_results`` via
+        :func:`cjpg_n_results` e retorna a soma. ``paginas`` e ignorado.
+
+        Multi-janela: se o intervalo ``data_julgamento_*`` excede 366 dias
+        e ``auto_chunk=True``, itera janelas disjuntas via
+        :func:`iter_date_windows`. ``auto_chunk=False`` + janela > 366d
+        levanta :class:`ValueError` (consistencia com caminho normal).
+        """
+        if paginas is not None:
+            warnings.warn(
+                "paginas e ignorado quando count_only=True (probe sempre olha so a pagina 1).",
+                UserWarning,
+                stacklevel=3,
+            )
+
+        inp = apply_input_pipeline_search(
+            InputCJPGTJSP,
+            f"{type(self).__name__}.cjpg(count_only=True)",
+            pesquisa=pesquisa,
+            paginas=None,
+            kwargs=kwargs,
+            consume_pesquisa_aliases=True,
+            nullable_pesquisa=True,
+            max_dias=None,
+            origem_mensagem="O eSAJ",
+        )
+        validate_pesquisa_length(inp.pesquisa, endpoint="CJPG")
+
+        auto_chunk = getattr(inp, "auto_chunk", True)
+        di = inp.data_julgamento_inicio
+        df_ = inp.data_julgamento_fim
+
+        if not auto_chunk:
+            validate_intervalo_datas(
+                di, df_, max_dias=366, rotulo="data_julgamento", origem="O eSAJ",
+            )
+
+        def _probe(win_i: str | None, win_f: str | None) -> int:
+            r0 = fetch_cjpg_first_page(
+                pesquisa=inp.pesquisa,
+                session=self.session,
+                u_base=self.u_base,
+                classe=inp.classe,
+                assunto=inp.assunto,
+                vara=inp.vara,
+                id_processo=inp.id_processo,
+                data_inicio=win_i,
+                data_fim=win_f,
+            )
+            return cjpg_n_results(r0.content)
+
+        if not auto_chunk or di is None or df_ is None:
+            return _probe(di, df_)
+
+        return sum(_probe(win_i, win_f) for win_i, win_f in iter_date_windows(di, df_, max_dias=366))
 
     def cjpg_download(
         self,

--- a/src/juscraper/courts/tjsp/schemas.py
+++ b/src/juscraper/courts/tjsp/schemas.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, ConfigDict
 from ...schemas import (
     AutoChunkMixin,
     CnjInputBase,
+    CountOnlyMixin,
     DataJulgamentoMixin,
     IdFiltro,
     IdFiltroUnico,
@@ -32,7 +33,7 @@ from ...schemas import (
 from ...schemas.cjsg import OutputCJSGBase
 
 
-class InputCJSGTJSP(SearchBase, DataJulgamentoMixin, AutoChunkMixin):
+class InputCJSGTJSP(SearchBase, DataJulgamentoMixin, AutoChunkMixin, CountOnlyMixin):
     """Accepted input for TJSP ``cjsg``. Unknown kwargs raise via ``extra='forbid'``.
 
     Herda filtro de data de julgamento via :class:`DataJulgamentoMixin`.
@@ -65,7 +66,7 @@ class OutputCJSGTJSP(OutputCJSGBase):
     orgao_julgador: str | None = None
 
 
-class InputCJPGTJSP(SearchBase, DataJulgamentoMixin, AutoChunkMixin):
+class InputCJPGTJSP(SearchBase, DataJulgamentoMixin, AutoChunkMixin, CountOnlyMixin):
     """Accepted input for TJSP ``cjpg``. Unknown kwargs raise via ``extra='forbid'``.
 
     Sobrescreve ``pesquisa`` com default vazio porque o TJSP permite buscar

--- a/src/juscraper/schemas/__init__.py
+++ b/src/juscraper/schemas/__init__.py
@@ -3,6 +3,7 @@ from .cjsg import OutputCJSGBase, SearchBase
 from .consulta import CnjInputBase, OutputCnjConsultaBase
 from .mixins import (
     AutoChunkMixin,
+    CountOnlyMixin,
     DataJulgamentoMixin,
     DataPublicacaoMixin,
     OutputDataPublicacaoMixin,
@@ -15,6 +16,7 @@ __all__ = [
     "SearchBase",
     "OutputCJSGBase",
     "AutoChunkMixin",
+    "CountOnlyMixin",
     "PaginasMixin",
     "DataJulgamentoMixin",
     "DataPublicacaoMixin",

--- a/src/juscraper/schemas/mixins.py
+++ b/src/juscraper/schemas/mixins.py
@@ -116,6 +116,13 @@ class CountOnlyMixin(BaseModel):
     no caminho normal quando ha documentos republicados (mesma chave em
     janelas distintas).
 
+    **Fail-fast no auto-chunk** (divergencia deliberada do caminho normal):
+    o caminho normal (:func:`juscraper.courts._esaj.base.run_auto_chunk`)
+    tolera falha por janela como :class:`UserWarning` e devolve parcial
+    deduplicado. ``count_only`` usa ``sum()`` — qualquer ``ValueError`` em
+    uma janela aborta toda a iteracao e propaga limpo. Estimativa parcial
+    silenciosa seria mais perigosa que erro explicito.
+
     Tribunais que ainda nao implementam ``count_only`` **nao devem herdar**
     deste mixin — ``extra='forbid'`` da classe concreta rejeita o flag com
     :class:`TypeError`, sinalizando ao usuario que o endpoint nao expoe a

--- a/src/juscraper/schemas/mixins.py
+++ b/src/juscraper/schemas/mixins.py
@@ -13,6 +13,8 @@ Atual:
 - :class:`DataJulgamentoMixin` — filtro de Input (~13 tribunais).
 - :class:`DataPublicacaoMixin` — filtro de Input (~11 tribunais).
 - :class:`AutoChunkMixin` — flag de Input (familia eSAJ; cjsg + cjpg).
+- :class:`CountOnlyMixin` — flag de Input que muda o tipo de retorno para
+  ``int`` (familia eSAJ cjsg + TJSP cjpg). Refs #92.
 - :class:`OutputRelatoriaMixin` — colunas de Output (>= 10 parsers cjsg
   concretos).
 - :class:`OutputDataPublicacaoMixin` — coluna de Output (>= 9 parsers).
@@ -93,6 +95,41 @@ class AutoChunkMixin(BaseModel):
     """
 
     auto_chunk: bool = True
+
+
+class CountOnlyMixin(BaseModel):
+    """Flag opcional ``count_only`` para probe pre-scraping (issue #92).
+
+    Default ``False``. Quando ``True``, o metodo publico (``cjsg``/``cjpg``):
+
+    - Faz **uma unica** chamada de rede por janela (POST inicial + 1 GET no
+      caso eSAJ; 1 GET no caso CJPG).
+    - Extrai ``n_results`` do HTML via ``cjsg_n_results``/``cjpg_n_results``.
+    - Retorna ``int`` em vez de ``pd.DataFrame``.
+    - **Nao** salva HTML em disco, **nao** parseia conteudo.
+
+    Multi-janela: se ``auto_chunk=True`` e o intervalo ``data_julgamento_*``
+    excede o teto do tribunal (eSAJ: 366 dias), o metodo itera as janelas
+    disjuntas (:func:`juscraper.utils.params.iter_date_windows`) e **soma
+    as contagens**. Soma bruta — sem dedup por ``cd_acordao``/``id_processo``.
+    Util para estimativa de wall-clock; pode divergir de ``len(cjsg(...))``
+    no caminho normal quando ha documentos republicados (mesma chave em
+    janelas distintas).
+
+    Tribunais que ainda nao implementam ``count_only`` **nao devem herdar**
+    deste mixin — ``extra='forbid'`` da classe concreta rejeita o flag com
+    :class:`TypeError`, sinalizando ao usuario que o endpoint nao expoe a
+    feature ainda. Hoje (refs #92): familia eSAJ cjsg (TJAC/TJAL/TJAM/TJCE/
+    TJMS/TJSP) + TJSP cjpg.
+
+    Nota: como :class:`AutoChunkMixin`, o flag ``count_only`` e consumido
+    no metodo publico **antes** da validacao completa do schema — o caminho
+    count_only chama o probe diretamente e nao passa por ``cjsg_download``/
+    ``cjpg_download``. O mixin documenta a API publica e da rede de seguranca
+    via paridade de assinatura/docstring.
+    """
+
+    count_only: bool = False
 
 
 class OutputRelatoriaMixin(BaseModel):

--- a/tests/tjac/test_cjsg_contract.py
+++ b/tests/tjac/test_cjsg_contract.py
@@ -5,6 +5,7 @@ Mocks ``resultadoCompleta.do`` + ``trocaDePagina.do`` with captured samples
 contract. Covers typical multi-page, single-page, and zero-result scenarios.
 """
 import pandas as pd
+import pytest
 import responses
 from responses.matchers import query_param_matcher, urlencoded_params_matcher
 
@@ -105,3 +106,22 @@ def test_cjsg_count_only_via_esaj_base(tmp_path, mocker):
     assert isinstance(n, int)
     assert n == 13929  # totalResultadoAbaRetornoFiltro-A no sample
     assert len(responses.calls) == 2  # POST + 1 GET, sem pagina 2
+
+
+def test_cjsg_count_only_rejects_long_data_publicacao_window(tmp_path):
+    """count_only=True com data_publicacao_* > 366d levanta ValueError (#92).
+
+    O auto-chunk so pivota em ``data_julgamento`` — ``data_publicacao`` nao
+    e dividida em janelas. O caminho normal valida o intervalo de
+    publicacao via ``apply_input_pipeline_search(max_dias=366)``; o probe
+    ``_cjsg_count_only`` precisa replicar para nao deixar passar janela
+    > 366d silenciosamente para o backend.
+    """
+    scraper = jus.scraper("tjac", download_path=str(tmp_path))
+    with pytest.raises(ValueError, match="366"):
+        scraper.cjsg(
+            "dano moral",
+            data_publicacao_inicio="01/01/2020",
+            data_publicacao_fim="01/01/2022",
+            count_only=True,
+        )

--- a/tests/tjac/test_cjsg_contract.py
+++ b/tests/tjac/test_cjsg_contract.py
@@ -84,3 +84,24 @@ def test_cjsg_no_results(tmp_path, mocker):
 
     assert isinstance(df, pd.DataFrame)
     assert df.empty
+
+
+@responses.activate
+def test_cjsg_count_only_via_esaj_base(tmp_path, mocker):
+    """Smoke: ``count_only=True`` em TJAC funciona via base eSAJ (issue #92).
+
+    Confirma que o ramo count_only declarado em :class:`EsajSearchScraper`
+    nao depende do override TJSP — vale tambem para TJAC/TJAL/TJAM/TJCE/
+    TJMS que herdam direto.
+    """
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+
+    n = jus.scraper("tjac", download_path=str(tmp_path)).cjsg(
+        "dano moral", count_only=True,
+    )
+
+    assert isinstance(n, int)
+    assert n == 13929  # totalResultadoAbaRetornoFiltro-A no sample
+    assert len(responses.calls) == 2  # POST + 1 GET, sem pagina 2

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -11,7 +11,7 @@ import pytest
 
 import juscraper
 from juscraper.courts.tjsp.cjpg_download import cjpg_download
-from juscraper.courts.tjsp.cjpg_parse import cjpg_n_pags, cjpg_parse_manager, cjpg_parse_single
+from juscraper.courts.tjsp.cjpg_parse import cjpg_n_pags, cjpg_n_results, cjpg_parse_manager, cjpg_parse_single
 from tests._helpers import load_sample
 
 
@@ -171,6 +171,29 @@ class TestCJPGUnit:
             assert len(df) == 0
         finally:
             os.unlink(temp_path)
+
+
+class TestCJPGNResults:
+    """Tests do helper :func:`cjpg_n_results` (issue #92)."""
+
+    def test_extracts_raw_count_legacy_format(self):
+        """Legacy 'Mostrando 1 a 10 de 25 resultados' -> 25."""
+        html = load_sample("tjsp", "cjpg/results_legacy.html")
+        assert cjpg_n_results(html) == 25
+
+    def test_extracts_raw_count_novo_formato(self):
+        """Novo formato 'Resultados 1 a 10 de 39764' -> 39764."""
+        html = load_sample("tjsp", "cjpg/results_novo_formato.html")
+        assert cjpg_n_results(html) == 39764
+
+    def test_zero_results_returns_zero(self):
+        html = load_sample("tjsp", "cjpg/no_results.html")
+        assert cjpg_n_results(html) == 0
+
+    def test_n_pags_e_wrapper_que_aplica_ceil_div(self):
+        """``cjpg_n_pags`` permanece um wrapper sobre ``cjpg_n_results``."""
+        html = load_sample("tjsp", "cjpg/results_novo_formato.html")
+        assert cjpg_n_pags(html) == (39764 + 9) // 10
 
 
 class TestCJPGDownload1Based:

--- a/tests/tjsp/test_cjpg_contract.py
+++ b/tests/tjsp/test_cjpg_contract.py
@@ -138,3 +138,82 @@ def test_cjpg_query_too_long_via_alias_raises(tmp_path):
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
     with pytest.warns(DeprecationWarning), pytest.raises(QueryTooLongError):
         scraper.cjpg(paginas=1, query=long_query)
+
+
+@responses.activate
+def test_cjpg_count_only_returns_int(tmp_path, mocker):
+    """``count_only=True`` short-circuits to int after the initial GET (#92)."""
+    mocker.patch("time.sleep")
+    _add_pesquisar("dano moral", "cjpg/results_novo_formato.html")
+
+    n = jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
+        "dano moral", count_only=True,
+    )
+
+    assert isinstance(n, int)
+    assert n == 39764  # "Resultados 1 a 10 de 39764" no sample
+    # Apenas 1 GET (pesquisar.do); nenhum trocarDePagina.do.
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_cjpg_count_only_zero_results(tmp_path, mocker):
+    """``count_only=True`` em busca sem hits retorna 0 (issue #92)."""
+    mocker.patch("time.sleep")
+    _add_pesquisar("juscraper_probe_zero_hits_xyzqwe", "cjpg/no_results.html")
+
+    n = jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
+        "juscraper_probe_zero_hits_xyzqwe", count_only=True,
+    )
+
+    assert n == 0
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjpg_count_only_sums_across_chunks(tmp_path, mocker):
+    """``count_only=True`` + janela > 366d soma contagens cross-window (#92).
+
+    Mocka 2 GETs distintos com `data_inicio` diferente (uma janela cada) e
+    afere que o total e a soma das contagens reportadas. Vai falhar se o
+    auto_chunk count-only path quebrar (ex.: iterar fora de
+    `iter_date_windows` ou nao somar). 39764 + 25 = 39789.
+    """
+    mocker.patch("time.sleep")
+    # Janela total: 02/01/2020 a 02/01/2022 = ~2 anos = 2 janelas de 366d.
+    # Janela 1: 02/01/2020 -> 02/01/2021. Janela 2: 03/01/2021 -> 02/01/2022.
+    expected_w1 = {
+        k: v for k, v in make_tjsp_cjpg_params("dano moral").items() if v is not None
+    }
+    expected_w1["dadosConsulta.dtInicio"] = "02/01/2020"
+    expected_w1["dadosConsulta.dtFim"] = "02/01/2021"
+    responses.add(
+        responses.GET,
+        f"{BASE}/pesquisar.do",
+        body=load_sample_bytes("tjsp", "cjpg/results_novo_formato.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+        match=[query_param_matcher(expected_w1)],
+    )
+
+    expected_w2 = dict(expected_w1)
+    expected_w2["dadosConsulta.dtInicio"] = "03/01/2021"
+    expected_w2["dadosConsulta.dtFim"] = "02/01/2022"
+    responses.add(
+        responses.GET,
+        f"{BASE}/pesquisar.do",
+        body=load_sample_bytes("tjsp", "cjpg/results_legacy.html"),
+        status=200,
+        content_type="text/html; charset=utf-8",
+        match=[query_param_matcher(expected_w2)],
+    )
+
+    n = jus.scraper("tjsp", download_path=str(tmp_path)).cjpg(
+        "dano moral",
+        data_julgamento_inicio="02/01/2020",
+        data_julgamento_fim="02/01/2022",
+        count_only=True,
+    )
+
+    assert isinstance(n, int)
+    assert n == 39764 + 25  # soma bruta cross-janela
+    assert len(responses.calls) == 2

--- a/tests/tjsp/test_cjsg_contract.py
+++ b/tests/tjsp/test_cjsg_contract.py
@@ -152,6 +152,52 @@ def test_cjsg_post_inicial_retenta_403(tmp_path, mocker):
 
 
 @responses.activate
+def test_cjsg_count_only_returns_int(tmp_path, mocker):
+    """``count_only=True`` short-circuits to an int after page 1 (issue #92)."""
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+
+    n = jus.scraper("tjsp", download_path=str(tmp_path)).cjsg(
+        "dano moral", count_only=True,
+    )
+
+    assert isinstance(n, int)
+    assert n == 2571077  # totalResultadoAbaRetornoFiltro-A no sample
+    # Garante que NAO houve fetch de pagina 2+. POST + 1 GET = 2 chamadas.
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_cjsg_count_only_zero_results(tmp_path, mocker):
+    """``count_only=True`` em busca sem hits retorna 0 (issue #92)."""
+    mocker.patch("time.sleep")
+    _add_post("juscraper_probe_zero_hits_xyzqwe")
+    _add_get(1, "cjsg/no_results.html")
+
+    n = jus.scraper("tjsp", download_path=str(tmp_path)).cjsg(
+        "juscraper_probe_zero_hits_xyzqwe", count_only=True,
+    )
+
+    assert n == 0
+
+
+@responses.activate
+def test_cjsg_count_only_ignora_paginas_com_warning(tmp_path, mocker):
+    """``count_only=True`` + ``paginas != None`` emite UserWarning e ignora."""
+    mocker.patch("time.sleep")
+    _add_post("dano moral")
+    _add_get(1, "cjsg/results_normal_page_01.html")
+
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.warns(UserWarning, match="paginas e ignorado"):
+        n = scraper.cjsg("dano moral", paginas=range(1, 5), count_only=True)
+
+    assert isinstance(n, int)
+    assert n == 2571077
+
+
+@responses.activate
 def test_cjsg_get_1a_pagina_retenta_503(tmp_path, mocker):
     """GET da pagina 1 retenta 503 transitorio (mesmo perfil das paginas >=2)."""
     mocker.patch("time.sleep")

--- a/tests/tjsp/test_cjsg_contract.py
+++ b/tests/tjsp/test_cjsg_contract.py
@@ -12,6 +12,7 @@ import pandas as pd
 import pytest
 import responses
 from responses.matchers import query_param_matcher, urlencoded_params_matcher
+from responses.registries import OrderedRegistry
 
 import juscraper as jus
 from juscraper.courts.tjsp.exceptions import QueryTooLongError
@@ -195,6 +196,108 @@ def test_cjsg_count_only_ignora_paginas_com_warning(tmp_path, mocker):
 
     assert isinstance(n, int)
     assert n == 2571077
+
+
+def test_cjsg_count_only_query_too_long_raises(tmp_path):
+    """TJSP cjsg + count_only=True mantem o guard de 120 chars (issue #92).
+
+    O ramo ``count_only`` desvia em :meth:`EsajSearchScraper.cjsg` antes
+    de chegar a :meth:`cjsg_download` (onde o caminho normal corre
+    :func:`validate_pesquisa_length`). O override TJSP de
+    ``_cjsg_count_only`` precisa preservar o check para que
+    ``QueryTooLongError`` continue propagando limpo em vez de virar
+    backend-reject opaco.
+    """
+    pesquisa = "a" * 121
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.raises(QueryTooLongError):
+        scraper.cjsg(pesquisa, count_only=True)
+
+
+def test_cjsg_count_only_auto_chunk_false_raises_on_long_window(tmp_path):
+    """auto_chunk=False + janela > 366d + count_only=True raises ValueError (#92).
+
+    Replica o comportamento estrito do caminho normal — ``cjsg_download``
+    valida via ``apply_input_pipeline_search(max_dias=366)``. Sem o check
+    explicito em ``_cjsg_count_only``, o probe enviaria a janela longa pro
+    backend e o usuario veria um erro opaco no probe em vez do
+    ``ValueError`` canonico.
+    """
+    scraper = jus.scraper("tjsp", download_path=str(tmp_path))
+    with pytest.raises(ValueError, match="366"):
+        scraper.cjsg(
+            "dano moral",
+            data_julgamento_inicio="01/01/2020",
+            data_julgamento_fim="01/01/2022",
+            auto_chunk=False,
+            count_only=True,
+        )
+
+
+@responses.activate(registry=OrderedRegistry)
+def test_cjsg_count_only_sums_across_chunks(tmp_path, mocker):
+    """count_only=True + janela > 366d soma contagens cross-window (#92).
+
+    Espelho do ``test_cjpg_count_only_sums_across_chunks`` para o caminho
+    base eSAJ (compartilhado por TJAC/TJAL/TJAM/TJCE/TJMS/TJSP). Mocka 2
+    POST+GET distintos por janela e afere a soma. Vai falhar se
+    ``_cjsg_count_only`` deixar de iterar via ``iter_date_windows`` ou
+    deixar de somar (ex.: regressao para usar so a primeira janela).
+    """
+    mocker.patch("time.sleep")
+
+    # Janela 1: 02/01/2020 -> 02/01/2021 (HTML retorna 2_571_077)
+    # Janela 2: 03/01/2021 -> 02/01/2022 (HTML retorna 78)
+    body_w1 = make_tjsp_cjsg_body(
+        "dano moral", data_inicio="02/01/2020", data_fim="02/01/2021",
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjsp", "cjsg/post_initial.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(body_w1, allow_blank=True)],
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjsp", "cjsg/results_normal_page_01.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": "1"})],
+    )
+
+    body_w2 = make_tjsp_cjsg_body(
+        "dano moral", data_inicio="03/01/2021", data_fim="02/01/2022",
+    )
+    responses.add(
+        responses.POST,
+        f"{BASE}/resultadoCompleta.do",
+        body=load_sample_bytes("tjsp", "cjsg/post_initial.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[urlencoded_params_matcher(body_w2, allow_blank=True)],
+    )
+    responses.add(
+        responses.GET,
+        f"{BASE}/trocaDePagina.do",
+        body=load_sample_bytes("tjsp", "cjsg/single_page.html"),
+        status=200,
+        content_type="text/html; charset=latin-1",
+        match=[query_param_matcher({"tipoDeDecisao": "A", "pagina": "1"})],
+    )
+
+    n = jus.scraper("tjsp", download_path=str(tmp_path)).cjsg(
+        "dano moral",
+        data_julgamento_inicio="02/01/2020",
+        data_julgamento_fim="02/01/2022",
+        count_only=True,
+    )
+
+    assert isinstance(n, int)
+    assert n == 2571077 + 78  # soma bruta cross-janela
+    assert len(responses.calls) == 4  # 2 POSTs + 2 GETs
 
 
 @responses.activate

--- a/tests/tjsp/test_cjsg_unit.py
+++ b/tests/tjsp/test_cjsg_unit.py
@@ -7,6 +7,7 @@ import tempfile
 import pandas as pd
 import pytest
 
+from juscraper.courts._esaj.parse import cjsg_n_results
 from juscraper.courts.tjsp.cjsg_parse import _cjsg_parse_single_page, cjsg_n_pags, cjsg_parse_manager
 from tests._helpers import load_sample
 
@@ -59,6 +60,35 @@ class TestCJSGNPages:
         )
         with pytest.raises(ValueError, match="Erro detectado"):
             cjsg_n_pags(html)
+
+
+class TestCJSGNResults:
+    """Tests do helper :func:`cjsg_n_results` (issue #92)."""
+
+    def test_extracts_raw_count_from_normal_results(self):
+        """Sample com paginacao explicita (``totalResultadoAbaRetornoFiltro``)."""
+        html = load_sample("tjsp", "cjsg/results_normal_page_01.html")
+        assert cjsg_n_results(html) == 2571077
+
+    def test_zero_results_returns_zero(self):
+        html = load_sample("tjsp", "cjsg/no_results.html")
+        assert cjsg_n_results(html) == 0
+
+    def test_single_result_fallback_counts_rows(self):
+        """Sample com 1 hit e sem marker de paginacao — fallback conta linhas."""
+        html = load_sample("tjsp", "cjsg/single_result.html")
+        assert cjsg_n_results(html) == 1
+
+    def test_single_page_uses_canonical_selector(self):
+        """Sample com totalResultado declarado — usa o numero do sample."""
+        html = load_sample("tjsp", "cjsg/single_page.html")
+        assert cjsg_n_results(html) == 78
+
+    def test_n_pags_e_wrapper_que_aplica_ceil_div(self):
+        """``cjsg_n_pags`` permanece um wrapper sobre ``cjsg_n_results``."""
+        html = load_sample("tjsp", "cjsg/results_normal_page_01.html")
+        # 2571077 resultados / 20 por pagina = 128554 paginas (ceil).
+        assert cjsg_n_pags(html) == (2571077 + 19) // 20
 
 
 class TestCJSGParseSinglePage:


### PR DESCRIPTION
## Resumo

Implementa a issue #92: adiciona o parâmetro `count_only: bool = False` em `cjsg` (TJAC, TJAL, TJAM, TJCE, TJMS, TJSP via base eSAJ) e `cjpg` (TJSP).

Quando passado, o método faz **só a chamada inicial** (POST + 1 GET no caso eSAJ; 1 GET no caso CJPG), extrai o total de resultados da primeira página via os helpers existentes e retorna `int` em vez de `pd.DataFrame`. Caso de uso: jurimetria/pesquisa empírica em direito — antes de rodar uma coleta de horas, o usuário consulta o total e decide se vale a pena, se refina filtros, ou se mapeia contagem por ano.

```python
import juscraper as jus
tjsp = jus.scraper("tjsp")

n = tjsp.cjpg(
    pesquisa="dano moral",
    data_julgamento_inicio="01/01/2024",
    data_julgamento_fim="31/12/2024",
    count_only=True,
)
print(f"~{n * 2 / 3600:.1f}h de coleta estimada")
```

## Decisões de design

1. **Surface API via schema pydantic.** `CountOnlyMixin` (em `schemas/mixins.py`, mesmo padrão de `AutoChunkMixin`) herdado por `InputCJSGEsajPuro`, `InputCJSGTJSP` e `InputCJPGTJSP`. Validação automática + paridade de docstring fiscalizada. `auto_chunk` é o precedente mais próximo — também é modificador de comportamento, não filtro de backend.

2. **Multi-janela soma contagens.** Quando `auto_chunk=True` (default) e o intervalo `data_julgamento_*` excede 366 dias, o probe itera `iter_date_windows` (janelas disjuntas: `cursor = win_end + one_day`) e **soma**. Sem dedup por `cd_acordao`/`id_processo` — `count_only` reflete a contagem **bruta do backend**, pode divergir levemente de `len(cjsg(...))` quando há acórdãos republicados em datas diferentes. Documentado na docstring e em `docs/api-conventions.qmd`.

3. **Escopo: TJSP + 5 eSAJ-puros automaticamente.** O ramo `count_only` está em `EsajSearchScraper.cjsg`, então TJAC/TJAL/TJAM/TJCE/TJMS ganham a feature de graça (mesmo diff que faria só pro TJSP). `cjpg` continua TJSP-only (não há base compartilhada).

## Mudanças

### Schema (3 arquivos)

- `src/juscraper/schemas/mixins.py`: novo `CountOnlyMixin`.
- `src/juscraper/schemas/__init__.py`: export.
- `src/juscraper/courts/_esaj/schemas.py` + `src/juscraper/courts/tjsp/schemas.py`: 3 schemas herdam o mixin.

### Parsers (2 arquivos)

- `cjsg_n_results` (em `_esaj/parse.py`) e `cjpg_n_results` (em `tjsp/cjpg_parse.py`) extraem o `n_results` cru reaproveitando a cascata de seletores/regex que já existia.
- `cjsg_n_pags` / `cjpg_n_pags` viram wrappers `(n + bucket - 1) // bucket` (bucket = 20 cjsg, 10 cjpg).
- Fallback "tabela presente, marker de paginação ausente" agora conta `tr.fundocinza1` em vez de retornar `1` hardcoded — melhora a estimativa.

### Helpers de fetch (2 arquivos)

- `fetch_cjsg_first_page` extraído de `_esaj/download.py` (POST + GET pagina=1).
- `fetch_cjpg_first_page` extraído de `tjsp/cjpg_download.py` (GET inicial).
- Reusados pelo caminho de download normal e pelo probe count_only — zero duplicação.

### Métodos públicos (2 arquivos)

- `EsajSearchScraper.cjsg` (cobre 6 tribunais) e `TJSPScraper.cjpg` ganharam ramo `count_only` antes do `run_auto_chunk`.
- `_cjsg_count_only` / `_cjpg_count_only` fazem a validação do schema (com `max_dias=None` para iterar janelas manualmente), replicam `validate_intervalo_datas(max_dias=366)` quando `auto_chunk=False`, e somam contagens cross-window quando `auto_chunk=True`.
- `paginas` é ignorado em count_only (emite `UserWarning`).

### Docs

- Bullet `count_only` adicionado nas docstrings de `EsajSearchScraper.cjsg`, `TJSPScraper.cjsg` (override) e `TJSPScraper.cjpg`. `Returns:` atualizado para `pd.DataFrame | int`.
- Nova seção "Pre-scraping count" em `docs/api-conventions.qmd` (inglês, regra do Quarto).
- Entrada em `CHANGELOG.md` sob `[Unreleased] > Added`.

### Testes (16 novos, total 1575 verde)

| Onde | Cenário |
|---|---|
| `tests/tjsp/test_cjsg_contract.py` | `count_only=True` retorna int (2.571.077) com só POST+1 GET; zero results; `paginas` ignorado com `UserWarning`. |
| `tests/tjsp/test_cjpg_contract.py` | `count_only=True` retorna int (39.764) com só 1 GET; zero results; **cross-chunk sum** (2 janelas, soma = 39.764 + 25). |
| `tests/tjac/test_cjsg_contract.py` | Smoke via base eSAJ: TJAC.cjsg com `count_only=True` retorna int (13.929). |
| `tests/tjsp/test_cjsg_unit.py` + `test_cjpg.py` | Granular: `*_n_results` em samples conhecidos (normal, zero, single_page, single_result, legacy, novo_formato) + regressão dos wrappers `*_n_pags`. |

Samples reaproveitados (não capturei nada novo): `tests/tjsp/samples/cjsg/results_normal_page_01.html`, `single_page.html`, `single_result.html`, `no_results.html`; `tests/tjsp/samples/cjpg/results_novo_formato.html`, `results_legacy.html`, `no_results.html`; `tests/tjac/samples/cjsg/results_normal_page_01.html`.

## Test plan

- [x] `pytest` — 1575 passed, 0 failed, 26 skipped (suite offline default).
- [x] `pre-commit run --files <18 arquivos>` — isort, pylint, flake8, mypy todos verdes.
- [x] Smoke manual de importação + verificação de campo no schema.
- [ ] Smoke de integração (uma chamada real a `tjsp.cjpg(..., count_only=True)`) — opcional, pode rodar antes do merge.

## Edge cases mapeados

- **`paginas` + `count_only=True`**: ignora `paginas` com `UserWarning` (probe sempre na pág 1).
- **`auto_chunk=False` + intervalo > 366d + `count_only=True`**: levanta `ValueError` (mesma mensagem do caminho normal).
- **Captcha / layout-change na pág 1**: `*_n_results` propaga `ValueError` (mesmo comportamento do caminho normal).
- **Tribunal não wired**: `extra="forbid"` rejeita `count_only` com `TypeError` (automático, porque o schema concreto não herda `CountOnlyMixin`).
- **`count_only` em `*_download`**: aceito pelo schema compartilhado mas inerte (o `_build_cjsg_body` não consulta o campo). Não é o ideal, mas evita ramo extra de validação — mesma estratégia que `auto_chunk`.

## Out of scope (follow-ups)

- Estender pra `listar_processos` (Datajud/JusBR), `cpopg`, `cposg`.
- Dedup cross-janela na soma (caro: exigiria chamada extra com info de `cd_acordao`; provavelmente não vale).
- Rejeitar `count_only` em `*_download` explicitamente (hoje silenciosamente inerte).

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)