### PR TITLE
refactor(utils): explicita etapas da normalização

### DIFF
--- a/src/juscraper/utils/params.py
+++ b/src/juscraper/utils/params.py
@@ -136,28 +136,21 @@ def normalize_pesquisa(pesquisa: str | None = None, **kwargs) -> str:
 
 
 def _collect_date_sources(kwargs: dict) -> dict[str, list[tuple[str, Any]]]:
-    """Collect ordered sources and reject conflicts before warning."""
+    """Collect date sources in canonical, specific-alias, generic-alias order."""
     sources: dict[str, list[tuple[str, Any]]] = {
         canonical: [] for canonical in DATE_CANONICAL
     }
 
-    def collect(name: str, canonical: str) -> None:
-        if name not in kwargs:
-            return
-        value = kwargs.pop(name)
+    for canonical in DATE_CANONICAL:
+        value = kwargs.pop(canonical, None)
+        if value is not None:
+            sources[canonical].append((canonical, value))
+
+    for name, canonical in DATE_ALIAS_TO_CANONICAL.items():
+        value = kwargs.pop(name, None)
         if value is not None:
             sources[canonical].append((name, value))
 
-    for canonical in DATE_CANONICAL:
-        collect(canonical, canonical)
-    for name, canonical in DATE_ALIAS_TO_CANONICAL.items():
-        if name.endswith(("_de", "_ate")):
-            collect(name, canonical)
-    for name, canonical in DATE_ALIAS_TO_CANONICAL.items():
-        if name in ("data_inicio", "data_fim"):
-            collect(name, canonical)
-
-    _raise_on_date_source_conflict(sources)
     return sources
 
 
