### PR TITLE
chore(dev): adicionar lizard + complexipy para diagnostico de complexidade (#307)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ juscraper e uma biblioteca Python para raspagem de dados de tribunais brasileiro
 - Pre-commit hooks configurados (trailing whitespace, isort, pylint, flake8, mypy)
 - Comprimento maximo de linha: 120
 - Preferir trabalhar em worktree com branch específica para a mudança que desejar implementar.
+- Complexidade sob demanda (eixo que o lint nao cobre), duas metricas complementares: `uv run lizard src` (ciclomatico) e `uv run complexipy -i -s desc src` (cognitivo). Detalhes, a tabela de divergencia e o gate planejado em `CONTRIBUTING.md` > **Complexidade de código (lizard + complexipy)**.
 
 ## Testes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,40 @@ Notas:
 - Falha 5xx em um único notebook normalmente é instabilidade do tribunal — re-rodar o notebook isolado antes de reportar regressão (`pytest --nbmake docs/notebooks/<tribunal>.ipynb`).
 - Quando o resultado real divergir do output cacheado (ex.: coluna nova, ementa em formato diferente), o notebook deve ser **commitado com outputs limpos** (`jupyter nbconvert --clear-output --inplace docs/notebooks/<tribunal>.ipynb`) para que `git diff` futuro fique focado em código.
 
+## Complexidade de código (lizard + complexipy)
+
+Complexidade é um eixo que o stack de lint do projeto (Ruff, flake8, isort, pylint, mypy) **não cobre** — esses veem estilo e tipos. Medimos duas métricas **complementares**, porque elas pegam coisas diferentes e divergem na prática (ver tabela abaixo). Ambas entram no extra `[dev]`. Refs #307.
+
+- **Complexidade ciclomática** (`lizard`, métrica CCN): conta caminhos independentes — começa em 1 e soma +1 por ponto de decisão (`if`, `for`, `while`, `except`, …). É um proxy de *testabilidade* (quantos casos cobrir). Não conta linhas nem aninhamento.
+- **Complexidade cognitiva** (`complexipy`, métrica do SonarSource): conta o quão difícil é *entender* o código, com **penalidade por aninhamento** — um `if` dentro de `for` dentro de `if` custa mais que três `if` rasos.
+
+Por que as duas: elas concordam nos extremos, mas divergem no meio. Código **plano com muitos ramos** (cascata de paginação, dispatch de datas) é ciclomático-alto mas cognitivo-baixo — legível. Código **aninhado com poucos ramos** é o oposto. Exemplos reais do `src`:
+
+| Função | CCN (lizard) | Cognitivo (complexipy) | Leitura |
+|---|---:|---:|---|
+| `cposg_parse_single_html` | 73 | 150 | ruim nas duas |
+| `tjpr cjsg_parse` | 28 | 71 | cognitivo prioriza muito mais |
+| `extract_count_with_cascade` | 26 | <14 | cascata plana — legível apesar do CCN |
+| `extract_escolha_button_id` | <15 | 31 | aninhada — só o cognitivo pega |
+
+### Diagnóstico sob demanda (não roda em pre-commit nem CI)
+
+```bash
+uv run lizard src               # ciclomático (CCN) + NLOC + tokens + nº de params, por função
+uv run complexipy -i -s desc src  # cognitivo por função, ordenado do maior para o menor
+```
+
+São as ferramentas a rodar antes de mexer num parser, para ver onde a dívida está concentrada — cada uma por uma lente.
+
+### Gate planejado (ainda não ativo)
+
+```bash
+uv run complexipy --snapshot-create src   # baseline; o CI compara e falha só em regressão (grandfather)
+uv run lizard -C 15 -w src                 # ciclomático: warning (e exit≠0) acima de CCN 15
+```
+
+Ligar um gate hoje deixaria o CI vermelho (várias funções acima do limiar). O gate entra no CI (job `quality`, #101) **depois** que as piores funções forem refatoradas — liderado pelo `complexipy --snapshot` (ratchet que congela o estado atual e só barra pioras), com o `lizard` como segunda lente. Refs #307, #101.
+
 ## Adding a new tribunal
 
 Todo raspador novo em `src/juscraper/courts/<xx>/` ou `src/juscraper/aggregators/<xx>/` deve entrar acompanhado de **pelo menos um teste de contrato** por método público (`cjsg`, `cjpg`, `cpopg`, `cposg`, `listar_processos`, etc.). O PR fica bloqueado sem isso.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ dev = [
     "pre-commit>=3.0.0",
     "nbmake>=1.5.0",
     "pytest-xdist>=3.0.0",
+    "lizard>=1.17.0",
+    "complexipy>=5.0.0",
 ]
 docs = [
     "quartodoc>=0.11.1",


### PR DESCRIPTION
## O quê

Adiciona **lizard** e **complexipy** ao extra `[dev]` e documenta o diagnóstico de complexidade em `CONTRIBUTING.md` (+ ponteiro no `CLAUDE.md`). Implementa a parte de tooling do #307.

## Por quê

Complexidade é um eixo que o stack de lint atual (Ruff, flake8, isort, pylint, mypy) **não cobre** — eles veem estilo e tipos. Medimos duas métricas **complementares**, porque divergem na prática:

- **Ciclomática** (`lizard`, CCN) — proxy de *testabilidade* (caminhos independentes).
- **Cognitiva** (`complexipy`, métrica do SonarSource) — *entendibilidade*, com penalidade por aninhamento.

Elas concordam nos extremos e divergem no meio. Medido no `src`: `extract_count_with_cascade` é CCN 26 mas cognitivo < 14 (cascata plana, legível), enquanto `tjpr cjsg_parse` é CCN 28 mas cognitivo 71 (aninhada — só a cognitiva pega). Rodar as duas dá um mapa de prioridade melhor que qualquer uma sozinha.

## Por que lizard + complexipy, e não radon + xenon (proposta original do #307)

1. **Manutenção.** radon e xenon estão parados desde out/2024 (~20 meses); o #304 já foi um *workaround* para uma limitação do `tokenize` que o radon usa. lizard (1.23.0) e complexipy (5.6.1) tiveram release este mês.
2. **Sem perda no ciclomático.** O CCN do lizard é **idêntico** ao CC do radon nas funções medidas (cposg 73, cpopg 42, jusbr 41).
3. **Ganho real.** O complexipy adiciona a métrica cognitiva; o MI do radon cai por ser redundante com a distribuição de complexidade por função.

Detalhes e a discussão completa estão em #307 (título e corpo atualizados).

## O que NÃO entra aqui

- **Gate no CI:** fica para depois — depende da CI (#101) e de refatorar as piores funções primeiro (ligar hoje deixaria o CI vermelho). A abordagem planejada está documentada: `complexipy --snapshot` (ratchet) + `lizard -C`.
- **CHANGELOG:** tooling de dev não afeta a API pública (filtro do CLAUDE.md).

## Refactors priorizados (issues abertas)

Pré-requisitos para o gate ficar verde, priorizados pelas duas métricas (CCN / cognitivo): #310 (73/150), #311 (42/87), #312 (41/69), #313 (28/71), #314 (21/47), #315 (22/38), #316 (28/36).

## Verificação

- `uv sync --extra dev` instala lizard 1.23.0 + complexipy 5.6.1.
- `uv run lizard src` e `uv run complexipy -i -s desc src` produzem os mapas documentados.
- `uv run pytest` verde (1753 passed, 29 skipped) — mudança não toca runtime.
- `pre-commit` limpo nos arquivos tocados.

Refs #307, #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
