### PR TITLE
refactor(tjpr): decompõe parser de jurisprudência

### DIFF
--- a/src/juscraper/courts/tjpr/parse.py
+++ b/src/juscraper/courts/tjpr/parse.py
@@ -4,12 +4,93 @@ Functions for parsing specific to TJPR
 import pandas as pd
 import requests
 from bs4 import BeautifulSoup
+from bs4.element import Tag
 
 from juscraper.core.exceptions import RetryExhaustedError
 from juscraper.core.http import RequestFn
 from juscraper.core.parse_utils import coerce_date_columns
 
 from .download import get_ementa_completa
+
+
+def _extract_processo(dados_td: Tag) -> str:
+    processo_a = dados_td.find("a", class_="decisao negrito")
+    if processo_a:
+        return str(processo_a.get_text(strip=True))
+
+    processo = ""
+    for div in dados_td.find_all("div"):
+        if "Processo:" not in div.get_text():
+            continue
+        processo_div = div.find_all("div")
+        if processo_div:
+            processo = str(processo_div[0].get_text(strip=True))
+    return processo
+
+
+def _extract_labeled_value(
+    dados_td: Tag,
+    label: str,
+    *,
+    use_text_sibling: bool = False,
+) -> str:
+    label_text = dados_td.find(string=lambda text: text and label in text)
+    if not label_text:
+        return ""
+
+    value = str(label_text).split(label)[-1].strip()
+    if value or not use_text_sibling or label_text.parent is None:
+        return value
+
+    sibling = label_text.parent.find_next_sibling(string=True)
+    return str(sibling).strip() if sibling else ""
+
+
+def _extract_document_id(dados_td: Tag) -> str:
+    process_input = dados_td.find("input", {"name": "idsSelecionados"})
+    if not process_input or "value" not in process_input.attrs:
+        return ""
+    return str(process_input["value"])
+
+
+def _extract_ementa(
+    dados_td: Tag,
+    ementa_td: Tag,
+    criterio: str | None,
+    request_fn: RequestFn | None,
+) -> str:
+    ementa = str(ementa_td.get_text("\n", strip=True))
+    if "leia mais" not in ementa.lower():
+        return ementa
+
+    id_processo = _extract_document_id(dados_td)
+    if not id_processo or not criterio or request_fn is None:
+        return ementa
+
+    try:
+        return get_ementa_completa(request_fn, id_processo, criterio)
+    except (requests.RequestException, RetryExhaustedError, AttributeError) as error:
+        # A falha de uma ementa completa não invalida os demais resultados da página.
+        return f"{ementa}\n[Erro ao buscar ementa completa: {error}]"
+
+
+def _parse_row(
+    row: Tag,
+    criterio: str | None,
+    request_fn: RequestFn | None,
+) -> dict[str, object] | None:
+    cols = row.find_all("td")
+    if len(cols) < 2:
+        return None
+
+    dados_td, ementa_td = cols[:2]
+    return {
+        "processo": _extract_processo(dados_td),
+        "orgao_julgador": _extract_labeled_value(dados_td, "Órgão Julgador:"),
+        "relator": _extract_labeled_value(dados_td, "Relator:", use_text_sibling=True),
+        "data_julgamento": _extract_labeled_value(dados_td, "Data Julgamento:", use_text_sibling=True),
+        "ementa": _extract_ementa(dados_td, ementa_td, criterio, request_fn),
+    }
 
 
 def cjsg_parse(
@@ -32,68 +113,10 @@ def cjsg_parse(
         tabela = soup.select_one("table.resultTable.jurisprudencia")
         if not tabela:
             continue
-        linhas = tabela.find_all("tr")[1:]  # pula o cabeçalho
-        for row in linhas:
-            cols = row.find_all("td")
-            if len(cols) < 2:
-                continue
-            dados_td = cols[0]
-            ementa_td = cols[1]
-            # Processo
-            processo = ''
-            processo_a = dados_td.find('a', class_='decisao negrito')
-            if processo_a:
-                processo = processo_a.get_text(strip=True)
-            else:
-                for div in dados_td.find_all('div'):
-                    if 'Processo:' in div.get_text():
-                        processo_div = div.find_all('div')
-                        if processo_div:
-                            processo = processo_div[0].get_text(strip=True)
-            # Relator
-            relator = ''
-            relator_label = dados_td.find(string=lambda t: t and 'Relator:' in t)
-            if relator_label:
-                relator = relator_label.split('Relator:')[-1].strip()
-                if not relator and relator_label.parent is not None:
-                    next_sib = relator_label.parent.find_next_sibling(string=True)
-                    if next_sib:
-                        relator = str(next_sib).strip()
-            # Órgão julgador
-            orgao_julgador = ''
-            orgao_label = dados_td.find(string=lambda t: t and 'Órgão Julgador:' in t)
-            if orgao_label:
-                orgao_julgador = orgao_label.split('Órgão Julgador:')[-1].strip()
-            # Data julgamento
-            data_julgamento = ''
-            data_label = dados_td.find(string=lambda t: t and 'Data Julgamento:' in t)
-            if data_label:
-                data_julgamento = data_label.split('Data Julgamento:')[-1].strip()
-                if not data_julgamento and data_label.parent is not None:
-                    next_sib = data_label.parent.find_next_sibling(string=True)
-                    if next_sib:
-                        data_julgamento = str(next_sib).strip()
-            # Ementa
-            ementa = ementa_td.get_text("\n", strip=True)
-            # Detecta "Leia mais..." e busca a ementa completa
-            if 'leia mais' in ementa.lower():
-                input_id = dados_td.find('input', {'name': 'idsSelecionados'})
-                id_processo = input_id['value'] if input_id and 'value' in input_id.attrs else ''
-                if id_processo and criterio and request_fn is not None:
-                    try:
-                        ementa = get_ementa_completa(request_fn, id_processo, criterio)
-                    except (requests.RequestException, RetryExhaustedError, AttributeError) as e:
-                        # RetryExhaustedError e RequestException sao engolidos para
-                        # preservar a degradacao graciosa por linha — uma ementa
-                        # truncada que falha no fetch nao deve derrubar o DataFrame.
-                        ementa += (f"\n[Erro ao buscar ementa completa: {e}]")
-            resultados.append({
-                'processo': processo,
-                'orgao_julgador': orgao_julgador,
-                'relator': relator,
-                'data_julgamento': data_julgamento,
-                'ementa': ementa,
-            })
+        for row in tabela.find_all("tr")[1:]:  # pula o cabeçalho
+            result = _parse_row(row, criterio, request_fn)
+            if result is not None:
+                resultados.append(result)
     df = pd.DataFrame(resultados)
     coerce_date_columns(df, ["data_julgamento"], date_format="%d/%m/%Y")
     return df

--- a/src/juscraper/courts/tjpr/parse.py
+++ b/src/juscraper/courts/tjpr/parse.py
@@ -46,13 +46,6 @@ def _extract_labeled_value(
     return str(sibling).strip() if sibling else ""
 
 
-def _extract_document_id(dados_td: Tag) -> str:
-    process_input = dados_td.find("input", {"name": "idsSelecionados"})
-    if not process_input or "value" not in process_input.attrs:
-        return ""
-    return str(process_input["value"])
-
-
 def _extract_ementa(
     dados_td: Tag,
     ementa_td: Tag,
@@ -63,13 +56,18 @@ def _extract_ementa(
     if "leia mais" not in ementa.lower():
         return ementa
 
-    id_processo = _extract_document_id(dados_td)
+    process_input = dados_td.find("input", {"name": "idsSelecionados"})
+    id_processo = (
+        str(process_input["value"])
+        if process_input and "value" in process_input.attrs
+        else ""
+    )
     if not id_processo or not criterio or request_fn is None:
         return ementa
 
     try:
         return get_ementa_completa(request_fn, id_processo, criterio)
-    except (requests.RequestException, RetryExhaustedError, AttributeError) as error:
+    except (requests.RequestException, RetryExhaustedError) as error:
         # A falha de uma ementa completa não invalida os demais resultados da página.
         return f"{ementa}\n[Erro ao buscar ementa completa: {error}]"
 
@@ -78,7 +76,7 @@ def _parse_row(
     row: Tag,
     criterio: str | None,
     request_fn: RequestFn | None,
-) -> dict[str, object] | None:
+) -> dict[str, str] | None:
     cols = row.find_all("td")
     if len(cols) < 2:
         return None

--- a/tests/tjpr/samples/cjsg/parser_edge_cases.html
+++ b/tests/tjpr/samples/cjsg/parser_edge_cases.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<body>
+<table class="resultTable jurisprudencia">
+    <tr>
+        <th>Tipo</th>
+        <th>Ementa</th>
+    </tr>
+    <tr>
+        <td>
+            <input name="idsSelecionados" value="link-id">
+            <a class="decisao negrito"><div><div>0000001-11.2024.8.16.0001</div></div></a>
+            <div>Relator: Relator Inline</div>
+            <div>Órgão Julgador: Câmara Inline</div>
+            <div>Data Julgamento: 01/02/2024</div>
+        </td>
+        <td>Ementa curta sem expansão.</td>
+    </tr>
+    <tr>
+        <td>
+            <input name="idsSelecionados" value="div-id">
+            <div><span>Processo:</span><div>0000002-22.2024.8.16.0002</div></div>
+            <span>Relator:</span> Relator Irmão
+            <div>Órgão Julgador: Câmara Irmã</div>
+            <span>Data Julgamento:</span> 03/04/2024
+        </td>
+        <td>Resumo truncado. Leia mais...</td>
+    </tr>
+    <tr>
+        <td><div>Metadados ausentes</div></td>
+        <td>Ementa sem metadados.</td>
+    </tr>
+    <tr>
+        <td>Linha sem a célula de ementa.</td>
+    </tr>
+</table>
+</body>
+</html>

--- a/tests/tjpr/test_cjsg_parse_granular.py
+++ b/tests/tjpr/test_cjsg_parse_granular.py
@@ -1,0 +1,82 @@
+"""Granular characterization tests for the TJPR CJSG parser."""
+from __future__ import annotations
+
+from datetime import date
+from types import SimpleNamespace
+
+import pandas as pd
+import requests
+
+from juscraper.courts.tjpr.parse import cjsg_parse
+from tests._helpers import load_sample
+
+EXPECTED_COLUMNS = ["processo", "orgao_julgador", "relator", "data_julgamento", "ementa"]
+
+
+def test_cjsg_parse_preserves_row_variants_and_exact_dtypes(mocker):
+    request_fn = mocker.Mock()
+
+    result = cjsg_parse(
+        [load_sample("tjpr", "cjsg/parser_edge_cases.html")],
+        criterio=None,
+        request_fn=request_fn,
+    )
+
+    assert result.columns.tolist() == EXPECTED_COLUMNS
+    assert result.dtypes.astype(str).to_dict() == dict.fromkeys(EXPECTED_COLUMNS, "object")
+    assert result.shape == (3, 5)
+    assert result.loc[0].to_dict() == {
+        "processo": "0000001-11.2024.8.16.0001",
+        "orgao_julgador": "Câmara Inline",
+        "relator": "Relator Inline",
+        "data_julgamento": date(2024, 2, 1),
+        "ementa": "Ementa curta sem expansão.",
+    }
+    assert result.loc[1].to_dict() == {
+        "processo": "0000002-22.2024.8.16.0002",
+        "orgao_julgador": "Câmara Irmã",
+        "relator": "Relator Irmão",
+        "data_julgamento": date(2024, 4, 3),
+        "ementa": "Resumo truncado. Leia mais...",
+    }
+    assert result.loc[2, ["processo", "orgao_julgador", "relator"]].tolist() == ["", "", ""]
+    assert pd.isna(result.loc[2, "data_julgamento"])
+    assert result.loc[2, "ementa"] == "Ementa sem metadados."
+    request_fn.assert_not_called()
+
+
+def test_cjsg_parse_fetches_full_ementa_with_injected_request(mocker):
+    request_fn = mocker.Mock(
+        return_value=SimpleNamespace(text="<div>Ementa completa</div><p>Segunda linha</p>")
+    )
+
+    result = cjsg_parse(
+        [load_sample("tjpr", "cjsg/parser_edge_cases.html")],
+        criterio="dano moral",
+        request_fn=request_fn,
+    )
+
+    assert result.loc[0, "ementa"] == "Ementa curta sem expansão."
+    assert result.loc[1, "ementa"] == "Ementa completa\nSegunda linha"
+    request_fn.assert_called_once()
+    method, url = request_fn.call_args.args
+    assert method == "GET"
+    assert "actionType=exibirTextoCompleto" in url
+    assert "idProcesso=div-id" in url
+    assert "criterio=dano moral" in url
+
+
+def test_cjsg_parse_keeps_truncated_ementa_after_row_request_error(mocker):
+    request_fn = mocker.Mock(side_effect=requests.RequestException("indisponível"))
+
+    result = cjsg_parse(
+        [load_sample("tjpr", "cjsg/parser_edge_cases.html")],
+        criterio="dano moral",
+        request_fn=request_fn,
+    )
+
+    assert result.loc[1, "ementa"] == (
+        "Resumo truncado. Leia mais...\n"
+        "[Erro ao buscar ementa completa: indisponível]"
+    )
+    assert result.loc[2, "ementa"] == "Ementa sem metadados."

--- a/tests/tjpr/test_cjsg_parse_granular.py
+++ b/tests/tjpr/test_cjsg_parse_granular.py
@@ -5,6 +5,7 @@ from datetime import date
 from types import SimpleNamespace
 
 import pandas as pd
+import pytest
 import requests
 
 from juscraper.courts.tjpr.parse import cjsg_parse
@@ -80,3 +81,14 @@ def test_cjsg_parse_keeps_truncated_ementa_after_row_request_error(mocker):
         "[Erro ao buscar ementa completa: indisponível]"
     )
     assert result.loc[2, "ementa"] == "Ementa sem metadados."
+
+
+def test_cjsg_parse_propagates_programming_errors_from_full_ementa_fetch(mocker):
+    request_fn = mocker.Mock(side_effect=AttributeError("contrato inválido"))
+
+    with pytest.raises(AttributeError, match="contrato inválido"):
+        cjsg_parse(
+            [load_sample("tjpr", "cjsg/parser_edge_cases.html")],
+            criterio="dano moral",
+            request_fn=request_fn,
+        )


### PR DESCRIPTION
## Resumo

- Decompõe o parser CJSG do TJPR em extração de processo, campos rotulados, ementa e linha.
- Preserva o `DataFrame` público de cinco colunas, a conversão de datas e a degradação por linha para falhas reais de rede ao buscar a ementa completa.
- Mantém os sete samples existentes equivalentes ao parser anterior.

## Simplificação e correções da revisão

- Incorpora a extração do ID documental, usada uma vez, ao único consumidor.
- Estreita `_parse_row` para `dict[str, str] | None`.
- Remove `AttributeError` do catch de falhas de rede: erros de programação do `request_fn` agora propagam em vez de serem convertidos em texto de resultado.

## Complexidade

- Maior CCN tocado: 8; maior complexidade cognitiva tocada: 8.
- Nenhuma função alterada excede o limite 15.

## Validação

- `tests/tjpr`: 20 testes offline passaram.
- `uv run pytest`: 1.750 testes passaram, 32 foram ignorados e 220 ficaram desmarcados.
- Pre-commit completo nos 2 arquivos alterados e `git diff --check`: passaram.

Closes #313
Refs #307
