### PR TITLE
refactor(tjpe): promover helpers de cjsg para API publica (#197 etapa 3)

### DIFF
--- a/src/juscraper/courts/tjpe/client.py
+++ b/src/juscraper/courts/tjpe/client.py
@@ -73,8 +73,8 @@ class TJPEScraper(HTTPScraper):
             data_julgamento_inicio=inp.data_julgamento_inicio,
             data_julgamento_fim=inp.data_julgamento_fim,
             relator=inp.relator,
-            classe_cnj=inp.classe,
-            assunto_cnj=inp.assunto,
+            classe=inp.classe,
+            assunto=inp.assunto,
             meio_tramitacao=inp.meio_tramitacao,
             tipo_decisao=inp.tipo_decisao,
         )

--- a/src/juscraper/courts/tjpe/download.py
+++ b/src/juscraper/courts/tjpe/download.py
@@ -112,7 +112,7 @@ def extract_escolha_button_id(html: str, tipo: str = "Acórdãos") -> str:
     raise ValueError(f"Could not find escolha button for '{tipo}'")
 
 
-def extract_pagination_ids(html: str):
+def extract_pagination_ids(html: str) -> tuple[str, str]:
     """Extract the form ID and datascroller ID for AJAX pagination."""
     # The datascroller ID reveals the form ID (e.g. "j_id81:j_id87")
     scroller_match = re.search(
@@ -152,14 +152,14 @@ def extract_submit_id(search_html: str | None) -> str:
 def build_cjsg_form_body(
     viewstate: str,
     submit_id: str,
-    pesquisa: str,
+    pesquisa: str | None,
     *,
-    data_julgamento_inicio: str = "",
-    data_julgamento_fim: str = "",
-    relator: str = "",
-    classe: str = "",
-    assunto: str = "",
-    meio_tramitacao: str = "",
+    data_julgamento_inicio: str | None = None,
+    data_julgamento_fim: str | None = None,
+    relator: str | None = None,
+    classe: str | None = None,
+    assunto: str | None = None,
+    meio_tramitacao: str | None = None,
     tipo_decisao: str = "acordaos",
     current_date_hint: str = _CURRENT_DATE_HINT,
 ) -> dict[str, str]:
@@ -170,7 +170,8 @@ def build_cjsg_form_body(
     so aparecem quando ativos (ausencia difere de string vazia para o
     backend). Todos os valores sao retornados como strings para que
     :func:`responses.matchers.urlencoded_params_matcher` possa ser usado
-    com ``allow_blank=True`` nos contratos.
+    com ``allow_blank=True`` nos contratos. ``None`` em qualquer filtro
+    opcional e tratado como string vazia (sem filtro).
     """
     body: dict[str, str] = {
         "formPesquisaJurisprudencia": "formPesquisaJurisprudencia",
@@ -180,14 +181,14 @@ def build_cjsg_form_body(
         "formPesquisaJurisprudencia:j_id48": "",
         "formPesquisaJurisprudencia:numeroAntigoDigito": "",
         "formPesquisaJurisprudencia:numeroAntigoBarramento": "",
-        "formPesquisaJurisprudencia:j_id59InputDate": data_julgamento_inicio,
+        "formPesquisaJurisprudencia:j_id59InputDate": data_julgamento_inicio or "",
         "formPesquisaJurisprudencia:j_id59InputCurrentDate": current_date_hint,
-        "formPesquisaJurisprudencia:periodoFimInputDate": data_julgamento_fim,
+        "formPesquisaJurisprudencia:periodoFimInputDate": data_julgamento_fim or "",
         "formPesquisaJurisprudencia:periodoFimInputCurrentDate": current_date_hint,
-        "formPesquisaJurisprudencia:selectRelator": relator,
-        "formPesquisaJurisprudencia:selectClasseCNJ": classe,
-        "formPesquisaJurisprudencia:selectAssuntoCNJ": assunto,
-        "formPesquisaJurisprudencia:selectMeioTramitacao": meio_tramitacao,
+        "formPesquisaJurisprudencia:selectRelator": relator or "",
+        "formPesquisaJurisprudencia:selectClasseCNJ": classe or "",
+        "formPesquisaJurisprudencia:selectAssuntoCNJ": assunto or "",
+        "formPesquisaJurisprudencia:selectMeioTramitacao": meio_tramitacao or "",
         "javax.faces.ViewState": viewstate,
         submit_id: submit_id,
     }
@@ -230,12 +231,12 @@ def step2_post_search(
         viewstate=viewstate,
         submit_id=submit_id,
         pesquisa=pesquisa,
-        data_julgamento_inicio=data_julgamento_inicio or "",
-        data_julgamento_fim=data_julgamento_fim or "",
-        relator=relator or "",
-        classe=classe or "",
-        assunto=assunto or "",
-        meio_tramitacao=meio_tramitacao or "",
+        data_julgamento_inicio=data_julgamento_inicio,
+        data_julgamento_fim=data_julgamento_fim,
+        relator=relator,
+        classe=classe,
+        assunto=assunto,
+        meio_tramitacao=meio_tramitacao,
         tipo_decisao=tipo_decisao,
     )
     resp = request_fn("POST", CONSULTA_URL, data=data, timeout=30)

--- a/src/juscraper/courts/tjpe/download.py
+++ b/src/juscraper/courts/tjpe/download.py
@@ -24,7 +24,20 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = "https://www.tjpe.jus.br/consultajurisprudenciaweb/xhtml/consulta"
 
+CONSULTA_URL = f"{BASE_URL}/consulta.xhtml"
+ESCOLHA_URL = f"{BASE_URL}/escolhaResultado.xhtml"
+RESULTADO_URL = f"{BASE_URL}/resultado.xhtml"
+
 RESULTS_PER_PAGE = 5
+
+# Hint do calendario RichFaces (mes/ano corrente exibido pelo widget). O
+# backend nao filtra por esses campos — sao echo do estado UI. Congelados
+# para permitir matching byte-a-byte nos contratos offline.
+_CURRENT_DATE_HINT = "04/2026"
+
+# Submit button ID padrao quando o regex de extracao nao casa em `search_html`.
+# O ID real vem do JS `jsfcljs(...)` na pagina de consulta.
+DEFAULT_SUBMIT_ID = "formPesquisaJurisprudencia:j_id101"
 
 _PAGINATION_CSS_SELECTORS: tuple[str, ...] = (
     "div.resultado-header table.table-header-resultado",
@@ -36,7 +49,7 @@ _PAGINATION_REGEXES: tuple[re.Pattern[str], ...] = (
 _ZERO_MARKERS: tuple[str, ...] = ("nenhum documento encontrado",)
 
 
-def _extract_viewstate(html: str) -> str:
+def extract_viewstate(html: str) -> str:
     """Extract javax.faces.ViewState from the HTML."""
     match = re.search(
         r'name="javax\.faces\.ViewState"[^>]*value="([^"]*)"', html
@@ -46,7 +59,7 @@ def _extract_viewstate(html: str) -> str:
     return match.group(1)
 
 
-def _extract_total_docs(html: str) -> int:
+def extract_total_docs(html: str) -> int:
     """Extract total document count using cascading selectors + regexes (refs #87)."""
     n = extract_count_with_cascade(
         html,
@@ -58,7 +71,7 @@ def _extract_total_docs(html: str) -> int:
     return n if n is not None else 0
 
 
-def _is_results_page(html: str) -> bool:
+def is_results_page(html: str) -> bool:
     """Check if the HTML is a results page (not the escolha page).
 
     Case-insensitive: a results page traz o rotulo ``Documentos encontrados:``
@@ -68,7 +81,7 @@ def _is_results_page(html: str) -> bool:
     return "documentos encontrados:" in html_lower and "documento 1" in html_lower
 
 
-def _is_escolha_page(html: str) -> bool:
+def is_escolha_page(html: str) -> bool:
     """Check if we got the 'escolha' page (choose result type).
 
     Case-insensitive: a pagina de escolha traz ``N documentos encontrados``
@@ -79,7 +92,7 @@ def _is_escolha_page(html: str) -> bool:
     return "documentos encontrados" in html_lower and "documento 1" not in html_lower
 
 
-def _extract_escolha_button_id(html: str, tipo: str = "Acórdãos") -> str:
+def extract_escolha_button_id(html: str, tipo: str = "Acórdãos") -> str:
     """Extract the form submit ID for the result type link on the escolha page."""
     soup = BeautifulSoup(html, "html.parser")
     for link in soup.find_all("a", onclick=True):
@@ -99,7 +112,7 @@ def _extract_escolha_button_id(html: str, tipo: str = "Acórdãos") -> str:
     raise ValueError(f"Could not find escolha button for '{tipo}'")
 
 
-def _extract_pagination_ids(html: str):
+def extract_pagination_ids(html: str):
     """Extract the form ID and datascroller ID for AJAX pagination."""
     # The datascroller ID reveals the form ID (e.g. "j_id81:j_id87")
     scroller_match = re.search(
@@ -119,23 +132,90 @@ def _extract_pagination_ids(html: str):
     return form_id, scroller_id
 
 
-def _step1_get_session(request_fn: RequestFn) -> tuple[str, str]:
+def extract_submit_id(search_html: str | None) -> str:
+    """Extract the form submit button ID from the consulta.xhtml HTML.
+
+    The ID comes from a ``jsfcljs(..., {'<form>:<id>':'...'}...)>Pesquisar``
+    JavaScript call. Falls back to :data:`DEFAULT_SUBMIT_ID` quando o regex
+    nao casa (defensivo — historicamente estavel).
+    """
+    if not search_html:
+        return DEFAULT_SUBMIT_ID
+    match = re.search(
+        r"jsfcljs\([^)]+\{'(formPesquisaJurisprudencia:[^']+)'"
+        r"[^)]*\)[^>]*>Pesquisar",
+        search_html,
+    )
+    return match.group(1) if match else DEFAULT_SUBMIT_ID
+
+
+def build_cjsg_form_body(
+    viewstate: str,
+    submit_id: str,
+    pesquisa: str,
+    *,
+    data_julgamento_inicio: str = "",
+    data_julgamento_fim: str = "",
+    relator: str = "",
+    classe: str = "",
+    assunto: str = "",
+    meio_tramitacao: str = "",
+    tipo_decisao: str = "acordaos",
+    current_date_hint: str = _CURRENT_DATE_HINT,
+) -> dict[str, str]:
+    """Build the form-encoded body for the TJPE CJSG search ``POST consulta.xhtml``.
+
+    Inclui apenas os campos que o JSF/RichFaces aceita; os tres checkboxes
+    de tipo (``tipoAcordao`` / ``tipoDecisaoMonocratica`` / ``tipoTodos``)
+    so aparecem quando ativos (ausencia difere de string vazia para o
+    backend). Todos os valores sao retornados como strings para que
+    :func:`responses.matchers.urlencoded_params_matcher` possa ser usado
+    com ``allow_blank=True`` nos contratos.
+    """
+    body: dict[str, str] = {
+        "formPesquisaJurisprudencia": "formPesquisaJurisprudencia",
+        "formPesquisaJurisprudencia:inputBuscaSimples": pesquisa or "",
+        "tipo_processo": "NPU",
+        "formPesquisaJurisprudencia:j_id46": "",
+        "formPesquisaJurisprudencia:j_id48": "",
+        "formPesquisaJurisprudencia:numeroAntigoDigito": "",
+        "formPesquisaJurisprudencia:numeroAntigoBarramento": "",
+        "formPesquisaJurisprudencia:j_id59InputDate": data_julgamento_inicio,
+        "formPesquisaJurisprudencia:j_id59InputCurrentDate": current_date_hint,
+        "formPesquisaJurisprudencia:periodoFimInputDate": data_julgamento_fim,
+        "formPesquisaJurisprudencia:periodoFimInputCurrentDate": current_date_hint,
+        "formPesquisaJurisprudencia:selectRelator": relator,
+        "formPesquisaJurisprudencia:selectClasseCNJ": classe,
+        "formPesquisaJurisprudencia:selectAssuntoCNJ": assunto,
+        "formPesquisaJurisprudencia:selectMeioTramitacao": meio_tramitacao,
+        "javax.faces.ViewState": viewstate,
+        submit_id: submit_id,
+    }
+    if tipo_decisao in ("acordaos", "todos"):
+        body["formPesquisaJurisprudencia:tipoAcordao"] = "on"
+    if tipo_decisao in ("monocraticas", "todos"):
+        body["formPesquisaJurisprudencia:tipoDecisaoMonocratica"] = "on"
+    if tipo_decisao == "todos":
+        body["formPesquisaJurisprudencia:tipoTodos"] = "on"
+    return body
+
+
+def step1_get_session(request_fn: RequestFn) -> tuple[str, str]:
     """GET the search page; return (HTML, ViewState)."""
-    url = f"{BASE_URL}/consulta.xhtml"
-    resp = request_fn("GET", url, timeout=30)
+    resp = request_fn("GET", CONSULTA_URL, timeout=30)
     resp.encoding = resp.apparent_encoding
-    return resp.text, _extract_viewstate(resp.text)
+    return resp.text, extract_viewstate(resp.text)
 
 
-def _step2_post_search(
+def step2_post_search(
     request_fn: RequestFn,
     viewstate: str,
     pesquisa: str,
     data_julgamento_inicio: str | None = None,
     data_julgamento_fim: str | None = None,
     relator: str | None = None,
-    classe_cnj: str | None = None,
-    assunto_cnj: str | None = None,
+    classe: str | None = None,
+    assunto: str | None = None,
     meio_tramitacao: str | None = None,
     tipo_decisao: str = "acordaos",
     search_html: str | None = None,
@@ -145,76 +225,44 @@ def _step2_post_search(
     The response is either the results page directly (single type)
     or the escolha page (multiple types).
     """
-    url = f"{BASE_URL}/consulta.xhtml"
-
-    # Try to extract submit button ID from search page
-    submit_id = "formPesquisaJurisprudencia:j_id101"
-    if search_html:
-        match = re.search(
-            r"jsfcljs\([^)]+\{'(formPesquisaJurisprudencia:[^']+)'"
-            r"[^)]*\)[^>]*>Pesquisar",
-            search_html,
-        )
-        if match:
-            submit_id = match.group(1)
-
-    # Build type checkboxes
-    tipo_acordao = "on" if tipo_decisao in ("acordaos", "todos") else ""
-    tipo_monocratica = "on" if tipo_decisao in ("monocraticas", "todos") else ""
-    tipo_todos = "on" if tipo_decisao == "todos" else ""
-
-    data = {
-        "formPesquisaJurisprudencia": "formPesquisaJurisprudencia",
-        "formPesquisaJurisprudencia:inputBuscaSimples": pesquisa or "",
-        "tipo_processo": "NPU",
-        "formPesquisaJurisprudencia:j_id46": "",
-        "formPesquisaJurisprudencia:j_id48": "",
-        "formPesquisaJurisprudencia:numeroAntigoDigito": "",
-        "formPesquisaJurisprudencia:numeroAntigoBarramento": "",
-        "formPesquisaJurisprudencia:j_id59InputDate": data_julgamento_inicio or "",
-        "formPesquisaJurisprudencia:j_id59InputCurrentDate": "04/2026",
-        "formPesquisaJurisprudencia:periodoFimInputDate": data_julgamento_fim or "",
-        "formPesquisaJurisprudencia:periodoFimInputCurrentDate": "04/2026",
-        "formPesquisaJurisprudencia:selectRelator": relator or "",
-        "formPesquisaJurisprudencia:selectClasseCNJ": classe_cnj or "",
-        "formPesquisaJurisprudencia:selectAssuntoCNJ": assunto_cnj or "",
-        "formPesquisaJurisprudencia:selectMeioTramitacao": meio_tramitacao or "",
-        "javax.faces.ViewState": viewstate,
-        submit_id: submit_id,
-    }
-    if tipo_acordao:
-        data["formPesquisaJurisprudencia:tipoAcordao"] = tipo_acordao
-    if tipo_monocratica:
-        data["formPesquisaJurisprudencia:tipoDecisaoMonocratica"] = tipo_monocratica
-    if tipo_todos:
-        data["formPesquisaJurisprudencia:tipoTodos"] = tipo_todos
-
-    resp = request_fn("POST", url, data=data, timeout=30)
+    submit_id = extract_submit_id(search_html)
+    data = build_cjsg_form_body(
+        viewstate=viewstate,
+        submit_id=submit_id,
+        pesquisa=pesquisa,
+        data_julgamento_inicio=data_julgamento_inicio or "",
+        data_julgamento_fim=data_julgamento_fim or "",
+        relator=relator or "",
+        classe=classe or "",
+        assunto=assunto or "",
+        meio_tramitacao=meio_tramitacao or "",
+        tipo_decisao=tipo_decisao,
+    )
+    resp = request_fn("POST", CONSULTA_URL, data=data, timeout=30)
     resp.encoding = resp.apparent_encoding
-    return resp.text, _extract_viewstate(resp.text)
+    return resp.text, extract_viewstate(resp.text)
 
 
-def _step3_choose_tipo(
+def step3_choose_tipo(
     request_fn: RequestFn,
     viewstate: str,
     escolha_html: str,
     tipo: str = "Acórdãos",
 ) -> tuple[str, str]:
     """POST to choose Acordaos or Decisoes Monocraticas; return (results HTML, ViewState)."""
-    url = f"{BASE_URL}/escolhaResultado.xhtml"
-    button_id = _extract_escolha_button_id(escolha_html, tipo)
+    button_id = extract_escolha_button_id(escolha_html, tipo)
 
     data = {
         "resultadoForm": "resultadoForm",
         "javax.faces.ViewState": viewstate,
         button_id: button_id,
     }
-    resp = request_fn("POST", url, data=data, timeout=30)
+    resp = request_fn("POST", ESCOLHA_URL, data=data, timeout=30)
     resp.encoding = resp.apparent_encoding
-    return resp.text, _extract_viewstate(resp.text)
+    return resp.text, extract_viewstate(resp.text)
 
 
-def _step4_paginate(
+def step4_paginate(
     request_fn: RequestFn,
     viewstate: str,
     form_id: str,
@@ -223,8 +271,6 @@ def _step4_paginate(
     page_number: int,
 ) -> str:
     """AJAX POST to fetch a specific page; return HTML."""
-    url = f"{BASE_URL}/resultado.xhtml"
-
     data = {
         "AJAXREQUEST": "_viewRoot",
         form_id: form_id,
@@ -237,7 +283,7 @@ def _step4_paginate(
         "X-Requested-With": "XMLHttpRequest",
         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
     }
-    resp = request_fn("POST", url, data=data, headers=headers, timeout=30)
+    resp = request_fn("POST", RESULTADO_URL, data=data, headers=headers, timeout=30)
     resp.encoding = resp.apparent_encoding
     return resp.text
 
@@ -250,8 +296,8 @@ def cjsg_download(
     data_julgamento_inicio: str | None = None,
     data_julgamento_fim: str | None = None,
     relator: str | None = None,
-    classe_cnj: str | None = None,
-    assunto_cnj: str | None = None,
+    classe: str | None = None,
+    assunto: str | None = None,
     meio_tramitacao: str | None = None,
     tipo_decisao: str = "acordaos",
 ) -> list[str]:
@@ -271,17 +317,17 @@ def cjsg_download(
     }.get(tipo_decisao, "Acórdãos")
 
     # Step 1 - GET search page
-    search_html, vs = _step1_get_session(request_fn)
+    search_html, vs = step1_get_session(request_fn)
     time.sleep(1)
 
     # Step 2 - POST search form
-    response_html, vs = _step2_post_search(
+    response_html, vs = step2_post_search(
         request_fn, vs, pesquisa,
         data_julgamento_inicio=data_julgamento_inicio,
         data_julgamento_fim=data_julgamento_fim,
         relator=relator,
-        classe_cnj=classe_cnj,
-        assunto_cnj=assunto_cnj,
+        classe=classe,
+        assunto=assunto,
         meio_tramitacao=meio_tramitacao,
         tipo_decisao=tipo_decisao,
         search_html=search_html,
@@ -289,17 +335,17 @@ def cjsg_download(
     time.sleep(1)
 
     # Step 2 may return results directly (single type) or escolha page (multiple types)
-    if _is_escolha_page(response_html):
+    if is_escolha_page(response_html):
         # Step 3 - choose result type
-        results_html, vs = _step3_choose_tipo(request_fn, vs, response_html, tipo_label)
+        results_html, vs = step3_choose_tipo(request_fn, vs, response_html, tipo_label)
         time.sleep(1)
-    elif _is_results_page(response_html):
+    elif is_results_page(response_html):
         results_html = response_html
     else:
         logger.warning("TJPE: unexpected response after search")
         return []
 
-    total_docs = _extract_total_docs(results_html)
+    total_docs = extract_total_docs(results_html)
     if total_docs == 0:
         logger.info("TJPE: no documents found for '%s'", pesquisa)
         return []
@@ -307,7 +353,7 @@ def cjsg_download(
     total_pages = math.ceil(total_docs / RESULTS_PER_PAGE)
     logger.info("TJPE: %d documents found (%d pages)", total_docs, total_pages)
 
-    form_id, scroller_id = _extract_pagination_ids(results_html)
+    form_id, scroller_id = extract_pagination_ids(results_html)
 
     # Determine pages to download
     pages_iter: list = (
@@ -320,7 +366,7 @@ def cjsg_download(
         if page_num == 1:
             results.append(results_html)
         else:
-            html = _step4_paginate(request_fn, vs, form_id, scroller_id, pesquisa, page_num)
+            html = step4_paginate(request_fn, vs, form_id, scroller_id, pesquisa, page_num)
             results.append(html)
             time.sleep(1)
 

--- a/tests/tjpe/test_cjsg_filters_contract.py
+++ b/tests/tjpe/test_cjsg_filters_contract.py
@@ -6,10 +6,10 @@ a suite usa ``OrderedRegistry`` (mesmo padrao do
 :mod:`tests.tjpe.test_cjsg_contract`) e cada teste registra GET + POST em ordem.
 
 Cada teste responde o POST com ``no_results.html`` ("Nenhum documento
-encontrado"). A sample nao bate em ``_is_results_page`` nem em
-``_is_escolha_page``, entao o scraper retorna lista vazia antes de qualquer
-AJAX de paginacao — duas chamadas HTTP bastam para fechar o contrato dos
-campos do form, sem precisar fixar pagina seguinte.
+encontrado"). A sample nao bate em :func:`is_results_page` nem em
+:func:`is_escolha_page`, entao o scraper retorna lista vazia antes de
+qualquer AJAX de paginacao — duas chamadas HTTP bastam para fechar o
+contrato dos campos do form, sem precisar fixar pagina seguinte.
 
 Wiring de :class:`InputCJSGTJPE` (etapa 2 da #197) ligou o pydantic ao
 ``cjsg_download`` — kwargs desconhecidos viram ``TypeError``, verificado
@@ -35,8 +35,8 @@ FORM = "formPesquisaJurisprudencia"
 
 @pytest.fixture(autouse=True)
 def _silence_unexpected_response_warning(caplog):
-    # ``no_results.html`` nao casa com ``_is_results_page`` nem com
-    # ``_is_escolha_page``, entao o scraper cai no ramo "unexpected response"
+    # ``no_results.html`` nao casa com :func:`is_results_page` nem com
+    # :func:`is_escolha_page`, entao o scraper cai no ramo "unexpected response"
     # e emite ``logger.warning``. Limita a captura do caplog para que o ruido
     # nao polua a saida se algum teste vier a falhar.
     caplog.set_level(logging.ERROR, logger="juscraper.courts.tjpe.download")

--- a/tests/tjpe/test_cjsg_pagination_unit.py
+++ b/tests/tjpe/test_cjsg_pagination_unit.py
@@ -1,7 +1,7 @@
 """Testes unitarios da parseria de paginacao TJPE (refs #87)."""
 from __future__ import annotations
 
-from juscraper.courts.tjpe.download import _extract_total_docs, _is_escolha_page, _is_results_page
+from juscraper.courts.tjpe.download import extract_total_docs, is_escolha_page, is_results_page
 from tests._helpers import load_sample
 
 
@@ -10,19 +10,19 @@ def _sample(name: str) -> str:
 
 
 def test_extract_total_docs_resultado_normal():
-    assert _extract_total_docs(_sample("step_03_resultado.html")) == 953
+    assert extract_total_docs(_sample("step_03_resultado.html")) == 953
 
 
 def test_extract_total_docs_simples_resultado():
-    assert _extract_total_docs(_sample("simples_resultado.html")) == 988
+    assert extract_total_docs(_sample("simples_resultado.html")) == 988
 
 
 def test_extract_total_docs_escolha_page_fallback():
-    assert _extract_total_docs(_sample("step_02_escolha.html")) == 953
+    assert extract_total_docs(_sample("step_02_escolha.html")) == 953
 
 
 def test_extract_total_docs_no_results_returns_zero():
-    assert _extract_total_docs(_sample("no_results.html")) == 0
+    assert extract_total_docs(_sample("no_results.html")) == 0
 
 
 def test_extract_total_docs_resilient_to_table_class_change():
@@ -30,20 +30,20 @@ def test_extract_total_docs_resilient_to_table_class_change():
         '<div class="painel-novo">'
         "<span>Documentos encontrados: 1234</span></div>"
     )
-    assert _extract_total_docs(html) == 1234
+    assert extract_total_docs(html) == 1234
 
 
 def test_extract_total_docs_falls_back_to_zero_when_unrecognized():
     html = "<div>HTML totalmente diferente sem informacao de contagem</div>"
-    assert _extract_total_docs(html) == 0
+    assert extract_total_docs(html) == 0
 
 
 def test_is_results_page_case_insensitive():
     html = "<html><body>DOCUMENTOS ENCONTRADOS: 5<br>DOCUMENTO 1</body></html>"
-    assert _is_results_page(html) is True
+    assert is_results_page(html) is True
 
 
 def test_is_escolha_page_case_insensitive():
     html = "<html><body>5 DOCUMENTOS ENCONTRADOS</body></html>"
-    assert _is_escolha_page(html) is True
-    assert _is_results_page(html) is False
+    assert is_escolha_page(html) is True
+    assert is_results_page(html) is False


### PR DESCRIPTION
## Resumo

Fecha a **etapa 3** da issue #197 (umbrella TJPE), seguindo o padrão da issue #144 / PR #258 (TJPR — mergeado um dia antes deste). As etapas 1 (contratos offline, PRs #238 e #252) e 2 (wiring `InputCJSGTJPE`, PR #257) já estão fechadas.

## Mudanças

### `src/juscraper/courts/tjpe/download.py` — promoções

- **Remove o prefix `_` de 10 helpers**: `extract_viewstate`, `extract_total_docs`, `is_results_page`, `is_escolha_page`, `extract_escolha_button_id`, `extract_pagination_ids`, `step1_get_session`, `step2_post_search`, `step3_choose_tipo`, `step4_paginate`. Helpers eram tecnicamente internos mas três já eram consumidos por `tests/tjpe/test_cjsg_pagination_unit.py` via import do nome com underscore (anti-pattern); renomear formaliza o contrato.
- **`extract_submit_id(search_html) -> str`**: extraído do bloco inline em `_step2_post_search`. Constante `DEFAULT_SUBMIT_ID` para o fallback defensivo (`formPesquisaJurisprudencia:j_id101`).
- **`build_cjsg_form_body(viewstate, submit_id, pesquisa, *, ...) -> dict[str, str]`**: extraído do dicionário inline em `_step2_post_search` (linhas 155-179 antes do PR). Retorna todos os valores como strings para permitir matching com `urlencoded_params_matcher(..., allow_blank=True)` em futuros contratos. Os três checkboxes de tipo (`tipoAcordao` / `tipoDecisaoMonocratica` / `tipoTodos`) são inclusão condicional (ausência ≠ string vazia para o JSF — comportamento preservado byte-a-byte).
- **`CONSULTA_URL`, `ESCOLHA_URL`, `RESULTADO_URL`**: expostas como constantes do módulo, em vez de strings construídas inline em cada step. Os testes já consumiam `BASE_URL` por import explícito; agora as URLs derivadas também são publicas.

### Refactor cosmético associado (deferido do PR #257)

- Renomeia `classe_cnj` → `classe` e `assunto_cnj` → `assunto` nas **assinaturas internas** de `cjsg_download` e `step2_post_search`. Os **nomes dos campos do form JSF** (`formPesquisaJurisprudencia:selectClasseCNJ` / `:selectAssuntoCNJ`) ficam intocados — são contrato com o backend. O alias deprecado externo continua via `resolve_deprecated_alias` em `client.py` (sem mudança visível pro usuário).
- `client.py:76-77`: ajusta o call de `cjsg_download` para usar `classe=`/`assunto=`.

### Atualizações em tests

- `tests/tjpe/test_cjsg_pagination_unit.py`: imports usam os novos nomes públicos (`extract_total_docs`, `is_results_page`, `is_escolha_page`).
- `tests/tjpe/test_cjsg_filters_contract.py`: docstring/comentários passam a referenciar `:func:is_results_page` / `:func:is_escolha_page` em vez dos nomes com `_`. Sem mudança de lógica.

## Decisão mantida

**Não promover para `_<familia>/`** — JSF/RichFaces é exclusiva do TJPE. Regra 1 do #84 exige 2+ ocorrências, aqui é 1. Helpers ficam em `src/juscraper/courts/tjpe/`.

## Test plan

- [x] `uv run pytest tests/tjpe tests/schemas` → 753 passed, 25 skipped.
- [x] `uv run pytest` (suite offline completa) → 1617 passed, 26 skipped, 1 xfailed (TJRR `test_cjsg_relator_lands_in_body` pré-existente).
- [x] Pre-commit hooks (trailing whitespace, isort, pylint, flake8, mypy) → ok.
- [x] Smoke-test manual:
  ```python
  >>> from juscraper.courts.tjpe.download import (
  ...     build_cjsg_form_body, extract_submit_id,
  ...     step1_get_session, step2_post_search, step3_choose_tipo, step4_paginate,
  ...     extract_viewstate, extract_total_docs, is_results_page, is_escolha_page,
  ...     extract_escolha_button_id, extract_pagination_ids,
  ...     BASE_URL, CONSULTA_URL, ESCOLHA_URL, RESULTADO_URL,
  ...     RESULTS_PER_PAGE, DEFAULT_SUBMIT_ID,
  ... )
  ```
- [ ] Opcional (live): `uv run pytest -m integration tests/tjpe -v`.

## Não entra no CHANGELOG

Refactor interno sem mudança de API pública do scraper (Filtro do `CLAUDE.md`: "Refactors internos sem mudança de API publica" → não entra). O `build_cjsg_form_body` extraído habilita migração futura dos contratos para o matcher canônico (`urlencoded_params_matcher(build_cjsg_form_body(...), allow_blank=True)`) — fica como follow-up; este PR foca em promover helpers.

## Follow-up que fica em aberto

A migração dos contratos para `urlencoded_params_matcher(build_cjsg_form_body(...), allow_blank=True)` (o que o PR #258 fez para o TJPR) é o passo natural seguinte. Não entrou aqui porque adicionaria ruído ao diff sem alterar o que de fato testamos (os contratos atuais já validam os campos relevantes via `urlencoded_body_subset_matcher`). Pode virar PR pequeno separado depois que o padrão estiver estabilizado em vários tribunais.

Refs #84, #93, #197 (etapa 3). Padrão: PR #258 (TJPR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)