### PR TITLE
refactor(esaj): decompõe parsers compartilhados

### DIFF
--- a/src/juscraper/courts/_esaj/parse.py
+++ b/src/juscraper/courts/_esaj/parse.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 import logging
 import re
 from pathlib import Path
+from typing import cast
 
 import pandas as pd
 import unidecode
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 from tqdm import tqdm
 
 logger = logging.getLogger("juscraper._esaj.parse")
@@ -31,6 +33,105 @@ _TYPO_FIXES = {
     "data_publicassapso": "data_publicacao",
     "argapso_julgador": "orgao_julgador",
 }
+
+_ERROR_CLASS_RE = re.compile(r"error|erro|mensagem.*erro", re.I)
+_FORM_ID_RE = re.compile(r"form|consulta", re.I)
+_PAGINATION_CLASS_RE = re.compile(r".*pag.*", re.I)
+_RESULT_TABLE_CLASS_RE = re.compile(r"fundocinza|resultado", re.I)
+_PAGINATION_COUNT_PATTERNS = (
+    re.compile(r"\d+$"),
+    re.compile(r"(?<=de )\d+"),
+    re.compile(r"\d+(?=\s*(?:resultado|registro|página))", re.I),
+)
+_FIELD_STAMPS = {
+    "data_publicacao": (
+        "Data de publicação:",
+        "Data de Publicação:",
+        "Data de publicassapso:",
+    ),
+    "orgao_julgador": (
+        "Órgão julgador:",
+        "Orgão julgador:",
+        "argapso julgador:",
+    ),
+}
+
+
+def _raise_page_error(soup: BeautifulSoup) -> None:
+    error_divs = soup.find_all(["div", "span", "p"], class_=_ERROR_CLASS_RE)
+    if not error_divs:
+        return
+
+    error_text = " ".join(elem.get_text().lower() for elem in error_divs[:3])
+    if "captcha" in error_text or "verificação" in error_text:
+        raise ValueError(
+            "Captcha não foi resolvido. A página pode requerer verificação manual."
+        )
+
+    error_msg = " ".join(elem.get_text() for elem in error_divs[:3]).strip()
+    if error_msg:
+        raise ValueError(f"Erro detectado na página: {error_msg[:200]}")
+
+
+def _has_zero_results(soup: BeautifulSoup) -> bool:
+    page_text = soup.get_text().lower()
+    return any(marker in page_text for marker in _ZERO_RESULT_MARKERS)
+
+
+def _find_short_results_cell(soup: BeautifulSoup) -> Tag | None:
+    for cell in soup.find_all("td"):
+        text = cell.get_text()
+        if "resultados" in text.lower() and len(text.strip()) < 400:
+            return cell
+    return None
+
+
+def _find_page_summary_cell(soup: BeautifulSoup) -> Tag | None:
+    for cell in soup.find_all("td"):
+        text = cell.get_text().lower()
+        if "página" in text and ("de" in text or "total" in text):
+            return cell
+    return None
+
+
+def _find_pagination_element(soup: BeautifulSoup) -> Tag | None:
+    return (
+        _find_short_results_cell(soup)
+        or soup.find("td", bgcolor="#EEEEEE")
+        or soup.find("td", class_=_PAGINATION_CLASS_RE)
+        or _find_page_summary_cell(soup)
+    )
+
+
+def _count_result_rows_or_raise(soup: BeautifulSoup) -> int:
+    results_table = soup.find("table", class_=_RESULT_TABLE_CLASS_RE)
+    if results_table is not None:
+        n_rows = len(soup.find_all("tr", class_="fundocinza1"))
+        return max(n_rows, 1)
+
+    if soup.find("form", id=_FORM_ID_RE):
+        raise ValueError(
+            "Ainda na página de consulta. "
+            "O formulário pode não ter sido submetido corretamente."
+        )
+    raise ValueError(
+        "Não foi possível encontrar o seletor de número de páginas "
+        "na resposta HTML. Verifique se a busca retornou resultados "
+        "ou se a estrutura da página mudou."
+    )
+
+
+def _extract_pagination_count(text: str) -> int | None:
+    stripped_text = text.strip()
+    for pattern in _PAGINATION_COUNT_PATTERNS:
+        match = pattern.search(stripped_text)
+        if match is not None:
+            return int(match.group())
+
+    all_numbers = re.findall(r"\d+", text)
+    if all_numbers:
+        return max(int(number) for number in all_numbers)
+    return None
 
 
 def cjsg_n_results(html_source: str) -> int:
