### PR TITLE
fix(tjmg): gravar captcha em arquivo temporário atômico (CWE-377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Endpoints com pydantic wired (TJSP `cjsg`/`cjpg`; familia eSAJ `cjsg` em TJAC/TJAL/TJAM/TJCE/TJMS; `cjsg` em TJDFT/TJES/TJBA/TJMT/TJAP/TJRS/TJPB/TJTO/TJPR/TJGO/TJRR/TJMG/TJRN/TJPA/TJRO/TJSC/TJPI; `cjpg` em TJES/TJTO) passam a autopreencher datas parciais. Quando o usuario informa apenas `data_*_inicio`, `data_*_fim` vira a data atual; quando informa apenas `data_*_fim`, `data_*_inicio` vira `01/01/1990` (e o auto-chunk divide a janela em chunks de 366 dias). Antes, o backend recebia uma data vazia em um dos lados e podia retornar resultado degenerado — no `cjpg` do TJSP, em particular, o paginador iterava sobre dezenas de milhares de paginas. `UserWarning` e emitido sinalizando o auto-fill e sugerindo passar a data explicitamente para restringir a janela.
 - `TJRRScraper.cjsg(relator=...)` voltou a funcionar. O backend TJRR migrou de um campo `relator` de texto livre para um `SelectManyCheckbox` (`menuinicial:relatorList`) cujos values sao beans Java serializados, e o scraper estava descartando o argumento silenciosamente (anotado `# noqa: ARG001`). Agora `cjsg(relator=["ALMIRO PADILHA"])` parseia o form GET inicial, resolve o nome regimental para o bean correspondente e injeta a lista no body — o filtro chega ao backend e a busca e efetivamente restringida ao(s) relator(es). Refs #158.
 
+### Security
+
+- TJMG (`cjsg`): a imagem do CAPTCHA passa a ser gravada com `tempfile.NamedTemporaryFile` (criacao atomica, nome imprevisivel) em vez de um caminho previsivel em `/tmp` (`tjmg_captcha_<timestamp>.png`). O caminho previsivel num diretorio compartilhado permitia, em host multiusuario, que um atacante local pre-criasse um symlink no caminho esperado e causasse overwrite de arquivo via TOCTOU (CWE-377). Severidade baixa — exige atacante local no mesmo host; nulo no uso single-user tipico, plausivel em CI/containers multi-tenant. Refs #271.
+
 ## [0.3.0] - 2026-05-03
 
 ### Added

--- a/src/juscraper/courts/tjmg/download.py
+++ b/src/juscraper/courts/tjmg/download.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import math
 import re
+import tempfile
 import time
 from pathlib import Path
 
@@ -55,16 +56,15 @@ def _solve_captcha(
             "GET", f"{CAPTCHA_IMG_URL}?{time.time()}", timeout=60
         )
         img = img_resp.content
-        tmp = Path(f"/tmp/tjmg_captcha_{int(time.time()*1000)}.png")
-        tmp.parent.mkdir(parents=True, exist_ok=True)
-        tmp.write_bytes(img)
+        with tempfile.NamedTemporaryFile(
+            mode="wb", prefix="tjmg_captcha_", suffix=".png", delete=False
+        ) as f:
+            f.write(img)
+            tmp = Path(f.name)
         try:
             codes = txtcaptcha.decrypt([str(tmp)], mask="[0-9]", length=5)
         finally:
-            try:
-                tmp.unlink()
-            except OSError:
-                pass
+            tmp.unlink(missing_ok=True)
         code = codes[0] if isinstance(codes, list) else codes
         body = (
             "callCount=1\n"

--- a/tests/tjmg/test_cjsg_download_granular.py
+++ b/tests/tjmg/test_cjsg_download_granular.py
@@ -284,11 +284,12 @@ class TestSolveCaptchaTempFile:
     """
 
     def test_usa_tempfile_atomico_e_limpa(self, mocker):
-        seen: dict = {}
+        seen: dict[str, Any] = {}
 
         def fake_decrypt(paths, **kwargs):
             path = paths[0]
             seen["path"] = path
+            seen["kwargs"] = kwargs
             # Durante o decrypt o arquivo ainda existe (cleanup so no finally).
             seen["exists_during"] = os.path.exists(path)
             return ["12345"]
@@ -306,6 +307,9 @@ class TestSolveCaptchaTempFile:
         session.cookies.get.return_value = "JSID123"
 
         assert _solve_captcha(request_fn, session) is True
+
+        # O codigo de producao passa o mask/length esperados ao decrypt.
+        assert seen["kwargs"] == {"mask": "[0-9]", "length": 5}
 
         path = seen["path"]
         basename = os.path.basename(path)

--- a/tests/tjmg/test_cjsg_download_granular.py
+++ b/tests/tjmg/test_cjsg_download_granular.py
@@ -14,7 +14,11 @@ conforme pedido explicito da issue #159.
 """
 from __future__ import annotations
 
+import os
+import re
 import sys
+import tempfile
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -27,7 +31,7 @@ from tests._helpers import query_param_subset_matcher
 
 def _build_params_defaults(**overrides):
     """Argumentos padrao para ``_build_params``; cada teste sobrescreve o que importa."""
-    kwargs = dict(
+    kwargs: dict[str, Any] = dict(
         pesquisa="termo",
         pagina=1,
         total=1,
@@ -265,3 +269,54 @@ class TestSolveCaptcha:
             _solve_captcha(request_fn, session)
         # O import e a primeira coisa: nenhum request foi disparado.
         request_fn.assert_not_called()
+
+
+class TestSolveCaptchaTempFile:
+    """Regressao da issue #271 (CWE-377): a imagem do captcha nao pode ir
+    para um caminho previsivel em ``/tmp``.
+
+    A gravacao usa ``tempfile.NamedTemporaryFile`` (criacao atomica, nome
+    imprevisivel, sem seguir symlink pre-criado). Aqui capturamos o caminho
+    repassado ao ``decrypt`` e afirmamos que (1) vive sob o tempdir do
+    sistema com o prefixo esperado, (2) o basename **nao** casa o padrao
+    previsivel antigo ``tjmg_captcha_<digits>.png``, e (3) o arquivo e
+    removido apos a decodificacao.
+    """
+
+    def test_usa_tempfile_atomico_e_limpa(self, mocker):
+        seen: dict = {}
+
+        def fake_decrypt(paths, **kwargs):
+            path = paths[0]
+            seen["path"] = path
+            # Durante o decrypt o arquivo ainda existe (cleanup so no finally).
+            seen["exists_during"] = os.path.exists(path)
+            return ["12345"]
+
+        fake = MagicMock()
+        fake.decrypt = fake_decrypt
+        mocker.patch.dict(sys.modules, {"txtcaptcha": fake})
+
+        img_resp = MagicMock()
+        img_resp.content = b"\x89PNG\r\n\x1a\n fake png bytes"
+        dwr_resp = MagicMock()
+        dwr_resp.text = "dwr.engine._remoteHandleCallback('0','0',true);"
+        request_fn = MagicMock(side_effect=[img_resp, dwr_resp])
+        session = MagicMock()
+        session.cookies.get.return_value = "JSID123"
+
+        assert _solve_captcha(request_fn, session) is True
+
+        path = seen["path"]
+        basename = os.path.basename(path)
+        # (1) sob o tempdir do sistema, com o prefixo esperado.
+        assert os.path.realpath(os.path.dirname(path)) == os.path.realpath(
+            tempfile.gettempdir()
+        )
+        assert basename.startswith("tjmg_captcha_")
+        assert basename.endswith(".png")
+        # (2) nome imprevisivel: nao e mais ``tjmg_captcha_<digits>.png``.
+        assert not re.fullmatch(r"tjmg_captcha_\d+\.png", basename)
+        # (3) existia durante o decrypt, removido depois (cleanup no finally).
+        assert seen["exists_during"] is True
+        assert not os.path.exists(path)


### PR DESCRIPTION
## Contexto

A função `_solve_captcha` do scraper do TJMG gravava a imagem do CAPTCHA em `/tmp/tjmg_captcha_<timestamp_ms>.png` — nome previsível num diretório compartilhado. Como `Path.write_bytes` segue symlinks, num host multiusuário um atacante local podia pré-criar um symlink no caminho previsto e provocar overwrite de outro arquivo gravável pelo processo (TOCTOU — CWE-377).

Severidade realista **baixa**: exige atacante local no mesmo host, com `/tmp` compartilhado e conhecimento de timing. Nulo no uso single-user típico (pesquisador rodando na própria máquina); plausível em CI/containers multi-tenant.

## Mudança

- `src/juscraper/courts/tjmg/download.py`: troca a criação manual do arquivo por `tempfile.NamedTemporaryFile` (criação atômica via `O_EXCL`, não segue symlink pré-existente; nome imprevisível). O cleanup no `finally` é preservado e simplificado para `tmp.unlink(missing_ok=True)`. Segue o padrão `tempfile` já usado em `core/base.py` e `aggregators/datajud/client.py`.
- Teste de regressão `TestSolveCaptchaTempFile`: afirma que o caminho passado ao `decrypt` vive sob o tempdir do sistema com o prefixo esperado, **não** casa o padrão previsível antigo (`tjmg_captcha_<digits>.png`) e é removido após a decodificação.
- `CHANGELOG.md`: entrada em `[Unreleased]` na categoria **Security**.

A mudança preserva colunas, payload e a semântica de retry de OCR (3 tentativas) do `_solve_captcha`.

## Verificação

- `pytest tests/tjmg tests/schemas` — 774 passed, 26 skipped (offline).
- `pre-commit run` nos arquivos editados — todos os hooks passam (incl. mypy, flake8, pylint).

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)