### PR TITLE
chore(ruff): ligar familias RET e SIM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,8 @@ select = [
     "B",      # flake8-bugbear: bug-risk (ex.: zip() sem strict=)
     "C4",     # flake8-comprehensions: comprehensions/calls desnecessarios
     "RUF",    # regras do proprio Ruff (ex.: mutable-class-default)
+    "RET",    # flake8-return: return flow (ex.: assign inutil antes de return)
+    "SIM",    # flake8-simplify: simplificacoes (ternario, with unico, yoda)
 ]
 ignore = [
     # Caracteres "ambiguos" em texto pt-BR sao legitimos. Docstrings e

--- a/src/juscraper/aggregators/datajud/client.py
+++ b/src/juscraper/aggregators/datajud/client.py
@@ -483,10 +483,7 @@ class DatajudScraper(HTTPScraper):
         elif numero_processo:
             # Group by alias if multiple CNJs from different tribunals are provided
             processos_por_alias = defaultdict(list)
-            if isinstance(numero_processo, str):
-                cnjs_to_query = [numero_processo]
-            else:
-                cnjs_to_query = numero_processo
+            cnjs_to_query = [numero_processo] if isinstance(numero_processo, str) else numero_processo
             for num_cnj in cnjs_to_query:
                 num_limpo = clean_cnj(num_cnj)
                 if len(num_limpo) == 20:
@@ -678,9 +675,7 @@ class DatajudScraper(HTTPScraper):
                     )
                     break  # Fallback or stop if search_after cannot be determined
 
-                if paginas_range is None:  # if fetching all, continue
-                    current_page += 1
-                elif current_page < paginas_range.stop - 1:  # if in specified range, continue
+                if paginas_range is None or current_page < paginas_range.stop - 1:  # if fetching all, continue
                     current_page += 1
                 else:  # reached end of specified range
                     break

