### PR TITLE
chore: limpar achados de lint pré-existentes (flake8/mypy)

### DIFF
--- a/scripts/build_trf6_notebook.py
+++ b/scripts/build_trf6_notebook.py
@@ -21,14 +21,17 @@ DOCS_NB = REPO_ROOT / "docs" / "notebooks"
 
 
 def md(source: str) -> nbformat.NotebookNode:
+    """Build a markdown notebook cell from ``source`` (outer newlines stripped)."""
     return nbformat.v4.new_markdown_cell(source.strip("\n"))
 
 
 def code(source: str) -> nbformat.NotebookNode:
+    """Build a code notebook cell from ``source`` (outer newlines stripped)."""
     return nbformat.v4.new_code_cell(source.strip("\n"))
 
 
 def make_trf6() -> nbformat.NotebookNode:
+    """Assemble the TRF6 tutorial notebook (markdown + code cells)."""
     nb = nbformat.v4.new_notebook()
     nb.cells = [
         md(
@@ -175,6 +178,7 @@ df_again[["id_cnj", "processo", "data_autuacao"]]
 
 
 def main() -> None:
+    """Render the TRF6 notebook and write it executed to ``docs/notebooks/``."""
     DOCS_NB.mkdir(parents=True, exist_ok=True)
     nb = make_trf6()
     path = DOCS_NB / "trf6.ipynb"

--- a/src/juscraper/core/exceptions.py
+++ b/src/juscraper/core/exceptions.py
@@ -54,7 +54,7 @@ class BotChallengeBlockedError(Exception):
             msg += f" Reference: {reference}."
         super().__init__(msg)
 
-            
+
 class InvalidJSONResponseError(HTTPSemanticError):
     """Resposta com status < 400 cujo corpo não é JSON válido, mesmo após retries.
 

--- a/src/juscraper/courts/_esaj/base.py
+++ b/src/juscraper/courts/_esaj/base.py
@@ -17,7 +17,7 @@ import logging
 import shutil
 import warnings
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 import pandas as pd
 from pydantic import BaseModel, ValidationError
@@ -41,9 +41,6 @@ from .download import _CHROME_HEADERS, _ESAJ_HEADERS, download_cjsg_pages, fetch
 from .forms import build_cjsg_form_body
 from .parse import cjsg_n_pags, cjsg_n_results, cjsg_parse_manager, parse_arvore
 from .schemas import InputCJSGEsajPuro
-
-if TYPE_CHECKING:
-    import pandas as pd
 
 logger = logging.getLogger("juscraper._esaj.base")
 

--- a/src/juscraper/courts/tjrj/download.py
+++ b/src/juscraper/courts/tjrj/download.py
@@ -54,7 +54,7 @@ def extract_viewstate_fields(html: str) -> dict:
 
 
 def extract_default_year(html: str) -> str:
-    """Devolve o ano-padrao do form — a primeira ``<option>`` de ``cmbAnoInicio``.
+    r"""Devolve o ano-padrao do form — a primeira ``<option>`` de ``cmbAnoInicio``.
 
     O backend do TJRJ passou a exigir ``cmbAnoInicio``/``cmbAnoFim`` nao-vazios:
     um POST com ano em branco dispara ``HTTP 500`` ja na submissao do form
@@ -79,7 +79,7 @@ def extract_default_year(html: str) -> str:
     if values:
         return values[0]
     anos = re.findall(r"\b(\d{4})\b", block) or re.findall(r"\b(\d{4})\b", html)
-    return max(anos) if anos else ""
+    return str(max(anos)) if anos else ""
 
 
 def build_cjsg_payload(

--- a/src/juscraper/courts/trf1/client.py
+++ b/src/juscraper/courts/trf1/client.py
@@ -100,7 +100,7 @@ class TRF1Scraper(BaseScraper):
         remaining pages.
         """
         ids = self._ensure_field_ids()
-        payload = build_search_payload(format_cnj(id_cnj_clean), ids)  # type: ignore[arg-type]
+        payload = build_search_payload(format_cnj(id_cnj_clean), ids)
         search_html = submit_search(self.session, payload)
         ca = extract_ca_token(search_html)
         if not ca:

--- a/src/juscraper/courts/trf3/client.py
+++ b/src/juscraper/courts/trf3/client.py
@@ -100,7 +100,7 @@ class TRF3Scraper(BaseScraper):
         remaining pages.
         """
         ids = self._ensure_field_ids()
-        payload = build_search_payload(format_cnj(id_cnj_clean), ids)  # type: ignore[arg-type]
+        payload = build_search_payload(format_cnj(id_cnj_clean), ids)
         search_html = submit_search(self.session, payload)
         ca = extract_ca_token(search_html)
         if not ca:

--- a/src/juscraper/courts/trf5/client.py
+++ b/src/juscraper/courts/trf5/client.py
@@ -99,7 +99,7 @@ class TRF5Scraper(BaseScraper):
         remaining pages.
         """
         ids = self._ensure_field_ids()
-        payload = build_search_payload(format_cnj(id_cnj_clean), ids)  # type: ignore[arg-type]
+        payload = build_search_payload(format_cnj(id_cnj_clean), ids)
         search_html = submit_search(self.session, payload)
         ca = extract_ca_token(search_html)
         if not ca:

--- a/src/juscraper/courts/trf6/client.py
+++ b/src/juscraper/courts/trf6/client.py
@@ -69,9 +69,6 @@ class TRF6Scraper(BaseScraper):
     def _fetch_one(self, id_cnj_clean: str) -> str | None:
         """Fetch the detail HTML for a single CNJ. ``None`` when not found."""
         formatted = format_cnj(id_cnj_clean)
-        # format_cnj(strict=True) sempre devolve str ou levanta ValueError;
-        # o None do tipo de retorno so ocorre em strict=False.
-        assert formatted is not None
         return fetch_detail(
             self.session,
             formatted,

--- a/src/juscraper/utils/cnj.py
+++ b/src/juscraper/utils/cnj.py
@@ -1,5 +1,6 @@
 """Funções utilitárias para manipulação de números CNJ (Conselho Nacional de Justiça)."""
 import re
+from typing import Literal, overload
 
 _NON_DIGIT_RE = re.compile(r"\D")
 
@@ -36,6 +37,14 @@ def split_cnj(numero: str) -> dict:
         "tribunal": numero_limpo[14:16],
         "orgao": numero_limpo[16:]
     }
+
+
+@overload
+def format_cnj(numero: str, strict: Literal[True] = ...) -> str: ...
+
+
+@overload
+def format_cnj(numero: str | None, strict: bool = ...) -> str | None: ...
 
 
 def format_cnj(numero: str | None, strict: bool = True) -> str | None:

--- a/tests/fixtures/capture/trf3.py
+++ b/tests/fixtures/capture/trf3.py
@@ -51,7 +51,7 @@ def main() -> None:
     field_ids = extract_form_field_ids(form_html)
     print(f"[trf3] field ids: {field_ids}")
 
-    found_payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), field_ids)  # type: ignore[arg-type]
+    found_payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), field_ids)
     found_html = submit_search(scraper.session, found_payload)
     (dest / "search_one_result.html").write_text(found_html, encoding="utf-8")
     ca = extract_ca_token(found_html)
