### PR TITLE
security(logging): redigir credenciais em logs de debug (JusBR/PDPJ)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ e este projeto adere ao [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Security
+
+- Hardening de logging nos agregadores JusBR e PDPJ: logs em modo verbose/DEBUG deixam de emitir credenciais. O header `Authorization` (e demais headers sensíveis) passa a ser redigido como `[REDACTED]` antes de ir para o log no download do JusBR; o dump claim-a-claim do JWT (`verbose > 1`) vira apenas a contagem de claims; e o `sub` do JWT deixa de ser logado no `auth` do PDPJ. Redação centralizada no novo helper `juscraper.utils.logging_cfg.redact_headers`, também adotado pelo Datajud. Refs #270.
+
 ### Added
 
 - Raspador TRF6 (`cpopg` — consulta pública de processos de 1º grau via eproc). Acessa o sistema eproc da Seção Judiciária de Minas Gerais em `eproc1g.trf6.jus.br/eproc/`. O formulário é gated por captcha de texto (imagem PNG embutida inline em base64 no HTML do form, validado server-side); o scraper resolve usando o pacote opcional [`txtcaptcha`](https://github.com/jtrecenti/txtcaptcha) (CRNN pretrained do HuggingFace, baixado on-demand e cacheado). Cada captcha é vinculado ao cookie `PHPSESSID`, então cada nova tentativa após rejeição faz um GET fresco do form para obter um captcha novo (controlado por `max_captcha_attempts`, default 3). API: `cpopg(id_cnj)` aceita um CNJ ou lista; devolve `pd.DataFrame` com colunas `id_cnj`, `processo`, `classe`, `data_autuacao`, `situacao`, `magistrado`, `orgao_julgador`, `assuntos`, `polo_ativo`, `polo_passivo`, `mpf`, `perito`, `movimentacoes`. Implementação completamente independente em `courts/trf6/` (`client.py`, `download.py`, `parse.py`, `schemas.py`) — sem infra compartilhada com TRF3/TRF5 ou outros tribunais (mesma justificativa: tribunais podem trocar de sistema). Schema pydantic com `extra='forbid'` no Input. Samples HTML em `tests/trf6/samples/cpopg/` (form_initial, detail_normal, search_no_results, search_bad_captcha) capturados via `tests/fixtures/capture/trf6.py`. Cobertura: contrato offline com captcha solver mockado (5 testes incluindo retry após rejeição e fail após N tentativas), schema, integração (`@pytest.mark.integration`).

--- a/src/juscraper/aggregators/datajud/download.py
+++ b/src/juscraper/aggregators/datajud/download.py
@@ -9,6 +9,7 @@ from typing import Any
 import requests
 
 from ...utils.cnj import clean_cnj
+from ...utils.logging_cfg import redact_headers
 
 logger = logging.getLogger(__name__)
 
@@ -278,11 +279,7 @@ def call_datajud_api(
 
     if verbose:
         logger.info("Calling Datajud API: %s", api_url)
-        # Redact key in log for security
-        logger.debug(
-            "Headers: {'Authorization': 'APIKey [REDACTED]',"
-            "'Content-Type': 'application/json'}"
-        )
+        logger.debug("Headers: %s", redact_headers(headers))
         logger.debug("Payload: %s", query_payload)
 
     def _do_post() -> dict[str, Any] | None:

--- a/src/juscraper/aggregators/jusbr/client.py
+++ b/src/juscraper/aggregators/jusbr/client.py
@@ -68,8 +68,7 @@ class JusbrScraper(HTTPScraper):
             if self.verbose > 0:
                 logger.info("Token JWT definido e decodificado com sucesso!")
                 if self.verbose > 1:
-                    for k, v in decoded.items():
-                        logger.debug("  Token claim %s: %s", k, v)
+                    logger.debug("  Token decodificado com %d claims.", len(decoded))
             return True
         except jwt.ExpiredSignatureError as exc:
             logger.error("Token JWT expirado.")

--- a/src/juscraper/aggregators/jusbr/download.py
+++ b/src/juscraper/aggregators/jusbr/download.py
@@ -16,6 +16,7 @@ import requests
 
 from ...core.exceptions import RetryExhaustedError
 from ...utils.cnj import clean_cnj
+from ...utils.logging_cfg import redact_headers
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +146,7 @@ def fetch_document_text(
     }
 
     logger.debug("[JUSBR DEBUG] Baixando documento: URL=%s", doc_url)
-    logger.debug("[JUSBR DEBUG] Headers: %s", request_headers)
+    logger.debug("[JUSBR DEBUG] Headers: %s", redact_headers(request_headers))
 
     response: requests.Response | None = None
     try:

--- a/src/juscraper/aggregators/pdpj/client.py
+++ b/src/juscraper/aggregators/pdpj/client.py
@@ -148,7 +148,9 @@ class PdpjScraper(BaseScraper):
         """
         InputAuthPdpj(token=token)
         try:
-            decoded = jwt.decode(
+            # Decodifica so para validar formato/expiracao; o conteudo do JWT
+            # nao e logado (hardening, #270).
+            jwt.decode(
                 token,
                 options={"verify_signature": False, "verify_aud": False},
                 algorithms=["RS256", "HS256", "ES256", "none"],
@@ -161,7 +163,7 @@ class PdpjScraper(BaseScraper):
         self.token = token
         self.session.headers["Authorization"] = f"Bearer {token}"
         if self.verbose:
-            logger.info("PDPJ: token JWT aceito (sub=%s).", decoded.get("sub"))
+            logger.info("PDPJ: token JWT aceito.")
         return True
 
     def _check_auth(self) -> None:

--- a/src/juscraper/utils/logging_cfg.py
+++ b/src/juscraper/utils/logging_cfg.py
@@ -1,1 +1,26 @@
 """Logging configuration for juscraper."""
+from collections.abc import Mapping
+
+_SENSITIVE_HEADERS = frozenset({
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "api-key",
+})
+_REDACTED = "[REDACTED]"
+
+
+def redact_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    """Devolve copia de ``headers`` com valores de credenciais redigidos.
+
+    Chaves sensiveis (``Authorization``, ``Cookie``, etc.) tem o valor trocado
+    por ``"[REDACTED]"``. A comparacao da chave e case-insensitive e o dict
+    original nao e mutado. Use antes de passar headers para
+    ``logger.debug``/``logger.info``, evitando emitir tokens em log.
+    """
+    return {
+        k: (_REDACTED if k.lower() in _SENSITIVE_HEADERS else v)
+        for k, v in headers.items()
+    }

--- a/src/juscraper/utils/logging_cfg.py
+++ b/src/juscraper/utils/logging_cfg.py
@@ -6,21 +6,33 @@ _SENSITIVE_HEADERS = frozenset({
     "proxy-authorization",
     "cookie",
     "set-cookie",
-    "x-api-key",
-    "api-key",
 })
 _REDACTED = "[REDACTED]"
+
+
+def _is_sensitive(key: str) -> bool:
+    """``True`` se ``key`` for um header de credencial (case-insensitive).
+
+    Cobre o conjunto fixo ``_SENSITIVE_HEADERS`` e qualquer chave de API:
+    ``api-key`` e o sufixo ``-api-key`` (``x-api-key``, ``vendor-api-key``).
+    """
+    lowered = key.lower()
+    return (
+        lowered in _SENSITIVE_HEADERS
+        or lowered == "api-key"
+        or lowered.endswith("-api-key")
+    )
 
 
 def redact_headers(headers: Mapping[str, str]) -> dict[str, str]:
     """Devolve copia de ``headers`` com valores de credenciais redigidos.
 
-    Chaves sensiveis (``Authorization``, ``Cookie``, etc.) tem o valor trocado
-    por ``"[REDACTED]"``. A comparacao da chave e case-insensitive e o dict
-    original nao e mutado. Use antes de passar headers para
+    Chaves sensiveis (``Authorization``, ``Cookie``, ``*-api-key``, etc.) tem o
+    valor trocado por ``"[REDACTED]"``. A comparacao da chave e case-insensitive
+    e o dict original nao e mutado. Use antes de passar headers para
     ``logger.debug``/``logger.info``, evitando emitir tokens em log.
     """
     return {
-        k: (_REDACTED if k.lower() in _SENSITIVE_HEADERS else v)
+        k: (_REDACTED if _is_sensitive(k) else v)
         for k, v in headers.items()
     }

--- a/tests/jusbr/test_auth_logging.py
+++ b/tests/jusbr/test_auth_logging.py
@@ -1,0 +1,24 @@
+"""Testes de hardening de logging no ``auth`` do JusBR (#270).
+
+Garante que, mesmo com ``verbose=2`` (DEBUG), os valores dos claims do JWT
+nao aparecem no log -- apenas a contagem de claims.
+"""
+import logging
+
+import jwt
+
+import juscraper as jus
+
+
+def test_auth_nao_loga_valores_dos_claims(caplog):
+    token = jwt.encode(
+        {"sub": "usuario-secreto-123", "email": "vazou@example.com"},
+        "x" * 32,
+        algorithm="HS256",
+    )
+    scraper = jus.scraper("jusbr", verbose=2)
+    with caplog.at_level(logging.DEBUG, logger="juscraper.aggregators.jusbr.client"):
+        assert scraper.auth(token) is True
+    assert "usuario-secreto-123" not in caplog.text
+    assert "vazou@example.com" not in caplog.text
+    assert "claims" in caplog.text

--- a/tests/pdpj/test_auth_logging.py
+++ b/tests/pdpj/test_auth_logging.py
@@ -1,0 +1,19 @@
+"""Testes de hardening de logging no ``auth`` do PDPJ (#270).
+
+Garante que o ``sub`` do JWT nao aparece no log de INFO emitido com
+``verbose=1``.
+"""
+import logging
+
+import jwt
+
+import juscraper as jus
+
+
+def test_auth_nao_loga_sub(caplog):
+    token = jwt.encode({"sub": "usuario-secreto-123"}, "x" * 32, algorithm="HS256")
+    scraper = jus.scraper("pdpj", verbose=1)
+    with caplog.at_level(logging.INFO, logger="juscraper.aggregators.pdpj.client"):
+        assert scraper.auth(token) is True
+    assert "usuario-secreto-123" not in caplog.text
+    assert "token JWT aceito" in caplog.text

--- a/tests/utils/test_redaction.py
+++ b/tests/utils/test_redaction.py
@@ -35,6 +35,19 @@ def test_redige_cookie_set_cookie_e_api_keys():
     }
 
 
+def test_redige_qualquer_sufixo_api_key():
+    out = redact_headers({
+        "Vendor-API-Key": "k1",
+        "x-acme-api-key": "k2",
+        "not-a-key": "visivel",
+    })
+    assert out == {
+        "Vendor-API-Key": "[REDACTED]",
+        "x-acme-api-key": "[REDACTED]",
+        "not-a-key": "visivel",
+    }
+
+
 def test_nao_muta_o_dict_original():
     original = {"authorization": "Bearer xyz", "accept": "*/*"}
     redact_headers(original)

--- a/tests/utils/test_redaction.py
+++ b/tests/utils/test_redaction.py
@@ -1,0 +1,45 @@
+"""Testes para ``juscraper.utils.logging_cfg.redact_headers``.
+
+Garante que o helper de redacao mascara credenciais (Authorization, Cookie,
+etc.) antes de irem para log, sem mutar o dict original (hardening #270).
+"""
+from juscraper.utils.logging_cfg import redact_headers
+
+
+def test_redige_authorization_case_insensitive():
+    assert redact_headers({"Authorization": "Bearer xyz"}) == {
+        "Authorization": "[REDACTED]"
+    }
+    assert redact_headers({"authorization": "Bearer xyz"}) == {
+        "authorization": "[REDACTED]"
+    }
+
+
+def test_preserva_headers_nao_sensiveis():
+    out = redact_headers({"authorization": "Bearer xyz", "accept": "*/*"})
+    assert out == {"authorization": "[REDACTED]", "accept": "*/*"}
+
+
+def test_redige_cookie_set_cookie_e_api_keys():
+    out = redact_headers({
+        "Cookie": "session=abc",
+        "Set-Cookie": "session=abc; HttpOnly",
+        "X-API-Key": "k1",
+        "api-key": "k2",
+    })
+    assert out == {
+        "Cookie": "[REDACTED]",
+        "Set-Cookie": "[REDACTED]",
+        "X-API-Key": "[REDACTED]",
+        "api-key": "[REDACTED]",
+    }
+
+
+def test_nao_muta_o_dict_original():
+    original = {"authorization": "Bearer xyz", "accept": "*/*"}
+    redact_headers(original)
+    assert original == {"authorization": "Bearer xyz", "accept": "*/*"}
+
+
+def test_mapping_vazio():
+    assert redact_headers({}) == {}


### PR DESCRIPTION
## Resumo

Hardening de logging da issue #270: os fluxos de autenticação/download do JusBR e do PDPJ deixam de emitir material de autenticação em log quando o usuário ativa modo verbose/DEBUG. Não é vulnerabilidade crítica (o vazamento depende de o usuário ligar o debug e tipicamente loga o próprio token de sessão dele), mas é boa prática: logs costumam ser retidos e centralizados, e credencial em log vira exposição acidental.

## Mudanças

- **Helper central** `juscraper.utils.logging_cfg.redact_headers` (módulo antes vazio): mascara valores de `Authorization`/`Cookie`/`Set-Cookie`/`*-api-key` como `[REDACTED]`, comparação case-insensitive na chave, sem mutar o dict original.
- **`jusbr/download.py`** (ponto principal): redige `request_headers` antes de logar — o token `Bearer` não vai mais inteiro para o DEBUG.
- **`jusbr/client.py`**: o dump claim-a-claim do JWT (`verbose > 1`) vira apenas a contagem de claims (`"Token decodificado com N claims."`).
- **`pdpj/client.py`**: o `sub` do JWT deixa de ser logado no `auth`; a decodificação é mantida só para validar formato/expiração.
- **`datajud/download.py`**: a redação hardcoded (string literal que não refletia o dict real) migra para o mesmo helper. A chave do datajud é a pública do CNJ, então o ganho aqui é robustez/consistência — e dá ao helper a 2ª chamada concreta que justifica centralizar (Regra 1 do #84).

## Testes

- `tests/utils/test_redaction.py` — unit do helper (case-insensitive, preserva não-sensíveis, não muta original, Cookie/Set-Cookie/api-keys, mapping vazio).
- `tests/jusbr/test_auth_logging.py` e `tests/pdpj/test_auth_logging.py` — `caplog` no `auth` confirmando que valores de claims / `sub` não aparecem no texto logado.

`uv run pytest` → 1687 passados, 0 falhas. Pre-commit (pylint/flake8/mypy/isort) limpo nos arquivos tocados.

## Changelog

Entrada na seção `### Security` em `[Unreleased]`.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)