--- a/src/juscraper/aggregators/datajud/download.py
+++ b/src/juscraper/aggregators/datajud/download.py
@@ -117,10 +117,7 @@ def _build_query_amigavel(
     """Monta ``query.bool.must`` a partir dos filtros amigaveis."""
     must_conditions: list[dict[str, Any]] = []
     if numero_processo:
-        if isinstance(numero_processo, str):
-            nproc = [numero_processo]
-        else:
-            nproc = list(numero_processo)
+        nproc = [numero_processo] if isinstance(numero_processo, str) else list(numero_processo)
         nproc = [clean_cnj(n) for n in nproc]
         must_conditions.append({"terms": {"numeroProcesso": nproc}})
     if ano_ajuizamento:

--- a/src/juscraper/aggregators/datajud/parse.py
+++ b/src/juscraper/aggregators/datajud/parse.py
@@ -60,8 +60,7 @@ def parse_datajud_api_response(
             logger.info("No process data extracted from hits.")
             return pd.DataFrame()
 
-        df = pd.DataFrame(processos)
-        return df
+        return pd.DataFrame(processos)
 
     except Exception as e:
         warnings.warn(

--- a/src/juscraper/aggregators/jusbr/parse.py
+++ b/src/juscraper/aggregators/jusbr/parse.py
@@ -70,13 +70,12 @@ def parse_process_details_response(json_data: dict[str, Any] | list[dict[str, An
 
     # Can add more sophisticated parsing here if needed, e.g., flattening nested structures
     # For now, it mostly returns the JSON data, augmented with the searched CNJ.
-    parsed_data = {
+    return {
         'processo': cnj_searched,  # Matches screenshot column 'processo'
         'numeroProcesso': details_dict.get('numeroProcesso'),  # Matches screenshot
         'idCodexTribunal': details_dict.get('idCodexTribunal'),  # Matches screenshot
         'detalhes': details_dict  # Full details dictionary as per screenshot
     }
-    return parsed_data
 
 
 def clean_document_text(text_content: str | None) -> str | None:
@@ -93,9 +92,8 @@ def clean_document_text(text_content: str | None) -> str | None:
         cleaned_text = cleaned_text.replace('\xa0', ' ')    # non-breaking space to regular space
         cleaned_text = cleaned_text.replace('\u2028', '\n')  # Line separator to newline
         cleaned_text = cleaned_text.replace('\u2029', '\n')  # Paragraph separator to nl
-        cleaned_text = cleaned_text.strip()  # Strip leading/trailing whitespace
         # Potentially add more specific cleaning if other problematic characters are found
-        return cleaned_text
+        return cleaned_text.strip()  # Strip leading/trailing whitespace
     except Exception as e:
         # Catching Exception as a last resort to avoid crashing
         # on unexpected text cleaning errors.

--- a/src/juscraper/courts/_esaj/parse.py
+++ b/src/juscraper/courts/_esaj/parse.py
@@ -88,10 +88,10 @@ def cjsg_n_results(html_source: str) -> int:
     td_npags = None
     for td in soup.find_all("td"):
         td_text = td.get_text()
-        if "Resultados" in td_text or "resultados" in td_text.lower():
-            if len(td_text.strip()) < 400:  # guard against matching result rows
-                td_npags = td
-                break
+        # guard against matching result rows with the 400-char length check
+        if ("Resultados" in td_text or "resultados" in td_text.lower()) and len(td_text.strip()) < 400:
+            td_npags = td
+            break
 
     if td_npags is None:
         td_npags = soup.find("td", bgcolor="#EEEEEE")

--- a/src/juscraper/courts/tjpi/download.py
+++ b/src/juscraper/courts/tjpi/download.py
@@ -89,8 +89,7 @@ def cjsg_download_manager(
         params = build_cjsg_params(pesquisa=pesquisa, page=pagina_1based, **kwargs)
         resp = request_fn("GET", BASE_URL, params=params, timeout=30)
         resp.encoding = "utf-8"
-        html = resp.text
-        return html
+        return resp.text
 
     if paginas is None:
         first = _get_page(1)

--- a/src/juscraper/courts/tjpr/parse.py
+++ b/src/juscraper/courts/tjpr/parse.py
@@ -78,10 +78,7 @@ def cjsg_parse(
             # Detecta "Leia mais..." e busca a ementa completa
             if 'leia mais' in ementa.lower():
                 input_id = dados_td.find('input', {'name': 'idsSelecionados'})
-                if input_id and 'value' in input_id.attrs:
-                    id_processo = input_id['value']
-                else:
-                    id_processo = ''
+                id_processo = input_id['value'] if input_id and 'value' in input_id.attrs else ''
                 if id_processo and criterio and request_fn is not None:
                     try:
                         ementa = get_ementa_completa(request_fn, id_processo, criterio)

--- a/src/juscraper/courts/tjsc/download.py
+++ b/src/juscraper/courts/tjsc/download.py
@@ -95,8 +95,7 @@ def cjsg_download_manager(
         url = cjsg_url_for_page(pagina_1based)
         resp = request_fn("POST", url, data=data, timeout=60)
         resp.encoding = resp.apparent_encoding
-        html = resp.text
-        return html
+        return resp.text
 
     if paginas is None:
         first = _get_page(1)

--- a/src/juscraper/courts/tjsc/parse.py
+++ b/src/juscraper/courts/tjsc/parse.py
@@ -61,9 +61,7 @@ def _parse_result_item(item) -> dict:
                     if len(parts) == 2:
                         result["classe"] = parts[1].strip()
                     break
-        elif key == "ementa":
-            result["ementa"] = text
-        elif key == "decisao" and "ementa" not in result:
+        elif key == "ementa" or (key == "decisao" and "ementa" not in result):
             result["ementa"] = text
         else:
             result[key] = text

--- a/src/juscraper/courts/tjsp/cjpg_parse.py
+++ b/src/juscraper/courts/tjsp/cjpg_parse.py
@@ -170,10 +170,7 @@ def cjpg_parse_single(path):
             div_decisao = tabela_dados.find('div', {'align': 'justify', 'style': 'display: none;'})
             if div_decisao:
                 spans = div_decisao.find_all('span')
-                if spans:
-                    decisao_text = spans[-1].get_text(separator=" ", strip=True)
-                else:
-                    decisao_text = ''
+                decisao_text = spans[-1].get_text(separator=" ", strip=True) if spans else ''
                 dados_processo['decisao'] = decisao_text
             processos.append(dados_processo)
     return pd.DataFrame(processos)
@@ -200,5 +197,4 @@ def cjpg_parse_manager(path):
                     continue
                 if single_result is not None:
                     result.append(single_result)
-    result = pd.concat(result, ignore_index=True)
-    return result
+    return pd.concat(result, ignore_index=True)

--- a/src/juscraper/courts/tjsp/cpopg_download.py
+++ b/src/juscraper/courts/tjsp/cpopg_download.py
@@ -113,7 +113,7 @@ def cpopg_download_html_single(
                 raise RuntimeError(
                     f"Nenhum link encontrado para o processo {id_clean}."
                 )
-            elif len(links) == 1:
+            if len(links) == 1:
                 file_name = f"{path}/{id_clean}_{cd_processo[0]}.html"
                 logger.info("Salvando em %s", file_name)
                 with open(file_name, 'w', encoding='utf-8') as f:

--- a/src/juscraper/courts/tjsp/cpopg_parse.py
+++ b/src/juscraper/courts/tjsp/cpopg_parse.py
@@ -40,8 +40,7 @@ def _normalize_field_name(label: str) -> str:
     for src, dst in replacements.items():
         text = text.replace(src, dst)
     text = re.sub(r'[^a-z0-9\s]', '', text)
-    text = re.sub(r'\s+', '_', text.strip())
-    return text
+    return re.sub(r'\s+', '_', text.strip())
 
 
 def cpopg_parse_manager(path: str):
@@ -330,14 +329,12 @@ def cpopg_parse_single_html(path: str):
     df_peticoes = pd.DataFrame(peticoes_diversas)
     df_basicos = pd.DataFrame([dados])
 
-    result = {
+    return {
         "basicos": df_basicos,
         "partes": df_partes,
         "movimentacoes": df_movs,
         "peticoes_diversas": df_peticoes
     }
-
-    return result
 
 
 def cpopg_parse_single_json(path: str):

--- a/src/juscraper/courts/tjsp/cposg_parse.py
+++ b/src/juscraper/courts/tjsp/cposg_parse.py
@@ -27,8 +27,7 @@ def cposg_parse(path: str):
             logger.error("Erro ao processar %s: %s", arq, e)
     if not dados:
         return pd.DataFrame()
-    df = pd.DataFrame(dados)
-    return df
+    return pd.DataFrame(dados)
 
 
 def cposg_parse_manager(path: str):
@@ -45,8 +44,7 @@ def cposg_parse_manager(path: str):
             logger.error("Erro ao processar %s: %s", arq, e)
     if not dados:
         return pd.DataFrame()
-    df = pd.DataFrame(dados)
-    return df
+    return pd.DataFrame(dados)
 
 
 def cposg_parse_single_json(path: str):

--- a/src/juscraper/tribunal_manager.py
+++ b/src/juscraper/tribunal_manager.py
@@ -15,15 +15,14 @@ def scraper(tribunal_name: str, **kwargs):
 
     if tribunal_name == "TJSP":
         return TJSPScraper(**kwargs)
-    elif tribunal_name == "TJRS":
+    if tribunal_name == "TJRS":
         return TJRSScraper()
-    elif tribunal_name == "TJPR":
+    if tribunal_name == "TJPR":
         return TJPRScraper()
-    elif tribunal_name == "JUSBR":
+    if tribunal_name == "JUSBR":
         return JusbrScraper(**kwargs)
-    elif tribunal_name == "DATAJUD":
+    if tribunal_name == "DATAJUD":
         return DatajudScraper(**kwargs)
-    elif tribunal_name == "TJDFT":
+    if tribunal_name == "TJDFT":
         return TJDFTScraper()
-    else:
-        raise ValueError(f"Tribunal '{tribunal_name}' ainda não é suportado.")
+    raise ValueError(f"Tribunal '{tribunal_name}' ainda não é suportado.")

--- a/tests/comunica_cnj/test_listar_comunicacoes_contract.py
+++ b/tests/comunica_cnj/test_listar_comunicacoes_contract.py
@@ -77,7 +77,7 @@ def test_listar_comunicacoes_typical_multi_page(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert LISTAR_COMUNICACOES_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= LISTAR_COMUNICACOES_MIN_COLUMNS
     assert len(df) == 20
 
 
@@ -101,7 +101,7 @@ def test_listar_comunicacoes_single_page(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert LISTAR_COMUNICACOES_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= LISTAR_COMUNICACOES_MIN_COLUMNS
     sample = json.loads(
         load_sample("comunica_cnj", "listar_comunicacoes/single_page.json")
     )

--- a/tests/datajud/test_listar_processos_contract.py
+++ b/tests/datajud/test_listar_processos_contract.py
@@ -78,7 +78,7 @@ def test_listar_processos_typical_multi_page(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert LISTAR_PROCESSOS_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= LISTAR_PROCESSOS_MIN_COLUMNS
     assert len(df) == 20
 
 
@@ -102,7 +102,7 @@ def test_listar_processos_single_page(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert LISTAR_PROCESSOS_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= LISTAR_PROCESSOS_MIN_COLUMNS
     assert len(df) == 1
 
 

--- a/tests/fixtures/capture/jusbr.py
+++ b/tests/fixtures/capture/jusbr.py
@@ -121,8 +121,7 @@ def _sanitize_string(value: str, replacements: dict[str, str]) -> str:
     for real, neutral in replacements.items():
         out = out.replace(real, neutral)
     out = _CPF_RE.sub("[CPF_REDACTED]", out)
-    out = _CNPJ_RE.sub("[CNPJ_REDACTED]", out)
-    return out
+    return _CNPJ_RE.sub("[CNPJ_REDACTED]", out)
 
 
 def _is_cpf_or_cnpj_value(value: Any) -> bool:
@@ -299,9 +298,8 @@ def _replace_numero_processo_in_list(list_data: dict, neutral_digits: str) -> di
 def _replace_numero_processo_in_details(details_data: Any, neutral_digits: str) -> Any:
     if isinstance(details_data, list):
         return [_replace_numero_processo_in_details(d, neutral_digits) for d in details_data]
-    if isinstance(details_data, dict):
-        if "numeroProcesso" in details_data:
-            details_data["numeroProcesso"] = neutral_digits
+    if isinstance(details_data, dict) and "numeroProcesso" in details_data:
+        details_data["numeroProcesso"] = neutral_digits
     return details_data
 
 

--- a/tests/pdpj/test_pdpj_contract.py
+++ b/tests/pdpj/test_pdpj_contract.py
@@ -110,7 +110,7 @@ def test_cpopg_processo_encontrado():
     )
     df = _mk_scraper().cpopg("10029886420194014100")
     assert isinstance(df, pd.DataFrame)
-    assert CPOPG_REQUIRED_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CPOPG_REQUIRED_COLUMNS
     assert len(df) == 1
     row = df.iloc[0]
     assert row["processo"] == "10029886420194014100"

--- a/tests/schemas/test_schema_contract.py
+++ b/tests/schemas/test_schema_contract.py
@@ -155,11 +155,7 @@ def _output_payload(schema_cls) -> dict:
                 out[name] = "Texto da ementa."
             elif name == "id_processo":
                 out[name] = "1000"
-            elif name == "numeroProcesso":
-                out[name] = "0000000-00.0000.0.00.0000"
-            elif name == "processo_pesquisado":
-                out[name] = "0000000-00.0000.0.00.0000"
-            elif name == "numero_processo":
+            elif name == "numeroProcesso" or name == "processo_pesquisado" or name == "numero_processo":
                 out[name] = "0000000-00.0000.0.00.0000"
             else:
                 out[name] = "x"

--- a/tests/tjac/test_cjsg_contract.py
+++ b/tests/tjac/test_cjsg_contract.py
@@ -52,7 +52,7 @@ def test_cjsg_typical_com_paginacao(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -68,7 +68,7 @@ def test_cjsg_single_page(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjal/test_cjsg_contract.py
+++ b/tests/tjal/test_cjsg_contract.py
@@ -51,7 +51,7 @@ def test_cjsg_typical_com_paginacao(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -67,7 +67,7 @@ def test_cjsg_single_page(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjam/test_cjsg_contract.py
+++ b/tests/tjam/test_cjsg_contract.py
@@ -51,7 +51,7 @@ def test_cjsg_typical_com_paginacao(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -67,7 +67,7 @@ def test_cjsg_single_page(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjap/test_cjsg_contract.py
+++ b/tests/tjap/test_cjsg_contract.py
@@ -75,7 +75,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjap").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -88,7 +88,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjap").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjba/test_cjsg_contract.py
+++ b/tests/tjba/test_cjsg_contract.py
@@ -87,7 +87,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjba").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -100,7 +100,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjba").cjsg("consumidor", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjce/test_cjsg_contract.py
+++ b/tests/tjce/test_cjsg_contract.py
@@ -58,7 +58,7 @@ def test_cjsg_typical_com_paginacao(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -74,7 +74,7 @@ def test_cjsg_single_page(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjdft/test_cjsg_contract.py
+++ b/tests/tjdft/test_cjsg_contract.py
@@ -54,7 +54,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjdft").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -67,7 +67,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjdft").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjes/test_cjpg_contract.py
+++ b/tests/tjes/test_cjpg_contract.py
@@ -42,7 +42,7 @@ def test_cjpg_typical_com_paginacao(mocker):
     df = jus.scraper("tjes").cjpg("obrigacao de fazer", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJPG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJPG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -60,7 +60,7 @@ def test_cjpg_single_page(mocker):
     df = jus.scraper("tjes").cjpg("obrigacao de fazer", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJPG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJPG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -92,7 +92,7 @@ def test_cjpg_empty_body_retried_then_succeeds(mocker):
     df = jus.scraper("tjes").cjpg("obrigacao de fazer", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJPG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJPG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjes/test_cjsg_contract.py
+++ b/tests/tjes/test_cjsg_contract.py
@@ -75,7 +75,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjes").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -88,7 +88,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjes").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjgo/test_cjsg_contract.py
+++ b/tests/tjgo/test_cjsg_contract.py
@@ -48,7 +48,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjgo").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) > 0
 
 
@@ -65,7 +65,7 @@ def test_cjsg_single_page(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) == 1
 
 

--- a/tests/tjgo/test_cjsg_filters_contract.py
+++ b/tests/tjgo/test_cjsg_filters_contract.py
@@ -110,14 +110,14 @@ def test_cjsg_data_inicio_alias_raises_typeerror():
     """``data_inicio``/``data_fim`` map to ``data_julgamento_*`` and TJGO
     rejects that — caller still sees the deprecation warning before the
     ``TypeError`` from the schema."""
-    with pytest.warns(DeprecationWarning) as warning_list:
-        with pytest.raises(TypeError, match=r"data_julgamento_inicio"):
-            jus.scraper("tjgo").cjsg(
-                "dano moral",
-                paginas=1,
-                data_inicio="2024-01-01",
-                data_fim="2024-03-31",
-            )
+    with pytest.warns(DeprecationWarning) as warning_list, \
+            pytest.raises(TypeError, match=r"data_julgamento_inicio"):
+        jus.scraper("tjgo").cjsg(
+            "dano moral",
+            paginas=1,
+            data_inicio="2024-01-01",
+            data_fim="2024-03-31",
+        )
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
 

--- a/tests/tjmg/test_cjsg_contract.py
+++ b/tests/tjmg/test_cjsg_contract.py
@@ -79,7 +79,7 @@ def test_cjsg_typical_com_paginacao(mock_txtcaptcha, mocker):
     df = jus.scraper("tjmg").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert df["processo"].notna().all(), "processo nulo em alguma linha"
     assert (df["processo"].astype(str).str.len() > 0).mean() >= 0.5, (
@@ -104,7 +104,7 @@ def test_cjsg_single_page(mock_txtcaptcha, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert df["processo"].notna().all(), "processo nulo em alguma linha"
     assert (df["processo"].astype(str).str.len() > 0).mean() >= 0.5, (

--- a/tests/tjms/test_cjsg_contract.py
+++ b/tests/tjms/test_cjsg_contract.py
@@ -51,7 +51,7 @@ def test_cjsg_typical_com_paginacao(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -67,7 +67,7 @@ def test_cjsg_single_page(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjmt/test_cjsg_contract.py
+++ b/tests/tjmt/test_cjsg_contract.py
@@ -92,7 +92,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjmt").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -106,7 +106,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjmt").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjpa/test_cjsg_contract.py
+++ b/tests/tjpa/test_cjsg_contract.py
@@ -41,7 +41,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjpa").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -54,7 +54,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjpa").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjpb/test_cjsg_contract.py
+++ b/tests/tjpb/test_cjsg_contract.py
@@ -55,7 +55,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjpb").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) > 0
 
 
@@ -72,7 +72,7 @@ def test_cjsg_single_page(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) > 0
 
 

--- a/tests/tjpe/test_cjsg_contract.py
+++ b/tests/tjpe/test_cjsg_contract.py
@@ -117,7 +117,7 @@ def test_cjsg_escolha_typical(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert df["processo"].notna().all(), "processo nulo em alguma linha"
     assert (df["processo"].astype(str).str.len() > 0).mean() >= 0.5, (
@@ -144,7 +144,7 @@ def test_cjsg_simples_typical(mocker):
     df = jus.scraper("tjpe").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert df["processo"].notna().all(), "processo nulo em alguma linha"
     assert (df["processo"].astype(str).str.len() > 0).mean() >= 0.5, (

--- a/tests/tjpi/test_cjsg_contract.py
+++ b/tests/tjpi/test_cjsg_contract.py
@@ -36,7 +36,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjpi").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -49,7 +49,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjpi").cjsg("mandado de seguranca usucapiao extraordinario", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -69,7 +69,7 @@ def test_cjsg_paginas_none_descobre_via_html(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert len(responses.calls) == 1
 

--- a/tests/tjpr/test_cjsg_contract.py
+++ b/tests/tjpr/test_cjsg_contract.py
@@ -72,7 +72,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjpr").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert df["processo"].notna().all(), "processo nulo em alguma linha"
     # Linhas com processo vazio existem legitimamente no TJPR (sigilo,
@@ -97,7 +97,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjpr").cjsg("direito civil", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert df["processo"].notna().all(), "processo nulo em alguma linha"
     # Linhas com processo vazio existem legitimamente no TJPR (sigilo,
@@ -151,7 +151,7 @@ def test_cjsg_ementa_completa_5xx_persistente(mocker):
     df = jus.scraper("tjpr").cjsg("dano moral", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0, "DataFrame vazio — fetch da ementa-completa quebrou o parse inteiro"
     erros = df["ementa"].astype(str).str.contains(
         r"\[Erro ao buscar ementa completa", regex=True, na=False

--- a/tests/tjrj/test_cjsg_contract.py
+++ b/tests/tjrj/test_cjsg_contract.py
@@ -85,7 +85,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) == 20  # 10 docs/page × 2 páginas
 
 
@@ -106,7 +106,7 @@ def test_cjsg_single_page(mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) == 2
 
 

--- a/tests/tjrj/test_cjsg_filters_contract.py
+++ b/tests/tjrj/test_cjsg_filters_contract.py
@@ -136,13 +136,13 @@ def test_cjsg_data_inicio_alias_raises_typeerror():
     """``data_inicio``/``data_fim`` map to ``data_julgamento_*`` and TJRJ
     rejects that — caller still sees the deprecation warning before the
     ``TypeError`` from the schema."""
-    with pytest.warns(DeprecationWarning) as warning_list:
-        with pytest.raises(TypeError, match=r"data_julgamento_inicio"):
-            jus.scraper("tjrj").cjsg(
-                "dano moral", paginas=1,
-                data_inicio="2024-01-01",
-                data_fim="2024-03-31",
-            )
+    with pytest.warns(DeprecationWarning) as warning_list, \
+            pytest.raises(TypeError, match=r"data_julgamento_inicio"):
+        jus.scraper("tjrj").cjsg(
+            "dano moral", paginas=1,
+            data_inicio="2024-01-01",
+            data_fim="2024-03-31",
+        )
     messages = [str(w.message) for w in warning_list]
     assert any("data_inicio" in m and "deprecado" in m for m in messages)
 

--- a/tests/tjrn/test_cjsg_contract.py
+++ b/tests/tjrn/test_cjsg_contract.py
@@ -39,7 +39,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjrn").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -52,7 +52,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjrn").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjro/test_cjsg_contract.py
+++ b/tests/tjro/test_cjsg_contract.py
@@ -40,7 +40,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjro").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -53,7 +53,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjro").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjrr/test_cjsg_contract.py
+++ b/tests/tjrr/test_cjsg_contract.py
@@ -108,7 +108,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df_p2 = jus.scraper("tjrr").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df_p2, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df_p2.columns)
+    assert set(df_p2.columns) >= CJSG_MIN_COLUMNS
     assert df_p2["processo"].notna().all(), "processo nulo em alguma linha"
     assert (df_p2["processo"].astype(str).str.len() > 0).mean() >= 0.5, (
         "mais da metade dos processos vazios — parser provavelmente quebrado"
@@ -128,7 +128,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjrr").cjsg("usucapiao", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
     assert df["processo"].notna().all(), "processo nulo em alguma linha"
     assert (df["processo"].astype(str).str.len() > 0).mean() >= 0.5, (

--- a/tests/tjrs/test_cjsg_contract.py
+++ b/tests/tjrs/test_cjsg_contract.py
@@ -97,7 +97,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjrs").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -110,7 +110,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjrs").cjsg("mandado de seguranca", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 

--- a/tests/tjsc/test_cjsg_contract.py
+++ b/tests/tjsc/test_cjsg_contract.py
@@ -49,7 +49,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjsc").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_PAGE1_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_PAGE1_FIELDS
     assert len(df) > 0
     # Confirm both URLs were hit — tests the dual-URL routing rule.
     hit_urls = {call.request.url for call in responses.calls}
@@ -66,7 +66,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjsc").cjsg("plano saude paciente doenca rara", paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_PAGE1_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_PAGE1_FIELDS
     assert len(df) > 0
     hit_urls = {call.request.url for call in responses.calls}
     assert hit_urls == {SEARCH_URL}
@@ -86,7 +86,7 @@ def test_cjsg_paginas_none_descobre_via_html(mocker):
     df = jus.scraper("tjsc").cjsg("plano saude paciente doenca rara", paginas=None)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_PAGE1_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_PAGE1_FIELDS
     assert len(df) > 0
     assert len(responses.calls) == 1
     assert responses.calls[0].request.url == SEARCH_URL

--- a/tests/tjsp/test_cjpg_contract.py
+++ b/tests/tjsp/test_cjpg_contract.py
@@ -70,7 +70,7 @@ def test_cjpg_typical_legacy_format(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJPG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJPG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -86,7 +86,7 @@ def test_cjpg_multi_page(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJPG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJPG_MIN_COLUMNS
     # 10 rows per page; cjpg_download.py:114 clamps range.stop to n_pags+1
     # which is large here, so both pages are fetched.
     assert len(df) == 20

--- a/tests/tjsp/test_cjsg_contract.py
+++ b/tests/tjsp/test_cjsg_contract.py
@@ -64,7 +64,7 @@ def test_cjsg_typical_com_paginacao(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -80,7 +80,7 @@ def test_cjsg_single_page(tmp_path, mocker):
     )
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     assert len(df) > 0
 
 
@@ -145,7 +145,7 @@ def test_cjsg_post_inicial_retenta_403(tmp_path, mocker):
     df = jus.scraper("tjsp", download_path=str(tmp_path)).cjsg(pesquisa, paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     # POST 403 + POST 200 + GET 200 = 3 chamadas. Trava regressão caso o retry
     # do POST inicial pare de acontecer (ex.: alguém remove o wrapping em
     # ``_request_with_retry``).
@@ -313,7 +313,7 @@ def test_cjsg_get_1a_pagina_retenta_503(tmp_path, mocker):
     df = jus.scraper("tjsp", download_path=str(tmp_path)).cjsg(pesquisa, paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_MIN_COLUMNS <= set(df.columns)
+    assert set(df.columns) >= CJSG_MIN_COLUMNS
     # POST 200 + GET 503 + GET 200 = 3 chamadas. Trava regressão simétrica
     # à do POST inicial.
     assert len(responses.calls) == 3

--- a/tests/tjsp/test_cpopg_contract.py
+++ b/tests/tjsp/test_cpopg_contract.py
@@ -64,10 +64,10 @@ def test_cpopg_html_single_match(tmp_path, mocker):
     result = jus.scraper("tjsp", download_path=str(tmp_path)).cpopg(CNJ, method="html")
 
     assert isinstance(result, dict)
-    assert CPOPG_HTML_KEYS <= set(result.keys())
+    assert set(result.keys()) >= CPOPG_HTML_KEYS
     basicos = result["basicos"]
     assert isinstance(basicos, pd.DataFrame)
-    assert CPOPG_BASICOS_MIN <= set(basicos.columns)
+    assert set(basicos.columns) >= CPOPG_BASICOS_MIN
     assert len(basicos) == 1
     assert basicos.iloc[0]["id_processo"] == CNJ
 
@@ -104,6 +104,6 @@ def test_cpopg_api(tmp_path, mocker):
     result = jus.scraper("tjsp", download_path=str(tmp_path)).cpopg(CNJ, method="api")
 
     assert isinstance(result, dict)
-    assert CPOPG_API_KEYS <= set(result.keys())
+    assert set(result.keys()) >= CPOPG_API_KEYS
     basicos = result["basicos"]
     assert isinstance(basicos, pd.DataFrame)

--- a/tests/tjsp/test_cposg_contract.py
+++ b/tests/tjsp/test_cposg_contract.py
@@ -69,7 +69,7 @@ def test_cposg_html_simple_response(tmp_path, mocker):
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 1
-    assert CPOSG_BASICOS_MIN <= set(df.columns)
+    assert set(df.columns) >= CPOSG_BASICOS_MIN
 
 
 # ---------- method='api' ------------------------------------------------

--- a/tests/tjsp/test_query_validation.py
+++ b/tests/tjsp/test_query_validation.py
@@ -65,12 +65,10 @@ class TestDeprecatedAliases:
 
     def test_cjsg_accepts_query_alias_with_warning(self, tmp_path):
         scraper = jus.scraper("tjsp", download_path=str(tmp_path))
-        with pytest.warns(DeprecationWarning, match="query.*deprecado"):
-            with pytest.raises(QueryTooLongError):
-                scraper.cjsg_download(pesquisa=None, query="a" * 121, paginas=1)
+        with pytest.warns(DeprecationWarning, match="query.*deprecado"), pytest.raises(QueryTooLongError):
+            scraper.cjsg_download(pesquisa=None, query="a" * 121, paginas=1)
 
     def test_cjpg_accepts_termo_alias_with_warning(self, tmp_path):
         scraper = jus.scraper("tjsp", download_path=str(tmp_path))
-        with pytest.warns(DeprecationWarning, match="termo.*deprecado"):
-            with pytest.raises(QueryTooLongError):
-                scraper.cjpg_download(termo="a" * 121, paginas=1)
+        with pytest.warns(DeprecationWarning, match="termo.*deprecado"), pytest.raises(QueryTooLongError):
+            scraper.cjpg_download(termo="a" * 121, paginas=1)

--- a/tests/tjto/test_cjpg_contract.py
+++ b/tests/tjto/test_cjpg_contract.py
@@ -43,7 +43,7 @@ def test_cjpg_typical_com_paginacao(mocker):
     df = jus.scraper("tjto").cjpg('"dano moral"', paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJPG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJPG_FIELDS
     assert len(df) > 0
 
 
@@ -56,7 +56,7 @@ def test_cjpg_single_page(mocker):
     df = jus.scraper("tjto").cjpg('"despejo"', paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJPG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJPG_FIELDS
     assert len(df) == 10
 
 

--- a/tests/tjto/test_cjsg_contract.py
+++ b/tests/tjto/test_cjsg_contract.py
@@ -43,7 +43,7 @@ def test_cjsg_typical_com_paginacao(mocker):
     df = jus.scraper("tjto").cjsg("dano moral", paginas=range(1, 3))
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) > 0
 
 
@@ -56,7 +56,7 @@ def test_cjsg_single_page(mocker):
     df = jus.scraper("tjto").cjsg('"alimentos avoengos"', paginas=1)
 
     assert isinstance(df, pd.DataFrame)
-    assert CJSG_FIELDS <= set(df.columns)
+    assert set(df.columns) >= CJSG_FIELDS
     assert len(df) == 9
 
 


### PR DESCRIPTION
## Contexto

PR 1/3 da #306 (ligar as famílias restantes do Ruff). Liga `RET` (flake8-return) e `SIM` (flake8-simplify) no `select` e zera os achados em `src` **e** `tests` na mesma passada — o hook do pre-commit cobre `^(src|tests)/` com `--fix`, então ligar sem zerar deixaria o pre-commit vermelho.

> **Stacked PR.** Base = `chore/ruff-tests-305-cleanup` (#320), que zera os `B/C4/RUF` pré-existentes em tests. Mesclar #320 primeiro; o GitHub re-aponta a base deste PR para `main` automaticamente. O diff aqui mostra **só** as mudanças de RET/SIM.

## O que muda

**Autofix seguro** (o grosso):
- **71 `SIM300`** (yoda-conditions) em tests: `assert ESPERADO == x` → `assert x == ESPERADO`.
- `SIM114` (combinar branches com `or`), `SIM117` (`with` único), `RET505`/`RET506` (`else` supérfluo após `return`/`raise`).

**Manuais mecânicos** (sem autofix seguro):
- **11 `RET504`** (assign inútil antes de `return`) → `return <expr>`.
- **4 `SIM108`** (`if/else` → ternário), **2 `SIM102`** (`if` aninhado colapsado), **2 `SIM117`** manuais (`pytest.warns` + `pytest.raises` combinados num único `with`).

Nota: um `SIM114` em `tjsc/parse.py` virou `a or b and c`; adicionei parênteses explícitos (`a or (b and c)`) para satisfazer `RUF021` e deixar a precedência clara — comportamento idêntico.

## Verificação

- `uvx ruff@0.15.12 check src tests --select RET,SIM` → **All checks passed!**
- `uvx ruff@0.15.12 check src tests` (todas as famílias) → **All checks passed!**
- `uv run pytest` → **1755 passed, 29 skipped**

Sem entrada no CHANGELOG (tooling, sem efeito na API pública).

Refs #306.