@@ -222,6 +215,7 @@ def normalize_datas(**kwargs):
             is the user's mistake to fix, not a soft deprecation event.
     """
     sources = _collect_date_sources(kwargs)
+    _raise_on_date_source_conflict(sources)
     return _materialize_normalized_dates(sources)
 
 
@@ -722,25 +716,23 @@ def _reinject_nominal_dates(
         kwargs[date_key] = date_value
 
 
-def _instantiate_pipeline_schema(
+def _validate_pipeline_schema(
     schema_cls: type[BaseModel],
     method_name: str,
-    *,
-    pesquisa: str | None,
-    paginas,
-    datas: dict[str, Any],
-    canonical_filters: dict[str, Any],
-    kwargs: dict,
+    sources: tuple[dict[str, Any], ...],
 ) -> BaseModel:
-    """Build the schema and translate only pure unknown-field errors."""
+    """Merge unique pipeline sources, instantiate, and translate unknown fields."""
+    values: dict[str, Any] = {}
+    for source in sources:
+        duplicate = next((name for name in source if name in values), None)
+        if duplicate is not None:
+            raise TypeError(
+                f"got multiple values for keyword argument '{duplicate}'"
+            )
+        values.update(source)
+
     try:
-        return schema_cls(
-            pesquisa=pesquisa,
-            paginas=paginas,
-            **{key: value for key, value in datas.items() if value is not None},
-            **canonical_filters,
-            **kwargs,
-        )
+        return schema_cls(**values)
     except ValidationError as exc:
         raise_on_extra_kwargs(exc, method_name, schema_cls=schema_cls)
         raise
@@ -834,7 +826,7 @@ def apply_input_pipeline_search(
             when ``extra_forbidden`` triggers (e.g. ``"TJRNScraper.cjsg()"``).
         pesquisa: Search term. ``None`` is allowed when ``nullable_pesquisa``
             is ``True`` (TJSP cjpg). When ``consume_pesquisa_aliases`` is
-            ``True`` (default), the value is normalized internally — pass the
+            ``True``, the value is normalized internally — pass the
             raw value from the public method.
         paginas: Pages parameter as accepted by the public method (``int``,
             ``list``, ``range``, or ``None``).
@@ -951,15 +943,13 @@ def apply_input_pipeline_search(
         formato=date_format,
     )
 
-    return _instantiate_pipeline_schema(
-        schema_cls,
-        method_name,
-        pesquisa=pesquisa,
-        paginas=paginas_norm,
-        datas=datas,
-        canonical_filters=canonical_filters,
-        kwargs=kwargs,
+    schema_sources = (
+        {"pesquisa": pesquisa, "paginas": paginas_norm},
+        {key: value for key, value in datas.items() if value is not None},
+        canonical_filters,
+        kwargs,
     )
+    return _validate_pipeline_schema(schema_cls, method_name, schema_sources)
 
 
 def resolve_deprecated_alias(

--- a/src/juscraper/utils/params.py
+++ b/src/juscraper/utils/params.py
@@ -135,6 +135,65 @@ def normalize_pesquisa(pesquisa: str | None = None, **kwargs) -> str:
     raise TypeError("É necessário fornecer o parâmetro 'pesquisa'.")
 
 
+def _collect_date_sources(kwargs: dict) -> dict[str, list[tuple[str, Any]]]:
+    """Collect ordered sources and reject conflicts before warning."""
+    sources: dict[str, list[tuple[str, Any]]] = {
+        canonical: [] for canonical in DATE_CANONICAL
+    }
+
+    def collect(name: str, canonical: str) -> None:
+        if name not in kwargs:
+            return
+        value = kwargs.pop(name)
+        if value is not None:
+            sources[canonical].append((name, value))
+
+    for canonical in DATE_CANONICAL:
+        collect(canonical, canonical)
+    for name, canonical in DATE_ALIAS_TO_CANONICAL.items():
+        if name.endswith(("_de", "_ate")):
+            collect(name, canonical)
+    for name, canonical in DATE_ALIAS_TO_CANONICAL.items():
+        if name in ("data_inicio", "data_fim"):
+            collect(name, canonical)
+
+    _raise_on_date_source_conflict(sources)
+    return sources
+
+
+def _raise_on_date_source_conflict(sources: dict[str, list[tuple[str, Any]]]) -> None:
+    """Reject multiple names for one canonical date before warning."""
+    for canonical, source_values in sources.items():
+        if len(source_values) <= 1:
+            continue
+        names = [name for name, _ in source_values]
+        quoted = [f"'{name}'" for name in names]
+        joined = ", ".join(quoted[:-1]) + f" e {quoted[-1]}"
+        raise ValueError(
+            f"Não é possível passar {joined} ao mesmo tempo. "
+            f"Use apenas '{canonical}'."
+        )
+
+
+def _materialize_normalized_dates(
+    sources: dict[str, list[tuple[str, Any]]],
+) -> dict[str, Any]:
+    """Build the four-key result and warn for each selected alias."""
+    result: dict[str, Any] = dict.fromkeys(DATE_CANONICAL)
+    for canonical, source_values in sources.items():
+        if not source_values:
+            continue
+        name, value = source_values[0]
+        if name != canonical:
+            warnings.warn(
+                f"O parâmetro '{name}' está deprecado. Use '{canonical}' em vez disso.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        result[canonical] = value
+    return result
+
+
 def normalize_datas(**kwargs):
     """Normalize date parameters to canonical names.
 
