### PR TITLE
chore(ruff): habilitar bugbear/comprehensions/RUF e tratar achados de bug-risk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,6 +223,23 @@ select = [
     "UP007",  # PEP 604 (Union[X, Y] -> X | Y)
     "UP035",  # deprecated import (typing.List -> builtins, etc.)
     "UP045",  # PEP 604 (Optional[X] -> X | None)
+    "B",      # flake8-bugbear: bug-risk (ex.: zip() sem strict=)
+    "C4",     # flake8-comprehensions: comprehensions/calls desnecessarios
+    "RUF",    # regras do proprio Ruff (ex.: mutable-class-default)
+]
+ignore = [
+    # Caracteres "ambiguos" em texto pt-BR sao legitimos. Docstrings e
+    # comentarios usam EN DASH (travessao) e afins de proposito; nao
+    # queremos que o Ruff peca para troca-los por ASCII.
+    "RUF001",
+    "RUF002",
+    "RUF003",
+    # RUF100 (unused-noqa) nao convive bem com este projeto: o flake8 roda
+    # em paralelo e ha `# noqa: E231/E702` (pycodestyle) e `# noqa: BLE001`
+    # (regra do Ruff ainda nao habilitada) que sao intencionais. O Ruff os
+    # trataria como obsoletos e removeria, quebrando o flake8 e apagando
+    # decisoes documentadas. Reavaliar se/quando BLE for habilitada.
+    "RUF100",
 ]
 
 [tool.isort]

--- a/src/juscraper/aggregators/jusbr/client.py
+++ b/src/juscraper/aggregators/jusbr/client.py
@@ -226,7 +226,7 @@ class JusbrScraper(HTTPScraper):
         df_resultados = pd.DataFrame(all_process_data)
         if 'processo_pesquisado' in df_resultados.columns:
             cols1 = [col for col in df_resultados.columns if col != 'processo_pesquisado']
-            cols = ['processo_pesquisado'] + cols1
+            cols = ['processo_pesquisado', *cols1]
             df_resultados = df_resultados[cols]
         return df_resultados
 
@@ -452,7 +452,7 @@ class JusbrScraper(HTTPScraper):
             if col in existing_cols_set:
                 final_cols.append(col)
                 existing_cols_set.remove(col)  # Avoid duplication
-        final_cols.extend(sorted(list(existing_cols_set)))  # Add remaining columns alphabetically
+        final_cols.extend(sorted(existing_cols_set))  # Add remaining columns alphabetically
 
         df_docs = df_docs[final_cols]
         # Fill with None if some preferred columns were entirely missing from all docs

--- a/src/juscraper/courts/_esaj/base.py
+++ b/src/juscraper/courts/_esaj/base.py
@@ -17,7 +17,7 @@ import logging
 import shutil
 import warnings
 from collections.abc import Callable
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import pandas as pd
 from pydantic import BaseModel, ValidationError
@@ -237,7 +237,7 @@ class EsajSearchScraper(HTTPScraper):
     # TJSP estender com as arvores de 1o grau (cjpg) sem if/else. Todos os
     # tribunais eSAJ expoem as arvores de cjsg (2o grau); cjpg so existe no
     # TJSP hoje, entao as entradas ``_1`` ficam no TJSPScraper. Refs #228.
