### PR TITLE
refactor(utils): decompõe cascata de paginação

### DIFF
--- a/src/juscraper/utils/pagination.py
+++ b/src/juscraper/utils/pagination.py
@@ -73,15 +73,6 @@ def _extract_first(
     return None
 
 
-def _extract_from_findall_match(raw: str | tuple[str, ...]) -> int | None:
-    groups = raw if isinstance(raw, tuple) else (raw,)
-    for group in groups:
-        value = _coerce_int(group)
-        if value is not None:
-            return value
-    return None
-
-
 def _extract_max(
     candidates: Sequence[str],
     regex_patterns: Sequence[re.Pattern[str]],
@@ -89,8 +80,8 @@ def _extract_max(
     values: list[int] = []
     for candidate in candidates:
         for pattern in regex_patterns:
-            for raw in pattern.findall(candidate):
-                value = _extract_from_findall_match(raw)
+            for match in pattern.finditer(candidate):
+                value = _extract_from_match(match)
                 if value is not None:
                     values.append(value)
     return max(values) if values else None
@@ -146,17 +137,17 @@ def extract_count_with_cascade(
         fallback_max_int: Se ``True``, ultimo recurso e pegar ``max(\\d+)``
             no primeiro candidato — util para layouts onde varios numeros
             aparecem mas o total e o maior. Default ``False`` (fail-fast:
-            retorna ``None``). Os 5 callers atuais usam ``False`` e
-            controlam o default semantico (1 pagina ou 0 resultados) do
-            lado deles; ``True`` deve ser opt-in explicito para evitar
-            extrair numeros irrelevantes da pagina (ano, codigo, etc.).
+            retorna ``None``). Os callers controlam o default semantico
+            (1 pagina ou 0 resultados) do lado deles; ``True`` deve ser
+            opt-in explicito para evitar extrair numeros irrelevantes da
+            pagina (ano, codigo, etc.).
         use_element_html: Quando ``True``, cada candidato e o HTML completo
             do elemento (``str(el)``) em vez de apenas o texto. Necessario
             quando o numero alvo esta em atributo (ex.: ``href="?page=N"``
             em paginadores estilo Bootstrap).
         aggregate: ``"first"`` (default) retorna o primeiro match valido na
             ordem de cascata. ``"max"`` percorre TODOS os matches em todos
-            os candidatos via ``pattern.findall`` e retorna o maior — util
+            os candidatos via ``pattern.finditer`` e retorna o maior — util
             para paginadores que listam varios numeros de pagina (1, 2, …,
             N) e o "total" e ``max(N)``.
 

--- a/src/juscraper/utils/pagination.py
+++ b/src/juscraper/utils/pagination.py
@@ -35,6 +35,76 @@ def _extract_from_match(match: re.Match[str]) -> int | None:
     return _coerce_int(match.group(0))
 
 
+def _has_zero_marker(soup: BeautifulSoup, zero_markers: Sequence[str]) -> bool:
+    if not zero_markers:
+        return False
+    text_lower = soup.get_text(" ", strip=True).lower()
+    return any(marker.lower() in text_lower for marker in zero_markers)
+
+
+def _collect_candidates(
+    soup: BeautifulSoup,
+    html: str,
+    css_selectors: Sequence[str],
+    *,
+    use_element_html: bool,
+) -> list[str]:
+    candidates: list[str] = []
+    for selector in css_selectors:
+        for element in soup.select(selector):
+            content = str(element) if use_element_html else element.get_text(" ", strip=True)
+            if content:
+                candidates.append(content)
+    return candidates or [html]
+
+
+def _extract_first(
+    candidates: Sequence[str],
+    regex_patterns: Sequence[re.Pattern[str]],
+) -> int | None:
+    for candidate in candidates:
+        for pattern in regex_patterns:
+            match = pattern.search(candidate)
+            if not match:
+                continue
+            value = _extract_from_match(match)
+            if value is not None:
+                return value
+    return None
+
+
+def _extract_from_findall_match(raw: str | tuple[str, ...]) -> int | None:
+    groups = raw if isinstance(raw, tuple) else (raw,)
+    for group in groups:
+        value = _coerce_int(group)
+        if value is not None:
+            return value
+    return None
+
+
+def _extract_max(
+    candidates: Sequence[str],
+    regex_patterns: Sequence[re.Pattern[str]],
+) -> int | None:
+    values: list[int] = []
+    for candidate in candidates:
+        for pattern in regex_patterns:
+            for raw in pattern.findall(candidate):
+                value = _extract_from_findall_match(raw)
+                if value is not None:
+                    values.append(value)
+    return max(values) if values else None
+
+
+def _extract_fallback_max(candidate: str) -> int | None:
+    values = [
+        value
+        for raw in _FALLBACK_NUMERO_RE.findall(candidate)
+        if (value := _coerce_int(raw)) is not None
+    ]
+    return max(values) if values else None
+
+
 def extract_count_with_cascade(
     html: str,
     *,
@@ -95,52 +165,22 @@ def extract_count_with_cascade(
         nao salvar. ``0`` quando ``zero_markers`` casarem.
     """
     soup = BeautifulSoup(html, "html.parser")
+    if _has_zero_marker(soup, zero_markers):
+        return 0
 
-    if zero_markers:
-        text_lower = soup.get_text(" ", strip=True).lower()
-        for marker in zero_markers:
-            if marker.lower() in text_lower:
-                return 0
-
-    candidates: list[str] = []
-    for selector in css_selectors:
-        for el in soup.select(selector):
-            content = str(el) if use_element_html else el.get_text(" ", strip=True)
-            if content:
-                candidates.append(content)
-
-    if not candidates:
-        candidates = [html]
-
-    if aggregate == "max":
-        all_matches: list[int] = []
-        for txt in candidates:
-            for pattern in regex_patterns:
-                for raw in pattern.findall(txt):
-                    groups: tuple[str, ...] = raw if isinstance(raw, tuple) else (raw,)
-                    for group in groups:
-                        coerced = _coerce_int(group)
-                        if coerced is not None:
-                            all_matches.append(coerced)
-                            break
-        if all_matches:
-            return max(all_matches)
-    else:
-        for txt in candidates:
-            for pattern in regex_patterns:
-                match = pattern.search(txt)
-                if match:
-                    value = _extract_from_match(match)
-                    if value is not None:
-                        return value
-
-    if fallback_max_int and candidates:
-        valid_nums: list[int] = []
-        for raw in _FALLBACK_NUMERO_RE.findall(candidates[0]):
-            coerced = _coerce_int(raw)
-            if coerced is not None:
-                valid_nums.append(coerced)
-        if valid_nums:
-            return max(valid_nums)
-
+    candidates = _collect_candidates(
+        soup,
+        html,
+        css_selectors,
+        use_element_html=use_element_html,
+    )
+    value = (
+        _extract_max(candidates, regex_patterns)
+        if aggregate == "max"
+        else _extract_first(candidates, regex_patterns)
+    )
+    if value is not None:
+        return value
+    if fallback_max_int:
+        return _extract_fallback_max(candidates[0])
     return None

--- a/tests/utils/test_pagination_util.py
+++ b/tests/utils/test_pagination_util.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import re
-from typing import Any, cast
 
 from juscraper.utils.pagination import extract_count_with_cascade
 
@@ -241,17 +240,6 @@ def test_first_preserves_selector_and_element_order_while_skipping_empty():
         css_selectors=("span.primary", "span.secondary"),
         regex_patterns=(re.compile(r"(\d+)\s+resultados"),),
     ) == 12
-
-
-def test_non_max_aggregate_keeps_first_semantics():
-    html = "<span>3 resultados</span><span>88 resultados</span>"
-
-    assert extract_count_with_cascade(
-        html,
-        css_selectors=("span",),
-        regex_patterns=(re.compile(r"(\d+)\s+resultados"),),
-        aggregate=cast(Any, "largest"),
-    ) == 3
 
 
 def test_fallback_max_int_only_reads_first_candidate():

--- a/tests/utils/test_pagination_util.py
+++ b/tests/utils/test_pagination_util.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any, cast
 
 from juscraper.utils.pagination import extract_count_with_cascade
 
@@ -184,3 +185,91 @@ def test_aggregate_max_iterates_all_selectors():
         use_element_html=True,
         aggregate="max",
     ) == 99
+
+
+def test_first_uses_first_numeric_group_across_optional_groups():
+    html = "<div class='counter'>pages: 27</div>"
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("div.counter",),
+        regex_patterns=(re.compile(r"(?:results:\s*(\d+)|pages:\s*(\d+))"),),
+    ) == 27
+
+
+def test_first_ignores_later_numeric_groups_in_same_match():
+    html = "<div class='counter'>page 4 of 90</div>"
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("div.counter",),
+        regex_patterns=(re.compile(r"page\s+(\d+)\s+of\s+(\d+)"),),
+    ) == 4
+
+
+def test_aggregate_max_uses_first_numeric_group_per_match():
+    html = "<div class='counter'>page=2 total=999; page=42 total=1000</div>"
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("div.counter",),
+        regex_patterns=(re.compile(r"page=(\d+)\s+total=(\d+)"),),
+        aggregate="max",
+    ) == 42
+
+
+def test_empty_selector_candidates_fall_back_to_raw_html():
+    html = "<span class='empty'> </span><meta data-total='77'>"
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("span.empty",),
+        regex_patterns=(re.compile(r"data-total=['\"](\d+)"),),
+    ) == 77
+
+
+def test_first_preserves_selector_and_element_order_while_skipping_empty():
+    html = """
+    <span class="primary"> </span>
+    <span class="primary">12 resultados</span>
+    <span class="primary">14 resultados</span>
+    <span class="secondary">99 resultados</span>
+    """
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("span.primary", "span.secondary"),
+        regex_patterns=(re.compile(r"(\d+)\s+resultados"),),
+    ) == 12
+
+
+def test_non_max_aggregate_keeps_first_semantics():
+    html = "<span>3 resultados</span><span>88 resultados</span>"
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("span",),
+        regex_patterns=(re.compile(r"(\d+)\s+resultados"),),
+        aggregate=cast(Any, "largest"),
+    ) == 3
+
+
+def test_fallback_max_int_only_reads_first_candidate():
+    html = "<span class='first'>page 1 of 12</span><span class='second'>page 99</span>"
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("span.first", "span.second"),
+        regex_patterns=(),
+        fallback_max_int=True,
+    ) == 12
+
+
+def test_number_with_comma_is_normalized():
+    html = "<span class='total'>1,234 resultados</span>"
+
+    assert extract_count_with_cascade(
+        html,
+        css_selectors=("span.total",),
+        regex_patterns=(re.compile(r"(\d[\d.,]*)\s+resultados"),),
+    ) == 1234


### PR DESCRIPTION
## Resumo

- Mantém a cascata de zero, seletores, regex e fallback numérico de `extract_count_with_cascade`.
- Preserva a ordem dos candidatos, o primeiro match para agregadores diferentes de `max` e o maior valor quando `aggregate="max"`.
- Mantém os sete tribunais consumidores cobertos por testes offline.

## Simplificação da revisão

- Remove `_extract_from_findall_match`, que duplicava a leitura de grupos de `_extract_from_match` apenas para adaptar uma tupla.
- `_extract_max` passa a usar `finditer` e o extrator canônico de match; não há duas representações intermediárias do mesmo resultado.
- Remove o teste e o cast de um agregador impossível pelo contrato `Literal["first", "max"]`.
- O follow-up reduz o diff em 21 linhas líquidas.

## Complexidade

- Maior CCN tocado: 6; maior complexidade cognitiva tocada: 11.
- Nenhuma função alterada excede o limite 15.

## Validação

- Teste focado de paginação: 22 testes passaram.
- Sete consumidores: 154 testes passaram.
- `uv run pytest`: 1.753 testes passaram, 32 foram ignorados e 220 ficaram desmarcados.
- Pre-commit completo nos arquivos alterados, Lizard, Complexipy, ratchet e `git diff --check`: passaram.

Refs #307