@@ -64,85 +165,22 @@ def cjsg_n_results(html_source: str) -> int:
     """
     soup = BeautifulSoup(html_source, "html.parser")
 
-    # eSAJ returns an HTTP 200 page with error divs when the captcha expires
-    # or validation fails. Surface a specific error instead of letting the
-    # cascade below raise a confusing "seletor não encontrado".
-    error_divs = soup.find_all(
-        ["div", "span", "p"], class_=re.compile(r"error|erro|mensagem.*erro", re.I)
-    )
-    if error_divs:
-        error_text = " ".join(elem.get_text().lower() for elem in error_divs[:3])
-        if "captcha" in error_text or "verificação" in error_text:
-            raise ValueError(
-                "Captcha não foi resolvido. A página pode requerer verificação manual."
-            )
-        error_msg = " ".join(elem.get_text() for elem in error_divs[:3]).strip()
-        if error_msg:
-            raise ValueError(f"Erro detectado na página: {error_msg[:200]}")
-
-    page_text = soup.get_text().lower()
-    if any(marker in page_text for marker in _ZERO_RESULT_MARKERS):
+    _raise_page_error(soup)
+    if _has_zero_results(soup):
         return 0
 
-    td_npags = None
-    for td in soup.find_all("td"):
-        td_text = td.get_text()
-        # guard against matching result rows with the 400-char length check
-        if ("Resultados" in td_text or "resultados" in td_text.lower()) and len(td_text.strip()) < 400:
-            td_npags = td
-            break
+    pagination_element = _find_pagination_element(soup)
+    if pagination_element is None:
+        return _count_result_rows_or_raise(soup)
 
-    if td_npags is None:
-        td_npags = soup.find("td", bgcolor="#EEEEEE")
-
-    if td_npags is None:
-        td_npags = soup.find("td", class_=re.compile(r".*pag.*", re.I))
-
-    if td_npags is None:
-        for td in soup.find_all("td"):
-            td_text = td.get_text().lower()
-            if "página" in td_text and ("de" in td_text or "total" in td_text):
-                td_npags = td
-                break
-
-    if td_npags is None:
-        results_table = soup.find("table", class_=re.compile(r"fundocinza|resultado", re.I))
-        if results_table is None:
-            if soup.find("form", id=re.compile(r"form|consulta", re.I)):
-                raise ValueError(
-                    "Ainda na página de consulta. "
-                    "O formulário pode não ter sido submetido corretamente."
-                )
-            raise ValueError(
-                "Não foi possível encontrar o seletor de número de páginas "
-                "na resposta HTML. Verifique se a busca retornou resultados "
-                "ou se a estrutura da página mudou."
-            )
-        # Pagination marker missing but results table present: count the
-        # result rows (eSAJ uses ``tr.fundocinza1`` for each hit). Minimum
-        # of 1 when the table exists but the row class differs.
-        n_rows = len(soup.find_all("tr", class_="fundocinza1"))
-        return max(n_rows, 1)
-
-    txt_pag = td_npags.get_text()
-
-    encontrados = re.findall(r"\d+$", txt_pag.strip())
-    if not encontrados:
-        encontrados = re.findall(r"(?<=de )\d+", txt_pag)
-    if not encontrados:
-        encontrados = re.findall(r"\d+(?=\s*(?:resultado|registro|página))", txt_pag, flags=re.I)
-    if not encontrados:
-        all_nums = re.findall(r"\d+", txt_pag)
-        if all_nums:
-            encontrados = [max(all_nums, key=int)]
-
-    if not encontrados:
+    pagination_text = pagination_element.get_text()
+    count = _extract_pagination_count(pagination_text)
+    if count is None:
         raise ValueError(
             "Não foi possível extrair o número de resultados da paginação. "
-            f"Formato inesperado encontrado. Texto: {txt_pag[:100]}"
+            f"Formato inesperado encontrado. Texto: {pagination_text[:100]}"
         )
-
-    return int(encontrados[0])
+    return count
 
 
 def cjsg_n_pags(html_source: str) -> int:
@@ -174,92 +212,112 @@ def _normalize_key(label: str) -> str:
 
 def _clean_value(value: str) -> str:
     return (
-        value
-        .replace("\xad", "")       # soft hyphen
-        .replace("\u200b", "")    # zero-width space
-        .replace("\u200c", "")    # zero-width non-joiner
-        .replace("\u200d", "")    # zero-width joiner
+        value.replace("\xad", "")  # soft hyphen
+        .replace("\u200b", "")  # zero-width space
+        .replace("\u200c", "")  # zero-width non-joiner
+        .replace("\u200d", "")  # zero-width joiner
     )
 
 
-def _parse_single_page(path: str) -> pd.DataFrame:
-    with Path(path).open("rb") as fp:
-        raw = fp.read()
-
+def _read_html(path: str) -> str:
+    raw = Path(path).read_bytes()
     try:
-        content = raw.decode("utf-8")
+        return raw.decode("utf-8")
     except UnicodeDecodeError:
-        try:
-            content = raw.decode("latin1")
-        except UnicodeDecodeError:
-            content = raw.decode("utf-8", errors="replace")
+        return raw.decode("latin1")
+
+
+def _extract_process_metadata(details_table: Tag, data: dict) -> None:
+    process_link = details_table.find("a", class_="esajLinkLogin downloadEmenta")
+    if process_link is None:
+        return
+
+    data["processo"] = process_link.get_text(strip=True)
+    data["cd_acordao"] = process_link.get("cdacordao")
+    data["cd_foro"] = process_link.get("cdforo")
+
+
+def _extract_ementa(detail_row: Tag) -> str:
+    for div in detail_row.find_all("div", align="justify"):
+        style = str(div.get("style", "display: none;"))
+        if "display: none" not in style:
+            text = cast(str, div.get_text(" ", strip=True))
+            return text.replace("Ementa:", "").strip()
+    text = cast(str, detail_row.get_text(" ", strip=True))
+    return text.replace("Ementa:", "").strip()
+
+
+def _canonicalize_field(key: str, value: str) -> tuple[str, str]:
+    for canonical_key, stamps in _FIELD_STAMPS.items():
+        if canonical_key not in key:
+            continue
+        for stamp in stamps:
+            value = value.replace(stamp, "")
+        return canonical_key, value.strip()
+    return key, value
+
+
+def _extract_labeled_value(detail_row: Tag, label: str) -> tuple[str, str] | None:
+    full_text = detail_row.get_text(" ", strip=True)
+    value = _clean_value(full_text.replace(label, "", 1).strip().lstrip(":").strip())
+    key = _normalize_key(label)
+    if key == "outros_numeros":
+        return None
+    return _canonicalize_field(key, value)
+
+
+def _extract_detail(detail_row: Tag, data: dict) -> None:
+    strong = detail_row.find("strong")
+    if strong is None:
+        return
+
+    label = strong.get_text(strip=True)
+    if "ementa:" in label.lower():
+        data["ementa"] = _extract_ementa(detail_row)
+        return
+
+    labeled_value = _extract_labeled_value(detail_row, label)
+    if labeled_value is not None:
+        key, value = labeled_value
+        data[key] = value
+
+
+def _parse_result_row(result_row: Tag) -> dict | None:
+    cells = result_row.find_all("td")
+    if len(cells) < 2:
+        return None
+
+    details_table = cells[1].find("table")
+    if details_table is None:
+        return None
+
+    data: dict = {"ementa": ""}
+    _extract_process_metadata(details_table, data)
+    for detail_row in details_table.find_all("tr", class_="ementaClass2"):
+        _extract_detail(detail_row, data)
+    return data
+
+
+def _to_dataframe(processes: list[dict]) -> pd.DataFrame:
+    dataframe = pd.DataFrame(processes)
+    if "ementa" not in dataframe.columns:
+        return dataframe
+    columns = [column for column in dataframe.columns if column != "ementa"]
+    return dataframe[[*columns, "ementa"]]
+
+
+def _parse_single_page(path: str) -> pd.DataFrame:
+    content = _read_html(path)
 
     soup = BeautifulSoup(content, "html.parser")
     processos: list[dict] = []
 
-    for tr in soup.find_all("tr", class_="fundocinza1"):
-        tds = tr.find_all("td")
-        if len(tds) < 2:
-            continue
+    for result_row in soup.find_all("tr", class_="fundocinza1"):
+        process = _parse_result_row(result_row)
+        if process is not None:
+            processos.append(process)
 
-        details_table = tds[1].find("table")
-        if not details_table:
-            continue
-
-        dados: dict = {"ementa": ""}
-
-        proc_a = details_table.find("a", class_="esajLinkLogin downloadEmenta")
-        if proc_a:
-            dados["processo"] = proc_a.get_text(strip=True)
-            dados["cd_acordao"] = proc_a.get("cdacordao")
-            dados["cd_foro"] = proc_a.get("cdforo")
-
-        for tr_detail in details_table.find_all("tr", class_="ementaClass2"):
-            strong = tr_detail.find("strong")
-            if not strong:
-                continue
-            label = strong.get_text(strip=True)
-
-            if "ementa:" in label.lower():
-                visible_div = None
-                for div in tr_detail.find_all("div", align="justify"):
-                    style = str(div.get("style", "display: none;"))
-                    if "display: none" not in style:
-                        visible_div = div
-                        break
-                if visible_div:
-                    ementa_text = visible_div.get_text(" ", strip=True)
-                else:
-                    ementa_text = tr_detail.get_text(" ", strip=True)
-                dados["ementa"] = ementa_text.replace("Ementa:", "").strip()
-                continue
-
-            full_text = tr_detail.get_text(" ", strip=True)
-            value = _clean_value(full_text.replace(label, "", 1).strip().lstrip(":").strip())
-
-            key = _normalize_key(label)
-            if key == "outros_numeros":
-                continue
-            if "data_publicacao" in key:
-                key = "data_publicacao"
-                for stamp in ("Data de publicação:", "Data de Publicação:", "Data de publicassapso:"):
-                    value = value.replace(stamp, "")
-                value = value.strip()
-            elif "orgao_julgador" in key:
-                key = "orgao_julgador"
-                for stamp in ("Órgão julgador:", "Orgão julgador:", "argapso julgador:"):
-                    value = value.replace(stamp, "")
-                value = value.strip()
-
-            dados[key] = value
-
-        processos.append(dados)
-
-    df = pd.DataFrame(processos)
-    if "ementa" in df.columns:
-        cols = [c for c in df.columns if c != "ementa"] + ["ementa"]
-        df = df[cols]
-    return df
+    return _to_dataframe(processos)
 
 
 _ARVORE_COLUNAS = ["id", "nome", "id_pai", "nivel", "selecionavel", "caminho"]

--- a/tests/tjsp/samples/cjsg/count_error_and_zero.html
+++ b/tests/tjsp/samples/cjsg/count_error_and_zero.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="pt-BR">
+<body>
+  <div class="mensagemErro">Falha na verificação do captcha.</div>
+  <p>Nenhum resultado encontrado.</p>
+</body>
+</html>

--- a/tests/tjsp/samples/cjsg/count_form_initial.html
+++ b/tests/tjsp/samples/cjsg/count_form_initial.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <form id="consultaForm">
+      <input name="pesquisa" />
+    </form>
+  </body>
+</html>

--- a/tests/tjsp/samples/cjsg/count_invalid_text.html
+++ b/tests/tjsp/samples/cjsg/count_invalid_text.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <table>
+      <tr><td bgcolor="#EEEEEE">Formato inesperado sem numero</td></tr>
+    </table>
+  </body>
+</html>

--- a/tests/tjsp/samples/cjsg/count_legacy_bgcolor.html
+++ b/tests/tjsp/samples/cjsg/count_legacy_bgcolor.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <table>
+      <tr><td bgcolor="#EEEEEE">Pagina 2 de 42 paginas encontradas</td></tr>
+    </table>
+  </body>
+</html>

--- a/tests/tjsp/samples/cjsg/count_page_text.html
+++ b/tests/tjsp/samples/cjsg/count_page_text.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <table>
+      <tr><td>Página atual: 3, total 99 itens</td></tr>
+    </table>
+  </body>
+</html>

--- a/tests/tjsp/samples/cjsg/count_pagination_class.html
+++ b/tests/tjsp/samples/cjsg/count_pagination_class.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <table>
+      <tr><td class="pagination-info">Total: 77 registros disponiveis</td></tr>
+    </table>
+  </body>
+</html>

--- a/tests/tjsp/samples/cjsg/count_rows_fallback.html
+++ b/tests/tjsp/samples/cjsg/count_rows_fallback.html
@@ -1,0 +1,9 @@
+<html>
+  <body>
+    <table class="resultado-lista">
+      <tr class="fundocinza1"><td>primeiro</td></tr>
+      <tr class="fundocinza1"><td>segundo</td></tr>
+      <tr class="fundocinza1"><td>terceiro</td></tr>
+    </table>
+  </body>
+</html>

--- a/tests/tjsp/samples/cjsg/count_table_without_standard_rows.html
+++ b/tests/tjsp/samples/cjsg/count_table_without_standard_rows.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html lang="pt-BR">
+<body>
+  <table class="resultado">
+    <tr class="novo-layout"><td>Resultado sem a classe legada de linha.</td></tr>
+  </table>
+</body>
+</html>

--- a/tests/tjsp/samples/cjsg/latin1_result.html
+++ b/tests/tjsp/samples/cjsg/latin1_result.html
@@ -1,0 +1,29 @@
+<html>
+  <body>
+    <table>
+      <tr class="fundocinza1">
+        <td></td>
+        <td>
+          <table>
+            <tr>
+              <td>
+                <a class="esajLinkLogin downloadEmenta" cdacordao="456" cdforo="7">
+                  0000002-03.2024.8.26.0002
+                </a>
+              </td>
+            </tr>
+            <tr class="ementaClass2">
+              <td><strong>Relator(a):</strong> Des. João Açú</td>
+            </tr>
+            <tr class="ementaClass2">
+              <td>
+                <strong>Ementa:</strong>
+                <div align="justify" style="display: block;">Ementa: Decisão sobre obrigação.</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/tests/tjsp/samples/cjsg/parser_edge_cases.html
+++ b/tests/tjsp/samples/cjsg/parser_edge_cases.html
@@ -1,0 +1,74 @@
+<html>
+  <body>
+    <table>
+      <tr class="fundocinza1"><td>linha sem segunda celula</td></tr>
+      <tr class="fundocinza1"><td></td><td>linha sem tabela de detalhes</td></tr>
+      <tr class="fundocinza1">
+        <td></td>
+        <td>
+          <table>
+            <tr>
+              <td>
+                <a class="esajLinkLogin downloadEmenta" cdacordao="123" cdforo="4">
+                  0000001-02.2024.8.26.0001
+                </a>
+              </td>
+            </tr>
+            <tr class="ementaClass2">
+              <td><strong>Classe / Assunto:</strong> Apelacao / Contratos</td>
+            </tr>
+            <tr class="ementaClass2">
+              <td><strong>Relator(a):</strong> Des. Joao­ Acu​</td>
+            </tr>
+            <tr class="ementaClass2">
+              <td><strong>Campo especial:</strong> valor dinamico</td>
+            </tr>
+            <tr class="ementaClass2">
+              <td><strong>Outros numeros:</strong> deve ser descartado</td>
+            </tr>
+            <tr class="ementaClass2">
+              <td>
+                <strong>Data de publicassapso:</strong>
+                Data de publicassapso: 01/02/2024
+              </td>
+            </tr>
+            <tr class="ementaClass2">
+              <td>
+                <strong>argapso julgador:</strong>
+                argapso julgador: Camara Especial
+              </td>
+            </tr>
+            <tr class="ementaClass2">
+              <td>
+                <strong>Ementa:</strong>
+                <div align="justify" style="display: none;">Ementa: texto oculto.</div>
+                <div align="justify" style="display: block;">Ementa: texto visivel.</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr class="fundocinza1">
+        <td></td>
+        <td>
+          <table>
+            <tr class="ementaClass2">
+              <td>
+                <strong>Ementa:</strong>
+                <div align="justify" style="display: none;">Ementa: fallback oculto.</div>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <tr class="fundocinza1">
+        <td></td>
+        <td>
+          <table>
+            <tr class="ementaClass2"><td>detalhe sem rotulo</td></tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/tests/tjsp/test_cjsg_unit.py
+++ b/tests/tjsp/test_cjsg_unit.py
@@ -7,9 +7,22 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from juscraper.courts._esaj.parse import cjsg_n_results
+from juscraper.courts._esaj.parse import _parse_single_page, cjsg_n_results
 from juscraper.courts.tjsp.cjsg_parse import _cjsg_parse_single_page, cjsg_n_pags, cjsg_parse_manager
 from tests._helpers import load_sample
+
+ESAJ_COLUMNS = (
+    "processo",
+    "cd_acordao",
+    "cd_foro",
+    "classe_assunto",
+    "relatora",
+    "comarca",
+    "orgao_julgador",
+    "data_julgamento",
+    "data_publicacao",
+    "ementa",
+)
 
 
 class TestCJSGNPages:
@@ -89,6 +102,58 @@ class TestCJSGNResults:
         html = load_sample("tjsp", "cjsg/results_normal_page_01.html")
         # 2571077 resultados / 20 por pagina = 128554 paginas (ceil).
         assert cjsg_n_pags(html) == (2571077 + 19) // 20
+
+    @pytest.mark.parametrize(
+        ("sample", "expected"),
+        [
+            ("count_legacy_bgcolor.html", 42),
+            ("count_pagination_class.html", 77),
+            ("count_page_text.html", 99),
+            ("count_rows_fallback.html", 3),
+        ],
+    )
+    def test_selector_and_regex_cascades(self, sample, expected):
+        html = load_sample("tjsp", f"cjsg/{sample}")
+        assert cjsg_n_results(html) == expected
+
+    def test_search_form_without_results_raises_specific_message(self):
+        html = load_sample("tjsp", "cjsg/count_form_initial.html")
+        with pytest.raises(ValueError, match="Ainda na página de consulta"):
+            cjsg_n_results(html)
+
+    def test_pagination_marker_without_number_raises_with_text(self):
+        html = load_sample("tjsp", "cjsg/count_invalid_text.html")
+        with pytest.raises(ValueError, match="Formato inesperado encontrado"):
+            cjsg_n_results(html)
+
+    @pytest.mark.parametrize(
+        ("court", "expected_count", "expected_rows", "first_process"),
+        [
+            ("tjac", 13929, 20, "1000233-68.2026.8.01.0000"),
+            ("tjal", 136804, 20, "0709767-89.2020.8.02.0001"),
+            ("tjam", 54334, 10, "0708349-62.2020.8.04.0001"),
+            ("tjce", 100860, 20, "0206389-11.2024.8.06.0300"),
+            ("tjms", 149670, 100, "0800383-78.2024.8.12.0038"),
+            ("tjsp", 2571077, 20, "2399632-18.2025.8.26.0000"),
+        ],
+    )
+    def test_real_first_page_contract_for_every_esaj_court(
+        self,
+        court,
+        expected_count,
+        expected_rows,
+        first_process,
+    ):
+        relative_path = "cjsg/results_normal_page_01.html"
+        html = load_sample(court, relative_path)
+        sample_path = Path(__file__).parent.parent / court / "samples" / relative_path
+
+        df = _parse_single_page(str(sample_path))
+
+        assert cjsg_n_results(html) == expected_count
+        assert len(df) == expected_rows
+        assert tuple(df.columns) == ESAJ_COLUMNS
+        assert df.iloc[0]["processo"] == first_process
 
 
 class TestCJSGParseSinglePage:
@@ -190,6 +255,52 @@ class TestCJSGParseSinglePage:
             assert len(df) >= 0
         finally:
             Path(temp_path).unlink()
+
+    def test_tjsp_reexport_preserves_internal_parser_identity(self):
+        assert _cjsg_parse_single_page is _parse_single_page
+
+    def test_dynamic_labels_malformed_rows_and_ementa_fallback(self):
+        sample_path = Path(__file__).parent / "samples/cjsg/parser_edge_cases.html"
+
+        df = _parse_single_page(str(sample_path))
+
+        assert len(df) == 3
+        assert tuple(df.columns) == (
+            "processo",
+            "cd_acordao",
+            "cd_foro",
+            "classe_assunto",
+            "relatora",
+            "campo_especial",
+            "data_publicacao",
+            "orgao_julgador",
+            "ementa",
+        )
+        assert df.iloc[0].to_dict() == {
+            "processo": "0000001-02.2024.8.26.0001",
+            "cd_acordao": "123",
+            "cd_foro": "4",
+            "classe_assunto": "Apelacao / Contratos",
+            "relatora": "Des. Joao Acu",
+            "campo_especial": "valor dinamico",
+            "data_publicacao": "01/02/2024",
+            "orgao_julgador": "Camara Especial",
+            "ementa": "texto visivel.",
+        }
+        assert df.iloc[1]["ementa"] == "fallback oculto."
+        assert df.iloc[2]["ementa"] == ""
+        assert "outros_numeros" not in df.columns
+
+    def test_latin1_file_is_decoded_without_mojibake(self, tmp_path):
+        html = load_sample("tjsp", "cjsg/latin1_result.html")
+        path = tmp_path / "latin1.html"
+        path.write_bytes(html.encode("latin-1"))
+
+        df = _parse_single_page(str(path))
+
+        assert df.iloc[0]["processo"] == "0000002-03.2024.8.26.0002"
+        assert df.iloc[0]["relatora"] == "Des. João Açú"
+        assert df.iloc[0]["ementa"] == "Decisão sobre obrigação."
 
 
 class TestCJSGParseManager:

--- a/tests/tjsp/test_cjsg_unit.py
+++ b/tests/tjsp/test_cjsg_unit.py
@@ -126,6 +126,15 @@ class TestCJSGNResults:
         with pytest.raises(ValueError, match="Formato inesperado encontrado"):
             cjsg_n_results(html)
 
+    def test_page_error_takes_precedence_over_zero_results_marker(self):
+        html = load_sample("tjsp", "cjsg/count_error_and_zero.html")
+        with pytest.raises(ValueError, match="Captcha"):
+            cjsg_n_results(html)
+
+    def test_results_table_without_standard_rows_returns_minimum_one(self):
+        html = load_sample("tjsp", "cjsg/count_table_without_standard_rows.html")
+        assert cjsg_n_results(html) == 1
+
     @pytest.mark.parametrize(
         ("court", "expected_count", "expected_rows", "first_process"),
         [


### PR DESCRIPTION
## O que mudou

- Decompõe `cjsg_n_results` em validação da resposta, seleção do marcador, fallback por linhas e extração textual da contagem.
- Decompõe `_parse_single_page` em leitura/decodificação, metadados do processo, ementa, campos rotulados e montagem do DataFrame.
- Mantém a cascata textual comum em helper privado reutilizável pelo futuro refactor do CJPG, sem acoplar a família eSAJ ao util genérico de paginação.
- Adiciona samples e testes de caracterização para os 6 tribunais eSAJ, latin-1, labels dinâmicos, linhas malformadas, ementa visível/fallback, todos os estágios da cascata de contagem, precedência de erro sobre zero e mínimo 1 quando a tabela existe sem a classe legada de linha.

## Por que

As duas funções concentravam seleção de HTML, fallbacks, normalização e montagem do resultado em corpos únicos. Isso produzia CCN 28/21 e complexidade cognitiva 37/48, além de dificultar identificar qual estágio havia quebrado quando o HTML de um tribunal mudava.

O refactor preserva o shim usado pelo TJSP, a precedência erro/captcha/zero, as mensagens públicas, latin-1, labels dinâmicos, o descarte de `outros_numeros` e o shape dos 6 tribunais.

## Validação

- Família eSAJ: 213 testes passaram; 53 testes de integração ficaram desmarcados.
- Suíte offline completa: 1.763 passaram, 32 foram ignorados e 220 ficaram desmarcados.
- `cjsg_n_results`: CCN 28 → 4; cognitivo 37 → 3.
- `_parse_single_page`: CCN 21 → 3; cognitivo 48 → 3.
- Lizard sem funções acima de 15 no arquivo; ratchet Complexipy verde contra `origin/main`.
- Pre-commit nos 12 arquivos alterados: todos os hooks passaram.

Sem mudança de API pública e sem entrada no changelog.

Closes #314
Closes #316
Refs #307