@@ -66,7 +66,7 @@ def main() -> None:
     (dest / "detail_normal.html").write_text(detail_html, encoding="latin-1")
 
     missing_payload = build_search_payload(
-        format_cnj(clean_cnj(MISSING_CNJ)), field_ids  # type: ignore[arg-type]
+        format_cnj(clean_cnj(MISSING_CNJ)), field_ids
     )
     missing_html = submit_search(scraper.session, missing_payload)
     (dest / "search_no_results.html").write_text(missing_html, encoding="utf-8")

--- a/tests/fixtures/capture/trf5.py
+++ b/tests/fixtures/capture/trf5.py
@@ -51,7 +51,7 @@ def main() -> None:
     field_ids = extract_form_field_ids(form_html)
     print(f"[trf5] field ids: {field_ids}")
 
-    found_payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), field_ids)  # type: ignore[arg-type]
+    found_payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), field_ids)
     found_html = submit_search(scraper.session, found_payload)
     (dest / "search_one_result.html").write_text(found_html, encoding="utf-8")
     ca = extract_ca_token(found_html)
@@ -66,7 +66,7 @@ def main() -> None:
     (dest / "detail_normal.html").write_text(detail_html, encoding="latin-1")
 
     missing_payload = build_search_payload(
-        format_cnj(clean_cnj(MISSING_CNJ)), field_ids  # type: ignore[arg-type]
+        format_cnj(clean_cnj(MISSING_CNJ)), field_ids
     )
     missing_html = submit_search(scraper.session, missing_payload)
     (dest / "search_no_results.html").write_text(missing_html, encoding="utf-8")

