### PR TITLE
chore(ruff): ligar familia PERF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,7 @@ select = [
     "RUF",    # regras do proprio Ruff (ex.: mutable-class-default)
     "RET",    # flake8-return: return flow (ex.: assign inutil antes de return)
     "SIM",    # flake8-simplify: simplificacoes (ternario, with unico, yoda)
+    "PERF",   # perflint: laco->comprehension/extend onde compensa
 ]
 ignore = [
     # Caracteres "ambiguos" em texto pt-BR sao legitimos. Docstrings e

--- a/src/juscraper/aggregators/pdpj/client.py
+++ b/src/juscraper/aggregators/pdpj/client.py
@@ -237,8 +237,7 @@ class PdpjScraper(BaseScraper):
                     "status_consulta": "Nao encontrado",
                 })
             else:
-                for det in detalhes:
-                    rows.append(build_processo_row(det, cnj))
+                rows.extend(build_processo_row(det, cnj) for det in detalhes)
             if self.sleep_time:
                 time.sleep(self.sleep_time)
         return pd.DataFrame(rows)
@@ -507,8 +506,9 @@ class PdpjScraper(BaseScraper):
             if isinstance(top_docs, list):
                 doc_lists.append(top_docs)
             for tram in detalhes.get("tramitacoes", []) or []:
+                # filtro composto + narrowing de tipo que o mypy le melhor no laco explicito
                 if isinstance(tram, dict) and isinstance(tram.get("documentos"), list):
-                    doc_lists.append(tram["documentos"])
+                    doc_lists.append(tram["documentos"])  # noqa: PERF401
 
             for docs in doc_lists:
                 for doc in docs:

--- a/src/juscraper/courts/tjgo/parse.py
+++ b/src/juscraper/courts/tjgo/parse.py
@@ -120,6 +120,5 @@ def cjsg_parse(raw_pages: list) -> pd.DataFrame:
     for html in raw_pages:
         if not html:
             continue
-        for block in _split_blocks(html):
-            rows.append(_parse_block(block))
+        rows.extend(_parse_block(block) for block in _split_blocks(html))
     return pd.DataFrame(rows)

--- a/src/juscraper/courts/tjmg/parse.py
+++ b/src/juscraper/courts/tjmg/parse.py
@@ -34,11 +34,8 @@ def _split_blocks(html: str) -> list:
     parts = html.split('<div class="caixa_processo"')
     if len(parts) <= 1:
         return []
-    blocks = []
     # Each caixa_processo marks the start of a result. End at next caixa_processo.
-    for chunk in parts[1:]:
-        blocks.append(chunk)
-    return blocks
+    return list(parts[1:])
 
 
 def _parse_block(block: str) -> dict:
@@ -75,8 +72,7 @@ def cjsg_parse(raw_pages: list) -> pd.DataFrame:
     for html in raw_pages:
         if not html:
             continue
-        for block in _split_blocks(html):
-            rows.append(_parse_block(block))
+        rows.extend(_parse_block(block) for block in _split_blocks(html))
     df = pd.DataFrame(rows)
     coerce_date_columns(df, ["data_julgamento", "data_publicacao"], date_format="%d/%m/%Y")
     return df

