### PR TITLE
chore(ruff): ligar familia PTH (migracao para pathlib)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ select = [
     "RET",    # flake8-return: return flow (ex.: assign inutil antes de return)
     "SIM",    # flake8-simplify: simplificacoes (ternario, with unico, yoda)
     "PERF",   # perflint: laco->comprehension/extend onde compensa
+    "PTH",    # flake8-use-pathlib: os.path/open/glob -> pathlib
 ]
 ignore = [
     # Caracteres "ambiguos" em texto pt-BR sao legitimos. Docstrings e

--- a/src/juscraper/core/base.py
+++ b/src/juscraper/core/base.py
@@ -2,9 +2,9 @@
 Base scraper class for court data extraction.
 """
 import logging
-import os
 import tempfile
 from abc import ABC
+from pathlib import Path
 
 logger = logging.getLogger("juscraper.core.base")
 
@@ -31,13 +31,13 @@ class BaseScraper(ABC):
         """Set the download path. If None, creates a temporary directory."""
         if path is None:
             path = tempfile.mkdtemp()
-        if not os.path.isdir(path):
+        if not Path(path).is_dir():
             if self.verbose:
                 logger.info(
                     "O caminho de download '%s' não é um diretório. Criando esse diretório...",
                     path
                 )
-            os.makedirs(path)
+            Path(path).mkdir(parents=True, exist_ok=True)
         self.download_path = path
         if self.verbose:
             logger.info(

--- a/src/juscraper/courts/_esaj/download.py
+++ b/src/juscraper/courts/_esaj/download.py
@@ -25,10 +25,10 @@ abaixo no nível de módulo.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from collections.abc import Callable
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from bs4 import BeautifulSoup
@@ -195,8 +195,8 @@ def download_cjsg_pages(
     """
     tipo_param = "A" if tipo_decisao == "acordao" else "D"
     timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-    path = os.path.join(download_path, "cjsg", timestamp)
-    os.makedirs(path, exist_ok=True)
+    path = Path(download_path) / "cjsg" / timestamp
+    path.mkdir(parents=True, exist_ok=True)
 
     link_cjsg = f"{base_url}cjsg/resultadoCompleta.do"
 
@@ -212,19 +212,19 @@ def download_cjsg_pages(
 
     n_pags = get_n_pags_callback(first_html)
 
-    with open(os.path.join(path, "cjsg_00001.html"), "w", encoding="latin1") as fp:
+    with (path / "cjsg_00001.html").open("w", encoding="latin1") as fp:
         fp.write(first_html)
 
     if n_pags == 0:
         logger.info("Nenhum resultado encontrado para a busca.")
-        return path
+        return str(path)
 
     conversation_id = _extract_conversation_id(first_html) if extract_conversation_id else ""
 
     paginas_list = _pages_to_fetch(paginas, n_pags)
     if not paginas_list:
         logger.info("Total de páginas: %s. Baixando apenas a primeira.", n_pags)
-        return path
+        return str(path)
 
     logger.info("Total de páginas: %s. Baixando: %s", n_pags, len(paginas_list) + 1)
 
@@ -245,10 +245,10 @@ def download_cjsg_pages(
             headers={"Accept": "text/html; charset=latin1;", "Referer": link_cjsg},
         )
         resp.encoding = "latin1"
-        with open(os.path.join(path, f"cjsg_{pag:05d}.html"), "w", encoding="latin1") as fp:
+        with (path / f"cjsg_{pag:05d}.html").open("w", encoding="latin1") as fp:
             fp.write(resp.text)
 
-    return path
+    return str(path)
 
 
 __all__ = ["download_cjsg_pages", "fetch_cjsg_first_page"]

--- a/src/juscraper/courts/_esaj/parse.py
+++ b/src/juscraper/courts/_esaj/parse.py
@@ -339,7 +339,7 @@ def cjsg_parse_manager(path: str) -> pd.DataFrame:
     if Path(path).is_file():
         return _parse_single_page(path)
 
-    arquivos = [f for f in Path(path).rglob("*.ht*") if f.is_file()]
+    arquivos = [str(f) for f in Path(path).rglob("*.ht*") if f.is_file()]
 
     result: list[pd.DataFrame] = []
     for file in tqdm(arquivos, desc="Processando documentos"):

--- a/src/juscraper/courts/_esaj/parse.py
+++ b/src/juscraper/courts/_esaj/parse.py
@@ -9,10 +9,9 @@ wording. The parser treats latin-1 as the expected server encoding
 """
 from __future__ import annotations
 
-import glob
 import logging
-import os
 import re
+from pathlib import Path
 
 import pandas as pd
 import unidecode
@@ -184,7 +183,7 @@ def _clean_value(value: str) -> str:
 
 
 def _parse_single_page(path: str) -> pd.DataFrame:
-    with open(path, "rb") as fp:
+    with Path(path).open("rb") as fp:
         raw = fp.read()
 
     try:
@@ -337,11 +336,10 @@ def cjsg_parse_manager(path: str) -> pd.DataFrame:
     Returns:
         Combined DataFrame. Empty when no files parse successfully.
     """
-    if os.path.isfile(path):
+    if Path(path).is_file():
         return _parse_single_page(path)
 
-    arquivos = glob.glob(os.path.join(path, "**", "*.ht*"), recursive=True)
-    arquivos = [f for f in arquivos if os.path.isfile(f)]
+    arquivos = [f for f in Path(path).rglob("*.ht*") if f.is_file()]
 
     result: list[pd.DataFrame] = []
     for file in tqdm(arquivos, desc="Processando documentos"):

--- a/src/juscraper/courts/tjsp/acordao_download.py
+++ b/src/juscraper/courts/tjsp/acordao_download.py
@@ -1,7 +1,7 @@
 """
 Downloads decisions from the TJSP CJSG.
 """
-import os
+from pathlib import Path
 
 from ...utils import safe_path_component
 
@@ -28,10 +28,10 @@ def download_acordao(
     if r.status_code != 200:
         raise AcordaoDownloadError(f"Erro ao baixar o acordão {cd_acordao}: {r.status_code}")
     safe_cd = safe_path_component(cd_acordao, field="cdAcordao")
-    path = os.path.join(download_path, "cjsg", f"{safe_cd}.pdf")
+    path = Path(download_path) / "cjsg" / f"{safe_cd}.pdf"
     # create folder if it doesn't exist
-    if not os.path.isdir(os.path.dirname(path)):
-        os.makedirs(os.path.dirname(path))
-    with open(path, 'wb') as f:
+    if not path.parent.is_dir():
+        path.parent.mkdir(parents=True)
+    with path.open('wb') as f:
         f.write(r.content)
     return r

--- a/src/juscraper/courts/tjsp/cjpg_download.py
+++ b/src/juscraper/courts/tjsp/cjpg_download.py
@@ -8,9 +8,9 @@ can continue importing it from here.
 from __future__ import annotations
 
 import logging
-import os
 import time
 from datetime import datetime
+from pathlib import Path
 
 import requests
 from tqdm import tqdm
@@ -112,11 +112,11 @@ def cjpg_download(
         n_pags = get_n_pags_callback(r0)
     except Exception as e:
         timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-        debug_dir = os.path.join(download_path, "cjpg_debug")
-        if not os.path.isdir(debug_dir):
-            os.makedirs(debug_dir)
-        debug_file = os.path.join(debug_dir, f"cjpg_primeira_pagina_{timestamp}.html")
-        with open(debug_file, 'w', encoding='utf-8') as f:
+        debug_dir = Path(download_path) / "cjpg_debug"
+        if not debug_dir.is_dir():
+            debug_dir.mkdir(parents=True)
+        debug_file = debug_dir / f"cjpg_primeira_pagina_{timestamp}.html"
+        with debug_file.open('w', encoding='utf-8') as f:
             f.write(r0.text)
         logger = logging.getLogger("juscraper.cjpg_download")
         logger.error(
@@ -130,11 +130,11 @@ def cjpg_download(
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     path = f"{download_path}/cjpg/{timestamp}"
-    if not os.path.isdir(path):
-        os.makedirs(path)
+    if not Path(path).is_dir():
+        Path(path).mkdir(parents=True)
 
     if n_pags == 0:
-        with open(f"{path}/cjpg_00001.html", 'w', encoding='utf-8') as f:
+        with Path(f"{path}/cjpg_00001.html").open('w', encoding='utf-8') as f:
             f.write(r0.text)
         return path
 
@@ -150,7 +150,7 @@ def cjpg_download(
 
     first_page_in_range = 1 in paginas
     if first_page_in_range:
-        with open(f"{path}/cjpg_00001.html", 'w', encoding='utf-8') as f:
+        with Path(f"{path}/cjpg_00001.html").open('w', encoding='utf-8') as f:
             f.write(r0.text)
 
     remaining = [p for p in paginas if p > 1]
@@ -161,6 +161,6 @@ def cjpg_download(
         time.sleep(sleep_time)
         u = f"{u_base}cjpg/trocarDePagina.do?pagina={page}&conversationId="
         r = session.get(u)
-        with open(f"{path}/cjpg_{page:05d}.html", 'w', encoding='utf-8') as f:  # noqa: E231
+        with Path(f"{path}/cjpg_{page:05d}.html").open('w', encoding='utf-8') as f:  # noqa: E231
             f.write(r.text)
     return path

--- a/src/juscraper/courts/tjsp/cjpg_parse.py
+++ b/src/juscraper/courts/tjsp/cjpg_parse.py
@@ -1,10 +1,9 @@
 """
 Parse of cases from the TJSP jurisprudence search.
 """
-import glob
 import logging
-import os
 import re
+from pathlib import Path
 
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -130,7 +129,7 @@ def cjpg_parse_single(path):
     """
     Parses a downloaded HTML file from the cjpg_download function.
     """
-    with open(path, 'r', encoding='utf-8') as f:
+    with Path(path).open('r', encoding='utf-8') as f:
         soup = BeautifulSoup(f, 'html.parser')
     processos = []
     div_dados_resultado = soup.find('div', {'id': 'divDadosResultado'})
@@ -181,14 +180,13 @@ def cjpg_parse_manager(path):
     Parses the downloaded files from the cjpg_download function.
     Returns a DataFrame with the information of the processes.
     """
-    if os.path.isfile(path):
+    if Path(path).is_file():
         result = [cjpg_parse_single(path)]
     else:
         result = []
-        arquivos = glob.glob(f"{path}/**/*.ht*", recursive=True)
-        arquivos = [f for f in arquivos if os.path.isfile(f)]
+        arquivos = [f for f in Path(path).rglob("*.ht*") if f.is_file()]
         for file in tqdm(arquivos, desc="Processando documentos"):
-            if os.path.isfile(file):
+            if file.is_file():
                 try:
                     single_result = cjpg_parse_single(file)
                 except (ValueError, OSError) as e:

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import logging
-import os
 import shutil
 import tempfile
 import warnings
+from pathlib import Path
 from typing import Any, ClassVar, Literal
 
 import pandas as pd
@@ -645,7 +645,7 @@ class TJSPScraper(EsajSearchScraper):
         path = self.download_path
         self.cposg_download(id_cnj, method)
         result = self.cposg_parse(path)
-        if os.path.exists(path):
+        if Path(path).exists():
             shutil.rmtree(path)
         else:
             logger.warning("[TJSP] Aviso: diretório %s não existe e não pôde ser removido.", path)

--- a/src/juscraper/courts/tjsp/cpopg_download.py
+++ b/src/juscraper/courts/tjsp/cpopg_download.py
@@ -2,8 +2,8 @@
 Downloads of processes from the TJSP Consulta de Processos Originarios do Primeiro Grau (CPOPG).
 """
 import logging
-import os
 import time
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import requests
@@ -73,10 +73,10 @@ def cpopg_download_html_single(
     id_clean = clean_cnj(id_cnj)
     path = f"{download_path}/cpopg/{id_clean}"
     logger.info("Salvando em %s", path)
-    if not os.path.isdir(path):
-        os.makedirs(path)
-    for file in os.listdir(path):
-        if file.endswith('.html'):
+    if not Path(path).is_dir():
+        Path(path).mkdir(parents=True)
+    for file in Path(path).iterdir():
+        if file.name.endswith('.html'):
             logger.info("O processo %s ja foi baixado.", id_clean)
             return path
     time.sleep(sleep_time)
@@ -116,7 +116,7 @@ def cpopg_download_html_single(
             if len(links) == 1:
                 file_name = f"{path}/{id_clean}_{cd_processo[0]}.html"
                 logger.info("Salvando em %s", file_name)
-                with open(file_name, 'w', encoding='utf-8') as f:
+                with Path(file_name).open('w', encoding='utf-8') as f:
                     f.write(r.text)
             else:
                 for index, link in enumerate(links):
@@ -130,7 +130,7 @@ def cpopg_download_html_single(
                         )
                     file_name = f"{path}/{id_clean}_{cd_processo[index]}.html"
                     logger.info("Salvando em %s", file_name)
-                    with open(file_name, 'w', encoding='utf-8') as f:
+                    with Path(file_name).open('w', encoding='utf-8') as f:
                         f.write(r2.text)
             break
         except (OSError, UnicodeDecodeError, ValueError,
@@ -191,15 +191,15 @@ def cpopg_download_api_single(
     u = f"{api_base}{endpoint}{id_clean}"
     # id_clean vem de clean_cnj (so digitos), seguro como componente de path.
     path = f"{download_path}/cpopg/{id_clean}"
-    if not os.path.isdir(path):
-        os.makedirs(path)
+    if not Path(path).is_dir():
+        Path(path).mkdir(parents=True)
     r = session.get(u)
     if r.status_code != 200:
         raise requests.HTTPError(
             f"A consulta à API falhou."
             f"Status code {r.status_code}."
         )
-    with open(f"{path}/{id_clean}.json", 'w', encoding='utf-8') as f:
+    with Path(f"{path}/{id_clean}.json").open('w', encoding='utf-8') as f:
         f.write(r.text)
     json_response = r.json()
     if not json_response:
@@ -216,14 +216,14 @@ def cpopg_download_api_single(
                 f"A consulta à API falhou."
                 f"Status code {r_basicos.status_code}."
             )
-        with open(os.path.join(path, f"{cd_processo_safe}_basicos.json"), 'w', encoding='utf-8') as f:
+        with (Path(path) / f"{cd_processo_safe}_basicos.json").open('w', encoding='utf-8') as f:
             f.write(r_basicos.text)
         componentes = ['partes', 'movimentacao', 'incidente', 'audiencia']
         for comp in componentes:
             endpoint_comp = f"processo/cpopg/{comp}/{cd_processo}"
             r_comp = session.get(f"{api_base}{endpoint_comp}")
             if r_comp.status_code == 200:
-                with open(os.path.join(path, f"{cd_processo_safe}_{comp}.json"), 'w', encoding='utf-8') as f:
+                with (Path(path) / f"{cd_processo_safe}_{comp}.json").open('w', encoding='utf-8') as f:
                     f.write(r_comp.text)
             else:
                 raise requests.HTTPError(

--- a/src/juscraper/courts/tjsp/cpopg_parse.py
+++ b/src/juscraper/courts/tjsp/cpopg_parse.py
@@ -1,7 +1,6 @@
 """Parses downloaded files from the first-degree procedural query."""
-import glob
-import os
 import re
+from pathlib import Path
 
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -58,16 +57,15 @@ def cpopg_parse_manager(path: str):
         with the parsed data from the case files.
     """
     lista_empilhada = {}
-    if os.path.isfile(path):
+    if Path(path).is_file():
         result = [cpopg_parse_single(path)]
     else:
         result = []
-        arquivos = glob.glob(f"{path}/**/*.[hj][st]*", recursive=True)
-        arquivos = [f for f in arquivos if os.path.isfile(f)]
+        arquivos = [str(f) for f in Path(path).rglob("*.[hj][st]*") if f.is_file()]
         # remover arquivos json cujo nome nao acaba com um número
         arquivos = [f for f in arquivos if not f.endswith('.json') or f[-6:-5].isnumeric()]
         for file in tqdm(arquivos, desc="Processando documentos"):
-            if os.path.isfile(file):
+            if Path(file).is_file():
                 try:
                     single_result = cpopg_parse_single(file)
                 except (OSError, UnicodeDecodeError, ValueError, AttributeError) as e:
@@ -101,7 +99,7 @@ def cpopg_parse_single(path: str):
 
 def cpopg_parse_single_html(path: str):
     """Parse a downloaded HTML file from the TJSP CPOPG consultation."""
-    with open(path, 'r', encoding='utf-8') as f:
+    with Path(path).open('r', encoding='utf-8') as f:
         html = f.read()
         soup = BeautifulSoup(html, 'html.parser')
 
@@ -341,14 +339,14 @@ def cpopg_parse_single_json(path: str):
     """Parse a JSON file downloaded by cpopg_download."""
     # primeiro, vamos listar todos os arquivos que estão na
     # mesma pasta que o arquivo que está em path
-    lista_arquivos = glob.glob(f"{os.path.dirname(path)}/*.json")
+    lista_arquivos = [str(p) for p in Path(path).parent.glob("*.json")]
     lista_processo = next(f for f in lista_arquivos if f[-6:-5].isnumeric())
     lista_arquivos = [f for f in lista_arquivos if f not in lista_processo]
 
     # agora, fazemos a leitura de cada arquivo e transformamos em um dataframe
     dfs = {}
     for arquivo in lista_arquivos:
-        nome = os.path.basename(arquivo)
+        nome = Path(arquivo).name
         # split name in two variables separating by _
         cd_processo, tipo = nome.split("_", 1)
         tipo = tipo.split(".", 1)[0]

--- a/src/juscraper/courts/tjsp/cposg_download.py
+++ b/src/juscraper/courts/tjsp/cposg_download.py
@@ -2,8 +2,8 @@
 Downloads processes from the TJSP Consulta de Processos Originarios do Primeiro Grau (CPOSG).
 """
 import logging
-import os
 import time
+from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
 import requests
@@ -64,8 +64,8 @@ def _cposg_download_html_single(id_cnj, session, u_base, download_path):
     soup = BeautifulSoup(r.text, 'html.parser')
     # id_clean vem de clean_cnj (so digitos), seguro como componente de path.
     path = f"{download_path}/cposg/{id_clean}"
-    if not os.path.isdir(path):
-        os.makedirs(path)
+    if not Path(path).is_dir():
+        Path(path).mkdir(parents=True)
     # 3. Tratar tipos de resposta
     # Caso 1: listagem de processos
     if soup.find('div', id='listagemDeProcessos'):
@@ -78,8 +78,8 @@ def _cposg_download_html_single(id_cnj, session, u_base, download_path):
             safe_codigo = safe_path_component(codigo, field="processo.codigo")
             show_url = f"{u_base}cposg/show.do?processo.codigo={codigo}"
             r_show = session.get(show_url)
-            file_name = os.path.join(path, f"{id_clean}_cd_processo_{safe_codigo}.html")
-            with open(file_name, 'w', encoding='utf-8') as f:
+            file_name = Path(path) / f"{id_clean}_cd_processo_{safe_codigo}.html"
+            with file_name.open('w', encoding='utf-8') as f:
                 f.write(r_show.text)
     # Caso 2: incidentes/modal
     elif soup.find('div', id='modalIncidentes'):
@@ -88,8 +88,8 @@ def _cposg_download_html_single(id_cnj, session, u_base, download_path):
             safe_codigo = safe_path_component(codigo, field="processo.codigo")
             show_url = f"{u_base}cposg/show.do?processo.codigo={codigo}"
             r_show = session.get(show_url)
-            file_name = os.path.join(path, f"{id_clean}_cd_processo_{safe_codigo}.html")
-            with open(file_name, 'w', encoding='utf-8') as f:
+            file_name = Path(path) / f"{id_clean}_cd_processo_{safe_codigo}.html"
+            with file_name.open('w', encoding='utf-8') as f:
                 f.write(r_show.text)
     # Caso 3: resposta simples — o id vem do input[name=cdProcesso] (nao de
     # processo.codigo como nos casos 1/2), dai field="cdProcesso".
@@ -100,8 +100,8 @@ def _cposg_download_html_single(id_cnj, session, u_base, download_path):
             value = input_cd.get('value')
             codigo_simples = str(value) if value is not None else None
         codigo_part = safe_path_component(codigo_simples, field="cdProcesso") if codigo_simples else "simples"
-        file_name = os.path.join(path, f"{id_clean}_cd_processo_{codigo_part}.html")
-        with open(file_name, 'w', encoding='utf-8') as f:
+        file_name = Path(path) / f"{id_clean}_cd_processo_{codigo_part}.html"
+        with file_name.open('w', encoding='utf-8') as f:
             f.write(r.text)
     return path
 
@@ -118,12 +118,12 @@ def cposg_download_api(id_cnj_list, session, api_base, download_path, sleep_time
         id_clean = clean_cnj(id_cnj)
         u = f"{api_base}{endpoint}{id_clean}"
         path = f"{download_path}/cposg/{id_clean}"
-        if not os.path.isdir(path):
-            os.makedirs(path)
+        if not Path(path).is_dir():
+            Path(path).mkdir(parents=True)
         r = session.get(u)
         if r.status_code != 200:
             raise RuntimeError(f"A consulta à API falhou. Status code {r.status_code}.")
-        with open(f"{path}/{id_clean}.json", 'w', encoding='utf-8') as f:
+        with Path(f"{path}/{id_clean}.json").open('w', encoding='utf-8') as f:
             f.write(r.text)
         paths.append(path)
         time.sleep(sleep_time)

--- a/src/juscraper/courts/tjsp/cposg_parse.py
+++ b/src/juscraper/courts/tjsp/cposg_parse.py
@@ -1,10 +1,9 @@
 """
 Parses downloaded files from the TJSP Consulta de Processos Originarios do Primeiro Grau (CPOSG).
 """
-import glob
 import logging
-import os
 import re
+from pathlib import Path
 
 import pandas as pd
 from bs4 import BeautifulSoup
@@ -17,7 +16,7 @@ def cposg_parse(path: str):
     """
     Parses all HTML files in the given directory.
     """
-    arquivos = glob.glob(os.path.join(path, '**/*.html'), recursive=True)
+    arquivos = list(Path(path).rglob('*.html'))
     dados = []
     for arq in tqdm(arquivos, total=len(arquivos), desc="Processando arquivos"):
         try:
@@ -34,7 +33,7 @@ def cposg_parse_manager(path: str):
     """
     Standalone parse manager for CPOSG HTML files. Returns a DataFrame with parsed data.
     """
-    arquivos = glob.glob(os.path.join(path, '**/*.html'), recursive=True)
+    arquivos = list(Path(path).rglob('*.html'))
     dados = []
     for arq in tqdm(arquivos, total=len(arquivos), desc="Processando arquivos"):
         try:
@@ -56,7 +55,7 @@ def cposg_parse_single_html(html_path):
     """
     Parses a single HTML document from CPOSG.
     """
-    with open(html_path, 'r', encoding='utf-8') as f:
+    with Path(html_path).open('r', encoding='utf-8') as f:
         html_content = f.read()
     soup = BeautifulSoup(html_content, 'html.parser')
     # Validate if the HTML contains expected content

--- a/src/juscraper/courts/trf1/client.py
+++ b/src/juscraper/courts/trf1/client.py
@@ -9,8 +9,8 @@ divergences live entirely in :data:`BASE_URL`.
 from __future__ import annotations
 
 import logging
-import os
 import time
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -245,7 +245,7 @@ class TRF1Scraper(BaseScraper):
         pecas_paths: list[list[str]] | None = None
         if download_pecas:
             base_dir = diretorio if diretorio is not None else self.download_path
-            os.makedirs(base_dir, exist_ok=True)
+            Path(base_dir).mkdir(parents=True, exist_ok=True)
             pecas_paths = self._download_pecas(htmls, cnjs, base_dir)
         df = self.cpopg_parse(htmls, cnjs)
         if pecas_paths is not None:
@@ -270,8 +270,8 @@ class TRF1Scraper(BaseScraper):
                 results.append([])
                 continue
             urls = extract_documento_urls(html)
-            proc_dir = os.path.join(base_dir, cnj)
-            os.makedirs(proc_dir, exist_ok=True)
+            proc_dir = str(Path(base_dir) / cnj)
+            Path(proc_dir).mkdir(parents=True, exist_ok=True)
             paths: list[str] = []
             for ca, doc_id in urls:
                 try:
@@ -283,8 +283,8 @@ class TRF1Scraper(BaseScraper):
                         "Erro ao baixar peça %s do %s: %s", doc_id, cnj, exc
                     )
                     continue
-                path = os.path.join(proc_dir, f"{doc_id}.html")
-                with open(path, "wb") as fh:
+                path = str(Path(proc_dir) / f"{doc_id}.html")
+                with Path(path).open("wb") as fh:
                     fh.write(content)
                 paths.append(path)
                 if self.sleep_time:

--- a/src/juscraper/courts/trf3/client.py
+++ b/src/juscraper/courts/trf3/client.py
@@ -9,8 +9,8 @@ are tuned to pass that challenge.
 from __future__ import annotations
 
 import logging
-import os
 import time
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -245,7 +245,7 @@ class TRF3Scraper(BaseScraper):
         pecas_paths: list[list[str]] | None = None
         if download_pecas:
             base_dir = diretorio if diretorio is not None else self.download_path
-            os.makedirs(base_dir, exist_ok=True)
+            Path(base_dir).mkdir(parents=True, exist_ok=True)
             pecas_paths = self._download_pecas(htmls, cnjs, base_dir)
         df = self.cpopg_parse(htmls, cnjs)
         if pecas_paths is not None:
@@ -270,8 +270,8 @@ class TRF3Scraper(BaseScraper):
                 results.append([])
                 continue
             urls = extract_documento_urls(html)
-            proc_dir = os.path.join(base_dir, cnj)
-            os.makedirs(proc_dir, exist_ok=True)
+            proc_dir = str(Path(base_dir) / cnj)
+            Path(proc_dir).mkdir(parents=True, exist_ok=True)
             paths: list[str] = []
             for ca, doc_id in urls:
                 try:
@@ -283,8 +283,8 @@ class TRF3Scraper(BaseScraper):
                         "Erro ao baixar peça %s do %s: %s", doc_id, cnj, exc
                     )
                     continue
-                path = os.path.join(proc_dir, f"{doc_id}.html")
-                with open(path, "wb") as fh:
+                path = str(Path(proc_dir) / f"{doc_id}.html")
+                with Path(path).open("wb") as fh:
                     fh.write(content)
                 paths.append(path)
                 if self.sleep_time:

--- a/src/juscraper/courts/trf5/client.py
+++ b/src/juscraper/courts/trf5/client.py
@@ -8,8 +8,8 @@ markup, but the ``executarReCaptcha()`` JS function short-circuits with
 from __future__ import annotations
 
 import logging
-import os
 import time
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
@@ -244,7 +244,7 @@ class TRF5Scraper(BaseScraper):
         pecas_paths: list[list[str]] | None = None
         if download_pecas:
             base_dir = diretorio if diretorio is not None else self.download_path
-            os.makedirs(base_dir, exist_ok=True)
+            Path(base_dir).mkdir(parents=True, exist_ok=True)
             pecas_paths = self._download_pecas(htmls, cnjs, base_dir)
         df = self.cpopg_parse(htmls, cnjs)
         if pecas_paths is not None:
@@ -269,8 +269,8 @@ class TRF5Scraper(BaseScraper):
                 results.append([])
                 continue
             urls = extract_documento_urls(html)
-            proc_dir = os.path.join(base_dir, cnj)
-            os.makedirs(proc_dir, exist_ok=True)
+            proc_dir = str(Path(base_dir) / cnj)
+            Path(proc_dir).mkdir(parents=True, exist_ok=True)
             paths: list[str] = []
             for ca, doc_id in urls:
                 try:
@@ -282,8 +282,8 @@ class TRF5Scraper(BaseScraper):
                         "Erro ao baixar peça %s do %s: %s", doc_id, cnj, exc
                     )
                     continue
-                path = os.path.join(proc_dir, f"{doc_id}.html")
-                with open(path, "wb") as fh:
+                path = str(Path(proc_dir) / f"{doc_id}.html")
+                with Path(path).open("wb") as fh:
                     fh.write(content)
                 paths.append(path)
                 if self.sleep_time:

--- a/src/juscraper/courts/trf6/download.py
+++ b/src/juscraper/courts/trf6/download.py
@@ -23,9 +23,9 @@ from __future__ import annotations
 
 import base64
 import logging
-import os
 import re
 import tempfile
+from pathlib import Path
 
 import requests
 
@@ -105,7 +105,7 @@ def solve_captcha(captcha_b64: str) -> str:
     try:
         return str(txtcaptcha.decrypt([tmp_path])[0])
     finally:
-        os.unlink(tmp_path)
+        Path(tmp_path).unlink()
 
 
 def build_search_payload(numero_processo: str, captcha_text: str) -> dict[str, str]:

--- a/tests/tjmg/test_cjsg_download_granular.py
+++ b/tests/tjmg/test_cjsg_download_granular.py
@@ -18,6 +18,7 @@ import os
 import re
 import sys
 import tempfile
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -291,7 +292,7 @@ class TestSolveCaptchaTempFile:
             seen["path"] = path
             seen["kwargs"] = kwargs
             # Durante o decrypt o arquivo ainda existe (cleanup so no finally).
-            seen["exists_during"] = os.path.exists(path)
+            seen["exists_during"] = Path(path).exists()
             return ["12345"]
 
         fake = MagicMock()
@@ -312,9 +313,9 @@ class TestSolveCaptchaTempFile:
         assert seen["kwargs"] == {"mask": "[0-9]", "length": 5}
 
         path = seen["path"]
-        basename = os.path.basename(path)
+        basename = Path(path).name
         # (1) sob o tempdir do sistema, com o prefixo esperado.
-        assert os.path.realpath(os.path.dirname(path)) == os.path.realpath(
+        assert os.path.realpath(Path(path).parent) == os.path.realpath(
             tempfile.gettempdir()
         )
         assert basename.startswith("tjmg_captcha_")
@@ -323,4 +324,4 @@ class TestSolveCaptchaTempFile:
         assert not re.fullmatch(r"tjmg_captcha_\d+\.png", basename)
         # (3) existia durante o decrypt, removido depois (cleanup no finally).
         assert seen["exists_during"] is True
-        assert not os.path.exists(path)
+        assert not Path(path).exists()

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -2,8 +2,8 @@
 Tests for TJSP CJPG functionality.
 Includes both integration and unit tests.
 """
-import os
 import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -136,19 +136,19 @@ class TestCJPGUnit:
             assert 'Procedimento do Juizado Especial Cível' in df.iloc[0].get('classe', '')
             assert 'decisao' in df.columns
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_cjpg_parse_manager_directory(self):
         """Test parsing multiple CJPG files from directory."""
         html = load_sample('tjsp', 'cjpg/results_legacy.html')
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            file1 = os.path.join(temp_dir, 'page1.html')
-            file2 = os.path.join(temp_dir, 'page2.html')
+            file1 = Path(temp_dir) / 'page1.html'
+            file2 = Path(temp_dir) / 'page2.html'
 
-            with open(file1, 'w', encoding='utf-8') as f:
+            with file1.open('w', encoding='utf-8') as f:
                 f.write(html)
-            with open(file2, 'w', encoding='utf-8') as f:
+            with file2.open('w', encoding='utf-8') as f:
                 f.write(html)
 
             df = cjpg_parse_manager(temp_dir)
@@ -170,7 +170,7 @@ class TestCJPGUnit:
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 0
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
 
 class TestCJPGNResults:
@@ -225,7 +225,7 @@ class TestCJPGDownload1Based:
                 paginas=paginas,
                 get_n_pags_callback=get_n_pags_callback,
             )
-            saved_files = sorted(os.listdir(path))
+            saved_files = sorted(p.name for p in Path(path).iterdir())
             # Collect URLs from session.get calls (skip first which is pesquisar.do)
             get_calls = mock_session.get.call_args_list
             trocar_urls = [c[0][0] for c in get_calls[1:] if 'trocarDePagina' in c[0][0]]

--- a/tests/tjsp/test_cjsg_unit.py
+++ b/tests/tjsp/test_cjsg_unit.py
@@ -1,8 +1,8 @@
 """
 Unit tests for TJSP CJSG functionality using mocked HTML responses.
 """
-import os
 import tempfile
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -120,7 +120,7 @@ class TestCJSGParseSinglePage:
             assert df.iloc[1]['processo'] == '1000124-46.2023.8.26.0101'
             assert df.iloc[1]['cd_acordao'] == '12346'
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_single_result(self):
         """Test parsing a page with a single result."""
@@ -141,7 +141,7 @@ class TestCJSGParseSinglePage:
             assert 'Apelação Cível' in df.iloc[0].get('classe', '')
             assert 'ementa' in df.columns
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_empty_page(self):
         """Test parsing an empty results page."""
@@ -156,7 +156,7 @@ class TestCJSGParseSinglePage:
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 0
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_missing_elements(self):
         """Test parsing page with missing elements."""
@@ -189,7 +189,7 @@ class TestCJSGParseSinglePage:
             # Should still create a row, but without process number
             assert len(df) >= 0
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
 
 class TestCJSGParseManager:
@@ -201,12 +201,12 @@ class TestCJSGParseManager:
         html2 = load_sample('tjsp', 'cjsg/single_result.html')
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            file1 = os.path.join(temp_dir, 'page1.html')
-            file2 = os.path.join(temp_dir, 'page2.html')
+            file1 = Path(temp_dir) / 'page1.html'
+            file2 = Path(temp_dir) / 'page2.html'
 
-            with open(file1, 'w', encoding='utf-8') as f:
+            with file1.open('w', encoding='utf-8') as f:
                 f.write(html1)
-            with open(file2, 'w', encoding='utf-8') as f:
+            with file2.open('w', encoding='utf-8') as f:
                 f.write(html2)
 
             df = cjsg_parse_manager(temp_dir)
@@ -228,7 +228,7 @@ class TestCJSGParseManager:
             assert isinstance(df, pd.DataFrame)
             assert len(df) == 2
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_empty_directory(self):
         """Test parsing an empty directory."""
@@ -242,13 +242,13 @@ class TestCJSGParseManager:
         html = load_sample('tjsp', 'cjsg/results_normal.html')
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            valid_file = os.path.join(temp_dir, 'valid.html')
-            invalid_file = os.path.join(temp_dir, 'invalid.html')
+            valid_file = Path(temp_dir) / 'valid.html'
+            invalid_file = Path(temp_dir) / 'invalid.html'
 
-            with open(valid_file, 'w', encoding='utf-8') as f:
+            with valid_file.open('w', encoding='utf-8') as f:
                 f.write(html)
             # Create an invalid file (binary data)
-            with open(invalid_file, 'wb') as f:
+            with invalid_file.open('wb') as f:
                 f.write(b'\x00\x01\x02\x03')
 
             # Should not raise exception, should skip invalid file

--- a/tests/tjsp/test_cpopg.py
+++ b/tests/tjsp/test_cpopg.py
@@ -2,8 +2,8 @@
 Tests for TJSP CPOPG functionality.
 Includes both integration and unit tests.
 """
-import os
 import tempfile
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -182,7 +182,7 @@ class TestCPOPGUnit:
             # Check peticoes
             assert len(result['peticoes_diversas']) == 2
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_cpopg_parse_manager_directory(self):
         """Test parsing multiple CPOPG files from directory."""
@@ -196,12 +196,12 @@ class TestCPOPGUnit:
         '''
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            file1 = os.path.join(temp_dir, 'process1.html')
-            file2 = os.path.join(temp_dir, 'process2.html')
+            file1 = Path(temp_dir) / 'process1.html'
+            file2 = Path(temp_dir) / 'process2.html'
 
-            with open(file1, 'w', encoding='utf-8') as f:
+            with file1.open('w', encoding='utf-8') as f:
                 f.write(html)
-            with open(file2, 'w', encoding='utf-8') as f:
+            with file2.open('w', encoding='utf-8') as f:
                 f.write(html.replace('1000149', '1000150'))
 
             result = cpopg_parse_manager(temp_dir)
@@ -228,7 +228,7 @@ class TestCPOPGUnit:
             assert len(result['partes']) == 0
             assert len(result['movimentacoes']) == 0
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
 
     def test_parse_alternative_template(self):
@@ -280,7 +280,7 @@ class TestCPOPGUnit:
             assert basicos['foro'] == 'Foro de São José dos Campos'
             assert basicos['vara'] == 'Anexo do Juizado Especial'
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_extra_fields_standard_template(self):
         """Test extra fields (Outros assuntos, Controle) are captured in standard template."""
@@ -339,7 +339,7 @@ class TestCPOPGUnit:
             assert basicos['area'] == 'Cível'
             assert basicos['outros_assuntos'] == 'ICMS/ Imposto sobre Circulação de Mercadorias'
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_alternative_template_with_processo_principal(self):
         """Test incidente template captures Processo principal field."""
@@ -415,7 +415,7 @@ class TestCPOPGUnit:
             assert basicos['controle'] == '2024/001363'
             assert basicos['area'] == 'Cível'
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_alternative_template_from_sample(self):
         """Test parsing the alternative template sample HTML file."""
@@ -441,7 +441,7 @@ class TestCPOPGUnit:
             assert len(result['partes']) == 1
             assert len(result['movimentacoes']) == 1
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_parse_standard_template_from_sample(self):
         """Test parsing the standard template sample HTML file with extra fields."""
@@ -466,7 +466,7 @@ class TestCPOPGUnit:
             assert basicos['area'] == 'Cível'
             assert basicos['outros_assuntos'] == 'ICMS/ Imposto sobre Circulação de Mercadorias'
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
 
 if __name__ == "__main__":

--- a/tests/tjsp/test_cposg.py
+++ b/tests/tjsp/test_cposg.py
@@ -2,8 +2,8 @@
 Tests for TJSP CPOSG functionality.
 Includes both integration and unit tests.
 """
-import os
 import tempfile
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -128,7 +128,7 @@ class TestCPOSGUnit:
             assert isinstance(row['movimentacoes'], list)
             assert len(row['movimentacoes']) == 2
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_cposg_parse_manager_directory(self):
         """Test parsing multiple CPOSG files from directory."""
@@ -149,12 +149,12 @@ class TestCPOSGUnit:
         '''
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            file1 = os.path.join(temp_dir, 'process1.html')
-            file2 = os.path.join(temp_dir, 'process2.html')
+            file1 = Path(temp_dir) / 'process1.html'
+            file2 = Path(temp_dir) / 'process2.html'
 
-            with open(file1, 'w', encoding='utf-8') as f:
+            with file1.open('w', encoding='utf-8') as f:
                 f.write(html)
-            with open(file2, 'w', encoding='utf-8') as f:
+            with file2.open('w', encoding='utf-8') as f:
                 f.write(html.replace('1000149', '1000150'))
 
             result = cposg_parse_manager(temp_dir)
@@ -176,7 +176,7 @@ class TestCPOSGUnit:
             assert isinstance(result, list)
             assert len(result) == 0
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_cposg_parse_no_movement_table(self):
         """Test parsing CPOSG HTML without movement table."""
@@ -198,7 +198,7 @@ class TestCPOSGUnit:
             assert isinstance(result, list)
             assert len(result) == 0
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
     def test_cposg_parse_with_parts_and_decisions(self):
         """Test parsing CPOSG HTML with parts and decisions."""
@@ -250,7 +250,7 @@ class TestCPOSGUnit:
             assert isinstance(row['partes'], list)
             assert isinstance(row['decisoes'], list)
         finally:
-            os.unlink(temp_path)
+            Path(temp_path).unlink()
 
 
 if __name__ == "__main__":

--- a/tests/trf1/test_cpopg_pecas_contract.py
+++ b/tests/trf1/test_cpopg_pecas_contract.py
@@ -5,7 +5,7 @@ Mirrors the TRF3 suite — the three TRF PJe deployments share the same
 """
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 import pytest
 import responses
@@ -92,4 +92,4 @@ def test_cpopg_with_download_pecas_writes_files_and_adds_column(tmp_path) -> Non
     saved = df.iloc[0]["pecas"]
     assert len(saved) == n_pecas
     for p in saved:
-        assert os.path.isfile(p)
+        assert Path(p).is_file()

--- a/tests/trf3/test_cpopg_integration.py
+++ b/tests/trf3/test_cpopg_integration.py
@@ -71,8 +71,8 @@ def test_cpopg_download_pecas_grava_arquivos(tmp_path) -> None:
     assert "pecas" in df.columns
     saved = df.iloc[0]["pecas"]
     assert saved, "processo conhecido deveria ter ao menos uma peça"
-    import os
+    from pathlib import Path
     for p in saved:
-        assert os.path.isfile(p)
-        assert os.path.getsize(p) > 0
+        assert Path(p).is_file()
+        assert Path(p).stat().st_size > 0
         assert p.endswith(".html")

--- a/tests/trf3/test_cpopg_pecas_contract.py
+++ b/tests/trf3/test_cpopg_pecas_contract.py
@@ -8,7 +8,7 @@ links, ``cpopg`` extracts them and issues one GET per peça when invoked with
 """
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 import pytest
 import responses
@@ -143,9 +143,9 @@ def test_cpopg_with_download_pecas_writes_files_and_adds_column(tmp_path) -> Non
     saved = df.iloc[0]["pecas"]
     assert len(saved) == 2
     for p in saved:
-        assert os.path.isfile(p)
+        assert Path(p).is_file()
         assert p.endswith(".html")
-        with open(p, "rb") as fh:
+        with Path(p).open("rb") as fh:
             assert fh.read() == doc_body
     # Layout: <tmp>/<cnj>/<id>.html
     proc_dir = tmp_path / "50059460920254036324"
@@ -215,4 +215,4 @@ def test_cpopg_with_download_pecas_continues_after_peca_error(tmp_path) -> None:
     saved = df.iloc[0]["pecas"]
     # Só a segunda peça foi salva.
     assert len(saved) == 1
-    assert os.path.isfile(saved[0])
+    assert Path(saved[0]).is_file()

--- a/tests/trf5/test_cpopg_pecas_contract.py
+++ b/tests/trf5/test_cpopg_pecas_contract.py
@@ -5,7 +5,7 @@ Mirrors the TRF3 suite — the three TRF PJe deployments share the same
 """
 from __future__ import annotations
 
-import os
+from pathlib import Path
 
 import pytest
 import responses
@@ -89,4 +89,4 @@ def test_cpopg_with_download_pecas_writes_files_and_adds_column(tmp_path) -> Non
     saved = df.iloc[0]["pecas"]
     assert len(saved) == n_pecas
     for p in saved:
-        assert os.path.isfile(p)
+        assert Path(p).is_file()


### PR DESCRIPTION
## Contexto

PR 3/3 da #306, a maior frente. Liga `PTH` (flake8-use-pathlib) no `select` e zera os **137 achados** em `src` (87) e `tests` (50): migração de `os.path`/`open`/`glob`/`os.makedirs` para `pathlib`. É a única frente que mexe em **I/O real** — criar diretórios, abrir/escrever/remover/listar arquivos de download.

> **Stacked PR.** Base = `chore/ruff-perf` (#322). Mesclar #320 → #321 → #322 → este, nessa ordem. O diff aqui mostra **só** as mudanças de PTH.

Nota: o Ruff 0.15.x **não autofixa** as regras PTH (são display-only), então a migração foi **manual**, arquivo a arquivo — concentrada em TJSP download/parse, na família `_esaj`, nos clients TRF e nos testes que exercitam I/O.

## Conversões (comportamento preservado)

- `os.path.join` → `Path(a) / b` (com `str(...)` onde o consumidor exige str: retornos tipados `-> str`, f-strings, logging `%s`).
- `open(p, ...)` → `Path(p).open(...)`.
- `os.makedirs(p, exist_ok=True)` → `Path(p).mkdir(parents=True, exist_ok=True)` (**`parents=True`** preserva a recursividade do `makedirs`).
- `os.path.isdir/isfile/exists` → `Path(p).is_dir()/is_file()/exists()`.
- `os.path.dirname/basename/getsize` → `Path(p).parent` / `.name` / `.stat().st_size`.
- `os.unlink` → `Path(p).unlink()`; `os.listdir` → `Path(p).iterdir()`.
- `glob.glob(join(d, '**/*.html'), recursive=True)` → `Path(d).rglob('*.html')` (ordem de filesystem idêntica; `+is_file()` defensivo onde aplicável).

Critério `Path` vs `str`: onde o glob alimentava slicing/`endswith` de string, mantido `str(...)`; onde o consumidor só itera/abre, mantido `Path`.

## Verificação

- `uvx ruff@0.15.12 check src tests --select PTH` → **All checks passed!**
- `uvx ruff@0.15.12 check src tests` (todas as famílias) → **All checks passed!**
- `pre-commit run mypy` (arquivos alterados) → **Passed** (sem `Path` vazando onde `str` é esperado)
- `pre-commit run ruff/isort/flake8` → **Passed**
- `uv run pytest` → **1755 passed, 29 skipped** (inclui testes de download/parse que exercitam I/O real)

Sem entrada no CHANGELOG (tooling, sem efeito na API pública).

Refs #306.