--- a/tests/fixtures/capture/trf6.py
+++ b/tests/fixtures/capture/trf6.py
@@ -48,18 +48,6 @@ FOUND_CNJ = "10052295520234063801"
 MISSING_CNJ = "00000000020994060000"
 
 
-def _cnj_formatado(numero: str) -> str:
-    """``clean_cnj`` + ``format_cnj`` com narrowing de ``str | None`` para ``str``.
-
-    ``format_cnj`` declara retorno ``str | None``; aqui os CNJs são constantes
-    válidas, então o ``None`` é impossível — o ``assert`` documenta isso e
-    satisfaz o type checker.
-    """
-    formatado = format_cnj(clean_cnj(numero))
-    assert formatado is not None, f"CNJ inválido: {numero}"
-    return formatado
-
-
 def _fresh_session() -> requests.Session:
     s = requests.Session()
     s.headers.update(BROWSER_HEADERS)
@@ -76,7 +64,7 @@ def _capture_detail(dest: Path, max_attempts: int = 5) -> None:
             print(f"[trf6]   saved form_initial.html ({len(form_html)} chars)")
         captcha_b64 = extract_captcha_b64(form_html)
         captcha_text = solve_captcha(captcha_b64)
-        payload = build_search_payload(_cnj_formatado(FOUND_CNJ), captcha_text)
+        payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), captcha_text)
         response = submit_search(s, payload)
         if is_detail_page(response):
             (dest / "detail_normal.html").write_text(response, encoding="latin-1")
@@ -105,7 +93,7 @@ def _capture_no_results(dest: Path, max_attempts: int = 5) -> None:
         form_html = fetch_form(s)
         captcha_b64 = extract_captcha_b64(form_html)
         captcha_text = solve_captcha(captcha_b64)
-        payload = build_search_payload(_cnj_formatado(MISSING_CNJ), captcha_text)
+        payload = build_search_payload(format_cnj(clean_cnj(MISSING_CNJ)), captcha_text)
         response = submit_search(s, payload)
         if is_detail_page(response):
             raise RuntimeError(
@@ -128,7 +116,7 @@ def _capture_bad_captcha(dest: Path) -> None:
     """Force a captcha rejection by submitting an obviously wrong value."""
     s = _fresh_session()
     fetch_form(s)  # primes the session
-    payload = build_search_payload(_cnj_formatado(FOUND_CNJ), "WRONG")
+    payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), "WRONG")
     response = submit_search(s, payload)
     (dest / "search_bad_captcha.html").write_text(response, encoding="latin-1")
     print("[trf6]   saved search_bad_captcha.html")

--- a/tests/fixtures/capture/trf6.py
+++ b/tests/fixtures/capture/trf6.py
@@ -48,6 +48,18 @@ FOUND_CNJ = "10052295520234063801"
 MISSING_CNJ = "00000000020994060000"
 
 
+def _cnj_formatado(numero: str) -> str:
+    """``clean_cnj`` + ``format_cnj`` com narrowing de ``str | None`` para ``str``.
+
+    ``format_cnj`` declara retorno ``str | None``; aqui os CNJs são constantes
+    válidas, então o ``None`` é impossível — o ``assert`` documenta isso e
+    satisfaz o type checker.
+    """
+    formatado = format_cnj(clean_cnj(numero))
+    assert formatado is not None, f"CNJ inválido: {numero}"
+    return formatado
+
+
 def _fresh_session() -> requests.Session:
     s = requests.Session()
     s.headers.update(BROWSER_HEADERS)
