### PR TITLE
docs: esclarecer limitações dos notebooks no Google Colab

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ Antes de refatorar um tribunal pela #84, ele precisa ter contratos passando. A c
 
 ### Notebooks como sanity check (`pytest --nbmake`)
 
-Os notebooks de exemplo em `docs/notebooks/<tribunal>.ipynb` exercitam o fluxo público de cada raspador (cjsg, cjpg, cpopg, cposg, listar_processos) com chamadas reais ao tribunal. Servem ao mesmo tempo como documentação executável (build do site Quarto) e como **canário de regressão pós-refactor** — pegam quebras visíveis ao usuário (parser quebrado, schema rejeitando input antes válido, coluna renomeada sem migração) que um teste granular pode mascarar.
+Os notebooks de exemplo em `docs/notebooks/<tribunal>.ipynb` exercitam o fluxo público de cada raspador (cjsg, cjpg, cpopg, cposg, listar_processos) com chamadas reais ao tribunal. Servem ao mesmo tempo como documentação executável (build do site Quarto) e como **canário de regressão pós-refactor** — pegam quebras visíveis ao usuário (parser quebrado, schema rejeitando input antes válido, coluna renomeada sem migração) que um teste granular pode mascarar. A execução local é o ambiente de referência; compatibilidade com o Google Colab ou outro provedor de notebooks em nuvem não integra os critérios de aceitação do projeto.
 
 Comando padrão (rodar localmente antes de release ou após refactor amplo):
 
@@ -133,6 +133,7 @@ pytest --nbmake docs/notebooks/ \
 Notas:
 
 - **Não rodar em `pre-commit` nem em CI por PR.** São 25 notebooks contra rede real (~10-30 min com `pytest-xdist`); flakiness de tribunal vai bloquear merge sem motivo. O lugar certo, se um dia entrar no CI, é o workflow nightly proposto em #101 com `continue-on-error`.
+- Falhas de conexão no Google Colab ou em outro ambiente de nuvem devem ser reproduzidas localmente antes de motivar mudanças em timeout, retry ou no scraper. Um `ConnectTimeout` sem resposta HTTP pode indicar bloqueio de IP compartilhado ou problema de rota; isoladamente, não demonstra regressão do `juscraper` nem bloqueio intencional pelo tribunal.
 - `jusbr.ipynb` é excluído porque depende de token gov.br (`JUSBR_ACCESS_TOKEN`); `tjmg.ipynb` depende do extra `[tjmg]` instalado (`txtcaptcha`). Ambos rodam sob demanda quando as condições estão presentes.
 - Falha 5xx em um único notebook normalmente é instabilidade do tribunal — re-rodar o notebook isolado antes de reportar regressão (`pytest --nbmake docs/notebooks/<tribunal>.ipynb`).
 - Quando o resultado real divergir do output cacheado (ex.: coluna nova, ementa em formato diferente), o notebook deve ser **commitado com outputs limpos** (`jupyter nbconvert --clear-output --inplace docs/notebooks/<tribunal>.ipynb`) para que `git diff` futuro fique focado em código.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ dados.head()
 
 ### Notebooks de Exemplo
 
+> [!WARNING]
+> **Ambiente de execução:** estes notebooks fazem requisições reais a serviços externos e não têm compatibilidade garantida com o Google Colab. Tribunais podem bloquear ou limitar IPs compartilhados de provedores de nuvem e datacenters, mesmo quando a mesma consulta funciona em uma conexão local. Alguns exemplos também dependem de CAPTCHA, tokens de acesso ou dependências opcionais. A execução local no Jupyter é o ambiente de referência do projeto; uma falha de conexão no Colab não indica, por si só, uma regressão do `juscraper`.
+
 - [Exemplo TJSP](docs/notebooks/tjsp.ipynb)
 - [Exemplo TJRS](docs/notebooks/tjrs.ipynb)
 - [Exemplo TJPR](docs/notebooks/tjpr.ipynb)

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -95,6 +95,12 @@ O método `.cjsg()` recebe como *input* parâmetros de busca de jurisprudência 
 
 ### Notebooks de Exemplo
 
+::: {.callout-warning}
+## Notebook runtime and Google Colab
+
+These notebooks send live requests to external services and are not guaranteed to work on Google Colab. Courts may block or throttle shared cloud and datacenter IP addresses even when the same request works from a local connection. Some examples also require CAPTCHA handling, access tokens, or optional dependencies. Local Jupyter execution is the project's reference environment; a connection failure on Colab does not, by itself, indicate a `juscraper` regression.
+:::
+
 - [Exemplo TJAC](notebooks/tjac.ipynb)
 - [Exemplo TJAL](notebooks/tjal.ipynb)
 - [Exemplo TJAM](notebooks/tjam.ipynb)


### PR DESCRIPTION
## Resumo

- informa no README que os notebooks fazem requisições reais e não têm compatibilidade garantida com o Google Colab
- define a execução local no Jupyter como ambiente de referência também na documentação do site
- orienta contribuidores a reproduzir falhas de ambientes em nuvem localmente antes de alterar timeout, retry ou scraper
- distingue `ConnectTimeout` ambiental de regressão do juscraper ou evidência conclusiva de bloqueio intencional

## Validação

- `git diff --check`
- `cd docs && quarto render index.qmd`
- revisão adversarial sem achados bloqueantes
- confirmado que os 31 notebooks e o `CHANGELOG.md` permaneceram inalterados

Closes #327
