### PR TITLE
fix(tjrr): descobrir id do datatable dinamicamente na paginação do cjsg

### DIFF
--- a/src/juscraper/courts/tjrr/download.py
+++ b/src/juscraper/courts/tjrr/download.py
@@ -222,6 +222,39 @@ def _get_total_pages(html: str) -> int:
     return n if n is not None else 1
 
 
+# JSF auto-generates the numeric segment of the results datatable id
+# (``formPesquisa:j_idtNNN:dataTablePesquisa``) and it shifts whenever the
+# page's component tree changes server-side (observed drift j_idt159 -> j_idt158
+# in 2026-06). Hardcoding it silently breaks pagination: the AJAX POST targets a
+# component that no longer exists and the backend replies with an opaque,
+# unparseable partial-response, so every page past the first yields zero rows.
+# Discover it from the rendered results page instead. Tried in cascade per the
+# project rule for tribunal-page extraction (see CLAUDE.md). The ``(?!\w)``
+# lookahead stops the match before ``dataTablePesquisa2`` (the second, distinct
+# results table) and ``dataTablePesquisa_data`` (the tbody), pinning the base id.
+_DATATABLE_ID_SELECTORS: tuple[re.Pattern[str], ...] = (
+    re.compile(r'id="(formPesquisa:j_idt\d+:dataTablePesquisa)(?!\w)'),
+    re.compile(r"(formPesquisa:j_idt\d+:dataTablePesquisa)(?!\w)"),
+    re.compile(r"(formPesquisa:[\w-]+:dataTablePesquisa)(?!\w)"),
+)
+
+
+def _extract_datatable_id(html: str) -> str:
+    """Discover the JSF id of the results datatable from the rendered page.
+
+    Cascade of selectors (most specific first) so a change in how the id is
+    surfaced does not silently fall back to a stale hardcoded value.
+    """
+    for pattern in _DATATABLE_ID_SELECTORS:
+        match = pattern.search(html)
+        if match:
+            return match.group(1)
+    raise RuntimeError(
+        "Could not find the results datatable id "
+        "(formPesquisa:j_idtNNN:dataTablePesquisa) on the TJRR results page."
+    )
+
+
 def _paginate(
     request_fn: RequestFn,
     html: str,
@@ -234,17 +267,18 @@ def _paginate(
         raise RuntimeError("Could not find ViewState for pagination.")
 
     viewstate = vs_input["value"]
+    datatable_id = _extract_datatable_id(html)
     rows = RESULTS_PER_PAGE
     first = (page - 1) * rows
 
     data = {
         "javax.faces.partial.ajax": "true",
-        "javax.faces.source": "formPesquisa:j_idt159:dataTablePesquisa",
-        "javax.faces.partial.execute": "formPesquisa:j_idt159:dataTablePesquisa",
-        "javax.faces.partial.render": "formPesquisa:j_idt159:dataTablePesquisa",
-        "formPesquisa:j_idt159:dataTablePesquisa_pagination": "true",
-        "formPesquisa:j_idt159:dataTablePesquisa_first": str(first),
-        "formPesquisa:j_idt159:dataTablePesquisa_rows": str(rows),
+        "javax.faces.source": datatable_id,
+        "javax.faces.partial.execute": datatable_id,
+        "javax.faces.partial.render": datatable_id,
+        f"{datatable_id}_pagination": "true",
+        f"{datatable_id}_first": str(first),
+        f"{datatable_id}_rows": str(rows),
         "formPesquisa": "formPesquisa",
         "javax.faces.ViewState": viewstate,
     }

--- a/tests/tjrr/test_cjsg_pagination_unit.py
+++ b/tests/tjrr/test_cjsg_pagination_unit.py
@@ -64,6 +64,25 @@ def test_extract_datatable_id_pins_base_table_not_second_or_tbody():
     assert _extract_datatable_id(html) == "formPesquisa:j_idt158:dataTablePesquisa"
 
 
+def test_extract_datatable_id_falls_back_when_no_id_attribute():
+    """Segundo nivel da cascata: o id aparece "solto" (ex.: em JS), sem o
+    atributo ``id="..."``. O primeiro seletor (ancorado em ``id="``) nao casa e
+    a busca cai para o seletor sem ancora, em vez de levantar."""
+    html = (
+        '<script>PrimeFaces.cw("DataTable","w",'
+        '{id:"formPesquisa:j_idt300:dataTablePesquisa"});</script>'
+    )
+    assert _extract_datatable_id(html) == "formPesquisa:j_idt300:dataTablePesquisa"
+
+
+def test_extract_datatable_id_falls_back_for_non_jidt_segment():
+    """Terceiro nivel da cascata: o segmento do meio nao segue ``j_idt\\d+``
+    (ex.: id nomeado ``resultTable``). Os dois primeiros seletores (presos a
+    ``j_idt\\d+``) nao casam e o seletor generico ``[\\w-]+`` resolve."""
+    html = '<div id="formPesquisa:resultTable:dataTablePesquisa"></div>'
+    assert _extract_datatable_id(html) == "formPesquisa:resultTable:dataTablePesquisa"
+
+
 def test_extract_datatable_id_raises_when_absent():
     with pytest.raises(RuntimeError, match="datatable id"):
         _extract_datatable_id("<html><body>no datatable here</body></html>")

--- a/tests/tjrr/test_cjsg_pagination_unit.py
+++ b/tests/tjrr/test_cjsg_pagination_unit.py
@@ -1,7 +1,9 @@
 """Testes unitarios da extracao de contagem TJRR via util compartilhado (refs #87)."""
 from __future__ import annotations
 
-from juscraper.courts.tjrr.download import _get_total_pages
+import pytest
+
+from juscraper.courts.tjrr.download import _extract_datatable_id, _get_total_pages
 from tests._helpers import load_sample
 
 
@@ -34,3 +36,34 @@ def test_get_total_pages_resilient_to_class_change():
         "(1 of 99)</span></div>"
     )
     assert _get_total_pages(html) == 99
+
+
+def test_extract_datatable_id_from_results_sample():
+    """The pagination id is read from the rendered page, never hardcoded."""
+    dtid = _extract_datatable_id(_sample("step_02_search.html"))
+    assert dtid.startswith("formPesquisa:j_idt")
+    assert dtid.endswith(":dataTablePesquisa")
+
+
+def test_extract_datatable_id_follows_jsf_drift():
+    """A different auto-generated id (the j_idt159 -> j_idt158 drift that broke
+    pagination in prod) is picked up verbatim instead of falling back to a stale
+    constant."""
+    html = '<div id="formPesquisa:j_idt777:dataTablePesquisa" class="ui-datatable"></div>'
+    assert _extract_datatable_id(html) == "formPesquisa:j_idt777:dataTablePesquisa"
+
+
+def test_extract_datatable_id_pins_base_table_not_second_or_tbody():
+    """Must pin the base datatable id, not ``dataTablePesquisa2`` (the second,
+    distinct results table) nor the ``_data`` tbody."""
+    html = (
+        '<div id="formPesquisa:j_idt158:dataTablePesquisa2"></div>'
+        '<tbody id="formPesquisa:j_idt158:dataTablePesquisa_data"></tbody>'
+        '<div id="formPesquisa:j_idt158:dataTablePesquisa"></div>'
+    )
+    assert _extract_datatable_id(html) == "formPesquisa:j_idt158:dataTablePesquisa"
+
+
+def test_extract_datatable_id_raises_when_absent():
+    with pytest.raises(RuntimeError, match="datatable id"):
+        _extract_datatable_id("<html><body>no datatable here</body></html>")

--- a/tests/tjrr/test_tjrr_cjsg.py
+++ b/tests/tjrr/test_tjrr_cjsg.py
@@ -26,11 +26,32 @@ class TestCJSGTJRR:
         colunas_minimas = {"processo", "ementa", "relator"}
         assert colunas_minimas.issubset(set(df.columns))
 
+    @pytest.mark.xfail(
+        strict=False,
+        reason=(
+            "Paginação do cjsg do TJRR não avança: o backend PrimeFaces ignora "
+            "o offset (_first) do datatable e devolve sempre a página 1, mesmo "
+            "com o id do componente descoberto dinamicamente (j_idt158) e o "
+            "evento de paginação (javax.faces.behavior.event=page) no payload — "
+            "verificado ao vivo. O fix do id (camada 1) tornou a resposta AJAX "
+            "parseável (antes vinha um blob opaco), mas a navegação de página "
+            "(camada 2) continua quebrada no servidor. Fechar exige capturar o "
+            "tráfego real de um navegador (HAR). Ver issue de follow-up."
+        ),
+    )
     def test_paginacao(self):
-        """Pagination brings results from multiple pages."""
+        """Pagination brings *new* results from page 2, not a re-fetch of page 1.
+
+        Asserting *new* processos (not just a larger count) pins the cursor
+        actually advancing — a plain ``len(df_p2) > len(df_p1)`` passes even
+        when page 2 merely repeats page 1's rows (which is exactly the current
+        TJRR backend behaviour; see the xfail reason).
+        """
         df_p1 = self.scraper.cjsg("dano moral", paginas=1)
         df_p2 = self.scraper.cjsg("dano moral", paginas=range(1, 3))
         assert len(df_p2) > len(df_p1)
+        novos = set(df_p2["processo"]) - set(df_p1["processo"])
+        assert novos, "página 2 não trouxe processos novos (paginação presa)"
 
     def test_download_e_parse(self):
         """Download + parse produces same result as cjsg."""


### PR DESCRIPTION
## Contexto

O `_paginate` do TJRR hardcodava o id JSF do datatable de resultados (`formPesquisa:j_idt159:dataTablePesquisa`) em 6 chaves do POST AJAX. O JSF regenera o segmento numérico quando a árvore de componentes muda server-side — observado drift `j_idt159 → j_idt158` em 2026-06. Com o id defasado, o POST de paginação mirava um componente inexistente e o backend devolvia um partial-response **opaco** (não-parseável), então toda página além da primeira virava zero linhas. Os contratos offline não pegavam porque o sample foi capturado com o id já desalinhado (auto-consistente com o hardcode).

## O que muda

Passa a descobrir o id na própria página de resultados, em cascata (regra do CLAUDE.md para extração em página de tribunal). Adiciona testes unit que travam contra regressão de hardcode e contra o drift de id.

## ⚠️ Fix parcial

Corrige a **camada 1** (resposta AJAX volta parseável). Persiste uma **camada 2**: verificado ao vivo que o backend ignora o offset (`_first`) e devolve sempre a página 1, mesmo com o id correto e o evento `javax.faces.behavior.event=page` no payload. `test_paginacao` fica `xfail` documentando esse bug de backend.

Detalhes e plano para fechar a camada 2: #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)