@@ -64,7 +76,7 @@ def _capture_detail(dest: Path, max_attempts: int = 5) -> None:
             print(f"[trf6]   saved form_initial.html ({len(form_html)} chars)")
         captcha_b64 = extract_captcha_b64(form_html)
         captcha_text = solve_captcha(captcha_b64)
-        payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), captcha_text)
+        payload = build_search_payload(_cnj_formatado(FOUND_CNJ), captcha_text)
         response = submit_search(s, payload)
         if is_detail_page(response):
             (dest / "detail_normal.html").write_text(response, encoding="latin-1")
@@ -93,11 +105,11 @@ def _capture_no_results(dest: Path, max_attempts: int = 5) -> None:
         form_html = fetch_form(s)
         captcha_b64 = extract_captcha_b64(form_html)
         captcha_text = solve_captcha(captcha_b64)
-        payload = build_search_payload(format_cnj(clean_cnj(MISSING_CNJ)), captcha_text)
+        payload = build_search_payload(_cnj_formatado(MISSING_CNJ), captcha_text)
         response = submit_search(s, payload)
         if is_detail_page(response):
             raise RuntimeError(
-                f"[trf6] MISSING_CNJ unexpectedly matched a process — "
+                "[trf6] MISSING_CNJ unexpectedly matched a process — "
                 "pick a different synthetic value."
             )
         if is_captcha_error(response):
@@ -116,7 +128,7 @@ def _capture_bad_captcha(dest: Path) -> None:
     """Force a captcha rejection by submitting an obviously wrong value."""
     s = _fresh_session()
     fetch_form(s)  # primes the session
-    payload = build_search_payload(format_cnj(clean_cnj(FOUND_CNJ)), "WRONG")
+    payload = build_search_payload(_cnj_formatado(FOUND_CNJ), "WRONG")
     response = submit_search(s, payload)
     (dest / "search_bad_captcha.html").write_text(response, encoding="latin-1")
     print("[trf6]   saved search_bad_captcha.html")

--- a/tests/tjrj/test_cjsg_contract.py
+++ b/tests/tjrj/test_cjsg_contract.py
@@ -164,13 +164,13 @@ def test_extract_default_year_uses_newest_dropdown_option():
 
 
 def test_extract_default_year_fallback_sem_select():
-    """Sem o ``<select>`` de ``cmbAnoInicio``, cai no maior ``\\d{4}`` do HTML."""
+    r"""Sem o ``<select>`` de ``cmbAnoInicio``, cai no maior ``\d{4}`` do HTML."""
     html = "<html><body><p>rodape 2019</p><p>atualizado em 2030</p></body></html>"
     assert extract_default_year(html) == "2030"
 
 
 def test_extract_default_year_fallback_select_sem_option_valida():
-    """``<select>`` presente mas sem ``<option value>`` cai no maior ``\\d{4}``."""
+    r"""``<select>`` presente mas sem ``<option value>`` cai no maior ``\d{4}``."""
     html = (
         '<select name="ctl00$ContentPlaceHolder1$cmbAnoInicio">'
         "<option>2021</option><option>2027</option>"


### PR DESCRIPTION
Higiene de lint revelada por um health-check do repo. **Sem mudança de API pública.** Com isto, `pre-commit run --all-files` passa 100% (flake8 e mypy estavam falhando em achados pré-existentes).

- `_esaj/base.py`: remove reimport redundante de `pandas` dentro de `TYPE_CHECKING` (F811) e o `TYPE_CHECKING` agora órfão.
- `core/exceptions.py`: remove trailing whitespace (W293).
- `scripts/build_trf6_notebook.py`: docstrings nas 4 funções públicas (D103).
- `tests/fixtures/capture/trf6.py`: f-string sem placeholder (F541) e narrowing `str|None`→`str` via helper `_cnj_formatado` (3 erros mypy `arg-type`).
- `tjrj/download.py`: r-string na docstring com `\d{4}` (D301) e `str(max(...))` no fallback de `extract_default_year` (mypy `no-any-return`).
- `tjrj/test_cjsg_contract.py`: r-string em 2 docstrings com `\d{4}` (D301).

🤖 Generated with [Claude Code](https://claude.com/claude-code)