--- a/src/juscraper/courts/tjpa/download.py
+++ b/src/juscraper/courts/tjpa/download.py
@@ -128,7 +128,8 @@ def cjsg_download_manager(
         if total_pages > 1:
             logger.info("TJPA: %d pages found. Downloading all...", total_pages)
             for pagina in tqdm(range(2, total_pages + 1), desc="Baixando páginas TJPA"):
-                resultados.append(_get_page(pagina))
+                # laco de I/O (rede por iteracao sob tqdm): comprehension esconderia o efeito
+                resultados.append(_get_page(pagina))  # noqa: PERF401
         return resultados
 
     paginas_iter = list(paginas)

--- a/src/juscraper/courts/tjpb/download.py
+++ b/src/juscraper/courts/tjpb/download.py
@@ -108,7 +108,8 @@ def cjsg_download_manager(
         n_pags = math.ceil(total / RESULTS_PER_PAGE) if total else 1
         if n_pags > 1:
             for pagina in tqdm(range(2, n_pags + 1), desc="Baixando CJSG TJPB"):
-                resultados.append(_get_page(pagina))
+                # laco de I/O (rede por iteracao sob tqdm): comprehension esconderia o efeito
+                resultados.append(_get_page(pagina))  # noqa: PERF401
         return resultados
 
     paginas_iter = list(paginas)

--- a/src/juscraper/courts/tjpb/parse.py
+++ b/src/juscraper/courts/tjpb/parse.py
@@ -13,12 +13,14 @@ def cjsg_parse_manager(resultados_brutos: list) -> pd.DataFrame:
     registros = []
     for response in resultados_brutos:
         hits = response.get("hits", [])
-        for hit in hits:
-            registros.append({
+        registros.extend(
+            {
                 "processo": hit.get("numero_processo"),
                 "ementa": hit.get("ementa"),
                 "data_julgamento": hit.get("dt_ementa"),
-            })
+            }
+            for hit in hits
+        )
 
     df = pd.DataFrame(registros)
     if df.empty:

--- a/src/juscraper/courts/tjpr/download.py
+++ b/src/juscraper/courts/tjpr/download.py
@@ -182,7 +182,8 @@ def cjsg_download(
         resultados = [first_html]
         if n_pags > 1:
             for pagina_atual in tqdm(range(2, n_pags + 1), desc='Baixando páginas TJPR'):
-                resultados.append(_fetch_page(pagina_atual))
+                # laco de I/O (rede por iteracao sob tqdm): comprehension esconderia o efeito
+                resultados.append(_fetch_page(pagina_atual))  # noqa: PERF401
         return resultados
 
     paginas_iter = list(paginas)

--- a/src/juscraper/courts/tjrj/parse.py
+++ b/src/juscraper/courts/tjrj/parse.py
@@ -43,21 +43,21 @@ def cjsg_parse(raw_pages: list) -> pd.DataFrame:
     for page in raw_pages:
         if not page:
             continue
-        for doc in page.get("DocumentosConsulta", []) or []:
-            rows.append(
-                {
-                    "cod_documento": doc.get("CodDoc"),
-                    "processo": doc.get("NumProcCnj") or doc.get("Processo"),
-                    "numero_antigo": doc.get("NumAntigo"),
-                    "classe": doc.get("Classe") or doc.get("DescrRecurso"),
-                    "tipo_documento": doc.get("DescrTipDoc"),
-                    "orgao_julgador": doc.get("NomeOrgJulg"),
-                    "relator": doc.get("NomeMagRel"),
-                    "data_julgamento": _parse_aspnet_date(doc.get("DtHrMov")),
-                    "data_publicacao": _parse_aspnet_date(doc.get("DtHrPubl")),
-                    "ementa": _strip_html(
-                        doc.get("TextoSemFormat") or doc.get("Texto")
-                    ),
-                }
-            )
+        rows.extend(
+            {
+                "cod_documento": doc.get("CodDoc"),
+                "processo": doc.get("NumProcCnj") or doc.get("Processo"),
+                "numero_antigo": doc.get("NumAntigo"),
+                "classe": doc.get("Classe") or doc.get("DescrRecurso"),
+                "tipo_documento": doc.get("DescrTipDoc"),
+                "orgao_julgador": doc.get("NomeOrgJulg"),
+                "relator": doc.get("NomeMagRel"),
+                "data_julgamento": _parse_aspnet_date(doc.get("DtHrMov")),
+                "data_publicacao": _parse_aspnet_date(doc.get("DtHrPubl")),
+                "ementa": _strip_html(
+                    doc.get("TextoSemFormat") or doc.get("Texto")
+                ),
+            }
+            for doc in page.get("DocumentosConsulta", []) or []
+        )
     return pd.DataFrame(rows)

--- a/src/juscraper/courts/tjrs/download.py
+++ b/src/juscraper/courts/tjrs/download.py
@@ -137,7 +137,8 @@ def cjsg_download_manager(
         n_pags = math.ceil(num_found / RESULTS_PER_PAGE) if num_found else 1
         if n_pags > 1:
             for pagina in tqdm(range(2, n_pags + 1), desc='Baixando páginas TJRS'):
-                resultados.append(_fetch_page(pagina))
+                # laco de I/O (rede por iteracao sob tqdm): comprehension esconderia o efeito
+                resultados.append(_fetch_page(pagina))  # noqa: PERF401
         return resultados
 
     paginas_iter = list(paginas)

--- a/src/juscraper/courts/tjsp/cpopg_parse.py
+++ b/src/juscraper/courts/tjsp/cpopg_parse.py
@@ -381,6 +381,5 @@ def get_cpopg_download_links(request):
         if href is not None and 'show.do' in str(href):
             links.append(href)
     else:
-        for a in lista.find_all('a', href=True):
-            links.append(str(a['href']))
+        links.extend(str(a['href']) for a in lista.find_all('a', href=True))
     return links

--- a/tests/schemas/test_canonical_types.py
+++ b/tests/schemas/test_canonical_types.py
@@ -239,7 +239,7 @@ def test_grace_period_exceptions_are_still_needed():
             EXPECTED_COURT_OUTPUT_SCHEMAS,
             EXPECTED_AGGREGATOR_OUTPUT_SCHEMAS,
         ):
-            for _, (module_path, cn) in mapping.items():
+            for module_path, cn in mapping.values():
                 if cn != class_name:
                     continue
                 schema_cls = _resolve(module_path, class_name)

--- a/tests/schemas/test_capture_drift.py
+++ b/tests/schemas/test_capture_drift.py
@@ -21,11 +21,11 @@ def _capture_modules() -> list[Path]:
 
 
 def _module_names(tree: ast.Module) -> list[tuple[str, int]]:
-    out: list[tuple[str, int]] = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            out.append((node.module or "", node.level))
-    return out
+    return [
+        (node.module or "", node.level)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+    ]
 
 
 @pytest.mark.parametrize("path", _capture_modules(), ids=lambda p: p.stem)


### PR DESCRIPTION
## Contexto

PR 2/3 da #306. Liga `PERF` (perflint) no `select` e zera os 14 achados em `src` e `tests`. Revisão **caso a caso**, não troca de token — alguns laços de I/O ficam melhores como laço explícito.

> **Stacked PR.** Base = `chore/ruff-ret-sim` (#321). Mesclar #320 → #321 → este, nessa ordem; o GitHub re-aponta a base automaticamente. O diff aqui mostra **só** as mudanças de PERF.

## O que muda

**Reescrito como comprehension/`extend`/`copy`** (dados puros, ganho real):
- 7 `PERF401` em parsers (`tjgo`, `tjmg`, `tjpb`, `tjrj`, `tjsp/cpopg`) e no agregador `pdpj` (laço interno puro sobre `detalhes`) → `list.extend` com generator.
- 1 `PERF402` (`tjmg._split_blocks`) → `list(parts[1:])`.
- tests: `PERF102` (`.values()` ignorando a chave) e `PERF401` (`ast.walk` → comprehension com filtro `isinstance`).

**Mantido como laço com `# noqa: PERF401`** (reescrita pioraria a leitura):
- 4 laços de download (`tjpa`, `tjpb`, `tjpr`, `tjrs`): cada iteração bate na rede sob `tqdm`; a comprehension esconderia o efeito de I/O.
- `pdpj/client.py`: append com filtro composto `isinstance` + narrowing de tipo que o mypy lê melhor no laço explícito.

Cada `# noqa` leva um comentário curto justificando.

## Verificação

- `uvx ruff@0.15.12 check src tests --select PERF` → **All checks passed!**
- `uvx ruff@0.15.12 check src tests` (todas as famílias) → **All checks passed!**
- `uv run pytest` → **1755 passed, 29 skipped**

Sem entrada no CHANGELOG (tooling, sem efeito na API pública).

Refs #306.