### PR TITLE
refactor(esaj): Template Method _run_search compartilhado por cjsg e cjpg

### DIFF
--- a/src/juscraper/courts/_esaj/base.py
+++ b/src/juscraper/courts/_esaj/base.py
@@ -17,7 +17,7 @@ import logging
 import shutil
 import warnings
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ValidationError
 
@@ -40,6 +40,9 @@ from .download import download_cjsg_pages, fetch_cjsg_first_page
 from .forms import build_cjsg_form_body
 from .parse import cjsg_n_pags, cjsg_n_results, cjsg_parse_manager
 from .schemas import InputCJSGEsajPuro
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 logger = logging.getLogger("juscraper._esaj.base")
 
@@ -255,14 +258,14 @@ class EsajSearchScraper(HTTPScraper):
     def _run_search(
         self,
         *,
-        endpoint: str,
+        endpoint: Literal["cjsg", "cjpg"],
         input_cls: type[BaseModel],
         dedup_key: str,
         pesquisa: str,
         paginas: int | list | range | None,
         kwargs: dict,
         pre_normalize: Callable[[dict], None] | None = None,
-    ) -> Any:
+    ) -> pd.DataFrame | int:
         """Template Method que orquestra um endpoint de busca eSAJ (refs #205).
 
         Compartilhado por :meth:`cjsg` e :meth:`TJSPScraper.cjpg`. O fluxo —
@@ -273,7 +276,10 @@ class EsajSearchScraper(HTTPScraper):
         ``getattr``, mantendo este metodo agnostico a HTTP e parsing.
 
         Args:
-            endpoint: ``"cjsg"`` ou ``"cjpg"``. Resolve os hooks
+            endpoint: ``"cjsg"`` ou ``"cjpg"`` — o vocabulario que esta
+                infra sabe orquestrar, nao a capability por tribunal (quais
+                endpoints cada scraper expoe depende da presenca do metodo:
+                so o TJSP tem ``cjpg``). Resolve os hooks
                 ``<endpoint>_download``, ``<endpoint>_parse`` e
                 ``_<endpoint>_count_only`` por ``getattr(self, ...)``.
             input_cls: Schema pydantic do endpoint (``INPUT_CJSG`` /

--- a/src/juscraper/courts/_esaj/base.py
+++ b/src/juscraper/courts/_esaj/base.py
@@ -250,6 +250,72 @@ class EsajSearchScraper(HTTPScraper):
             **kwargs,
         )
 
+    # --- search template ------------------------------------------------
+
+    def _run_search(
+        self,
+        *,
+        endpoint: str,
+        input_cls: type[BaseModel],
+        dedup_key: str,
+        pesquisa: str,
+        paginas: int | list | range | None,
+        kwargs: dict,
+        pre_normalize: Callable[[dict], None] | None = None,
+    ) -> Any:
+        """Template Method que orquestra um endpoint de busca eSAJ (refs #205).
+
+        Compartilhado por :meth:`cjsg` e :meth:`TJSPScraper.cjpg`. O fluxo —
+        probe ``count_only`` -> auto-chunk -> download -> parse -> cleanup do
+        diretorio temporario — e identico entre os dois endpoints. O que
+        diverge (schema, chave de dedup, normalizacao previa, metodos de
+        download/parse/count) entra por parametro ou e resolvido por nome via
+        ``getattr``, mantendo este metodo agnostico a HTTP e parsing.
+
+        Args:
+            endpoint: ``"cjsg"`` ou ``"cjpg"``. Resolve os hooks
+                ``<endpoint>_download``, ``<endpoint>_parse`` e
+                ``_<endpoint>_count_only`` por ``getattr(self, ...)``.
+            input_cls: Schema pydantic do endpoint (``INPUT_CJSG`` /
+                ``INPUT_CJPG``), repassado ao auto-chunk.
+            dedup_key: Coluna usada para deduplicar resultados cross-janela no
+                auto-chunk (``cd_acordao`` no cjsg, ``id_processo`` no cjpg).
+            pre_normalize: Hook opcional aplicado a ``kwargs`` antes de tudo —
+                cjpg usa para popar os aliases plurais (#232).
+
+        Returns:
+            ``pd.DataFrame`` com os resultados parseados, ou ``int`` quando
+            ``count_only=True``.
+        """
+        if pre_normalize is not None:
+            pre_normalize(kwargs)
+
+        # count_only=True: probe leve antes do run_auto_chunk (issue #92).
+        # auto_chunk soma DataFrames com dedup; count_only soma ints brutos.
+        if kwargs.get("count_only", False):
+            count_probe = getattr(self, f"_{endpoint}_count_only")
+            return count_probe(pesquisa=pesquisa, paginas=paginas, **kwargs)
+
+        chunked = run_auto_chunk(
+            method=getattr(self, endpoint),
+            method_label=f"{type(self).__name__}.{endpoint}()",
+            input_cls=input_cls,
+            dedup_key=dedup_key,
+            pesquisa=pesquisa,
+            paginas=paginas,
+            kwargs=kwargs,
+        )
+        if chunked is not None:
+            return chunked
+
+        download = getattr(self, f"{endpoint}_download")
+        parse = getattr(self, f"{endpoint}_parse")
+        path = download(pesquisa=pesquisa, paginas=paginas, **kwargs)
+        try:
+            return parse(path)
+        finally:
+            shutil.rmtree(path, ignore_errors=True)
+
     # --- cjsg -----------------------------------------------------------
 
     def cjsg(
@@ -356,28 +422,14 @@ class EsajSearchScraper(HTTPScraper):
             comportamento estrito antigo (``ValueError`` em janelas
             longas), passe ``auto_chunk=False``.
         """
-        # count_only=True: probe leve antes do run_auto_chunk (issue #92).
-        # auto_chunk soma DataFrames com dedup; count_only soma ints brutos.
-        if kwargs.get("count_only", False):
-            return self._cjsg_count_only(pesquisa=pesquisa, paginas=paginas, **kwargs)
-
-        chunked = run_auto_chunk(
-            method=self.cjsg,
-            method_label=f"{type(self).__name__}.cjsg()",
+        return self._run_search(
+            endpoint="cjsg",
             input_cls=self.INPUT_CJSG,
             dedup_key="cd_acordao",
             pesquisa=pesquisa,
             paginas=paginas,
             kwargs=kwargs,
         )
-        if chunked is not None:
-            return chunked
-
-        path = self.cjsg_download(pesquisa=pesquisa, paginas=paginas, **kwargs)
-        try:
-            return self.cjsg_parse(path)
-        finally:
-            shutil.rmtree(path, ignore_errors=True)
 
     def _cjsg_count_only(
         self,

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -18,7 +18,7 @@ from ...utils.params import (
     pop_deprecated_alias,
     validate_intervalo_datas,
 )
-from .._esaj.base import EsajSearchScraper, run_auto_chunk
+from .._esaj.base import EsajSearchScraper
 from .cjpg_download import cjpg_download as cjpg_download_mod
 from .cjpg_download import fetch_cjpg_first_page
 from .cjpg_parse import cjpg_n_pags, cjpg_n_results, cjpg_parse_manager
@@ -75,6 +75,7 @@ class TJSPScraper(EsajSearchScraper):
     BASE_URL = "https://esaj.tjsp.jus.br/"
     TRIBUNAL_NAME = "TJSP"
     INPUT_CJSG = InputCJSGTJSP
+    INPUT_CJPG = InputCJPGTJSP
     CJSG_CHROME_UA = True
     CJSG_EXTRACT_CONVERSATION_ID = True
 
@@ -283,10 +284,11 @@ class TJSPScraper(EsajSearchScraper):
         return body
 
     # --- cjpg -----------------------------------------------------------
-    # Internals (``cjpg_download.py`` + ``cjpg_parse.py``) are unique to
-    # TJSP, so they're kept as-is. The public entry point still routes
-    # through pydantic (``InputCJPGTJSP``) for documentation + rejection
-    # of unknown kwargs.
+    # A orquestracao (probe count_only -> auto-chunk -> download -> parse)
+    # e compartilhada com ``cjsg`` via ``EsajSearchScraper._run_search``
+    # (Template Method, #205). Os internals de download/parse
+    # (``cjpg_download.py`` + ``cjpg_parse.py``) sao unicos do TJSP e
+    # entram em ``_run_search`` como hooks resolvidos por nome.
 
     def cjpg(
         self,
@@ -391,33 +393,20 @@ class TJSPScraper(EsajSearchScraper):
             (parcial + warning). ``auto_chunk=True`` + ``paginas != None``
             em janela > 366 dias e :class:`ValueError`.
         """
-        # Popa plurais antes de ``run_auto_chunk`` — a validacao upfront
-        # do schema dentro do chunking via ``extra_forbidden`` em
-        # ``classes``/``assuntos``/``varas`` antes de o caminho noop
-        # delegar para ``cjpg_download``. Refs #232.
-        _pop_cjpg_plural_aliases(kwargs)
-
-        # count_only=True: probe leve antes do run_auto_chunk (issue #92).
-        if kwargs.get("count_only", False):
-            return self._cjpg_count_only(pesquisa=pesquisa, paginas=paginas, **kwargs)
-
-        chunked = run_auto_chunk(
-            method=self.cjpg,
-            method_label="TJSPScraper.cjpg()",
-            input_cls=InputCJPGTJSP,
+        # Orquestracao (probe count_only -> auto-chunk -> download -> parse
+        # -> cleanup) compartilhada com ``cjsg`` via ``_run_search`` (#205).
+        # ``pre_normalize`` popa os plurais antes do auto-chunk: a validacao
+        # upfront do schema dentro do chunking rejeita ``classes``/``assuntos``/
+        # ``varas`` via ``extra_forbidden``. Refs #232.
+        return self._run_search(
+            endpoint="cjpg",
+            input_cls=self.INPUT_CJPG,
             dedup_key="id_processo",
             pesquisa=pesquisa,
             paginas=paginas,
             kwargs=kwargs,
+            pre_normalize=_pop_cjpg_plural_aliases,
         )
-        if chunked is not None:
-            return chunked
-
-        path = self.cjpg_download(pesquisa=pesquisa, paginas=paginas, **kwargs)
-        try:
-            return self.cjpg_parse(path)
-        finally:
-            shutil.rmtree(path, ignore_errors=True)
 
     def _cjpg_count_only(
         self,

--- a/tests/schemas/test_signature_parity.py
+++ b/tests/schemas/test_signature_parity.py
@@ -115,11 +115,11 @@ def _schema_fields(module_path: str, class_name: str) -> set[str]:
 # acontece dentro de um metodo irmao ou de um download manager). Na pratica,
 # o scraper ja usa o schema pydantic para rejeitar kwargs desconhecidos, mas
 # o padrao "INPUT_CJSG = ..." do EsajSearchScraper nao se aplica.
-WIRED_WITHOUT_CLASS_ATTR: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("tjsp", "cjpg"),  # valida dentro de cjpg_download via InputCJPGTJSP
-    }
-)
+#
+# Vazio desde #205: o TJSP cjpg passou a expor ``INPUT_CJPG`` como atributo
+# de classe (simetrico a ``INPUT_CJSG``), entao cai no ramo ``hasattr`` de
+# ``_is_wired``. A constante permanece como ponto de extensao documentado.
+WIRED_WITHOUT_CLASS_ATTR: frozenset[tuple[str, str]] = frozenset()
 
 
 def _is_wired(scraper_cls: type, endpoint: str) -> bool:


### PR DESCRIPTION
## Contexto

Sub-issue #205 do guarda-chuva #194 — consolidar o endpoint `cjpg`. A leitura das 3 implementações (TJSP, TJTO, TJES) durante o planejamento mostrou que **TJTO e TJES já são DRY**: o `cjpg` deles é o próprio `cjsg` com um único parâmetro trocado, zero linha de código `cjpg`-específico. Só o TJSP tem `cjpg` independente — e mesmo nele a duplicação não está no download/parse (legitimamente TJSP-específicos), e sim na **orquestração**: `TJSPScraper.cjpg` era um clone linha-a-linha de `EsajSearchScraper.cjsg`.

Diante disso, o **caminho (c)** original da issue (orquestrador universal `core/SearchScraperMixin` para os 3 tribunais) foi descartado como overengineering — abstrairia 3 tipos de retorno incompatíveis para servir 2 tribunais que não precisam. Adotado o **caminho (b)**: consolidação contida na família eSAJ.

## O que muda

- **`EsajSearchScraper._run_search`** (`_esaj/base.py`) — novo Template Method que concentra o fluxo `probe count_only → auto-chunk → download → parse → cleanup`, idêntico entre `cjsg` e `cjpg`. O que diverge entra por parâmetro (schema, chave de dedup, hook de `pre_normalize`) ou é resolvido por nome via `getattr` (`<endpoint>_download`/`_parse`/`_<endpoint>_count_only`) — o template fica agnóstico a HTTP e parsing.
- **`EsajSearchScraper.cjsg`** e **`TJSPScraper.cjpg`** passam a ser especializações de uma única orquestração. `_run_search` tem 2 usuários concretos (`cjsg` em 6 tribunais + `cjpg` no TJSP), satisfazendo a Regra 1 do #84.
- **`TJSPScraper`** expõe `INPUT_CJPG` como atributo de classe, simétrico a `INPUT_CJSG` — torna `cjpg` "wired with class attr" e esvazia `WIRED_WITHOUT_CLASS_ATTR` no teste de paridade.

## Desvio em relação ao plano aprovado

O plano previa **mover** `tjsp/cjpg_download.py` + `cjpg_parse.py` para `_esaj/`. Isso foi **deliberadamente descopado**: os métodos `cjpg`/`cjpg_download`/`cjpg_parse` precisam permanecer em `TJSPScraper` (a convenção de docstring do `CLAUDE.md` exige âncora de docstring por tribunal — o próprio `TJSPScraper.cjsg` existe só como override para isso; e os 5 eSAJ-puros não suportam `cjpg`). Com os métodos em `tjsp/`, mover só os helpers para `_esaj/` seria "promover para `_esaj/` com 1 ocorrência" — exatamente o que a Regra 1 proíbe — por ganho funcional nulo e churn em ~4 módulos de teste. A consolidação que a issue cita como justificativa real do caminho (b) ("ganho qualitativo — orquestrador único") é o `_run_search`, entregue aqui.

## Testes

Refactor puramente interno — nenhuma mudança de API pública nem de comportamento observável. Sem entrada no CHANGELOG (regra do projeto: refactor interno não entra).

- `pytest` (suite offline completa): **1621 passed**
- `pytest -k contract`: **565 passed**, zero-diff de schema
- `pre-commit` (pylint, flake8, mypy, isort): verde

Closes #205
Refs #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)