@@ -162,60 +221,8 @@ def normalize_datas(**kwargs):
             ``DeprecationWarning`` is emitted before the raise; the conflict
             is the user's mistake to fix, not a soft deprecation event.
     """
-    # Particiona DATE_ALIAS_TO_CANONICAL em _de/_ate (específicos) vs.
-    # data_inicio/data_fim (genéricos) preservando a ordem de coleta: específicos
-    # antes do genérico, para que uma colisão entre eles surja com o nome
-    # específico no erro.
-    deprecated_map = {k: v for k, v in DATE_ALIAS_TO_CANONICAL.items() if k.endswith(("_de", "_ate"))}
-    generic_map = {k: v for k, v in DATE_ALIAS_TO_CANONICAL.items() if k in ("data_inicio", "data_fim")}
-
-    # canonical -> [(source_name, value), ...] na ordem em que apareceram
-    # nas três fases (canônico, _de/_ate, genérico). Único valor None
-    # entra silenciosamente no pop e nao gera fonte — preserva o
-    # comportamento antigo de aceitar canonical=None ao lado de alias.
-    sources: dict[str, list[tuple[str, Any]]] = {c: [] for c in DATE_CANONICAL}
-
-    def _collect(name: str, canonical: str) -> None:
-        if name not in kwargs:
-            return
-        value = kwargs.pop(name)
-        if value is not None:
-            sources[canonical].append((name, value))
-
-    for canonical in DATE_CANONICAL:
-        _collect(canonical, canonical)
-    for old_name, canonical in deprecated_map.items():
-        _collect(old_name, canonical)
-    for generic, canonical in generic_map.items():
-        _collect(generic, canonical)
-
-    # Detecta colisão olhando todas as fontes coletadas. Mensagem cita os
-    # nomes que o usuário escreveu (em vez do canônico, que ele pode nem
-    # ter digitado — refs #193).
-    for canonical, srcs in sources.items():
-        if len(srcs) > 1:
-            names = [name for name, _ in srcs]
-            quoted = [f"'{n}'" for n in names]
-            joined = ", ".join(quoted[:-1]) + f" e {quoted[-1]}"
-            raise ValueError(
-                f"Não é possível passar {joined} ao mesmo tempo. "
-                f"Use apenas '{canonical}'."
-            )
-
-    result: dict[str, Any] = dict.fromkeys(DATE_CANONICAL)
-    for canonical, srcs in sources.items():
-        if not srcs:
-            continue
-        name, value = srcs[0]
-        if name != canonical:
-            warnings.warn(
-                f"O parâmetro '{name}' está deprecado. Use '{canonical}' em vez disso.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-        result[canonical] = value
-
-    return result
+    sources = _collect_date_sources(kwargs)
+    return _materialize_normalized_dates(sources)
 
 
 def to_br_date(date_str):
@@ -699,6 +706,46 @@ def raise_on_extra_kwargs(
         ) from exc
 
 
+def _reinject_nominal_dates(
+    kwargs: dict,
+    nominal_dates: dict[str, Any],
+) -> None:
+    """Merge named date arguments sequentially into the caller's ``kwargs``."""
+    for date_key, date_value in nominal_dates.items():
+        if date_value is None:
+            continue
+        if date_key in kwargs and kwargs[date_key] is not None:
+            raise ValueError(
+                f"'{date_key}' foi passado como argumento nominal e via "
+                f"kwargs ao mesmo tempo. Use apenas uma das formas."
+            )
+        kwargs[date_key] = date_value
+
+
+def _instantiate_pipeline_schema(
+    schema_cls: type[BaseModel],
+    method_name: str,
+    *,
+    pesquisa: str | None,
+    paginas,
+    datas: dict[str, Any],
+    canonical_filters: dict[str, Any],
+    kwargs: dict,
+) -> BaseModel:
+    """Build the schema and translate only pure unknown-field errors."""
+    try:
+        return schema_cls(
+            pesquisa=pesquisa,
+            paginas=paginas,
+            **{key: value for key, value in datas.items() if value is not None},
+            **canonical_filters,
+            **kwargs,
+        )
+    except ValidationError as exc:
+        raise_on_extra_kwargs(exc, method_name, schema_cls=schema_cls)
+        raise
+
+
 def apply_input_pipeline_search(
     schema_cls: type[BaseModel],
     method_name: str,
@@ -851,20 +898,15 @@ def apply_input_pipeline_search(
         else:
             pesquisa = normalize_pesquisa(pesquisa_input, **kwargs)
 
-    for _date_key, _date_val in (
-        ("data_julgamento_inicio", data_julgamento_inicio),
-        ("data_julgamento_fim", data_julgamento_fim),
-        ("data_publicacao_inicio", data_publicacao_inicio),
-        ("data_publicacao_fim", data_publicacao_fim),
-    ):
-        if _date_val is None:
-            continue
-        if _date_key in kwargs and kwargs[_date_key] is not None:
-            raise ValueError(
-                f"'{_date_key}' foi passado como argumento nominal e via "
-                f"kwargs ao mesmo tempo. Use apenas uma das formas."
-            )
-        kwargs[_date_key] = _date_val
+    _reinject_nominal_dates(
+        kwargs,
+        {
+            "data_julgamento_inicio": data_julgamento_inicio,
+            "data_julgamento_fim": data_julgamento_fim,
+            "data_publicacao_inicio": data_publicacao_inicio,
+            "data_publicacao_fim": data_publicacao_fim,
+        },
+    )
 
     paginas_norm = normalize_paginas(paginas)
     datas = normalize_datas(**kwargs)
@@ -872,9 +914,8 @@ def apply_input_pipeline_search(
 
     origem_resolvida = origem_mensagem if origem_mensagem is not None else "O backend"
     date_format = getattr(schema_cls, "BACKEND_DATE_FORMAT", "%d/%m/%Y")
-
-    for _key in DATE_CANONICAL:
-        datas[_key] = coerce_brazilian_date(datas[_key], date_format)
+    for key in DATE_CANONICAL:
+        datas[key] = coerce_brazilian_date(datas[key], date_format)
 
     # Auto-fill datas parciais antes da validação. Idempotente: para
     # tribunais que passam por ``run_auto_chunk`` (família eSAJ + TJSP cjpg),
@@ -910,17 +951,15 @@ def apply_input_pipeline_search(
         formato=date_format,
     )
 
-    try:
-        return schema_cls(
-            pesquisa=pesquisa,
-            paginas=paginas_norm,
-            **{k: v for k, v in datas.items() if v is not None},
-            **canonical_filters,
-            **kwargs,
-        )
-    except ValidationError as exc:
-        raise_on_extra_kwargs(exc, method_name, schema_cls=schema_cls)
-        raise
+    return _instantiate_pipeline_schema(
+        schema_cls,
+        method_name,
+        pesquisa=pesquisa,
+        paginas=paginas_norm,
+        datas=datas,
+        canonical_filters=canonical_filters,
+        kwargs=kwargs,
+    )
 
 
 def resolve_deprecated_alias(

--- a/tests/test_params.py
+++ b/tests/test_params.py
@@ -96,6 +96,20 @@ class TestNormalizeDatas:
         assert result["data_publicacao_inicio"] is None
         assert result["data_publicacao_fim"] is None
 
+    def test_canonical_none_does_not_conflict_with_deprecated_alias(self):
+        with pytest.warns(DeprecationWarning, match="'data_julgamento_de'"):
+            result = normalize_datas(
+                data_julgamento_inicio=None,
+                data_julgamento_de="01/01/2023",
+            )
+
+        assert result == {
+            "data_julgamento_inicio": "01/01/2023",
+            "data_julgamento_fim": None,
+            "data_publicacao_inicio": None,
+            "data_publicacao_fim": None,
+        }
+
     def test_deprecated_de_ate(self):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -179,9 +193,11 @@ class TestNormalizeDatas:
                 data_julgamento_de="02/01/2023",
                 data_inicio="03/01/2023",
             )
-        msg = str(excinfo.value)
-        for nome in ("'data_julgamento_inicio'", "'data_julgamento_de'", "'data_inicio'"):
-            assert nome in msg
+        assert str(excinfo.value) == (
+            "Não é possível passar 'data_julgamento_inicio', "
+            "'data_julgamento_de' e 'data_inicio' ao mesmo tempo. "
+            "Use apenas 'data_julgamento_inicio'."
+        )
 
     def test_all_none(self):
         result = normalize_datas()

--- a/tests/utils/test_input_pipeline.py
+++ b/tests/utils/test_input_pipeline.py
@@ -159,22 +159,6 @@ def test_apply_input_pipeline_kwargs_dict_is_consumed_in_place():
     assert "data_julgamento_inicio" not in kwargs
 
 
-def test_apply_input_pipeline_reinjects_nominal_date_before_page_validation():
-    kwargs: dict = {}
-
-    with pytest.raises(TypeError, match="paginas deve ser"):
-        apply_input_pipeline_search(
-            _SchemaComJulgamento,
-            "Test.cjsg()",
-            pesquisa="x",
-            paginas="invalid",
-            kwargs=kwargs,
-            data_julgamento_inicio="01/01/2024",
-        )
-
-    assert kwargs == {"data_julgamento_inicio": "01/01/2024"}
-
-
 def test_apply_input_pipeline_date_conflict_precedes_kwargs_consumption():
     kwargs = {
         "data_julgamento_de": "01/01/2024",

--- a/tests/utils/test_input_pipeline.py
+++ b/tests/utils/test_input_pipeline.py
@@ -1,6 +1,7 @@
 """Unit tests for the canonical input-validation pipeline (cjsg/cjpg)."""
 from __future__ import annotations
 
+import warnings
 from datetime import date, datetime
 from typing import ClassVar
 
@@ -134,11 +135,15 @@ def test_apply_input_pipeline_data_filter_on_schema_without_mixin_raises_typeerr
     o ``extra_forbidden`` virar ``TypeError`` direto.
     """
     kwargs = {"data_julgamento_inicio": "01/01/2024"}
-    with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'data_julgamento_inicio'"):
-        apply_input_pipeline_search(
-            _SchemaSimples, "Test.cjsg()",
-            pesquisa="x", paginas=1, kwargs=kwargs,
-        )
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(TypeError, match=r"got unexpected keyword argument\(s\): 'data_julgamento_inicio'"):
+            apply_input_pipeline_search(
+                _SchemaSimples, "Test.cjsg()",
+                pesquisa="x", paginas=1, kwargs=kwargs,
+            )
+
+    assert not any(issubclass(warning.category, UserWarning) for warning in caught)
 
 
 def test_apply_input_pipeline_kwargs_dict_is_consumed_in_place():
@@ -152,6 +157,88 @@ def test_apply_input_pipeline_kwargs_dict_is_consumed_in_place():
     assert "data_inicio" not in kwargs
     assert "data_fim" not in kwargs
     assert "data_julgamento_inicio" not in kwargs
+
+
+def test_apply_input_pipeline_reinjects_nominal_date_before_page_validation():
+    kwargs: dict = {}
+
+    with pytest.raises(TypeError, match="paginas deve ser"):
+        apply_input_pipeline_search(
+            _SchemaComJulgamento,
+            "Test.cjsg()",
+            pesquisa="x",
+            paginas="invalid",
+            kwargs=kwargs,
+            data_julgamento_inicio="01/01/2024",
+        )
+
+    assert kwargs == {"data_julgamento_inicio": "01/01/2024"}
+
+
+def test_apply_input_pipeline_date_conflict_precedes_kwargs_consumption():
+    kwargs = {
+        "data_julgamento_de": "01/01/2024",
+        "data_inicio": "02/01/2024",
+        "marker": "preserved",
+    }
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError, match=r"data_julgamento_de.*data_inicio"):
+            apply_input_pipeline_search(
+                _SchemaComJulgamento,
+                "Test.cjsg()",
+                pesquisa="x",
+                paginas=1,
+                kwargs=kwargs,
+            )
+
+    assert kwargs == {
+        "data_julgamento_de": "01/01/2024",
+        "data_inicio": "02/01/2024",
+        "marker": "preserved",
+    }
+    assert not any(issubclass(warning.category, DeprecationWarning) for warning in caught)
+
+
+def test_apply_input_pipeline_search_conflict_precedes_date_reinjection():
+    kwargs = {"query": "alias"}
+
+    with pytest.raises(ValueError, match=r"'pesquisa'.*'query'"):
+        apply_input_pipeline_search(
+            _SchemaComJulgamento,
+            "Test.cjsg()",
+            pesquisa="canonical",
+            paginas=1,
+            kwargs=kwargs,
+            data_julgamento_inicio="01/01/2024",
+            consume_pesquisa_aliases=True,
+        )
+
+    assert kwargs == {"query": "alias"}
+
+
+def test_apply_input_pipeline_validates_julgamento_before_publicacao():
+    kwargs = {
+        "data_julgamento_inicio": "invalid-julgamento",
+        "data_julgamento_fim": "also-invalid-julgamento",
+        "data_publicacao_inicio": "invalid-publicacao",
+        "data_publicacao_fim": "also-invalid-publicacao",
+        "marker": "preserved",
+    }
+
+    with pytest.raises(ValueError) as exc_info:
+        apply_input_pipeline_search(
+            _SchemaComAmbas,
+            "Test.cjsg()",
+            pesquisa="x",
+            paginas=1,
+            kwargs=kwargs,
+        )
+
+    assert "data_julgamento_inicio" in str(exc_info.value)
+    assert "data_publicacao" not in str(exc_info.value)
+    assert kwargs == {"marker": "preserved"}
 
 
 def test_raise_on_extra_kwargs_passes_through_when_other_errors_present():

--- a/tests/utils/test_params.py
+++ b/tests/utils/test_params.py
@@ -10,6 +10,7 @@ from juscraper.utils.params import (
     OPEN_ENDED_DATE_FLOOR,
     coerce_brazilian_date,
     fill_open_ended_dates,
+    normalize_datas,
 )
 
 
@@ -150,16 +151,15 @@ def test_open_ended_date_floor_constant():
     assert OPEN_ENDED_DATE_FLOOR == "01/01/1990"
 
 
-def test_date_alias_partition_covers_all():
-    """``deprecated_map`` ∪ ``generic_map`` cobre ``DATE_ALIAS_TO_CANONICAL`` sem sobreposição.
+def test_normalize_datas_uses_alias_mapping_as_single_source(monkeypatch):
+    """An alias added to the canonical mapping is consumed without another registry."""
+    monkeypatch.setitem(
+        DATE_ALIAS_TO_CANONICAL,
+        "data_julgamento_legada",
+        "data_julgamento_inicio",
+    )
 
-    Trava o invariante do particionamento em ``normalize_datas`` e do loop
-    de re-emissão manual no caminho noop de ``run_auto_chunk``: qualquer
-    alias novo em ``DATE_ALIAS_TO_CANONICAL`` precisa cair em exatamente
-    uma das duas categorias (``_de``/``_ate`` ou genérico). Sem isso, um
-    alias órfão sairia silenciosamente do consumo de ``normalize_datas``.
-    """
-    deprecated = {k for k in DATE_ALIAS_TO_CANONICAL if k.endswith(("_de", "_ate"))}
-    generic = {k for k in DATE_ALIAS_TO_CANONICAL if k in ("data_inicio", "data_fim")}
-    assert deprecated | generic == set(DATE_ALIAS_TO_CANONICAL.keys())
-    assert deprecated & generic == set()
+    with pytest.warns(DeprecationWarning, match="data_julgamento_legada"):
+        result = normalize_datas(data_julgamento_legada="01/01/2024")
+
+    assert result["data_julgamento_inicio"] == "01/01/2024"


### PR DESCRIPTION
## Resumo

- Mantém em `normalize_datas` a ordem canônico → alias específico → alias genérico, a detecção de conflitos antes dos warnings e a materialização das quatro datas canônicas.
- Mantém no pipeline a reinjeção das datas nominais, a validação pydantic e a tradução exclusiva de `extra_forbidden` para `TypeError`.

## Simplificação da revisão

- `_collect_date_sources` percorre diretamente os campos canônicos e o mapa ordenado `DATE_ALIAS_TO_CANONICAL`; não reconstrói mapas por sufixo nem reclassifica aliases.
- A detecção de conflitos fica explícita no único consumidor, `normalize_datas`.
- Substitui o helper de instanciação com 7 argumentos por `_validate_pipeline_schema(schema_cls, method_name, sources)`, que recebe as fontes reais e preserva a colisão de keyword.
- Remove o teste de mutação incidental de `kwargs` depois de uma página inválida e testa a fonte única do mapa de aliases.

## Complexidade

- `apply_input_pipeline_search`: CCN 15 e complexidade cognitiva 15.
- Todas as funções alteradas permanecem dentro dos gates; a primeira versão do follow-up chegou a CCN 16 e foi simplificada antes do commit.

## Validação

- Testes focados de `utils` e schemas: passaram.
- `uv run pytest`: 1.750 testes passaram, 32 foram ignorados e 220 ficaram desmarcados.
- Pre-commit completo nos arquivos alterados, Lizard, Complexipy, ratchet e `git diff --check`: passaram.

Refs #307