-    TREE_ENDPOINTS: dict[str, str] = {
+    TREE_ENDPOINTS: ClassVar[dict[str, str]] = {
         "classes_2": "cjsg/classesTreeSelect.do?campoId=classes",
         "assuntos_2": "cjsg/assuntosTreeSelect.do?campoId=assuntos",
         "orgaos_2": "cjsg/secaoTreeSelect.do?campoId=secoes",

--- a/src/juscraper/courts/tjes/download.py
+++ b/src/juscraper/courts/tjes/download.py
@@ -90,20 +90,20 @@ def cjsg_download(
     centraliza retry exponencial para 429/5xx.
     """
     url = f"{BASE_URL}/search"
-    common = dict(
-        pesquisa=pesquisa,
-        per_page=per_page,
-        core=core,
-        busca_exata=busca_exata,
-        data_inicio=data_inicio,
-        data_fim=data_fim,
-        magistrado=magistrado,
-        orgao_julgador=orgao_julgador,
-        classe_judicial=classe_judicial,
-        jurisdicao=jurisdicao,
-        assunto=assunto,
-        ordenacao=ordenacao,
-    )
+    common = {
+        "pesquisa": pesquisa,
+        "per_page": per_page,
+        "core": core,
+        "busca_exata": busca_exata,
+        "data_inicio": data_inicio,
+        "data_fim": data_fim,
+        "magistrado": magistrado,
+        "orgao_julgador": orgao_julgador,
+        "classe_judicial": classe_judicial,
+        "jurisdicao": jurisdicao,
+        "assunto": assunto,
+        "ordenacao": ordenacao,
+    }
 
     def _get_page(pagina):
         params = _build_params(pagina=pagina, **common)

--- a/src/juscraper/courts/tjrs/client.py
+++ b/src/juscraper/courts/tjrs/client.py
@@ -1,4 +1,6 @@
 """Scraper for the Tribunal de Justiça do Rio Grande do Sul (TJRS)."""
+from typing import ClassVar
+
 import pandas as pd
 
 from juscraper.core.http import HTTPScraper
@@ -13,7 +15,7 @@ class TJRSScraper(HTTPScraper):
     """Scraper for the Tribunal de Justiça do Rio Grande do Sul."""
 
     BASE_URL = "https://www.tjrs.jus.br/buscas/jurisprudencia/ajax.php"
-    DEFAULT_PARAMS = {
+    DEFAULT_PARAMS: ClassVar[dict[str, str]] = {
         "tipo-busca": "jurisprudencia-mob",
         "client": "tjrs_index",
         "proxystylesheet": "tjrs_index",

--- a/src/juscraper/courts/tjsc/parse.py
+++ b/src/juscraper/courts/tjsc/parse.py
@@ -26,7 +26,7 @@ def _parse_result_item(item) -> dict:
         "DECISAO": "decisao",
     }
 
-    for label, value in zip(labels, values):
+    for label, value in zip(labels, values, strict=False):
         label_text = label.get_text(strip=True).upper()
         # Normalize accented chars for matching
         label_norm = (

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import tempfile
 import warnings
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 import pandas as pd
 from pydantic import BaseModel
@@ -83,7 +83,7 @@ class TJSPScraper(EsajSearchScraper):
     # Alem das arvores de cjsg herdadas de EsajSearchScraper, o TJSP expoe as
     # arvores de 1o grau (cjpg). Os stems do cjpg sao no SINGULAR
     # (``classeTreeSelect`` etc.), diferente do plural do cjsg. Refs #228.
-    TREE_ENDPOINTS = {
+    TREE_ENDPOINTS: ClassVar[dict[str, str]] = {
         **EsajSearchScraper.TREE_ENDPOINTS,
         "classes_1": "cjpg/classeTreeSelect.do?campoId=classes",
         "assuntos_1": "cjpg/assuntoTreeSelect.do?campoId=assuntos",
@@ -680,4 +680,4 @@ class TJSPScraper(EsajSearchScraper):
         return cposg_parse_manager(path)
 
 
-__all__ = ["TJSPScraper", "QueryTooLongError"]
+__all__ = ["QueryTooLongError", "TJSPScraper"]

--- a/src/juscraper/courts/tjsp/cpopg_parse.py
+++ b/src/juscraper/courts/tjsp/cpopg_parse.py
@@ -345,7 +345,7 @@ def cpopg_parse_single_json(path: str):
     # primeiro, vamos listar todos os arquivos que estão na
     # mesma pasta que o arquivo que está em path
     lista_arquivos = glob.glob(f"{os.path.dirname(path)}/*.json")
-    lista_processo = [f for f in lista_arquivos if f[-6:-5].isnumeric()][0]
+    lista_processo = next(f for f in lista_arquivos if f[-6:-5].isnumeric())
     lista_arquivos = [f for f in lista_arquivos if f not in lista_processo]
 
     # agora, fazemos a leitura de cada arquivo e transformamos em um dataframe

--- a/src/juscraper/courts/trf1/client.py
+++ b/src/juscraper/courts/trf1/client.py
@@ -178,7 +178,7 @@ class TRF1Scraper(BaseScraper):
                 f"({len(htmls)} != {len(id_cnj_list)})"
             )
         rows: list[dict[str, Any]] = []
-        for cnj, html in zip(id_cnj_list, htmls):
+        for cnj, html in zip(id_cnj_list, htmls, strict=False):
             if html is None:
                 rows.append({"id_cnj": cnj})
                 continue
@@ -265,7 +265,7 @@ class TRF1Scraper(BaseScraper):
         propaga (session-wide).
         """
         results: list[list[str]] = []
-        for i, (cnj, html) in enumerate(zip(cnjs, htmls)):
+        for i, (cnj, html) in enumerate(zip(cnjs, htmls, strict=False)):
             if html is None:
                 results.append([])
                 continue

--- a/src/juscraper/courts/trf1/parse.py
+++ b/src/juscraper/courts/trf1/parse.py
@@ -41,7 +41,7 @@ def _norm_ws(text: str | None) -> str | None:
 
 def _parse_property_views(soup: BeautifulSoup) -> dict[str, str | None]:
     """Pull ``label -> value`` pairs out of the top ``propertyView`` panels."""
-    out: dict[str, str | None] = {key: None for key in _PROCESS_LABELS.values()}
+    out: dict[str, str | None] = dict.fromkeys(_PROCESS_LABELS.values())
     for div in soup.select("div.propertyView"):
         label_el = div.find(class_="name")
         value_el = div.find(class_="value")

--- a/src/juscraper/courts/trf3/client.py
+++ b/src/juscraper/courts/trf3/client.py
@@ -178,7 +178,7 @@ class TRF3Scraper(BaseScraper):
                 f"({len(htmls)} != {len(id_cnj_list)})"
             )
         rows: list[dict[str, Any]] = []
-        for cnj, html in zip(id_cnj_list, htmls):
+        for cnj, html in zip(id_cnj_list, htmls, strict=False):
             if html is None:
                 rows.append({"id_cnj": cnj})
                 continue
@@ -265,7 +265,7 @@ class TRF3Scraper(BaseScraper):
         propaga (session-wide).
         """
         results: list[list[str]] = []
-        for i, (cnj, html) in enumerate(zip(cnjs, htmls)):
+        for i, (cnj, html) in enumerate(zip(cnjs, htmls, strict=False)):
             if html is None:
                 results.append([])
                 continue

--- a/src/juscraper/courts/trf3/parse.py
+++ b/src/juscraper/courts/trf3/parse.py
@@ -41,7 +41,7 @@ def _norm_ws(text: str | None) -> str | None:
 
 def _parse_property_views(soup: BeautifulSoup) -> dict[str, str | None]:
     """Pull ``label -> value`` pairs out of the top ``propertyView`` panels."""
-    out: dict[str, str | None] = {key: None for key in _PROCESS_LABELS.values()}
+    out: dict[str, str | None] = dict.fromkeys(_PROCESS_LABELS.values())
     for div in soup.select("div.propertyView"):
         label_el = div.find(class_="name")
         value_el = div.find(class_="value")

--- a/src/juscraper/courts/trf5/client.py
+++ b/src/juscraper/courts/trf5/client.py
@@ -177,7 +177,7 @@ class TRF5Scraper(BaseScraper):
                 f"({len(htmls)} != {len(id_cnj_list)})"
             )
         rows: list[dict[str, Any]] = []
-        for cnj, html in zip(id_cnj_list, htmls):
+        for cnj, html in zip(id_cnj_list, htmls, strict=False):
             if html is None:
                 rows.append({"id_cnj": cnj})
                 continue
@@ -264,7 +264,7 @@ class TRF5Scraper(BaseScraper):
         propaga (session-wide).
         """
         results: list[list[str]] = []
-        for i, (cnj, html) in enumerate(zip(cnjs, htmls)):
+        for i, (cnj, html) in enumerate(zip(cnjs, htmls, strict=False)):
             if html is None:
                 results.append([])
                 continue

--- a/src/juscraper/courts/trf5/parse.py
+++ b/src/juscraper/courts/trf5/parse.py
@@ -41,7 +41,7 @@ def _norm_ws(text: str | None) -> str | None:
 
 def _parse_property_views(soup: BeautifulSoup) -> dict[str, str | None]:
     """Pull ``label -> value`` pairs out of the top ``propertyView`` panels."""
-    out: dict[str, str | None] = {key: None for key in _PROCESS_LABELS.values()}
+    out: dict[str, str | None] = dict.fromkeys(_PROCESS_LABELS.values())
     for div in soup.select("div.propertyView"):
         label_el = div.find(class_="name")
         value_el = div.find(class_="value")

--- a/src/juscraper/courts/trf6/client.py
+++ b/src/juscraper/courts/trf6/client.py
@@ -117,7 +117,7 @@ class TRF6Scraper(BaseScraper):
                 f"({len(htmls)} != {len(id_cnj_list)})"
             )
         rows: list[dict[str, Any]] = []
-        for cnj, html in zip(id_cnj_list, htmls):
+        for cnj, html in zip(id_cnj_list, htmls, strict=False):
             if html is None:
                 rows.append({"id_cnj": cnj})
             else:

--- a/src/juscraper/courts/trf6/parse.py
+++ b/src/juscraper/courts/trf6/parse.py
@@ -44,7 +44,7 @@ def _norm_ws(text: str | None) -> str | None:
 
 def _parse_capa(soup: BeautifulSoup) -> dict[str, str | None]:
     """Pull dt/dd pairs from the ``Capa do Processo`` fieldset."""
-    out: dict[str, str | None] = {key: None for key in _CAPA_FIELD_IDS.values()}
+    out: dict[str, str | None] = dict.fromkeys(_CAPA_FIELD_IDS.values())
     out["orgao_julgador"] = None
     fieldset = None
     for fs in soup.find_all("fieldset"):
@@ -127,7 +127,7 @@ def _parse_partes(
                 poles.setdefault(key, [])
             continue
         if tds and current_keys:
-            for key, td in zip(current_keys, tds):
+            for key, td in zip(current_keys, tds, strict=False):
                 text = _norm_ws(td.get_text(separator=" | "))
                 if text:
                     poles.setdefault(key, []).append({"descricao": text})

--- a/src/juscraper/schemas/__init__.py
+++ b/src/juscraper/schemas/__init__.py
@@ -13,17 +13,17 @@ from .mixins import (
 from .types import IdFiltro, IdFiltroUnico
 
 __all__ = [
-    "SearchBase",
-    "OutputCJSGBase",
     "AutoChunkMixin",
+    "CnjInputBase",
     "CountOnlyMixin",
-    "PaginasMixin",
     "DataJulgamentoMixin",
     "DataPublicacaoMixin",
-    "OutputRelatoriaMixin",
-    "OutputDataPublicacaoMixin",
-    "CnjInputBase",
-    "OutputCnjConsultaBase",
     "IdFiltro",
     "IdFiltroUnico",
+    "OutputCJSGBase",
+    "OutputCnjConsultaBase",
+    "OutputDataPublicacaoMixin",
+    "OutputRelatoriaMixin",
+    "PaginasMixin",
+    "SearchBase",
 ]

--- a/src/juscraper/utils/params.py
+++ b/src/juscraper/utils/params.py
@@ -202,7 +202,7 @@ def normalize_datas(**kwargs):
                 f"Use apenas '{canonical}'."
             )
 
-    result: dict[str, Any] = {c: None for c in DATE_CANONICAL}
+    result: dict[str, Any] = dict.fromkeys(DATE_CANONICAL)
     for canonical, srcs in sources.items():
         if not srcs:
             continue


### PR DESCRIPTION
## Contexto

Item 1 da avaliação de qualidade (#303): o Ruff já está instalado mas roda com **apenas 4 regras** (`UP006/UP007/UP035/UP045`, só modernização de sintaxe). Este PR destrava o que estava parado na mesa, habilitando três famílias de alto sinal e tratando os achados.

## O que muda na config (`pyproject.toml`)

`select` ganha `B` (flake8-bugbear), `C4` (flake8-comprehensions) e `RUF` (regras do próprio Ruff). Foram 35 achados: 7 saíram por autofix seguro, 16 corrigidos à mão, e o restante já era coberto.

## Bug-risk (o motivo de habilitar `B`/`RUF`)

- **B905 — 9 `zip()` sem `strict=`** (parsers TRF1/3/5/6, tjsc): passam a declarar `strict=False`. Preserva **exatamente** o comportamento atual (truncar pelo menor lado) e torna a intenção explícita — daqui pra frente todo `zip()` novo terá de decidir `strict`. Optei por `False`, e não `True`, deliberadamente: num scraper, HTML irregular deve degradar (truncar) e não virar exceção no meio da coleta. Onde há validação de tamanho prévia (ex.: `trf1/client.py:181` tem `raise` de mismatch logo acima), `strict=False` é inócuo.
- **RUF012 — 3 mutable-class-default**: `TREE_ENDPOINTS` (`_esaj/base.py`, `tjsp/client.py`) e `DEFAULT_PARAMS` (`tjrs/client.py`) são tabelas de constantes read-only. Anoto com `ClassVar`, o que documenta a intenção e previne mutação acidental compartilhada entre instâncias. Sem mudança de comportamento.

## Higiene (autofix seguro + mecânicos)

`C420` (`dict.fromkeys`), `RUF022` (`__all__` ordenado), `C408` (`dict()` → literal), `C414` (`list()` redundante em `sorted`), `RUF005` (spread no lugar de `+`), `RUF015` (`next(...)` no lugar de `[...][0]`).

## Ignorados de propósito

- **RUF001/002/003** (ambiguous-unicode): docstrings e comentários em pt-BR usam EN DASH (travessão) e afins legitimamente — não queremos que o Ruff peça ASCII.
- **RUF100** (unused-noqa): não convive com o flake8, que roda em paralelo. Removeria `# noqa: E231/E702` (pycodestyle, falsos positivos silenciados de propósito) e `# noqa: BLE001` (regra do Ruff ainda não habilitada, com intenção documentada). Reavaliar se/quando `BLE` for ligada.

## Fora do escopo (follow-ups próprios — #306)

`PTH` (**87**, migração `os.path` → `pathlib`), `PERF` (**12**) e `RET`/`SIM` (**19** cosméticos). Ficam para PRs dedicados para manter este revisável — rastreados na #306.

## Validação

Pre-commit completo (ruff, isort, pylint, flake8, mypy) e suíte offline (`pytest`) verdes.

Refs #303.
