### PR TITLE
refactor(jusbr): wirar schemas pydantic em auth/cpopg/download_documents (#196)

### DIFF
--- a/src/juscraper/aggregators/jusbr/client.py
+++ b/src/juscraper/aggregators/jusbr/client.py
@@ -16,11 +16,14 @@ import jwt
 import numpy as np
 import pandas as pd
 import requests
+from pydantic import ValidationError
 
 from ...core.http import HTTPScraper
 from ...utils.cnj import clean_cnj
+from ...utils.params import raise_on_extra_kwargs
 from .download import USER_AGENT, fetch_document_binary, fetch_document_text, fetch_process_details, fetch_process_list
 from .parse import clean_document_text, parse_process_details_response, parse_process_list_response
+from .schemas import InputAuthJusBR, InputCPOPGJusBR, InputDownloadDocumentsJusBR
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,14 @@ class JusbrScraper(HTTPScraper):
     BASE_API_URL_V1_DOCS = (
         "https://api-processo.data-lake.pdpj.jus.br/processo-api/api/v1/processos/"
     )
+
+    # Schemas pydantic da API publica (``extra="forbid"``). Expostos como
+    # atributos de classe — fonte da verdade dos parametros aceitos e marcador
+    # de "wired" para ``tests/schemas/test_signature_parity.py`` (mesmo padrao
+    # do agregador irmao PDPJ).
+    INPUT_AUTH = InputAuthJusBR
+    INPUT_CPOPG = InputCPOPGJusBR
+    INPUT_DOWNLOAD_DOCUMENTS = InputDownloadDocumentsJusBR
 
     def __init__(
         self,
@@ -55,10 +66,21 @@ class JusbrScraper(HTTPScraper):
         # HTTPScraper (``juscraper/<version>``) por uma string Chrome/Edg.
         session.headers.update({'user-agent': USER_AGENT})
 
-    def auth(self, token: str) -> bool:
+    def auth(self, token: str, **kwargs: Any) -> bool:
         """
         Define o token JWT para autenticacao e o decodifica para verificacao.
+
+        Raises:
+            TypeError: Quando um kwarg desconhecido e passado (schema
+                :class:`InputAuthJusBR`, ``extra="forbid"``).
+            ValueError: Quando o token e invalido ou esta expirado.
         """
+        try:
+            inp = self.INPUT_AUTH(token=token, **kwargs)
+        except ValidationError as exc:
+            raise_on_extra_kwargs(exc, "JusbrScraper.auth()", schema_cls=self.INPUT_AUTH)
+            raise
+        token = inp.token
         try:
             # ``verify_exp: True`` e explicito porque com ``verify_signature=False``
             # o PyJWT desativa ``verify_exp`` por padrao — sem isso, o ramo
@@ -128,10 +150,21 @@ class JusbrScraper(HTTPScraper):
         self.session.headers.update({'authorization': f'Bearer {self.token}'})
         return True
 
-    def cpopg(self, id_cnj: str | list[str]) -> pd.DataFrame:
+    def cpopg(self, id_cnj: str | list[str], **kwargs: Any) -> pd.DataFrame:
         """
         Consulta processos pelo numero CNJ (ou lista de numeros CNJ) via API nacional.
+
+        Raises:
+            TypeError: Quando um kwarg desconhecido e passado (schema
+                :class:`InputCPOPGJusBR`, ``extra="forbid"``).
+            RuntimeError: Quando ``auth(token)`` nao foi chamado antes.
         """
+        try:
+            inp = self.INPUT_CPOPG(id_cnj=id_cnj, **kwargs)
+        except ValidationError as exc:
+            raise_on_extra_kwargs(exc, "JusbrScraper.cpopg()", schema_cls=self.INPUT_CPOPG)
+            raise
+        id_cnj = inp.id_cnj
         if not self.token:
             raise RuntimeError("Autenticacao necessaria. Chame o metodo auth(token) primeiro.")
 
@@ -199,13 +232,30 @@ class JusbrScraper(HTTPScraper):
 
     def download_documents(self,
                            base_df: pd.DataFrame,
-                           max_docs_per_process: int | None = None) -> pd.DataFrame:
+                           max_docs_per_process: int | None = None,
+                           **kwargs: Any) -> pd.DataFrame:
         """
         Downloads document texts for processes in base_df.
         Iterates through processes in base_df, extracts document metadata from the
         'detalhes' column, fetches, and cleans document texts.
         Returns a DataFrame where each row is a document.
+
+        Raises:
+            TypeError: Quando um kwarg desconhecido e passado (schema
+                :class:`InputDownloadDocumentsJusBR`, ``extra="forbid"``).
+            RuntimeError: Quando ``auth(token)`` nao foi chamado antes.
         """
+        try:
+            inp = self.INPUT_DOWNLOAD_DOCUMENTS(
+                base_df=base_df, max_docs_per_process=max_docs_per_process, **kwargs
+            )
+        except ValidationError as exc:
+            raise_on_extra_kwargs(
+                exc, "JusbrScraper.download_documents()", schema_cls=self.INPUT_DOWNLOAD_DOCUMENTS
+            )
+            raise
+        base_df = inp.base_df
+        max_docs_per_process = inp.max_docs_per_process
         if not self.token:
             raise RuntimeError("Autenticação necessária. Chame o método auth(token) primeiro.")
 

--- a/tests/jusbr/test_auth_contract.py
+++ b/tests/jusbr/test_auth_contract.py
@@ -14,6 +14,7 @@ import jwt
 import pytest
 
 import juscraper as jus
+from tests._helpers import assert_unknown_kwarg_raises
 
 # PyJWT emite ``InsecureKeyLengthWarning`` para chaves HMAC < 32 bytes em SHA256;
 # o ``filterwarnings = ["error"]`` do pytest converte isso em falha. Chave de 32+
@@ -72,3 +73,15 @@ def test_auth_token_malformado_levanta_value_error():
         scraper.auth("not-a-jwt")
     assert "authorization" not in scraper.session.headers
     assert scraper.token is None
+
+
+def test_auth_kwarg_desconhecido_levanta_type_error():
+    """Kwarg desconhecido vira ``TypeError`` canonico via ``InputAuthJusBR`` wirado.
+
+    A validacao do schema precede o ``jwt.decode``, entao o ``TypeError`` sai
+    mesmo com um token estruturalmente valido.
+    """
+    scraper = jus.scraper("jusbr")
+    assert_unknown_kwarg_raises(
+        scraper.auth, "kwarg_inventado", _token({"sub": "tester", "exp": 9999999999})
+    )

--- a/tests/jusbr/test_cpopg_filters_contract.py
+++ b/tests/jusbr/test_cpopg_filters_contract.py
@@ -14,13 +14,12 @@ import json
 
 import jwt
 import pandas as pd
-import pytest
 import responses
 from responses.matchers import query_param_matcher
 from responses.registries import OrderedRegistry
 
 import juscraper as jus
-from tests._helpers import load_sample
+from tests._helpers import assert_unknown_kwarg_raises, load_sample
 
 LIST_URL = "https://portaldeservicos.pdpj.jus.br/api/v2/processos/"
 DETAILS_URL_PREFIX = "https://portaldeservicos.pdpj.jus.br/api/v2/processos/"
@@ -124,13 +123,12 @@ def test_lista_de_cnjs_propaga_cada_um(mocker):
 
 
 def test_kwarg_desconhecido_e_rejeitado():
-    """``cpopg`` nao tem ``**kwargs`` -> Python puro levanta ``TypeError``.
+    """Kwarg desconhecido vira ``TypeError`` canonico via ``InputCPOPGJusBR`` wirado.
 
-    Quando ``InputCPOPGJusBR`` for wirado como follow-up, o
-    ``ValidationError`` do pydantic vai levantar antes; ate la, o
-    ``TypeError`` ja garante a rejeicao silenciosa.
+    Antes do wiring o ``TypeError`` vinha do Python puro (``cpopg`` sem
+    ``**kwargs``); agora vem de ``raise_on_extra_kwargs``, com o nome do metodo
+    no prefixo. A validacao precede a checagem de auth — por isso o teste nao
+    chama ``auth()`` antes.
     """
     scraper = jus.scraper("jusbr")
-    scraper.auth(_fake_jwt())
-    with pytest.raises(TypeError, match="filtro_inexistente"):
-        scraper.cpopg(NEUTRAL_CNJ_1, filtro_inexistente="x")
+    assert_unknown_kwarg_raises(scraper.cpopg, "filtro_inexistente", NEUTRAL_CNJ_1)

--- a/tests/jusbr/test_download_documents_contract.py
+++ b/tests/jusbr/test_download_documents_contract.py
@@ -28,7 +28,7 @@ import responses
 from responses.registries import OrderedRegistry
 
 import juscraper as jus
-from tests._helpers import load_sample, load_sample_bytes
+from tests._helpers import assert_unknown_kwarg_raises, load_sample, load_sample_bytes
 
 BASE_TEXT_URL = "https://api-processo.data-lake.pdpj.jus.br/processo-api/api/v1/processos"
 BASE_BINARY_URL = "https://portaldeservicos.pdpj.jus.br/api/v2/processos"
@@ -265,3 +265,13 @@ def test_download_documents_sem_auth_levanta_runtime_error():
     base_df = _base_df([_doc_meta(href_texto=_href_texto(UUID_TEXT_1), href_binario=_href_binario(UUID_BIN_1))])
     with pytest.raises(RuntimeError, match="[Aa]utentica"):
         scraper.download_documents(base_df)
+
+
+def test_download_documents_kwarg_desconhecido_levanta_type_error():
+    """Kwarg desconhecido vira ``TypeError`` canonico via ``InputDownloadDocumentsJusBR``.
+
+    A validacao do schema precede a checagem de auth, entao o ``TypeError`` sai
+    sem ``auth()`` previo.
+    """
+    scraper = jus.scraper("jusbr")
+    assert_unknown_kwarg_raises(scraper.download_documents, "kwarg_inventado", _base_df([]))


### PR DESCRIPTION
## Sumário

Etapa 2 da issue umbrella #196 (wiring pydantic do agregador JusBR). Wira os schemas que já existiam como documentação executável — `InputAuthJusBR`, `InputCPOPGJusBR`, `InputDownloadDocumentsJusBR` — na entrada dos 3 métodos públicos, seguindo o padrão do agregador **irmão** `PdpjScraper` (`#231`).

Depende da etapa 1 (contratos offline, #154/#141), já mergeada.

## Mudanças

- `JusbrScraper` expõe `INPUT_AUTH` / `INPUT_CPOPG` / `INPUT_DOWNLOAD_DOCUMENTS` como atributos de classe — fonte da verdade dos parâmetros e marcador de "wired" para `tests/schemas/test_signature_parity.py` (idêntico ao PDPJ).
- `auth` / `cpopg` / `download_documents` ganham `**kwargs` e instanciam o schema (`extra="forbid"`); kwargs desconhecidos viram `TypeError` canônico via `raise_on_extra_kwargs` — com o nome do método no prefixo e sugestão de typo via `difflib` (ex.: `max_docs_per_processo` → *você quis dizer 'max_docs_per_process'?*).
- `test_*_unknown_kwarg` nos 3 endpoints via `assert_unknown_kwarg_raises` (helper compartilhado), espelhando o padrão TJRN/TJPA pedido na #196 e o uso do PDPJ.

## Decisões de design

- **Estilo alinhado ao PDPJ pesquisa/contar** (`**kwargs` + `raise_on_extra_kwargs` inline), em vez de um helper genérico novo. Os métodos do JusBR não têm filtros (só os parâmetros nomeados), então não cabe `apply_input_pipeline_search` (que é específico de busca textual).
- **Sem entrada de CHANGELOG.** Os 3 métodos já rejeitavam kwargs desconhecidos (via Python, por não terem `**kwargs`). O wiring só torna a mensagem canônica (prefixo + sugestão de typo) e valida o formato dos campos — mudança interna sem efeito observável novo na API pública, conforme a regra do `CLAUDE.md` (wiring de schema em si não entra no changelog). Se preferir uma linha registrando a mensagem canônica, adiciono.

## Test plan

- [x] `pytest tests/jusbr/` — verde (auth/cpopg/download unknown_kwarg incluídos).
- [x] `pytest tests/schemas/` — `signature_parity` trata os 3 endpoints como wired.
- [x] `pytest` (suíte offline completa) — sem regressão.
- [x] `pre-commit` (flake8/mypy/isort/pylint) — verde.

## Refs

Closes #196. Refs #141 (contratos, etapa 1), #84 (agregadores fora do refactor estrutural — etapa 3 descartada por design), #231 (PdpjScraper, padrão de referência).

🤖 Generated with [Claude Code](https://claude.com/claude-code)