### PR TITLE
refactor(tjsp): decompõe download do CJPG

### DIFF
--- a/src/juscraper/courts/tjsp/cjpg_download.py
+++ b/src/juscraper/courts/tjsp/cjpg_download.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
@@ -17,6 +16,7 @@ import requests
 from tqdm import tqdm
 
 from ...utils.cnj import clean_cnj
+from .cjpg_parse import cjpg_n_pags
 from .exceptions import QueryTooLongError
 
 __all__ = ["QueryTooLongError", "cjpg_download", "fetch_cjpg_first_page"]
@@ -38,15 +38,10 @@ def _save_debug_html(response: requests.Response, download_path: str, error: Exc
 
 def _extract_page_count(
     response: requests.Response,
-    callback: Callable[[requests.Response], int] | None,
     download_path: str,
 ) -> int:
     try:
-        if callback is None:
-            raise ValueError(
-                "É necessário fornecer get_n_pags_callback para extrair o número de páginas."
-            )
-        return callback(response)
+        return cjpg_n_pags(response.content)
     except Exception as error:
         debug_file = _save_debug_html(response, download_path, error)
         raise ValueError(
@@ -54,14 +49,7 @@ def _extract_page_count(
         ) from error
 
 
-def _create_download_directory(download_path: str) -> str:
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    path = f"{download_path}/cjpg/{timestamp}"
-    Path(path).mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def _normalize_pages(paginas: list | range | None, n_pags: int) -> list | range:
+def _normalize_pages(paginas: list[int] | range | None, n_pags: int) -> list[int] | range:
     if paginas is None:
         return range(1, n_pags + 1)
     if isinstance(paginas, range):
@@ -69,8 +57,8 @@ def _normalize_pages(paginas: list | range | None, n_pags: int) -> list | range:
     return [page for page in paginas if page <= n_pags]
 
 
-def _save_page(path: str, page: int, html: str) -> None:
-    Path(f"{path}/cjpg_{page:05d}.html").write_text(html, encoding="utf-8")
+def _save_page(path: Path, page: int, html: str) -> None:
+    path.joinpath(f"cjpg_{page:05d}.html").write_text(html, encoding="utf-8")
 
 
 def fetch_cjpg_first_page(
@@ -127,9 +115,8 @@ def cjpg_download(
     id_processo: str | None = None,
     data_inicio: str | None = None,
     data_fim: str | None = None,
-    paginas: 'list | range | None' = None,
-    get_n_pags_callback=None,
-):
+    paginas: list[int] | range | None = None,
+) -> str:
     """Download cases from the TJSP jurisprudence search.
 
     Internal helper — the public scraper entry point
@@ -142,8 +129,8 @@ def cjpg_download(
     :data:`IdFiltro`. Refs #232.
 
     Raises:
-        ValueError: If ``get_n_pags_callback`` is missing or fails to
-            extract the page count from the first-page HTML.
+        ValueError: If the page count cannot be extracted from the first-page
+            HTML. The response is saved for diagnosis before raising.
     """
     r0 = fetch_cjpg_first_page(
         pesquisa=pesquisa,
@@ -156,12 +143,14 @@ def cjpg_download(
         data_inicio=data_inicio,
         data_fim=data_fim,
     )
-    n_pags = _extract_page_count(r0, get_n_pags_callback, download_path)
-    path = _create_download_directory(download_path)
+    n_pags = _extract_page_count(r0, download_path)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = Path(download_path) / "cjpg" / timestamp
+    path.mkdir(parents=True, exist_ok=True)
 
     if n_pags == 0:
         _save_page(path, 1, r0.text)
-        return path
+        return str(path)
 
     paginas = _normalize_pages(paginas, n_pags)
 
@@ -178,4 +167,4 @@ def cjpg_download(
         u = f"{u_base}cjpg/trocarDePagina.do?pagina={page}&conversationId="
         r = session.get(u)
         _save_page(path, page, r.text)
-    return path
+    return str(path)

--- a/src/juscraper/courts/tjsp/cjpg_download.py
+++ b/src/juscraper/courts/tjsp/cjpg_download.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
@@ -19,6 +20,57 @@ from ...utils.cnj import clean_cnj
 from .exceptions import QueryTooLongError
 
 __all__ = ["QueryTooLongError", "cjpg_download", "fetch_cjpg_first_page"]
+
+
+def _save_debug_html(response: requests.Response, download_path: str, error: Exception) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+    debug_dir = Path(download_path) / "cjpg_debug"
+    debug_dir.mkdir(parents=True, exist_ok=True)
+    debug_file = debug_dir / f"cjpg_primeira_pagina_{timestamp}.html"
+    debug_file.write_text(response.text, encoding="utf-8")
+    logging.getLogger("juscraper.cjpg_download").error(
+        "Erro ao extrair número de páginas: %s. HTML salvo em: %s",
+        str(error),
+        debug_file,
+    )
+    return debug_file
+
+
+def _extract_page_count(
+    response: requests.Response,
+    callback: Callable[[requests.Response], int] | None,
+    download_path: str,
+) -> int:
+    try:
+        if callback is None:
+            raise ValueError(
+                "É necessário fornecer get_n_pags_callback para extrair o número de páginas."
+            )
+        return callback(response)
+    except Exception as error:
+        debug_file = _save_debug_html(response, download_path, error)
+        raise ValueError(
+            f"Erro ao extrair número de páginas: {error}. HTML salvo em: {debug_file}"
+        ) from error
+
+
+def _create_download_directory(download_path: str) -> str:
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = f"{download_path}/cjpg/{timestamp}"
+    Path(path).mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _normalize_pages(paginas: list | range | None, n_pags: int) -> list | range:
+    if paginas is None:
+        return range(1, n_pags + 1)
+    if isinstance(paginas, range):
+        return range(paginas.start, min(paginas.stop, n_pags + 1), paginas.step)
+    return [page for page in paginas if page <= n_pags]
+
+
+def _save_page(path: str, page: int, html: str) -> None:
+    Path(f"{path}/cjpg_{page:05d}.html").write_text(html, encoding="utf-8")
 
 
 def fetch_cjpg_first_page(
@@ -104,54 +156,18 @@ def cjpg_download(
         data_inicio=data_inicio,
         data_fim=data_fim,
     )
-    try:
-        if get_n_pags_callback is None:
-            raise ValueError(
-                "É necessário fornecer get_n_pags_callback para extrair o número de páginas."
-            )
-        n_pags = get_n_pags_callback(r0)
-    except Exception as e:
-        timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
-        debug_dir = Path(download_path) / "cjpg_debug"
-        if not debug_dir.is_dir():
-            debug_dir.mkdir(parents=True)
-        debug_file = debug_dir / f"cjpg_primeira_pagina_{timestamp}.html"
-        with debug_file.open('w', encoding='utf-8') as f:
-            f.write(r0.text)
-        logger = logging.getLogger("juscraper.cjpg_download")
-        logger.error(
-            "Erro ao extrair número de páginas: %s. HTML salvo em: %s",
-            str(e),
-            debug_file
-        )
-        raise ValueError(
-            f"Erro ao extrair número de páginas: {e}. HTML salvo em: {debug_file}"
-        ) from e
-
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    path = f"{download_path}/cjpg/{timestamp}"
-    if not Path(path).is_dir():
-        Path(path).mkdir(parents=True)
+    n_pags = _extract_page_count(r0, get_n_pags_callback, download_path)
+    path = _create_download_directory(download_path)
 
     if n_pags == 0:
-        with Path(f"{path}/cjpg_00001.html").open('w', encoding='utf-8') as f:
-            f.write(r0.text)
+        _save_page(path, 1, r0.text)
         return path
 
-    if paginas is None:
-        paginas = range(1, n_pags + 1)
-    elif isinstance(paginas, range):
-        start = paginas.start if paginas.start is not None else 1
-        stop = min(paginas.stop, n_pags + 1) if paginas.stop is not None else n_pags + 1
-        step = paginas.step if paginas.step is not None else 1
-        paginas = range(start, stop, step)
-    else:
-        paginas = [p for p in paginas if p <= n_pags]
+    paginas = _normalize_pages(paginas, n_pags)
 
     first_page_in_range = 1 in paginas
     if first_page_in_range:
-        with Path(f"{path}/cjpg_00001.html").open('w', encoding='utf-8') as f:
-            f.write(r0.text)
+        _save_page(path, 1, r0.text)
 
     remaining = [p for p in paginas if p > 1]
     total = len(remaining) + (1 if first_page_in_range else 0)
@@ -161,6 +177,5 @@ def cjpg_download(
         time.sleep(sleep_time)
         u = f"{u_base}cjpg/trocarDePagina.do?pagina={page}&conversationId="
         r = session.get(u)
-        with Path(f"{path}/cjpg_{page:05d}.html").open('w', encoding='utf-8') as f:  # noqa: E231
-            f.write(r.text)
+        _save_page(path, page, r.text)
     return path

--- a/src/juscraper/courts/tjsp/client.py
+++ b/src/juscraper/courts/tjsp/client.py
@@ -22,7 +22,7 @@ from ...utils.params import (
 from .._esaj.base import EsajSearchScraper
 from .cjpg_download import cjpg_download as cjpg_download_mod
 from .cjpg_download import fetch_cjpg_first_page
-from .cjpg_parse import cjpg_n_pags, cjpg_n_results, cjpg_parse_manager
+from .cjpg_parse import cjpg_n_results, cjpg_parse_manager
 from .cpopg_download import cpopg_download_api, cpopg_download_html
 from .cpopg_parse import cpopg_parse_manager, get_cpopg_download_links
 from .cposg_download import cposg_download_api, cposg_download_html
@@ -567,10 +567,6 @@ class TJSPScraper(EsajSearchScraper):
         # pydantic e funcionalmente equivalente.
         validate_pesquisa_length(inp.pesquisa, endpoint="CJPG")
 
-        def _get_n_pags(r0):
-            html = r0.content if hasattr(r0, "content") else r0
-            return cjpg_n_pags(html)
-
         path: str = cjpg_download_mod(
             pesquisa=inp.pesquisa,
             session=self.session,
@@ -584,7 +580,6 @@ class TJSPScraper(EsajSearchScraper):
             data_inicio=inp.data_julgamento_inicio,
             data_fim=inp.data_julgamento_fim,
             paginas=inp.paginas,
-            get_n_pags_callback=_get_n_pags,
         )
         return path
 

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -205,42 +205,16 @@ class TestCJPGDownload1Based:
         mock.content = text.encode('utf-8')
         return mock
 
-    def _run_download(self, n_pags, paginas=None, sleep_time=0):
-        """Helper: runs cjpg_download with mocked session and callbacks."""
-        mock_session = MagicMock()
-        r0_response = self._make_mock_response("<html>page1</html>")
-        page_response = self._make_mock_response("<html>other</html>")
-        mock_session.get.side_effect = [r0_response] + [page_response] * (n_pags + 10)
-
-        def get_n_pags_callback(r0):
-            return n_pags
-
-        with tempfile.TemporaryDirectory() as tmp:
-            path = cjpg_download(
-                pesquisa="teste",
-                session=mock_session,
-                u_base="https://esaj.tjsp.jus.br/",
-                download_path=tmp,
-                sleep_time=sleep_time,
-                paginas=paginas,
-                get_n_pags_callback=get_n_pags_callback,
-            )
-            saved_files = sorted(p.name for p in Path(path).iterdir())
-            # Collect URLs from session.get calls (skip first which is pesquisar.do)
-            get_calls = mock_session.get.call_args_list
-            trocar_urls = [c[0][0] for c in get_calls[1:] if 'trocarDePagina' in c[0][0]]
-            return saved_files, trocar_urls
-
-    def _download_with_mocks(self, tmp_path, *, n_pags, paginas=None, sleep_time=0, callback=None):
+    def _download_with_mocks(self, tmp_path, mocker, *, n_pags, paginas=None, sleep_time=0):
         """Run the internal downloader while retaining its collaborators."""
         mock_session = MagicMock()
         r0_response = self._make_mock_response("<html>page1</html>")
-        mock_session.get.side_effect = [
-            r0_response,
-            self._make_mock_response("<html>page2+</html>"),
-            self._make_mock_response("<html>page2+</html>"),
-        ]
-        get_n_pags_callback = callback or MagicMock(return_value=n_pags)
+        page_response = self._make_mock_response("<html>page2+</html>")
+        mock_session.get.side_effect = [r0_response] + [page_response] * (n_pags + 10)
+        count_pages = mocker.patch(
+            "juscraper.courts.tjsp.cjpg_download.cjpg_n_pags",
+            return_value=n_pags,
+        )
 
         path = cjpg_download(
             pesquisa="teste",
@@ -249,76 +223,101 @@ class TestCJPGDownload1Based:
             download_path=str(tmp_path),
             sleep_time=sleep_time,
             paginas=paginas,
-            get_n_pags_callback=get_n_pags_callback,
         )
 
-        return path, mock_session, r0_response, get_n_pags_callback
+        saved_files = sorted(file.name for file in Path(path).iterdir())
+        trocar_urls = [
+            item.args[0]
+            for item in mock_session.get.call_args_list[1:]
+            if "trocarDePagina" in item.args[0]
+        ]
+        return path, saved_files, trocar_urls, mock_session, r0_response, count_pages
 
-    def test_default_all_pages(self):
+    def test_default_all_pages(self, tmp_path, mocker):
         """Default (None) downloads all 3 pages: saves 00001, 00002, 00003."""
-        files, urls = self._run_download(n_pags=3, paginas=None)
+        _, files, urls, _, _, _ = self._download_with_mocks(tmp_path, mocker, n_pags=3)
         assert files == ["cjpg_00001.html", "cjpg_00002.html", "cjpg_00003.html"]
         assert len(urls) == 2  # trocarDePagina for pages 2 and 3
 
-    def test_single_page(self):
+    def test_single_page(self, tmp_path, mocker):
         """range(1, 2) downloads only page 1."""
-        files, urls = self._run_download(n_pags=3, paginas=range(1, 2))
+        _, files, urls, _, _, _ = self._download_with_mocks(
+            tmp_path,
+            mocker,
+            n_pags=3,
+            paginas=range(1, 2),
+        )
         assert files == ["cjpg_00001.html"]
         assert len(urls) == 0  # no trocarDePagina calls
 
-    def test_three_pages(self):
+    def test_three_pages(self, tmp_path, mocker):
         """range(1, 4) downloads pages 1, 2, 3."""
-        files, urls = self._run_download(n_pags=5, paginas=range(1, 4))
+        _, files, urls, _, _, _ = self._download_with_mocks(
+            tmp_path,
+            mocker,
+            n_pags=5,
+            paginas=range(1, 4),
+        )
         assert files == ["cjpg_00001.html", "cjpg_00002.html", "cjpg_00003.html"]
         assert len(urls) == 2
 
-    def test_custom_range(self):
+    def test_custom_range(self, tmp_path, mocker):
         """range(6, 11) downloads pages 6-10 (no page 1)."""
-        files, urls = self._run_download(n_pags=20, paginas=range(6, 11))
+        _, files, urls, _, _, _ = self._download_with_mocks(
+            tmp_path,
+            mocker,
+            n_pags=20,
+            paginas=range(6, 11),
+        )
         assert files == [f"cjpg_{p:05d}.html" for p in range(6, 11)]
         assert len(urls) == 5  # all via trocarDePagina
 
-    def test_exceeds_available(self):
+    def test_exceeds_available(self, tmp_path, mocker):
         """range(1, 101) with only 3 pages available: downloads only 1, 2, 3."""
-        files, urls = self._run_download(n_pags=3, paginas=range(1, 101))
+        _, files, urls, _, _, _ = self._download_with_mocks(
+            tmp_path,
+            mocker,
+            n_pags=3,
+            paginas=range(1, 101),
+        )
         assert files == ["cjpg_00001.html", "cjpg_00002.html", "cjpg_00003.html"]
         assert len(urls) == 2
 
-    def test_callback_receives_first_page_response_and_return_is_str(self, tmp_path):
-        callback = MagicMock(return_value=1)
-
-        path, _, r0_response, _ = self._download_with_mocks(
+    def test_counter_receives_first_page_content_and_return_is_str(self, tmp_path, mocker):
+        path, _, _, _, r0_response, count_pages = self._download_with_mocks(
             tmp_path,
+            mocker,
             n_pags=1,
             paginas=[1],
-            callback=callback,
         )
 
         assert isinstance(path, str)
-        callback.assert_called_once_with(r0_response)
+        count_pages.assert_called_once_with(r0_response.content)
 
-    def test_zero_pages_still_saves_first_page(self, tmp_path):
-        path, mock_session, _, _ = self._download_with_mocks(
+    def test_zero_pages_still_saves_first_page(self, tmp_path, mocker):
+        path, files, _, mock_session, _, _ = self._download_with_mocks(
             tmp_path,
+            mocker,
             n_pags=0,
             paginas=[3],
         )
 
-        assert [file.name for file in Path(path).iterdir()] == ["cjpg_00001.html"]
+        assert files == ["cjpg_00001.html"]
         assert Path(path, "cjpg_00001.html").read_text(encoding="utf-8") == "<html>page1</html>"
         assert mock_session.get.call_count == 1
 
     def test_sparse_page_list_discards_unavailable_pages(self, tmp_path, mocker):
         sleep = mocker.patch("juscraper.courts.tjsp.cjpg_download.time.sleep")
 
-        path, mock_session, _, _ = self._download_with_mocks(
+        _, files, _, mock_session, _, _ = self._download_with_mocks(
             tmp_path,
+            mocker,
             n_pags=3,
             paginas=[1, 3, 99],
             sleep_time=0.25,
         )
 
-        assert sorted(file.name for file in Path(path).iterdir()) == ["cjpg_00001.html", "cjpg_00003.html"]
+        assert files == ["cjpg_00001.html", "cjpg_00003.html"]
         assert mock_session.get.call_args_list[1:] == [
             call("https://esaj.tjsp.jus.br/cjpg/trocarDePagina.do?pagina=3&conversationId=")
         ]
@@ -327,14 +326,15 @@ class TestCJPGDownload1Based:
     def test_range_step_preserves_page_order_and_request_urls(self, tmp_path, mocker):
         sleep = mocker.patch("juscraper.courts.tjsp.cjpg_download.time.sleep")
 
-        path, mock_session, _, _ = self._download_with_mocks(
+        _, files, _, mock_session, _, _ = self._download_with_mocks(
             tmp_path,
+            mocker,
             n_pags=5,
             paginas=range(1, 8, 2),
             sleep_time=0.4,
         )
 
-        assert sorted(file.name for file in Path(path).iterdir()) == [
+        assert files == [
             "cjpg_00001.html",
             "cjpg_00003.html",
             "cjpg_00005.html",
@@ -345,11 +345,16 @@ class TestCJPGDownload1Based:
         ]
         assert sleep.call_args_list == [call(0.4), call(0.4)]
 
-    def test_missing_callback_saves_debug_html_and_chains_value_error(self, tmp_path):
+    def test_count_error_saves_debug_html_and_preserves_cause(self, tmp_path, mocker):
         mock_session = MagicMock()
         mock_session.get.return_value = self._make_mock_response("<html>diagnostico</html>")
+        upstream_error = RuntimeError("falha ao contar páginas")
+        mocker.patch(
+            "juscraper.courts.tjsp.cjpg_download.cjpg_n_pags",
+            side_effect=upstream_error,
+        )
 
-        with pytest.raises(ValueError, match="HTML salvo em") as exc_info:
+        with pytest.raises(ValueError, match="falha ao contar páginas") as exc_info:
             cjpg_download(
                 pesquisa="teste",
                 session=mock_session,
@@ -357,27 +362,10 @@ class TestCJPGDownload1Based:
                 download_path=str(tmp_path),
             )
 
-        assert isinstance(exc_info.value.__cause__, ValueError)
-        assert "É necessário fornecer get_n_pags_callback" in str(exc_info.value.__cause__)
-        debug_files = list(Path(tmp_path, "cjpg_debug").glob("cjpg_primeira_pagina_*.html"))
-        assert len(debug_files) == 1
-        assert debug_files[0].read_text(encoding="utf-8") == "<html>diagnostico</html>"
-
-    def test_callback_error_saves_debug_html_and_preserves_cause(self, tmp_path):
-        upstream_error = RuntimeError("falha no callback")
-        callback = MagicMock(side_effect=upstream_error)
-
-        with pytest.raises(ValueError, match="falha no callback") as exc_info:
-            self._download_with_mocks(
-                tmp_path,
-                n_pags=1,
-                callback=callback,
-            )
-
         assert exc_info.value.__cause__ is upstream_error
         debug_files = list(Path(tmp_path, "cjpg_debug").glob("cjpg_primeira_pagina_*.html"))
         assert len(debug_files) == 1
-        assert debug_files[0].read_text(encoding="utf-8") == "<html>page1</html>"
+        assert debug_files[0].read_text(encoding="utf-8") == "<html>diagnostico</html>"
 
 
 class TestCJPGDateRangeValidation:

--- a/tests/tjsp/test_cjpg.py
+++ b/tests/tjsp/test_cjpg.py
@@ -4,7 +4,7 @@ Includes both integration and unit tests.
 """
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pandas as pd
 import pytest
@@ -231,6 +231,29 @@ class TestCJPGDownload1Based:
             trocar_urls = [c[0][0] for c in get_calls[1:] if 'trocarDePagina' in c[0][0]]
             return saved_files, trocar_urls
 
+    def _download_with_mocks(self, tmp_path, *, n_pags, paginas=None, sleep_time=0, callback=None):
+        """Run the internal downloader while retaining its collaborators."""
+        mock_session = MagicMock()
+        r0_response = self._make_mock_response("<html>page1</html>")
+        mock_session.get.side_effect = [
+            r0_response,
+            self._make_mock_response("<html>page2+</html>"),
+            self._make_mock_response("<html>page2+</html>"),
+        ]
+        get_n_pags_callback = callback or MagicMock(return_value=n_pags)
+
+        path = cjpg_download(
+            pesquisa="teste",
+            session=mock_session,
+            u_base="https://esaj.tjsp.jus.br/",
+            download_path=str(tmp_path),
+            sleep_time=sleep_time,
+            paginas=paginas,
+            get_n_pags_callback=get_n_pags_callback,
+        )
+
+        return path, mock_session, r0_response, get_n_pags_callback
+
     def test_default_all_pages(self):
         """Default (None) downloads all 3 pages: saves 00001, 00002, 00003."""
         files, urls = self._run_download(n_pags=3, paginas=None)
@@ -260,6 +283,101 @@ class TestCJPGDownload1Based:
         files, urls = self._run_download(n_pags=3, paginas=range(1, 101))
         assert files == ["cjpg_00001.html", "cjpg_00002.html", "cjpg_00003.html"]
         assert len(urls) == 2
+
+    def test_callback_receives_first_page_response_and_return_is_str(self, tmp_path):
+        callback = MagicMock(return_value=1)
+
+        path, _, r0_response, _ = self._download_with_mocks(
+            tmp_path,
+            n_pags=1,
+            paginas=[1],
+            callback=callback,
+        )
+
+        assert isinstance(path, str)
+        callback.assert_called_once_with(r0_response)
+
+    def test_zero_pages_still_saves_first_page(self, tmp_path):
+        path, mock_session, _, _ = self._download_with_mocks(
+            tmp_path,
+            n_pags=0,
+            paginas=[3],
+        )
+
+        assert [file.name for file in Path(path).iterdir()] == ["cjpg_00001.html"]
+        assert Path(path, "cjpg_00001.html").read_text(encoding="utf-8") == "<html>page1</html>"
+        assert mock_session.get.call_count == 1
+
+    def test_sparse_page_list_discards_unavailable_pages(self, tmp_path, mocker):
+        sleep = mocker.patch("juscraper.courts.tjsp.cjpg_download.time.sleep")
+
+        path, mock_session, _, _ = self._download_with_mocks(
+            tmp_path,
+            n_pags=3,
+            paginas=[1, 3, 99],
+            sleep_time=0.25,
+        )
+
+        assert sorted(file.name for file in Path(path).iterdir()) == ["cjpg_00001.html", "cjpg_00003.html"]
+        assert mock_session.get.call_args_list[1:] == [
+            call("https://esaj.tjsp.jus.br/cjpg/trocarDePagina.do?pagina=3&conversationId=")
+        ]
+        sleep.assert_called_once_with(0.25)
+
+    def test_range_step_preserves_page_order_and_request_urls(self, tmp_path, mocker):
+        sleep = mocker.patch("juscraper.courts.tjsp.cjpg_download.time.sleep")
+
+        path, mock_session, _, _ = self._download_with_mocks(
+            tmp_path,
+            n_pags=5,
+            paginas=range(1, 8, 2),
+            sleep_time=0.4,
+        )
+
+        assert sorted(file.name for file in Path(path).iterdir()) == [
+            "cjpg_00001.html",
+            "cjpg_00003.html",
+            "cjpg_00005.html",
+        ]
+        assert mock_session.get.call_args_list[1:] == [
+            call("https://esaj.tjsp.jus.br/cjpg/trocarDePagina.do?pagina=3&conversationId="),
+            call("https://esaj.tjsp.jus.br/cjpg/trocarDePagina.do?pagina=5&conversationId="),
+        ]
+        assert sleep.call_args_list == [call(0.4), call(0.4)]
+
+    def test_missing_callback_saves_debug_html_and_chains_value_error(self, tmp_path):
+        mock_session = MagicMock()
+        mock_session.get.return_value = self._make_mock_response("<html>diagnostico</html>")
+
+        with pytest.raises(ValueError, match="HTML salvo em") as exc_info:
+            cjpg_download(
+                pesquisa="teste",
+                session=mock_session,
+                u_base="https://esaj.tjsp.jus.br/",
+                download_path=str(tmp_path),
+            )
+
+        assert isinstance(exc_info.value.__cause__, ValueError)
+        assert "É necessário fornecer get_n_pags_callback" in str(exc_info.value.__cause__)
+        debug_files = list(Path(tmp_path, "cjpg_debug").glob("cjpg_primeira_pagina_*.html"))
+        assert len(debug_files) == 1
+        assert debug_files[0].read_text(encoding="utf-8") == "<html>diagnostico</html>"
+
+    def test_callback_error_saves_debug_html_and_preserves_cause(self, tmp_path):
+        upstream_error = RuntimeError("falha no callback")
+        callback = MagicMock(side_effect=upstream_error)
+
+        with pytest.raises(ValueError, match="falha no callback") as exc_info:
+            self._download_with_mocks(
+                tmp_path,
+                n_pags=1,
+                callback=callback,
+            )
+
+        assert exc_info.value.__cause__ is upstream_error
+        debug_files = list(Path(tmp_path, "cjpg_debug").glob("cjpg_primeira_pagina_*.html"))
+        assert len(debug_files) == 1
+        assert debug_files[0].read_text(encoding="utf-8") == "<html>page1</html>"
 
 
 class TestCJPGDateRangeValidation:


### PR DESCRIPTION
## Resumo

- Mantém a decomposição do download CJPG em primeira página, diagnóstico, normalização das páginas e gravação dos arquivos.
- Preserva `cjpg_debug`, o HTML diagnóstico e o encadeamento da exceção quando a contagem falha.
- Mantém listas esparsas, `range` com passo, URLs, ordem das requisições e pausas entre páginas.

## Simplificação da revisão

- Remove a injeção opcional de callback e a closure criada no client; `cjpg_download` chama diretamente a fonte canônica `cjpg_n_pags`.
- Remove o estado inválido de callback ausente, sem criar fallback.
- Usa `Path` internamente e converte para `str` somente na fronteira pública; consolida helpers duplicados nos testes.

## Complexidade

- `cjpg_download`: CCN 8 e complexidade cognitiva 6.
- Nenhuma função alterada excede o limite 15.

## Validação

- `uv run pytest`: 1.751 testes passaram, 32 foram ignorados e 220 ficaram desmarcados.
- Testes focados do fluxo e dos diagnósticos CJPG: passaram.
- Pre-commit completo nos arquivos alterados e `git diff --check`: passaram.

Refs #307
