### PR TITLE
test: marcador anti_bot converte bloqueio Akamai em xfail (#292)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ juscraper e uma biblioteca Python para raspagem de dados de tribunais brasileiro
 - `pytest -m integration` — roda so integracao (lento, hit live).
 - `pytest -m ""` — roda tudo (offline + integracao).
 - `pytest tests/tjsp` — escopo a um tribunal.
+- `pytest -m "integration and not anti_bot"` — integracao sem os testes sujeitos a bloqueio Akamai (TRF1/TRF3/TRF5 `cpopg`); use em CI/datacenter. O marker `anti_bot` faz o conftest converter `BotChallengeBlockedError` em xfail (falha ambiental, nao regressao) — detalhes em `CONTRIBUTING.md` > **Tests** > **Marker `anti_bot`**. Refs #292.
 - `--strict-markers` esta ativo — todo marker deve ser registrado no `pyproject.toml`.
 
 ### Regras para autor de teste

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,22 @@ As seções a seguir são notas internas para quem contribui com novos raspadore
 | **Cassete** — fluxo multi-step com `pytest-recording` | `test_*_cassette.py` | `vcr` | Caso a caso (TJPE, TJRR, JusBR) |
 | **Integracao** — scraper contra tribunal real | `test_*_integration.py` | `integration` | Sob demanda |
 
+### Marker `anti_bot` — bloqueio anti-bot esperado (refs #292)
+
+A consulta pública PJe de TRF1, TRF3 e TRF5 fica atrás do bot manager Akamai. De IPs de datacenter/CI o portal devolve `HTTP 403 Access Denied` e o scraper levanta `BotChallengeBlockedError` de propósito (bloqueio session-wide). Isso é **falha ambiental** — depende do IP do cliente, passa de IP residencial — e não regressão de código. O marker `anti_bot` distingue os dois casos sem esconder regressão real.
+
+O `tests/conftest.py` registra um hook (`pytest_runtest_makereport`, `wrapper=True`) que, **apenas** para testes marcados `anti_bot`, converte `BotChallengeBlockedError` em `xfail`. Qualquer outra exceção — parser quebrado, schema rejeitando input antes válido, coluna renomeada — continua falhando vermelho, e de IP residencial (sem bloqueio) o teste passa normal. Diferente do `xfail(strict=False)` cego de TJAP (Turnstile) e TJRR (PrimeFaces), que são bloqueios *permanentes*: o Akamai é *condicional ao IP*, então o teste só vira xfail quando o bloqueio de fato acontece.
+
+Aplicar com `pytestmark = pytest.mark.anti_bot` no topo do arquivo de integração (cobre todos os testes do arquivo, que batem no mesmo backend protegido). Comandos:
+
+```bash
+pytest -m "integration and anti_bot"        # IP residencial: cobertura real dos TRFs
+pytest -m "integration and not anti_bot"    # CI/datacenter: pula os anti-bot por completo
+pytest -m integration                        # roda tudo; bloqueio Akamai vira xfail, regressao real falha
+```
+
+O hook é coberto por `tests/test_anti_bot_marker.py` (offline, via `pytester`), que reusa a implementação real e afirma os três casos: bloqueio+marker → xfail; regressão real → fail; bloqueio sem marker → fail.
+
 ### Ferramentas
 
 - **`responses`** (getsentry) — padrao para mockar `requests.Session` em testes de contrato. Usar `@responses.activate` ou context manager. Validar payload enviado com matchers (`urlencoded_params_matcher`, `json_params_matcher`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -280,6 +280,7 @@ markers = [
     "integration: hits live external services (run with '-m integration')",
     "release: comprehensive tests run before major releases (deselect with '-m \"not release\"')",
     "vcr: uses pytest-recording cassettes",
+    "anti_bot: integration test prone to anti-bot blocking (e.g. Akamai on TRF PJe); a BotChallengeBlockedError is reported as xfail (env-dependent on the client IP), so a real regression still fails loudly",
 ]
 filterwarnings = ["error"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,37 @@ from pathlib import Path
 
 import pytest
 
+from juscraper.core.exceptions import BotChallengeBlockedError
 from tests.helpers import DATA_ALVO_BR, DATA_ALVO_FIM_BR, DATA_ALVO_FIM_ISO, DATA_ALVO_ISO
+
+# Habilita a fixture ``pytester`` (sessões pytest isoladas) usada por
+# ``tests/test_anti_bot_marker.py`` para exercitar o hook ``anti_bot`` abaixo.
+pytest_plugins = ["pytester"]
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Converte um bloqueio anti-bot em xfail para testes marcados ``anti_bot``.
+
+    Portais protegidos por Akamai (TRF1/TRF3/TRF5 ``cpopg``) devolvem HTTP 403
+    ``Access Denied`` a partir de IPs de datacenter/CI; o código levanta
+    ``BotChallengeBlockedError`` de propósito (bloqueio session-wide). Isso é
+    falha *ambiental* — depende do IP do cliente, não é regressão —, então vira
+    xfail em vez de vermelho. Qualquer outra exceção continua falhando
+    normalmente, preservando o sinal de regressão real (parser quebrado, schema
+    rejeitando input antes válido, coluna renomeada). De IP residencial, sem
+    bloqueio, o teste passa de forma limpa. Ver issue #292.
+    """
+    report = yield
+    if (
+        report.when == "call"
+        and call.excinfo is not None
+        and item.get_closest_marker("anti_bot") is not None
+        and call.excinfo.errisinstance(BotChallengeBlockedError)
+    ):
+        report.outcome = "skipped"
+        report.wasxfail = "bloqueio anti-bot (Akamai) — falha ambiental, não regressão"
+    return report
 
 
 @pytest.fixture

--- a/tests/test_anti_bot_marker.py
+++ b/tests/test_anti_bot_marker.py
@@ -5,6 +5,11 @@ xfail **apenas** para testes marcados ``anti_bot`` — o bloqueio Akamai dos TRF
 é falha ambiental (depende do IP), não regressão. Qualquer outra exceção, ou a
 mesma exceção num teste sem o marker, continua falhando vermelho.
 
+A cobertura exercita as **duas formas de aplicar o marker**: por decorator de
+função (``@pytest.mark.anti_bot``) e por ``pytestmark`` de módulo — esta última
+é a usada de verdade nos arquivos de integração dos TRFs. O hook resolve ambas
+porque ``item.get_closest_marker`` percorre os nós-pai (incluindo o Module).
+
 O teste roda uma sessão pytest isolada com a fixture ``pytester`` que **reusa o
 hook real** (re-exportado no conftest gerado), em vez de duplicar a lógica:
 assim o teste protege a implementação de verdade, não uma cópia.
@@ -34,6 +39,20 @@ def test_block_without_marker_still_fails():
     raise BotChallengeBlockedError("TRF3", "https://pje1g.trf3.jus.br")
 '''
 
+# Espelha o uso real nos TRFs: o marker aplicado a nível de módulo via
+# ``pytestmark`` (em vez de decorator por função). ``get_closest_marker``
+# enxerga o marker pelo nó Module, então o bloqueio também vira xfail aqui.
+_TEST_MODULE_PYTESTMARK = '''
+import pytest
+from juscraper.core.exceptions import BotChallengeBlockedError
+
+pytestmark = pytest.mark.anti_bot
+
+
+def test_module_level_block_becomes_xfail():
+    raise BotChallengeBlockedError("TRF1", "https://pje1g.trf1.jus.br", reference="9.x")
+'''
+
 _INI = """
 [pytest]
 markers =
@@ -42,9 +61,16 @@ markers =
 
 
 def test_anti_bot_hook_distinguishes_block_from_regression(pytester):
-    """Bloqueio+marker vira xfail; regressão real e bloqueio sem marker falham."""
+    """Bloqueio+marker vira xfail; regressão real e bloqueio sem marker falham.
+
+    Cobre o marker por decorator de função e por ``pytestmark`` de módulo (a
+    forma usada nos TRFs): ambos os bloqueios viram xfail.
+    """
     pytester.makeconftest(_CONFTEST)
-    pytester.makepyfile(_TEST_MODULE)
+    pytester.makepyfile(
+        test_func_marker=_TEST_MODULE,
+        test_module_marker=_TEST_MODULE_PYTESTMARK,
+    )
     pytester.makeini(_INI)
 
     # ``-p no:asyncio``: a sessão aninhada reconfigura todos os plugins do
@@ -54,4 +80,6 @@ def test_anti_bot_hook_distinguishes_block_from_regression(pytester):
     # o teste desse ruído de terceiros.
     result = pytester.runpytest("-p", "no:asyncio")
 
-    result.assert_outcomes(xfailed=1, failed=2)
+    # xfailed: bloqueio+marker-de-função e bloqueio+pytestmark-de-módulo.
+    # failed: regressão real (AssertionError) e bloqueio sem marker.
+    result.assert_outcomes(xfailed=2, failed=2)

--- a/tests/test_anti_bot_marker.py
+++ b/tests/test_anti_bot_marker.py
@@ -1,0 +1,57 @@
+"""Testa o hook ``anti_bot`` definido em ``tests/conftest.py`` (issue #292).
+
+O hook (`pytest_runtest_makereport`) converte ``BotChallengeBlockedError`` em
+xfail **apenas** para testes marcados ``anti_bot`` — o bloqueio Akamai dos TRFs
+é falha ambiental (depende do IP), não regressão. Qualquer outra exceção, ou a
+mesma exceção num teste sem o marker, continua falhando vermelho.
+
+O teste roda uma sessão pytest isolada com a fixture ``pytester`` que **reusa o
+hook real** (re-exportado no conftest gerado), em vez de duplicar a lógica:
+assim o teste protege a implementação de verdade, não uma cópia.
+"""
+from __future__ import annotations
+
+# Re-exporta o hook real para a sessão pytester. ``tests`` é importável como
+# pacote (``pythonpath = ["tests"]`` + ``tests/__init__.py``).
+_CONFTEST = "from tests.conftest import pytest_runtest_makereport  # noqa: F401\n"
+
+_TEST_MODULE = '''
+import pytest
+from juscraper.core.exceptions import BotChallengeBlockedError
+
+
+@pytest.mark.anti_bot
+def test_block_becomes_xfail():
+    raise BotChallengeBlockedError("TRF3", "https://pje1g.trf3.jus.br", reference="18.x")
+
+
+@pytest.mark.anti_bot
+def test_real_regression_still_fails():
+    assert False, "parser quebrado — regressão real"
+
+
+def test_block_without_marker_still_fails():
+    raise BotChallengeBlockedError("TRF3", "https://pje1g.trf3.jus.br")
+'''
+
+_INI = """
+[pytest]
+markers =
+    anti_bot: anti-bot block becomes xfail
+"""
+
+
+def test_anti_bot_hook_distinguishes_block_from_regression(pytester):
+    """Bloqueio+marker vira xfail; regressão real e bloqueio sem marker falham."""
+    pytester.makeconftest(_CONFTEST)
+    pytester.makepyfile(_TEST_MODULE)
+    pytester.makeini(_INI)
+
+    # ``-p no:asyncio``: a sessão aninhada reconfigura todos os plugins do
+    # processo; o pytest-asyncio emite um DeprecationWarning no ``configure``
+    # que o ``filterwarnings = error`` da sessão externa transformaria em erro
+    # fatal. O hook ``anti_bot`` não tem relação com asyncio — desligá-lo isola
+    # o teste desse ruído de terceiros.
+    result = pytester.runpytest("-p", "no:asyncio")
+
+    result.assert_outcomes(xfailed=1, failed=2)

--- a/tests/trf1/test_cpopg_integration.py
+++ b/tests/trf1/test_cpopg_integration.py
@@ -9,6 +9,12 @@ import pytest
 
 import juscraper as jus
 
+# A consulta pública PJe do TRF1 é protegida por Akamai: de IPs de datacenter/CI
+# o portal devolve 403 ``Access Denied`` e o scraper levanta
+# ``BotChallengeBlockedError``. O marker ``anti_bot`` faz o conftest converter
+# esse bloqueio em xfail (falha ambiental, não regressão). Ver issue #292.
+pytestmark = pytest.mark.anti_bot
+
 # CNJs picked from the user-supplied test set. ``KNOWN_GOOD`` has < 15 movs so
 # it exercises the no-pagination short-circuit; ``PAGINATED`` has > 15 movs and
 # locks in the Richfaces slider fix.

--- a/tests/trf3/test_cpopg_integration.py
+++ b/tests/trf3/test_cpopg_integration.py
@@ -11,6 +11,12 @@ import pytest
 
 import juscraper as jus
 
+# A consulta pública PJe do TRF3 é protegida por Akamai: de IPs de datacenter/CI
+# o portal devolve 403 ``Access Denied`` e o scraper levanta
+# ``BotChallengeBlockedError``. O marker ``anti_bot`` faz o conftest converter
+# esse bloqueio em xfail (falha ambiental, não regressão). Ver issue #292.
+pytestmark = pytest.mark.anti_bot
+
 # CNJ pulled from data/amostra_jf_primeiro_grau.csv. Picked because it's a
 # recent JEF process from São José do Rio Preto (TRF3 / SP) that has many
 # movements but is not under sigilo.

--- a/tests/trf5/test_cpopg_integration.py
+++ b/tests/trf5/test_cpopg_integration.py
@@ -9,6 +9,12 @@ import pytest
 
 import juscraper as jus
 
+# A consulta pública PJe do TRF5 é protegida por Akamai: de IPs de datacenter/CI
+# o portal devolve 403 ``Access Denied`` e o scraper levanta
+# ``BotChallengeBlockedError``. O marker ``anti_bot`` faz o conftest converter
+# esse bloqueio em xfail (falha ambiental, não regressão). Ver issue #292.
+pytestmark = pytest.mark.anti_bot
+
 # CNJ pulled from data/amostra_jf_primeiro_grau.csv (CEJUSC Maceió, AL).
 _KNOWN_GOOD_CNJ = "00584573120254058000"
 


### PR DESCRIPTION
## Contexto

Implementa a sugestão acionável da issue #292: um marcador pytest para testes de integração sabidamente sujeitos a bloqueio anti-bot, distinguindo **falha ambiental esperada** de **regressão real** quando a suíte `-m integration` roda em CI/datacenter.

A consulta pública PJe de **TRF1, TRF3 e TRF5** fica atrás do bot manager **Akamai**. De IPs de datacenter/CI o portal devolve `HTTP 403 Access Denied` e o scraper levanta `BotChallengeBlockedError` de propósito (bloqueio session-wide). Isso é falha *ambiental* — depende do IP do cliente, passa de IP residencial — e não regressão de código. Antes, porém, falhava vermelho na suíte, indistinguível de um bug real (parser quebrado, schema, coluna renomeada).

## O que muda

- **`pyproject.toml`** — registra o marker `anti_bot` (o `--strict-markers` exige declaração).
- **`tests/conftest.py`** — hook `pytest_runtest_makereport` (`wrapper=True`, protocolo moderno do pluggy) que converte **somente** `BotChallengeBlockedError` em `xfail`, e **apenas** para testes marcados `anti_bot`. Habilita também a fixture `pytester`.
- **`tests/trf{1,3,5}/test_cpopg_integration.py`** — `pytestmark = pytest.mark.anti_bot` (cobre os 9 testes).
- **`tests/test_anti_bot_marker.py`** (novo) — teste offline via `pytester` que reusa o hook **real** e afirma os três casos: bloqueio+marker → xfail; regressão real → fail; bloqueio sem marker → fail.
- **`CONTRIBUTING.md`** / **`CLAUDE.md`** — documentação do marker e do comando `pytest -m "integration and not anti_bot"` para CI/datacenter.

Diferente do `xfail(strict=False)` cego de TJAP (Turnstile) e TJRR (PrimeFaces) — bloqueios *permanentes* —, o Akamai é *condicional ao IP*: o teste só vira xfail quando o bloqueio de fato acontece. De IP residencial passa normal; qualquer outra exceção continua vermelha.

Sem entrada no CHANGELOG: pelo filtro do projeto, "tooling — marker novo" não afeta quem usa a API pública.

## Verificação

- `pytest --markers` lista o `anti_bot`.
- Suíte offline default verde: **1747 passed, 29 skipped, 220 deselected** (~16s).
- `tests/test_anti_bot_marker.py` passa.
- pre-commit (ruff/isort/flake8/mypy) verde.

**Limite do que dá para verificar offline:** os três caminhos do hook foram validados em cenário sintético. O comportamento *live* (Akamai → xfail de IP datacenter; passa de IP residencial) só se confirma rodando `pytest -m "integration and anti_bot" tests/trf3` nos dois tipos de IP.

## Escopo da issue

Cobre a sugestão de marcador. As demais falhas registradas na #292 (TJRS `ReadTimeout`, TJTO/TJDFT `503`) são intermitentes e voltam sozinhas — sem ação de código. Como a issue também serve de registro dessas falhas ambientais, deixo o fechamento a seu critério (por isso `Refs`, não `Closes`).

Refs #292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
