### PR TITLE
chore(pdpj): escapar U+2028/U+2029 em clean_document_text (destrava Radon)

### DIFF
--- a/src/juscraper/aggregators/pdpj/parse.py
+++ b/src/juscraper/aggregators/pdpj/parse.py
@@ -177,5 +177,5 @@ def clean_document_text(text: str | None) -> str | None:
     cleaned = text.replace("\x00", "").replace("\x1a", "")
     cleaned = cleaned.replace("\r\n", "\n").replace("\r", "\n")
     cleaned = cleaned.replace("\xa0", " ")
-    cleaned = cleaned.replace(" ", "\n").replace(" ", "\n")
+    cleaned = cleaned.replace("\u2028", "\n").replace("\u2029", "\n")
     return cleaned.strip() or None


### PR DESCRIPTION
## O quê

`aggregators/pdpj/parse.py:180` usava os caracteres **LINE SEPARATOR (U+2028)** e **PARAGRAPH SEPARATOR (U+2029)** literais dentro de `clean_document_text`, em `cleaned.replace(<U+2028>, "\n").replace(<U+2029>, "\n")`. Este PR troca os dois literais pelos escapes de seis caracteres equivalentes.

## Por quê

O `compile()`/import do CPython aceita esses code points num literal de string, mas o módulo `tokenize` (que Radon, wily e outras métricas baseadas em tokens usam) os trata como **quebra de linha lógica** e aborta com `SyntaxError`. Resultado: `radon mi` falhava exatamente neste arquivo — o único do `src/` que ficava fora da análise de manutenibilidade (187 de 188 arquivos cobertos).

Surgiu na avaliação de ferramentas de qualidade (#303), como limitação que travava o teste do Radon.

## Garantias

- **Comportamento idêntico**: o escape denota o mesmo code point, então o valor das strings não muda e `clean_document_text` segue normalizando U+2028/U+2029 para `\n` como antes. Bônus: o escape deixa explícito qual separador está sendo tratado.
- `radon mi src` passa a cobrir **188/188** arquivos (era 187/188).
- Suíte offline completa verde; `tests/pdpj` (34 testes) passando; `ruff` limpo no arquivo.
- Única ocorrência de U+2028/U+2029 em todo o `src/` (conferido por `grep -P`).

Refs #303.
