### PR TITLE
chore(ruff): zerar B/C4/RUF pendentes em tests (loose ends #305)

### DIFF
--- a/tests/datajud/test_client_warnings.py
+++ b/tests/datajud/test_client_warnings.py
@@ -17,7 +17,7 @@ class TestRaisesValueError:
             datajud.listar_processos(tribunal="XPTO_INEXISTENTE")
 
     def test_missing_required_params_raises(self, datajud):
-        with pytest.raises(ValueError, match="tribunal.*numero_processo"):
+        with pytest.raises(ValueError, match=r"tribunal.*numero_processo"):
             datajud.listar_processos()
 
 

--- a/tests/datajud/test_contar_processos.py
+++ b/tests/datajud/test_contar_processos.py
@@ -243,7 +243,7 @@ class TestExtraKwargs:
 
     def test_sem_tribunal_nem_numero_processo_levanta_valueerror(self):
         scraper = jus.scraper("datajud")
-        with pytest.raises(ValueError, match="tribunal.*numero_processo"):
+        with pytest.raises(ValueError, match=r"tribunal.*numero_processo"):
             scraper.contar_processos(ano_ajuizamento=2023)
 
 

--- a/tests/fixtures/capture/_util.py
+++ b/tests/fixtures/capture/_util.py
@@ -314,7 +314,7 @@ def capture_cjsg_samples(
         session, base_url, typical_query, paginas=typical_pages, body_builder=body_builder
     )
     dump(dest / "post_initial.html", post_resp.content)
-    for pag, resp in zip(typical_pages, get_resps):
+    for pag, resp in zip(typical_pages, get_resps, strict=False):
         dump(dest / f"results_normal_page_{pag:02d}.html", resp.content)  # noqa: E231
     print(f"[{tribunal}] typical ({typical_query!r}) → {len(get_resps)} page(s)")
 

--- a/tests/fixtures/capture/jusbr.py
+++ b/tests/fixtures/capture/jusbr.py
@@ -94,7 +94,7 @@ def _is_cpf(s: str) -> bool:
         return False
 
     def dv(nums: str) -> int:
-        total = sum(int(n) * p for n, p in zip(nums, range(len(nums) + 1, 1, -1)))
+        total = sum(int(n) * p for n, p in zip(nums, range(len(nums) + 1, 1, -1), strict=False))
         rest = (total * 10) % 11
         return 0 if rest == 10 else rest
 
@@ -107,7 +107,7 @@ def _is_cnpj(s: str) -> bool:
         return False
 
     def dv(nums: str, weights: list[int]) -> int:
-        total = sum(int(n) * w for n, w in zip(nums, weights))
+        total = sum(int(n) * w for n, w in zip(nums, weights, strict=False))
         rest = total % 11
         return 0 if rest < 2 else 11 - rest
 

--- a/tests/fixtures/capture/tjto.py
+++ b/tests/fixtures/capture/tjto.py
@@ -47,7 +47,7 @@ def _capture_endpoint(session: requests.Session, dest, endpoint: str,
                       instancia: str, queries: list) -> None:
     out = samples_dir_for("tjto", endpoint)
     for query, pages, files in queries:
-        for page, filename in zip(pages, files):
+        for page, filename in zip(pages, files, strict=False):
             start = (page - 1) * 20
             response = _post(session, query, start=start, instancia=instancia)
             stripped = _minify(response.content)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -100,7 +100,7 @@ def assert_date_matches(df: pd.DataFrame) -> str | None:
     raw = df[col].astype(str).str.strip()
     parsed = [_parse_row_date(r) for r in raw]
     bad = [
-        (r, p) for r, p in zip(raw, parsed)
+        (r, p) for r, p in zip(raw, parsed, strict=False)
         if p is None or not (_ALVO_START <= p <= end)
     ]
     assert not bad, (

--- a/tests/jusbr/test_auth_contract.py
+++ b/tests/jusbr/test_auth_contract.py
@@ -69,7 +69,7 @@ def test_auth_token_malformado_levanta_value_error():
     """
     scraper = jus.scraper("jusbr")
 
-    with pytest.raises(ValueError, match="inv[áa]lido"):
+    with pytest.raises(ValueError, match=r"inv[áa]lido"):
         scraper.auth("not-a-jwt")
     assert "authorization" not in scraper.session.headers
     assert scraper.token is None

--- a/tests/jusbr/test_cpopg_contract.py
+++ b/tests/jusbr/test_cpopg_contract.py
@@ -198,5 +198,5 @@ def test_cpopg_cnj_invalido_nao_dispara_http(mocker):
 def test_cpopg_sem_auth_levanta_runtime_error():
     """Sem ``auth(token)`` previo, ``cpopg`` aborta antes de qualquer HTTP."""
     scraper = jus.scraper("jusbr")
-    with pytest.raises(RuntimeError, match="[Aa]utentica"):
+    with pytest.raises(RuntimeError, match=r"[Aa]utentica"):
         scraper.cpopg(NEUTRAL_CNJ_1)

--- a/tests/jusbr/test_download_documents_contract.py
+++ b/tests/jusbr/test_download_documents_contract.py
@@ -263,7 +263,7 @@ def test_download_documents_sem_auth_levanta_runtime_error():
     """Sem ``auth(token)`` previo, ``download_documents`` aborta antes do loop."""
     scraper = jus.scraper("jusbr")
     base_df = _base_df([_doc_meta(href_texto=_href_texto(UUID_TEXT_1), href_binario=_href_binario(UUID_BIN_1))])
-    with pytest.raises(RuntimeError, match="[Aa]utentica"):
+    with pytest.raises(RuntimeError, match=r"[Aa]utentica"):
         scraper.download_documents(base_df)
 
 

--- a/tests/pdpj/test_pdpj_download_documents.py
+++ b/tests/pdpj/test_pdpj_download_documents.py
@@ -136,14 +136,14 @@ def test_download_documents_exige_pelo_menos_um_modo():
         "id_documento": "abc",
         "numero_processo": PROC,
     }])
-    with pytest.raises(ValueError, match="with_text.*with_binary"):
+    with pytest.raises(ValueError, match=r"with_text.*with_binary"):
         s.download_documents(df, with_text=False, with_binary=False)
 
 
 def test_download_documents_rejeita_df_sem_id_documento_ou_detalhes():
     s = _mk_scraper()
     df = pd.DataFrame([{"processo": PROC, "outra_coluna": 1}])
-    with pytest.raises(ValueError, match="id_documento.*detalhes"):
+    with pytest.raises(ValueError, match=r"id_documento.*detalhes"):
         s.download_documents(df)
 
 

--- a/tests/schemas/test_paginas_acceptance.py
+++ b/tests/schemas/test_paginas_acceptance.py
@@ -72,7 +72,7 @@ def _resolve_method(scraper_cls: type, endpoint: str):
 
 
 def _search_cases(expected_map, scraper_iter):
-    scrapers = {name: cls for name, cls in scraper_iter()}
+    scrapers = dict(scraper_iter())
     out = []
     for (name, endpoint), (module_path, class_name) in expected_map.items():
         if endpoint not in SEARCH_ENDPOINTS:

--- a/tests/schemas/test_signature_parity.py
+++ b/tests/schemas/test_signature_parity.py
@@ -136,7 +136,7 @@ def _build_parity_cases(
     expected_map: dict,
     scraper_iter,
 ) -> list[tuple[str, str, type, str, str]]:
-    scrapers = {name: cls for name, cls in scraper_iter()}
+    scrapers = dict(scraper_iter())
     cases = []
     for (name, endpoint), (module_path, class_name) in expected_map.items():
         cls = scrapers.get(name)

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -1,4 +1,5 @@
 """Tests for the parameter normalization utilities."""
+import itertools
 import warnings
 
 import pandas as pd
@@ -68,11 +69,11 @@ class TestNormalizePesquisa:
         assert "termo" in str(w[0].message)
 
     def test_conflict_pesquisa_and_query(self):
-        with pytest.raises(ValueError, match="pesquisa.*query"):
+        with pytest.raises(ValueError, match=r"pesquisa.*query"):
             normalize_pesquisa(pesquisa="a", query="b")
 
     def test_conflict_pesquisa_and_termo(self):
-        with pytest.raises(ValueError, match="pesquisa.*termo"):
+        with pytest.raises(ValueError, match=r"pesquisa.*termo"):
             normalize_pesquisa(pesquisa="a", termo="b")
 
     def test_missing(self):
@@ -119,14 +120,14 @@ class TestNormalizeDatas:
         assert len(w) == 2
 
     def test_conflict_generic_and_specific(self):
-        with pytest.raises(ValueError, match="data_inicio.*data_julgamento_inicio"):
+        with pytest.raises(ValueError, match=r"data_inicio.*data_julgamento_inicio"):
             normalize_datas(
                 data_inicio="01/01/2023",
                 data_julgamento_inicio="01/01/2023",
             )
 
     def test_conflict_deprecated_and_canonical(self):
-        with pytest.raises(ValueError, match="data_julgamento_de.*data_julgamento_inicio"):
+        with pytest.raises(ValueError, match=r"data_julgamento_de.*data_julgamento_inicio"):
             normalize_datas(
                 data_julgamento_de="01/01/2023",
                 data_julgamento_inicio="01/01/2023",
@@ -328,7 +329,7 @@ class TestResolveDeprecatedAlias:
         kwargs = {"magistrado": "Fulano"}
         with warnings.catch_warnings():
             warnings.simplefilter("always")
-            with pytest.raises(ValueError, match="relator.*magistrado"):
+            with pytest.raises(ValueError, match=r"relator.*magistrado"):
                 resolve_deprecated_alias(kwargs, "magistrado", "relator", "Beltrana")
 
     def test_custom_sentinel_empty_string(self):
@@ -345,7 +346,7 @@ class TestResolveDeprecatedAlias:
         kwargs = {"nr_processo": "A"}
         with warnings.catch_warnings():
             warnings.simplefilter("always")
-            with pytest.raises(ValueError, match="numero_processo.*nr_processo"):
+            with pytest.raises(ValueError, match=r"numero_processo.*nr_processo"):
                 resolve_deprecated_alias(
                     kwargs, "nr_processo", "numero_processo", "B", sentinel=""
                 )
@@ -395,7 +396,7 @@ class TestIterDateWindows:
         assert windows[-1][1] == "31/12/2024"
         # Janelas não-sobrepostas (cada início > fim anterior).
         from datetime import datetime
-        for prev, nxt in zip(windows, windows[1:]):
+        for prev, nxt in itertools.pairwise(windows):
             assert prev[1] is not None and nxt[0] is not None
             prev_fim = datetime.strptime(prev[1], "%d/%m/%Y")
             nxt_ini = datetime.strptime(nxt[0], "%d/%m/%Y")
@@ -521,7 +522,7 @@ class TestRunChunkedSearch:
         def fetch(i, f):
             return pd.DataFrame({"cd_acordao": ["a"]})
 
-        with pytest.raises(ValueError, match="auto_chunk.*paginas"):
+        with pytest.raises(ValueError, match=r"auto_chunk.*paginas"):
             run_chunked_search(
                 fetch,
                 data_inicio="01/01/2022",

--- a/tests/tjac/test_cjsg_filters_contract.py
+++ b/tests/tjac/test_cjsg_filters_contract.py
@@ -17,20 +17,20 @@ from tests.fixtures.capture._util import make_esaj_body
 
 BASE = "https://esaj.tjac.jus.br/cjsg"
 
-_ALL_FILTERS = dict(
-    ementa="responsabilidade",
-    numero_recurso="1000123-45.2023.8.26.0100",
-    classe="cls-value",
-    assunto="subj-value",
-    comarca="comarca-value",
-    orgao_julgador="og-value",
-    data_julgamento_inicio="01/01/2024",
-    data_julgamento_fim="31/03/2024",
-    data_publicacao_inicio="01/02/2024",
-    data_publicacao_fim="29/02/2024",
-    origem="R",
-    tipo_decisao="monocratica",
-)
+_ALL_FILTERS = {
+    "ementa": "responsabilidade",
+    "numero_recurso": "1000123-45.2023.8.26.0100",
+    "classe": "cls-value",
+    "assunto": "subj-value",
+    "comarca": "comarca-value",
+    "orgao_julgador": "og-value",
+    "data_julgamento_inicio": "01/01/2024",
+    "data_julgamento_fim": "31/03/2024",
+    "data_publicacao_inicio": "01/02/2024",
+    "data_publicacao_fim": "29/02/2024",
+    "origem": "R",
+    "tipo_decisao": "monocratica",
+}
 
 
 @responses.activate

--- a/tests/tjal/test_cjsg_filters_contract.py
+++ b/tests/tjal/test_cjsg_filters_contract.py
@@ -9,20 +9,20 @@ from tests.fixtures.capture._util import make_esaj_body
 
 BASE = "https://www2.tjal.jus.br/cjsg"
 
-_ALL_FILTERS = dict(
-    ementa="responsabilidade",
-    numero_recurso="1000123-45.2023.8.26.0100",
-    classe="cls-value",
-    assunto="subj-value",
-    comarca="comarca-value",
-    orgao_julgador="og-value",
-    data_julgamento_inicio="01/01/2024",
-    data_julgamento_fim="31/03/2024",
-    data_publicacao_inicio="01/02/2024",
-    data_publicacao_fim="29/02/2024",
-    origem="R",
-    tipo_decisao="monocratica",
-)
+_ALL_FILTERS = {
+    "ementa": "responsabilidade",
+    "numero_recurso": "1000123-45.2023.8.26.0100",
+    "classe": "cls-value",
+    "assunto": "subj-value",
+    "comarca": "comarca-value",
+    "orgao_julgador": "og-value",
+    "data_julgamento_inicio": "01/01/2024",
+    "data_julgamento_fim": "31/03/2024",
+    "data_publicacao_inicio": "01/02/2024",
+    "data_publicacao_fim": "29/02/2024",
+    "origem": "R",
+    "tipo_decisao": "monocratica",
+}
 
 
 @responses.activate

--- a/tests/tjam/test_cjsg_filters_contract.py
+++ b/tests/tjam/test_cjsg_filters_contract.py
@@ -9,20 +9,20 @@ from tests.fixtures.capture._util import make_esaj_body
 
 BASE = "https://consultasaj.tjam.jus.br/cjsg"
 
-_ALL_FILTERS = dict(
-    ementa="responsabilidade",
-    numero_recurso="1000123-45.2023.8.26.0100",
-    classe="cls-value",
-    assunto="subj-value",
-    comarca="comarca-value",
-    orgao_julgador="og-value",
-    data_julgamento_inicio="01/01/2024",
-    data_julgamento_fim="31/03/2024",
-    data_publicacao_inicio="01/02/2024",
-    data_publicacao_fim="29/02/2024",
-    origem="R",
-    tipo_decisao="monocratica",
-)
+_ALL_FILTERS = {
+    "ementa": "responsabilidade",
+    "numero_recurso": "1000123-45.2023.8.26.0100",
+    "classe": "cls-value",
+    "assunto": "subj-value",
+    "comarca": "comarca-value",
+    "orgao_julgador": "og-value",
+    "data_julgamento_inicio": "01/01/2024",
+    "data_julgamento_fim": "31/03/2024",
+    "data_publicacao_inicio": "01/02/2024",
+    "data_publicacao_fim": "29/02/2024",
+    "origem": "R",
+    "tipo_decisao": "monocratica",
+}
 
 
 @responses.activate

--- a/tests/tjap/test_cjsg_filters_contract.py
+++ b/tests/tjap/test_cjsg_filters_contract.py
@@ -15,18 +15,18 @@ from tests.tjap.test_cjsg_contract import BASE, _payload
 def test_cjsg_all_filters_land_in_json_body(mocker):
     """All TJAP public filters must reach the Tucujuris JSON payload."""
     mocker.patch("time.sleep")
-    filters: dict[str, Any] = dict(
-        orgao="tj",
-        numero_processo="0000001-11.2024.8.03.0001",
-        numero_acordao="12345",
-        numero_ano="001858/1999",
-        palavras_exatas=True,
-        relator="FULANO DE TAL",
-        secretaria="CAMARA UNICA",
-        classe="APELACAO",
-        votacao="Unanime",
-        origem="MACAPA",
-    )
+    filters: dict[str, Any] = {
+        "orgao": "tj",
+        "numero_processo": "0000001-11.2024.8.03.0001",
+        "numero_acordao": "12345",
+        "numero_ano": "001858/1999",
+        "palavras_exatas": True,
+        "relator": "FULANO DE TAL",
+        "secretaria": "CAMARA UNICA",
+        "classe": "APELACAO",
+        "votacao": "Unanime",
+        "origem": "MACAPA",
+    }
     responses.add(
         responses.POST,
         BASE,

--- a/tests/tjba/test_cjsg_filters_contract.py
+++ b/tests/tjba/test_cjsg_filters_contract.py
@@ -15,20 +15,20 @@ from tests.tjba.test_cjsg_contract import BASE, _payload
 def test_cjsg_all_filters_land_in_graphql_body(mocker):
     """All TJBA public filters must reach the GraphQL variables payload."""
     mocker.patch("time.sleep")
-    filters: dict[str, Any] = dict(
-        numero_recurso="8000001-11.2024.8.05.0001",
-        orgaos=[10, 20],
-        relatores=[1],
-        classe=[100],
-        data_publicacao_inicio="2024-01-01",
-        data_publicacao_fim="2024-03-31",
-        segundo_grau=False,
-        turmas_recursais=True,
-        tipo_acordaos=False,
-        tipo_decisoes_monocraticas=True,
-        ordenado_por="relevancia",
-        tamanho_pagina=5,
-    )
+    filters: dict[str, Any] = {
+        "numero_recurso": "8000001-11.2024.8.05.0001",
+        "orgaos": [10, 20],
+        "relatores": [1],
+        "classe": [100],
+        "data_publicacao_inicio": "2024-01-01",
+        "data_publicacao_fim": "2024-03-31",
+        "segundo_grau": False,
+        "turmas_recursais": True,
+        "tipo_acordaos": False,
+        "tipo_decisoes_monocraticas": True,
+        "ordenado_por": "relevancia",
+        "tamanho_pagina": 5,
+    }
     responses.add(
         responses.POST,
         BASE,

--- a/tests/tjce/test_cjsg_filters_contract.py
+++ b/tests/tjce/test_cjsg_filters_contract.py
@@ -9,20 +9,20 @@ from tests.fixtures.capture._util import make_esaj_body
 
 BASE = "https://esaj.tjce.jus.br/cjsg"
 
-_ALL_FILTERS = dict(
-    ementa="responsabilidade",
-    numero_recurso="1000123-45.2023.8.26.0100",
-    classe="cls-value",
-    assunto="subj-value",
-    comarca="comarca-value",
-    orgao_julgador="og-value",
-    data_julgamento_inicio="01/01/2024",
-    data_julgamento_fim="31/03/2024",
-    data_publicacao_inicio="01/02/2024",
-    data_publicacao_fim="29/02/2024",
-    origem="R",
-    tipo_decisao="monocratica",
-)
+_ALL_FILTERS = {
+    "ementa": "responsabilidade",
+    "numero_recurso": "1000123-45.2023.8.26.0100",
+    "classe": "cls-value",
+    "assunto": "subj-value",
+    "comarca": "comarca-value",
+    "orgao_julgador": "og-value",
+    "data_julgamento_inicio": "01/01/2024",
+    "data_julgamento_fim": "31/03/2024",
+    "data_publicacao_inicio": "01/02/2024",
+    "data_publicacao_fim": "29/02/2024",
+    "origem": "R",
+    "tipo_decisao": "monocratica",
+}
 
 
 @responses.activate

--- a/tests/tjmg/test_cjsg_download_granular.py
+++ b/tests/tjmg/test_cjsg_download_granular.py
@@ -31,18 +31,18 @@ from tests._helpers import query_param_subset_matcher
 
 def _build_params_defaults(**overrides):
     """Argumentos padrao para ``_build_params``; cada teste sobrescreve o que importa."""
-    kwargs: dict[str, Any] = dict(
-        pesquisa="termo",
-        pagina=1,
-        total=1,
-        pesquisar_por="ementa",
-        order_by="2",
-        data_julgamento_inicial="",
-        data_julgamento_final="",
-        data_publicacao_inicial="",
-        data_publicacao_final="",
-        linhas_por_pagina=10,
-    )
+    kwargs: dict[str, Any] = {
+        "pesquisa": "termo",
+        "pagina": 1,
+        "total": 1,
+        "pesquisar_por": "ementa",
+        "order_by": "2",
+        "data_julgamento_inicial": "",
+        "data_julgamento_final": "",
+        "data_publicacao_inicial": "",
+        "data_publicacao_final": "",
+        "linhas_por_pagina": 10,
+    }
     kwargs.update(overrides)
     return _build_params(**kwargs)
 

--- a/tests/tjms/test_cjsg_filters_contract.py
+++ b/tests/tjms/test_cjsg_filters_contract.py
@@ -9,20 +9,20 @@ from tests.fixtures.capture._util import make_esaj_body
 
 BASE = "https://esaj.tjms.jus.br/cjsg"
 
-_ALL_FILTERS = dict(
-    ementa="responsabilidade",
-    numero_recurso="1000123-45.2023.8.26.0100",
-    classe="cls-value",
-    assunto="subj-value",
-    comarca="comarca-value",
-    orgao_julgador="og-value",
-    data_julgamento_inicio="01/01/2024",
-    data_julgamento_fim="31/03/2024",
-    data_publicacao_inicio="01/02/2024",
-    data_publicacao_fim="29/02/2024",
-    origem="R",
-    tipo_decisao="monocratica",
-)
+_ALL_FILTERS = {
+    "ementa": "responsabilidade",
+    "numero_recurso": "1000123-45.2023.8.26.0100",
+    "classe": "cls-value",
+    "assunto": "subj-value",
+    "comarca": "comarca-value",
+    "orgao_julgador": "og-value",
+    "data_julgamento_inicio": "01/01/2024",
+    "data_julgamento_fim": "31/03/2024",
+    "data_publicacao_inicio": "01/02/2024",
+    "data_publicacao_fim": "29/02/2024",
+    "origem": "R",
+    "tipo_decisao": "monocratica",
+}
 
 
 @responses.activate

--- a/tests/tjrn/test_cjsg_filters_contract.py
+++ b/tests/tjrn/test_cjsg_filters_contract.py
@@ -225,7 +225,7 @@ def test_cjsg_data_publicacao_raises_typeerror():
 
 def test_cjsg_alias_conflict_raises():
     """Passar canonical e alias deprecado simultaneamente leva a ``ValueError``."""
-    with pytest.raises(ValueError, match="numero_processo.*nr_processo"):
+    with pytest.raises(ValueError, match=r"numero_processo.*nr_processo"):
         jus.scraper("tjrn").cjsg(
             "dano moral", paginas=1,
             numero_processo="X", nr_processo="Y",

--- a/tests/tjro/test_cjsg_filters_contract.py
+++ b/tests/tjro/test_cjsg_filters_contract.py
@@ -258,7 +258,7 @@ def test_cjsg_unknown_kwarg_suggests_close_match():
 
 def test_cjsg_alias_conflict_raises():
     """Passar canonical e alias deprecado simultaneamente leva a ``ValueError``."""
-    with pytest.raises(ValueError, match="numero_processo.*nr_processo"):
+    with pytest.raises(ValueError, match=r"numero_processo.*nr_processo"):
         jus.scraper("tjro").cjsg(
             "dano moral", paginas=1,
             numero_processo="X", nr_processo="Y",

--- a/tests/tjsp/test_cjpg_auto_chunk_contract.py
+++ b/tests/tjsp/test_cjpg_auto_chunk_contract.py
@@ -78,7 +78,7 @@ def test_auto_chunk_default_long_window_chunks_and_dedups(tmp_path, mocker):
 
 def test_auto_chunk_default_long_window_with_paginas_raises(tmp_path):
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
-    with pytest.raises(ValueError, match="auto_chunk.*paginas"):
+    with pytest.raises(ValueError, match=r"auto_chunk.*paginas"):
         scraper.cjpg(
             "dano moral",
             paginas=range(1, 3),
@@ -190,7 +190,7 @@ def test_pesquisa_plus_query_alias_long_window_raises(tmp_path, mocker):
     download, _ = _patch_pipeline(mocker)
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
 
-    with pytest.raises(ValueError, match="'pesquisa'.*'query'"):
+    with pytest.raises(ValueError, match=r"'pesquisa'.*'query'"):
         scraper.cjpg(
             "dano moral",
             query="outra coisa",

--- a/tests/tjsp/test_cjsg_auto_chunk_contract.py
+++ b/tests/tjsp/test_cjsg_auto_chunk_contract.py
@@ -92,7 +92,7 @@ def test_auto_chunk_default_long_window_chunks_and_dedups(tmp_path, mocker):
 def test_auto_chunk_default_long_window_with_paginas_raises(tmp_path):
     """``auto_chunk=True`` + ``paginas != None`` + janela longa = ValueError."""
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
-    with pytest.raises(ValueError, match="auto_chunk.*paginas"):
+    with pytest.raises(ValueError, match=r"auto_chunk.*paginas"):
         scraper.cjsg(
             "dano moral",
             paginas=range(1, 3),
@@ -211,7 +211,7 @@ def test_pesquisa_plus_query_alias_long_window_raises(tmp_path, mocker):
     download, _ = _patch_pipeline(mocker)
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
 
-    with pytest.raises(ValueError, match="'pesquisa'.*'query'"):
+    with pytest.raises(ValueError, match=r"'pesquisa'.*'query'"):
         scraper.cjsg(
             "dano moral",
             query="outra coisa",
@@ -227,7 +227,7 @@ def test_pesquisa_plus_termo_alias_long_window_raises(tmp_path, mocker):
     download, _ = _patch_pipeline(mocker)
     scraper = jus.scraper("tjsp", download_path=str(tmp_path))
 
-    with pytest.raises(ValueError, match="'pesquisa'.*'termo'"):
+    with pytest.raises(ValueError, match=r"'pesquisa'.*'termo'"):
         scraper.cjsg(
             "dano moral",
             termo="outra coisa",

--- a/tests/tjsp/test_path_traversal_contract.py
+++ b/tests/tjsp/test_path_traversal_contract.py
@@ -104,7 +104,7 @@ def test_cposg_html_rejeita_codigo_malicioso(tmp_path, mocker):
         body=_LISTAGEM_MALICIOSA, status=200, content_type="text/html",
     )
 
-    with pytest.raises(ValueError, match="processo.codigo"):
+    with pytest.raises(ValueError, match=r"processo.codigo"):
         _cposg_download_html_single(CNJ, scraper.session, scraper.u_base, str(tmp_path))
 
     # nenhum HTML de processo gravado
@@ -125,7 +125,7 @@ def test_cposg_html_modal_rejeita_codigo_malicioso(tmp_path, mocker):
         body=_MODAL_MALICIOSO, status=200, content_type="text/html",
     )
 
-    with pytest.raises(ValueError, match="processo.codigo"):
+    with pytest.raises(ValueError, match=r"processo.codigo"):
         _cposg_download_html_single(CNJ, scraper.session, scraper.u_base, str(tmp_path))
 
     assert not list(tmp_path.rglob("*.html"))


### PR DESCRIPTION
## Contexto

Ao preparar o trabalho da #306 (ligar PTH/PERF/RET/SIM), descobri que o **#305 deixou loose ends**: ligou as famílias `B`, `C4` e `RUF`, mas zerou apenas os achados em `src/`. Como **não há ruff no CI** e o hook do pre-commit só roda nos arquivos alterados de cada commit, **40 violações ficaram latentes em `tests/`** — espalhadas por 26 arquivos que ninguém tocou desde o #305. Um `ruff check tests` / `pre-commit run ruff --all-files` completo estava **vermelho em `main`**.

Este PR zera essas 40 antes de qualquer PR da #306, para o pre-commit não tropeçar em achados pré-existentes ao ligar RET/SIM.

## O que muda (tudo em `tests/`, mecânico, comportamento preservado)

| Regra | Qtd | Correção |
|---|---:|---|
| `RUF043` | 23 | `match="…"` → `match=r"…"` (regex intencional: `.*`, `[áa]`, wildcard; sem escapes, comportamento idêntico) |
| `C408` | 8 | `dict(a=1)` → `{"a": 1}` |
| `B905` | 6 | `zip(a, b)` → `zip(a, b, strict=False)` (preserva truncamento) |
| `C416` | 2 | dict-comprehension desnecessária → `dict(…)` |
| `RUF007` | 1 | `zip(x, x[1:])` → `itertools.pairwise(x)` |

## Verificação

- `uvx ruff@0.15.12 check tests` → **All checks passed!**
- `uvx ruff@0.15.12 check src tests` → sem regressão
- `uv run pytest` → **1755 passed, 29 skipped**
- `pre-commit run ruff/isort` nos arquivos alterados → Passed

Sem entrada no CHANGELOG (tooling, sem efeito na API pública).

Refs #305, #306.